### PR TITLE
[VMSS] Fix subtle issue with `VMSS diagnostics set`

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1038,7 +1038,7 @@ def set_vmss_diagnostics_extension(
     result = LongRunningOperation()(poller)
     UpgradeMode = get_sdk(ResourceType.MGMT_COMPUTE, "UpgradeMode", mod='models')
     if vmss.upgrade_policy.mode == UpgradeMode.manual:
-        poller2 = update_vmss_instances(resource_group_name, vmss_name, '*')
+        poller2 = update_vmss_instances(resource_group_name, vmss_name, ['*'])
         LongRunningOperation()(poller2)
     return result
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_diagnostics_extension_install.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_diagnostics_extension_install.yaml
@@ -7,49 +7,43 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [473cc90a-9cc5-11e7-a4c0-a0b3ccf7272a]
+      x-ms-client-request-id: [ac6dc470-a533-11e7-877e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
-        \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
-        : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
-        \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdc453\"\
-        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
-        : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
-        \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
-        \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
-        \       \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n  \
-        \          \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n   \
-        \     },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
-        ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\"\
-        ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdc453Nic\"\
-        ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
-        dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testdc453IPConfig\"\
-        ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
-        },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
-        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
-        }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
-        }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"deb7ac41-9407-4579-aa3f-80b32600f1ab\"\
-        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
-        ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
+    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n    \"tier\":
+        \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
+        true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\":
+        false\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"testd4a52\",\r\n        \"adminUsername\":
+        \"user11\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\":
+        {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n
+        \         \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n
+        \           \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n
+        \       \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n
+        \         \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\",\r\n
+        \         \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\":
+        {\"networkInterfaceConfigurations\":[{\"name\":\"testd4a52Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testd4a52IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"}]}}]}}]}\r\n
+        \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\":
+        true,\r\n    \"uniqueId\": \"1ccfe592-bd33-4939-b208-fbc435404627\"\r\n  },\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
+        \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\",\r\n
+        \ \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:01:17 GMT']
+      Date: ['Fri, 29 Sep 2017 16:31:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2331']
+      content-length: ['2367']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -59,217 +53,211 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [475781b6-9cc5-11e7-9d82-a0b3ccf7272a]
+      x-ms-client-request-id: [ac904e7a-a533-11e7-a0a4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
-        \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
-        : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
-        \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdc453\"\
-        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
-        : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
-        \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
-        \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
-        \       \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n  \
-        \          \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n   \
-        \     },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
-        ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\"\
-        ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdc453Nic\"\
-        ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
-        dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testdc453IPConfig\"\
-        ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
-        },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
-        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
-        }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
-        }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"deb7ac41-9407-4579-aa3f-80b32600f1ab\"\
-        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
-        ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
+    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n    \"tier\":
+        \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
+        true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\":
+        false\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"testd4a52\",\r\n        \"adminUsername\":
+        \"user11\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\":
+        {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n
+        \         \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n
+        \           \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n
+        \       \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n
+        \         \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\",\r\n
+        \         \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\":
+        {\"networkInterfaceConfigurations\":[{\"name\":\"testd4a52Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testd4a52IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"}]}}]}}]}\r\n
+        \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\":
+        true,\r\n    \"uniqueId\": \"1ccfe592-bd33-4939-b208-fbc435404627\"\r\n  },\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
+        \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\",\r\n
+        \ \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:01:17 GMT']
+      Date: ['Fri, 29 Sep 2017 16:31:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2331']
+      content-length: ['2367']
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {}, "properties": {"singlePlacementGroup": true, "overprovision":
-      true, "virtualMachineProfile": {"extensionProfile": {"extensions": [{"properties":
-      {"autoUpgradeMinorVersion": true, "settings": {"ladCfg": {"sampleRateInSeconds":
-      15, "diagnosticMonitorConfiguration": {"syslogEvents": {"syslogEventConfiguration":
-      {"LOG_KERN": "LOG_DEBUG", "LOG_LOCAL5": "LOG_DEBUG", "LOG_LOCAL0": "LOG_DEBUG",
-      "LOG_NEWS": "LOG_DEBUG", "LOG_LPR": "LOG_DEBUG", "LOG_FTP": "LOG_DEBUG", "LOG_AUTH":
-      "LOG_DEBUG", "LOG_DAEMON": "LOG_DEBUG", "LOG_LOCAL3": "LOG_DEBUG", "LOG_LOCAL7":
-      "LOG_DEBUG", "LOG_LOCAL1": "LOG_DEBUG", "LOG_CRON": "LOG_DEBUG", "LOG_MAIL":
-      "LOG_DEBUG", "LOG_UUCP": "LOG_DEBUG", "LOG_LOCAL4": "LOG_DEBUG", "LOG_USER":
-      "LOG_DEBUG", "LOG_LOCAL2": "LOG_DEBUG", "LOG_SYSLOG": "LOG_DEBUG", "LOG_LOCAL6":
-      "LOG_DEBUG", "LOG_AUTHPRIV": "LOG_DEBUG"}}, "performanceCounters": {"performanceCounterConfiguration":
-      [{"annotation": [{"locale": "en-us", "displayName": "Disk read guest OS"}],
-      "condition": "IsAggregate=TRUE", "counter": "readbytespersecond", "unit": "BytesPerSecond",
-      "class": "disk", "counterSpecifier": "/builtin/disk/readbytespersecond", "type":
-      "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk writes"}],
-      "condition": "IsAggregate=TRUE", "counter": "writespersecond", "unit": "CountPerSecond",
-      "class": "disk", "counterSpecifier": "/builtin/disk/writespersecond", "type":
-      "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk transfer
-      time"}], "condition": "IsAggregate=TRUE", "counter": "averagetransfertime",
-      "unit": "Seconds", "class": "disk", "counterSpecifier": "/builtin/disk/averagetransfertime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      transfers"}], "condition": "IsAggregate=TRUE", "counter": "transferspersecond",
-      "unit": "CountPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/transferspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      write guest OS"}], "condition": "IsAggregate=TRUE", "counter": "writebytespersecond",
-      "unit": "BytesPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/writebytespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      read time"}], "condition": "IsAggregate=TRUE", "counter": "averagereadtime",
-      "unit": "Seconds", "class": "disk", "counterSpecifier": "/builtin/disk/averagereadtime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      write time"}], "condition": "IsAggregate=TRUE", "counter": "averagewritetime",
-      "unit": "Seconds", "class": "disk", "counterSpecifier": "/builtin/disk/averagewritetime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      total bytes"}], "condition": "IsAggregate=TRUE", "counter": "bytespersecond",
-      "unit": "BytesPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/bytespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      reads"}], "condition": "IsAggregate=TRUE", "counter": "readspersecond", "unit":
-      "CountPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/readspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      queue length"}], "condition": "IsAggregate=TRUE", "counter": "averagediskqueuelength",
-      "unit": "Count", "class": "disk", "counterSpecifier": "/builtin/disk/averagediskqueuelength",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Network
-      in guest OS"}], "type": "builtin", "counter": "bytesreceived", "unit": "Bytes",
-      "class": "network", "counterSpecifier": "/builtin/network/bytesreceived"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Network total bytes"}], "type": "builtin",
-      "counter": "bytestotal", "unit": "Bytes", "class": "network", "counterSpecifier":
-      "/builtin/network/bytestotal"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Network out guest OS"}], "type": "builtin", "counter": "bytestransmitted",
-      "unit": "Bytes", "class": "network", "counterSpecifier": "/builtin/network/bytestransmitted"},
-      {"annotation": [{"locale": "en-us", "displayName": "Network collisions"}], "type":
-      "builtin", "counter": "totalcollisions", "unit": "Count", "class": "network",
-      "counterSpecifier": "/builtin/network/totalcollisions"}, {"annotation": [{"locale":
-      "en-us", "displayName": "Packets received errors"}], "type": "builtin", "counter":
-      "totalrxerrors", "unit": "Count", "class": "network", "counterSpecifier": "/builtin/network/totalrxerrors"},
-      {"annotation": [{"locale": "en-us", "displayName": "Packets sent"}], "type":
-      "builtin", "counter": "packetstransmitted", "unit": "Count", "class": "network",
-      "counterSpecifier": "/builtin/network/packetstransmitted"}, {"annotation": [{"locale":
-      "en-us", "displayName": "Packets received"}], "type": "builtin", "counter":
-      "packetsreceived", "unit": "Count", "class": "network", "counterSpecifier":
-      "/builtin/network/packetsreceived"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Packets sent errors"}], "type": "builtin", "counter": "totaltxerrors", "unit":
-      "Count", "class": "network", "counterSpecifier": "/builtin/network/totaltxerrors"},
-      {"annotation": [{"locale": "en-us", "displayName": "Filesystem transfers/sec"}],
-      "condition": "IsAggregate=TRUE", "counter": "transferspersecond", "unit": "CountPerSecond",
-      "class": "filesystem", "counterSpecifier": "/builtin/filesystem/transferspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % free space"}], "condition": "IsAggregate=TRUE", "counter": "percentfreespace",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentfreespace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % used space"}], "condition": "IsAggregate=TRUE", "counter": "percentusedspace",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentusedspace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      used space"}], "condition": "IsAggregate=TRUE", "counter": "usedspace", "unit":
-      "Bytes", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/usedspace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      read bytes/sec"}], "condition": "IsAggregate=TRUE", "counter": "bytesreadpersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/bytesreadpersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      free space"}], "condition": "IsAggregate=TRUE", "counter": "freespace", "unit":
-      "Bytes", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/freespace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % free inodes"}], "condition": "IsAggregate=TRUE", "counter": "percentfreeinodes",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentfreeinodes",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      bytes/sec"}], "condition": "IsAggregate=TRUE", "counter": "bytespersecond",
-      "unit": "BytesPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/bytespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      reads/sec"}], "condition": "IsAggregate=TRUE", "counter": "readspersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/readspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      write bytes/sec"}], "condition": "IsAggregate=TRUE", "counter": "byteswrittenpersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/byteswrittenpersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      writes/sec"}], "condition": "IsAggregate=TRUE", "counter": "writespersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/writespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % used inodes"}], "condition": "IsAggregate=TRUE", "counter": "percentusedinodes",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentusedinodes",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      IO wait time"}], "condition": "IsAggregate=TRUE", "counter": "percentiowaittime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentiowaittime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      user time"}], "condition": "IsAggregate=TRUE", "counter": "percentusertime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentusertime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      nice time"}], "condition": "IsAggregate=TRUE", "counter": "percentnicetime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentnicetime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      percentage guest OS"}], "condition": "IsAggregate=TRUE", "counter": "percentprocessortime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentprocessortime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      interrupt time"}], "condition": "IsAggregate=TRUE", "counter": "percentinterrupttime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentinterrupttime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      idle time"}], "condition": "IsAggregate=TRUE", "counter": "percentidletime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentidletime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      privileged time"}], "condition": "IsAggregate=TRUE", "counter": "percentprivilegedtime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentprivilegedtime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Memory
-      available"}], "type": "builtin", "counter": "availablememory", "unit": "Bytes",
-      "class": "memory", "counterSpecifier": "/builtin/memory/availablememory"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Swap percent used"}], "type": "builtin",
-      "counter": "percentusedswap", "unit": "Percent", "class": "memory", "counterSpecifier":
-      "/builtin/memory/percentusedswap"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Memory used"}], "type": "builtin", "counter": "usedmemory", "unit": "Bytes",
-      "class": "memory", "counterSpecifier": "/builtin/memory/usedmemory"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Page reads"}], "type": "builtin", "counter":
-      "pagesreadpersec", "unit": "CountPerSecond", "class": "memory", "counterSpecifier":
-      "/builtin/memory/pagesreadpersec"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Swap available"}], "type": "builtin", "counter": "availableswap", "unit": "Bytes",
-      "class": "memory", "counterSpecifier": "/builtin/memory/availableswap"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Swap percent available"}], "type": "builtin",
-      "counter": "percentavailableswap", "unit": "Percent", "class": "memory", "counterSpecifier":
-      "/builtin/memory/percentavailableswap"}, {"annotation": [{"locale": "en-us",
-      "displayName": "Mem. percent available"}], "type": "builtin", "counter": "percentavailablememory",
-      "unit": "Percent", "class": "memory", "counterSpecifier": "/builtin/memory/percentavailablememory"},
-      {"annotation": [{"locale": "en-us", "displayName": "Pages"}], "type": "builtin",
-      "counter": "pagespersec", "unit": "CountPerSecond", "class": "memory", "counterSpecifier":
-      "/builtin/memory/pagespersec"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Swap used"}], "type": "builtin", "counter": "usedswap", "unit": "Bytes", "class":
-      "memory", "counterSpecifier": "/builtin/memory/usedswap"}, {"annotation": [{"locale":
-      "en-us", "displayName": "Memory percentage"}], "type": "builtin", "counter":
-      "percentusedmemory", "unit": "Percent", "class": "memory", "counterSpecifier":
-      "/builtin/memory/percentusedmemory"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Page writes"}], "type": "builtin", "counter": "pageswrittenpersec", "unit":
-      "CountPerSecond", "class": "memory", "counterSpecifier": "/builtin/memory/pageswrittenpersec"}]},
-      "metrics": {"resourceId": "__VM_RESOURCE_ID__", "metricAggregation": [{"scheduledTransferPeriod":
-      "PT1H"}, {"scheduledTransferPeriod": "PT1M"}]}, "eventVolume": "Medium"}}, "StorageAccount":
-      "clitestdiagextsa20170510"}, "type": "LinuxDiagnostic", "publisher": "Microsoft.Azure.Diagnostics",
-      "typeHandlerVersion": "3.0", "protectedSettings": {"storageAccountName": "clitestdiagextsa20170510",
-      "storageAccountSasToken": "123"}}, "name": "LinuxDiagnostic"}]}, "osProfile":
-      {"adminUsername": "user11", "computerNamePrefix": "testdc453", "linuxConfiguration":
-      {"disablePasswordAuthentication": false}, "secrets": []}, "storageProfile":
-      {"osDisk": {"managedDisk": {"storageAccountType": "Standard_LRS"}, "caching":
-      "ReadWrite", "createOption": "fromImage"}, "imageReference": {"offer": "UbuntuServer",
-      "publisher": "Canonical", "sku": "16.04-LTS", "version": "latest"}}, "networkProfile":
-      {"networkInterfaceConfigurations": [{"properties": {"dnsSettings": {"dnsServers":
-      []}, "primary": true, "enableAcceleratedNetworking": false, "ipConfigurations":
-      [{"properties": {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet"},
+    body: '{"properties": {"upgradePolicy": {"mode": "Manual"}, "overprovision": true,
+      "singlePlacementGroup": true, "virtualMachineProfile": {"networkProfile": {"networkInterfaceConfigurations":
+      [{"properties": {"ipConfigurations": [{"properties": {"privateIPAddressVersion":
+      "IPv4", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet"},
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool"}],
-      "privateIPAddressVersion": "IPv4", "loadBalancerBackendAddressPools": [{"id":
-      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool"}]},
-      "name": "testdc453IPConfig"}]}, "name": "testdc453Nic"}]}}, "upgradePolicy":
-      {"mode": "Manual"}}, "location": "westus", "sku": {"tier": "Standard", "name":
-      "Standard_D1_v2", "capacity": 2}}'
+      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool"}]},
+      "name": "testd4a52IPConfig"}], "primary": true, "dnsSettings": {"dnsServers":
+      []}, "enableAcceleratedNetworking": false}, "name": "testd4a52Nic"}]}, "storageProfile":
+      {"imageReference": {"publisher": "Canonical", "version": "latest", "offer":
+      "UbuntuServer", "sku": "16.04-LTS"}, "osDisk": {"caching": "ReadWrite", "managedDisk":
+      {"storageAccountType": "Standard_LRS"}, "createOption": "fromImage"}}, "osProfile":
+      {"adminUsername": "user11", "computerNamePrefix": "testd4a52", "secrets": [],
+      "linuxConfiguration": {"disablePasswordAuthentication": false}}, "extensionProfile":
+      {"extensions": [{"properties": {"publisher": "Microsoft.Azure.Diagnostics",
+      "autoUpgradeMinorVersion": true, "protectedSettings": {"storageAccountName":
+      "clitestdiagextsa20170510", "storageAccountSasToken": "123"}, "settings": {"ladCfg":
+      {"sampleRateInSeconds": 15, "diagnosticMonitorConfiguration": {"eventVolume":
+      "Medium", "syslogEvents": {"syslogEventConfiguration": {"LOG_LOCAL2": "LOG_DEBUG",
+      "LOG_LOCAL1": "LOG_DEBUG", "LOG_NEWS": "LOG_DEBUG", "LOG_UUCP": "LOG_DEBUG",
+      "LOG_AUTHPRIV": "LOG_DEBUG", "LOG_LOCAL7": "LOG_DEBUG", "LOG_KERN": "LOG_DEBUG",
+      "LOG_LOCAL4": "LOG_DEBUG", "LOG_AUTH": "LOG_DEBUG", "LOG_CRON": "LOG_DEBUG",
+      "LOG_LOCAL3": "LOG_DEBUG", "LOG_DAEMON": "LOG_DEBUG", "LOG_LOCAL5": "LOG_DEBUG",
+      "LOG_USER": "LOG_DEBUG", "LOG_LOCAL6": "LOG_DEBUG", "LOG_LOCAL0": "LOG_DEBUG",
+      "LOG_LPR": "LOG_DEBUG", "LOG_FTP": "LOG_DEBUG", "LOG_SYSLOG": "LOG_DEBUG", "LOG_MAIL":
+      "LOG_DEBUG"}}, "performanceCounters": {"performanceCounterConfiguration": [{"condition":
+      "IsAggregate=TRUE", "counter": "readbytespersecond", "type": "builtin", "class":
+      "disk", "annotation": [{"locale": "en-us", "displayName": "Disk read guest OS"}],
+      "unit": "BytesPerSecond", "counterSpecifier": "/builtin/disk/readbytespersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "writespersecond", "type": "builtin",
+      "class": "disk", "annotation": [{"locale": "en-us", "displayName": "Disk writes"}],
+      "unit": "CountPerSecond", "counterSpecifier": "/builtin/disk/writespersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "averagetransfertime", "type":
+      "builtin", "class": "disk", "annotation": [{"locale": "en-us", "displayName":
+      "Disk transfer time"}], "unit": "Seconds", "counterSpecifier": "/builtin/disk/averagetransfertime"},
+      {"condition": "IsAggregate=TRUE", "counter": "transferspersecond", "type": "builtin",
+      "class": "disk", "annotation": [{"locale": "en-us", "displayName": "Disk transfers"}],
+      "unit": "CountPerSecond", "counterSpecifier": "/builtin/disk/transferspersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "writebytespersecond", "type":
+      "builtin", "class": "disk", "annotation": [{"locale": "en-us", "displayName":
+      "Disk write guest OS"}], "unit": "BytesPerSecond", "counterSpecifier": "/builtin/disk/writebytespersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "averagereadtime", "type": "builtin",
+      "class": "disk", "annotation": [{"locale": "en-us", "displayName": "Disk read
+      time"}], "unit": "Seconds", "counterSpecifier": "/builtin/disk/averagereadtime"},
+      {"condition": "IsAggregate=TRUE", "counter": "averagewritetime", "type": "builtin",
+      "class": "disk", "annotation": [{"locale": "en-us", "displayName": "Disk write
+      time"}], "unit": "Seconds", "counterSpecifier": "/builtin/disk/averagewritetime"},
+      {"condition": "IsAggregate=TRUE", "counter": "bytespersecond", "type": "builtin",
+      "class": "disk", "annotation": [{"locale": "en-us", "displayName": "Disk total
+      bytes"}], "unit": "BytesPerSecond", "counterSpecifier": "/builtin/disk/bytespersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "readspersecond", "type": "builtin",
+      "class": "disk", "annotation": [{"locale": "en-us", "displayName": "Disk reads"}],
+      "unit": "CountPerSecond", "counterSpecifier": "/builtin/disk/readspersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "averagediskqueuelength", "type":
+      "builtin", "class": "disk", "annotation": [{"locale": "en-us", "displayName":
+      "Disk queue length"}], "unit": "Count", "counterSpecifier": "/builtin/disk/averagediskqueuelength"},
+      {"counter": "bytesreceived", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Network in guest OS"}], "unit": "Bytes",
+      "counterSpecifier": "/builtin/network/bytesreceived"}, {"counter": "bytestotal",
+      "type": "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Network total bytes"}], "unit": "Bytes", "counterSpecifier": "/builtin/network/bytestotal"},
+      {"counter": "bytestransmitted", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Network out guest OS"}], "unit": "Bytes",
+      "counterSpecifier": "/builtin/network/bytestransmitted"}, {"counter": "totalcollisions",
+      "type": "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Network collisions"}], "unit": "Count", "counterSpecifier": "/builtin/network/totalcollisions"},
+      {"counter": "totalrxerrors", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Packets received errors"}], "unit": "Count",
+      "counterSpecifier": "/builtin/network/totalrxerrors"}, {"counter": "packetstransmitted",
+      "type": "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Packets sent"}], "unit": "Count", "counterSpecifier": "/builtin/network/packetstransmitted"},
+      {"counter": "packetsreceived", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Packets received"}], "unit": "Count", "counterSpecifier":
+      "/builtin/network/packetsreceived"}, {"counter": "totaltxerrors", "type": "builtin",
+      "class": "network", "annotation": [{"locale": "en-us", "displayName": "Packets
+      sent errors"}], "unit": "Count", "counterSpecifier": "/builtin/network/totaltxerrors"},
+      {"condition": "IsAggregate=TRUE", "counter": "transferspersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      transfers/sec"}], "unit": "CountPerSecond", "counterSpecifier": "/builtin/filesystem/transferspersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentfreespace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      % free space"}], "unit": "Percent", "counterSpecifier": "/builtin/filesystem/percentfreespace"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentusedspace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      % used space"}], "unit": "Percent", "counterSpecifier": "/builtin/filesystem/percentusedspace"},
+      {"condition": "IsAggregate=TRUE", "counter": "usedspace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      used space"}], "unit": "Bytes", "counterSpecifier": "/builtin/filesystem/usedspace"},
+      {"condition": "IsAggregate=TRUE", "counter": "bytesreadpersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      read bytes/sec"}], "unit": "CountPerSecond", "counterSpecifier": "/builtin/filesystem/bytesreadpersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "freespace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      free space"}], "unit": "Bytes", "counterSpecifier": "/builtin/filesystem/freespace"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentfreeinodes", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      % free inodes"}], "unit": "Percent", "counterSpecifier": "/builtin/filesystem/percentfreeinodes"},
+      {"condition": "IsAggregate=TRUE", "counter": "bytespersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      bytes/sec"}], "unit": "BytesPerSecond", "counterSpecifier": "/builtin/filesystem/bytespersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "readspersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      reads/sec"}], "unit": "CountPerSecond", "counterSpecifier": "/builtin/filesystem/readspersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "byteswrittenpersecond", "type":
+      "builtin", "class": "filesystem", "annotation": [{"locale": "en-us", "displayName":
+      "Filesystem write bytes/sec"}], "unit": "CountPerSecond", "counterSpecifier":
+      "/builtin/filesystem/byteswrittenpersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "writespersecond", "type": "builtin", "class": "filesystem", "annotation":
+      [{"locale": "en-us", "displayName": "Filesystem writes/sec"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/filesystem/writespersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "percentusedinodes", "type": "builtin", "class": "filesystem", "annotation":
+      [{"locale": "en-us", "displayName": "Filesystem % used inodes"}], "unit": "Percent",
+      "counterSpecifier": "/builtin/filesystem/percentusedinodes"}, {"condition":
+      "IsAggregate=TRUE", "counter": "percentiowaittime", "type": "builtin", "class":
+      "processor", "annotation": [{"locale": "en-us", "displayName": "CPU IO wait
+      time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentiowaittime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentusertime", "type": "builtin",
+      "class": "processor", "annotation": [{"locale": "en-us", "displayName": "CPU
+      user time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentusertime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentnicetime", "type": "builtin",
+      "class": "processor", "annotation": [{"locale": "en-us", "displayName": "CPU
+      nice time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentnicetime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentprocessortime", "type":
+      "builtin", "class": "processor", "annotation": [{"locale": "en-us", "displayName":
+      "CPU percentage guest OS"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentprocessortime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentinterrupttime", "type":
+      "builtin", "class": "processor", "annotation": [{"locale": "en-us", "displayName":
+      "CPU interrupt time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentinterrupttime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentidletime", "type": "builtin",
+      "class": "processor", "annotation": [{"locale": "en-us", "displayName": "CPU
+      idle time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentidletime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentprivilegedtime", "type":
+      "builtin", "class": "processor", "annotation": [{"locale": "en-us", "displayName":
+      "CPU privileged time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentprivilegedtime"},
+      {"counter": "availablememory", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Memory available"}], "unit": "Bytes", "counterSpecifier":
+      "/builtin/memory/availablememory"}, {"counter": "percentusedswap", "type": "builtin",
+      "class": "memory", "annotation": [{"locale": "en-us", "displayName": "Swap percent
+      used"}], "unit": "Percent", "counterSpecifier": "/builtin/memory/percentusedswap"},
+      {"counter": "usedmemory", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Memory used"}], "unit": "Bytes", "counterSpecifier":
+      "/builtin/memory/usedmemory"}, {"counter": "pagesreadpersec", "type": "builtin",
+      "class": "memory", "annotation": [{"locale": "en-us", "displayName": "Page reads"}],
+      "unit": "CountPerSecond", "counterSpecifier": "/builtin/memory/pagesreadpersec"},
+      {"counter": "availableswap", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Swap available"}], "unit": "Bytes", "counterSpecifier":
+      "/builtin/memory/availableswap"}, {"counter": "percentavailableswap", "type":
+      "builtin", "class": "memory", "annotation": [{"locale": "en-us", "displayName":
+      "Swap percent available"}], "unit": "Percent", "counterSpecifier": "/builtin/memory/percentavailableswap"},
+      {"counter": "percentavailablememory", "type": "builtin", "class": "memory",
+      "annotation": [{"locale": "en-us", "displayName": "Mem. percent available"}],
+      "unit": "Percent", "counterSpecifier": "/builtin/memory/percentavailablememory"},
+      {"counter": "pagespersec", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Pages"}], "unit": "CountPerSecond", "counterSpecifier":
+      "/builtin/memory/pagespersec"}, {"counter": "usedswap", "type": "builtin", "class":
+      "memory", "annotation": [{"locale": "en-us", "displayName": "Swap used"}], "unit":
+      "Bytes", "counterSpecifier": "/builtin/memory/usedswap"}, {"counter": "percentusedmemory",
+      "type": "builtin", "class": "memory", "annotation": [{"locale": "en-us", "displayName":
+      "Memory percentage"}], "unit": "Percent", "counterSpecifier": "/builtin/memory/percentusedmemory"},
+      {"counter": "pageswrittenpersec", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Page writes"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/memory/pageswrittenpersec"}]}, "metrics": {"metricAggregation":
+      [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod": "PT1M"}],
+      "resourceId": "__VM_RESOURCE_ID__"}}}, "StorageAccount": "clitestdiagextsa20170510"},
+      "type": "LinuxDiagnostic", "typeHandlerVersion": "3.0"}, "name": "LinuxDiagnostic"}]}}},
+      "location": "westus", "tags": {}, "sku": {"tier": "Standard", "name": "Standard_D1_v2",
+      "capacity": 2}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -277,224 +265,98 @@ interactions:
       Content-Length: ['14580']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [478eef24-9cc5-11e7-960c-a0b3ccf7272a]
+      x-ms-client-request-id: [acb5f514-a533-11e7-99d4-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
-        \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
-        : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
-        \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdc453\"\
-        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
-        : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
-        \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
-        \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
-        \       \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n  \
-        \          \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n   \
-        \     },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
-        ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\"\
-        ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdc453Nic\"\
-        ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
-        dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testdc453IPConfig\"\
-        ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
-        },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
-        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
-        }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
-        }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
-        \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
-        : \"Microsoft.Azure.Diagnostics\",\r\n              \"type\": \"LinuxDiagnostic\"\
-        ,\r\n              \"typeHandlerVersion\": \"3.0\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"ladCfg\":{\"sampleRateInSeconds\"\
-        :15,\"diagnosticMonitorConfiguration\":{\"syslogEvents\":{\"syslogEventConfiguration\"\
-        :{\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"\
-        LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\"\
-        :\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"\
-        LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\",\"LOG_UUCP\"\
-        :\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"\
-        LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\"\
-        :[{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read guest\
-        \ OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\"\
-        ,\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk writes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk transfer time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        averagetransfertime\",\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/averagetransfertime\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk transfers\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"writebytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"\
-        counterSpecifier\":\"/builtin/disk/writebytespersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read time\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"unit\"\
-        :\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\"\
-        ,\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk total bytes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        bytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/bytespersecond\",\"type\":\"builtin\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Disk reads\"}],\"condition\":\"IsAggregate=TRUE\"\
-        ,\"counter\":\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"disk\"\
-        ,\"counterSpecifier\":\"/builtin/disk/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk queue length\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\"\
-        ,\"unit\":\"Count\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Network in guest OS\"}],\"type\":\"builtin\",\"counter\":\"bytesreceived\"\
-        ,\"unit\":\"Bytes\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network total bytes\"\
-        }],\"type\":\"builtin\",\"counter\":\"bytestotal\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Network out guest OS\"}],\"type\"\
-        :\"builtin\",\"counter\":\"bytestransmitted\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"\
-        annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network collisions\"\
-        }],\"type\":\"builtin\",\"counter\":\"totalcollisions\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\
-        \ errors\"}],\"type\":\"builtin\",\"counter\":\"totalrxerrors\",\"unit\":\"\
-        Count\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetstransmitted\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetsreceived\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent errors\"\
-        }],\"type\":\"builtin\",\"counter\":\"totaltxerrors\",\"unit\":\"Count\",\"\
-        class\":\"network\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem transfers/sec\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"\
-        unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\":\"\
-        /builtin/filesystem/transferspersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem % free space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"unit\":\"Percent\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedspace\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedspace\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem used space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"unit\":\"Bytes\",\"class\"\
-        :\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\",\"\
-        type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem read bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"bytesreadpersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\"\
-        ,\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\",\"type\"\
-        :\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem\
-        \ free space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\"\
-        ,\"unit\":\"Bytes\",\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % free inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentfreeinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentfreeinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem bytes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem reads/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"\
-        counterSpecifier\":\"/builtin/filesystem/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem write\
-        \ bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/byteswrittenpersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem writes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"CPU IO wait time\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"unit\":\"Percent\"\
-        ,\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU user time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU nice time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU percentage guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprocessortime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprocessortime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU interrupt\
-        \ time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU idle time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU privileged time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprivilegedtime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprivilegedtime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory\
-        \ available\"}],\"type\":\"builtin\",\"counter\":\"availablememory\",\"unit\"\
-        :\"Bytes\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/availablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap percent used\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentusedswap\",\"unit\":\"Percent\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory used\"}],\"\
-        type\":\"builtin\",\"counter\":\"usedmemory\",\"unit\":\"Bytes\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Page reads\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"pagesreadpersec\",\"unit\":\"CountPerSecond\",\"class\":\"\
-        memory\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap available\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"availableswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"\
-        counterSpecifier\":\"/builtin/memory/availableswap\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Swap percent available\"}],\"type\":\"\
-        builtin\",\"counter\":\"percentavailableswap\",\"unit\":\"Percent\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem. percent available\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentavailablememory\",\"unit\":\"\
-        Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"type\"\
-        :\"builtin\",\"counter\":\"pagespersec\",\"unit\":\"CountPerSecond\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap used\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"usedswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"counterSpecifier\"\
-        :\"/builtin/memory/usedswap\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Memory percentage\"}],\"type\":\"builtin\",\"counter\":\"percentusedmemory\"\
-        ,\"unit\":\"Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page writes\"}],\"\
-        type\":\"builtin\",\"counter\":\"pageswrittenpersec\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"\
-        }]},\"metrics\":{\"resourceId\":\"__VM_RESOURCE_ID__\",\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"eventVolume\":\"Medium\"}},\"StorageAccount\":\"clitestdiagextsa20170510\"\
-        }\r\n            },\r\n            \"name\": \"LinuxDiagnostic\"\r\n     \
-        \     }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"\
-        Updating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"deb7ac41-9407-4579-aa3f-80b32600f1ab\"\
-        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
-        ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
+    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n    \"tier\":
+        \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
+        true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\":
+        false\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"testd4a52\",\r\n        \"adminUsername\":
+        \"user11\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\":
+        {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n
+        \         \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n
+        \           \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n
+        \       \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n
+        \         \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\",\r\n
+        \         \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\":
+        {\"networkInterfaceConfigurations\":[{\"name\":\"testd4a52Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testd4a52IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"}]}}]}}]},\r\n
+        \     \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n
+        \           \"properties\": {\r\n              \"publisher\": \"Microsoft.Azure.Diagnostics\",\r\n
+        \             \"type\": \"LinuxDiagnostic\",\r\n              \"typeHandlerVersion\":
+        \"3.0\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\":
+        {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"eventVolume\":\"Medium\",\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagetransfertime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfer time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagetransfertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfers\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writebytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/writebytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        total bytes\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        queue length\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"},{\"counter\":\"bytesreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        in guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"},{\"counter\":\"bytestotal\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        total bytes\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"counter\":\"bytestransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        out guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"counter\":\"totalcollisions\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        collisions\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"},{\"counter\":\"totalrxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"},{\"counter\":\"packetstransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"},{\"counter\":\"packetsreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"},{\"counter\":\"totaltxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        transfers/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        used space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytesreadpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        read bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        free space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreeinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreeinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        bytes/sec\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        reads/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        write bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/byteswrittenpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        writes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        IO wait time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        user time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        nice time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprocessortime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        percentage guest OS\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprocessortime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        interrupt time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        idle time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprivilegedtime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        privileged time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprivilegedtime\"},{\"counter\":\"availablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availablememory\"},{\"counter\":\"percentusedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent used\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"},{\"counter\":\"usedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"counter\":\"pagesreadpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"counter\":\"availableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availableswap\"},{\"counter\":\"percentavailableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"},{\"counter\":\"percentavailablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem.
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"},{\"counter\":\"pagespersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"counter\":\"usedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedswap\"},{\"counter\":\"percentusedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        percentage\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"},{\"counter\":\"pageswrittenpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"}]},\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"__VM_RESOURCE_ID__\"}}},\"StorageAccount\":\"clitestdiagextsa20170510\"}\r\n
+        \           },\r\n            \"name\": \"LinuxDiagnostic\"\r\n          }\r\n
+        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"overprovision\": true,\r\n    \"uniqueId\": \"1ccfe592-bd33-4939-b208-fbc435404627\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
+        \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\",\r\n
+        \ \"name\": \"testdiagvmss\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/038b8676-20d9-44b8-bc0a-7cd100ab4735?api-version=2017-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/8df70854-b25e-443a-9b93-35ca194f1e68?api-version=2017-03-30']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:01:18 GMT']
+      Date: ['Fri, 29 Sep 2017 16:31:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['14476']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      content-length: ['14512']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -504,19 +366,20 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [478eef24-9cc5-11e7-960c-a0b3ccf7272a]
+      x-ms-client-request-id: [acb5f514-a533-11e7-99d4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/038b8676-20d9-44b8-bc0a-7cd100ab4735?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/8df70854-b25e-443a-9b93-35ca194f1e68?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-09-18T23:01:16.6469517+00:00\",\r\
-        \n  \"endTime\": \"2017-09-18T23:01:16.8501147+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"038b8676-20d9-44b8-bc0a-7cd100ab4735\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-09-29T16:31:40.5745837+00:00\",\r\n
+        \ \"endTime\": \"2017-09-29T16:31:40.8089574+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"8df70854-b25e-443a-9b93-35ca194f1e68\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:01:48 GMT']
+      Date: ['Fri, 29 Sep 2017 16:32:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -533,222 +396,96 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [478eef24-9cc5-11e7-960c-a0b3ccf7272a]
+      x-ms-client-request-id: [acb5f514-a533-11e7-99d4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
-        \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
-        : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
-        \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdc453\"\
-        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
-        : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
-        \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
-        \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
-        \       \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n  \
-        \          \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n   \
-        \     },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
-        ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\"\
-        ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdc453Nic\"\
-        ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
-        dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testdc453IPConfig\"\
-        ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
-        },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
-        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
-        }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
-        }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
-        \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
-        : \"Microsoft.Azure.Diagnostics\",\r\n              \"type\": \"LinuxDiagnostic\"\
-        ,\r\n              \"typeHandlerVersion\": \"3.0\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"ladCfg\":{\"sampleRateInSeconds\"\
-        :15,\"diagnosticMonitorConfiguration\":{\"syslogEvents\":{\"syslogEventConfiguration\"\
-        :{\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"\
-        LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\"\
-        :\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"\
-        LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\",\"LOG_UUCP\"\
-        :\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"\
-        LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\"\
-        :[{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read guest\
-        \ OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\"\
-        ,\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk writes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk transfer time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        averagetransfertime\",\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/averagetransfertime\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk transfers\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"writebytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"\
-        counterSpecifier\":\"/builtin/disk/writebytespersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read time\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"unit\"\
-        :\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\"\
-        ,\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk total bytes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        bytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/bytespersecond\",\"type\":\"builtin\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Disk reads\"}],\"condition\":\"IsAggregate=TRUE\"\
-        ,\"counter\":\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"disk\"\
-        ,\"counterSpecifier\":\"/builtin/disk/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk queue length\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\"\
-        ,\"unit\":\"Count\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Network in guest OS\"}],\"type\":\"builtin\",\"counter\":\"bytesreceived\"\
-        ,\"unit\":\"Bytes\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network total bytes\"\
-        }],\"type\":\"builtin\",\"counter\":\"bytestotal\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Network out guest OS\"}],\"type\"\
-        :\"builtin\",\"counter\":\"bytestransmitted\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"\
-        annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network collisions\"\
-        }],\"type\":\"builtin\",\"counter\":\"totalcollisions\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\
-        \ errors\"}],\"type\":\"builtin\",\"counter\":\"totalrxerrors\",\"unit\":\"\
-        Count\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetstransmitted\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetsreceived\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent errors\"\
-        }],\"type\":\"builtin\",\"counter\":\"totaltxerrors\",\"unit\":\"Count\",\"\
-        class\":\"network\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem transfers/sec\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"\
-        unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\":\"\
-        /builtin/filesystem/transferspersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem % free space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"unit\":\"Percent\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedspace\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedspace\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem used space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"unit\":\"Bytes\",\"class\"\
-        :\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\",\"\
-        type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem read bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"bytesreadpersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\"\
-        ,\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\",\"type\"\
-        :\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem\
-        \ free space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\"\
-        ,\"unit\":\"Bytes\",\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % free inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentfreeinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentfreeinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem bytes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem reads/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"\
-        counterSpecifier\":\"/builtin/filesystem/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem write\
-        \ bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/byteswrittenpersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem writes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"CPU IO wait time\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"unit\":\"Percent\"\
-        ,\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU user time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU nice time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU percentage guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprocessortime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprocessortime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU interrupt\
-        \ time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU idle time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU privileged time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprivilegedtime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprivilegedtime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory\
-        \ available\"}],\"type\":\"builtin\",\"counter\":\"availablememory\",\"unit\"\
-        :\"Bytes\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/availablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap percent used\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentusedswap\",\"unit\":\"Percent\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory used\"}],\"\
-        type\":\"builtin\",\"counter\":\"usedmemory\",\"unit\":\"Bytes\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Page reads\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"pagesreadpersec\",\"unit\":\"CountPerSecond\",\"class\":\"\
-        memory\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap available\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"availableswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"\
-        counterSpecifier\":\"/builtin/memory/availableswap\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Swap percent available\"}],\"type\":\"\
-        builtin\",\"counter\":\"percentavailableswap\",\"unit\":\"Percent\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem. percent available\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentavailablememory\",\"unit\":\"\
-        Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"type\"\
-        :\"builtin\",\"counter\":\"pagespersec\",\"unit\":\"CountPerSecond\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap used\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"usedswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"counterSpecifier\"\
-        :\"/builtin/memory/usedswap\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Memory percentage\"}],\"type\":\"builtin\",\"counter\":\"percentusedmemory\"\
-        ,\"unit\":\"Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page writes\"}],\"\
-        type\":\"builtin\",\"counter\":\"pageswrittenpersec\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"\
-        }]},\"metrics\":{\"resourceId\":\"__VM_RESOURCE_ID__\",\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"eventVolume\":\"Medium\"}},\"StorageAccount\":\"clitestdiagextsa20170510\"\
-        }\r\n            },\r\n            \"name\": \"LinuxDiagnostic\"\r\n     \
-        \     }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"\
-        Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"deb7ac41-9407-4579-aa3f-80b32600f1ab\"\
-        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
-        ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
+    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n    \"tier\":
+        \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
+        true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\":
+        false\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"testd4a52\",\r\n        \"adminUsername\":
+        \"user11\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\":
+        {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n
+        \         \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n
+        \           \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n
+        \       \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n
+        \         \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\",\r\n
+        \         \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\":
+        {\"networkInterfaceConfigurations\":[{\"name\":\"testd4a52Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testd4a52IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"}]}}]}}]},\r\n
+        \     \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n
+        \           \"properties\": {\r\n              \"publisher\": \"Microsoft.Azure.Diagnostics\",\r\n
+        \             \"type\": \"LinuxDiagnostic\",\r\n              \"typeHandlerVersion\":
+        \"3.0\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\":
+        {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"eventVolume\":\"Medium\",\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagetransfertime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfer time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagetransfertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfers\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writebytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/writebytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        total bytes\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        queue length\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"},{\"counter\":\"bytesreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        in guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"},{\"counter\":\"bytestotal\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        total bytes\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"counter\":\"bytestransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        out guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"counter\":\"totalcollisions\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        collisions\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"},{\"counter\":\"totalrxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"},{\"counter\":\"packetstransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"},{\"counter\":\"packetsreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"},{\"counter\":\"totaltxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        transfers/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        used space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytesreadpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        read bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        free space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreeinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreeinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        bytes/sec\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        reads/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        write bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/byteswrittenpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        writes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        IO wait time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        user time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        nice time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprocessortime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        percentage guest OS\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprocessortime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        interrupt time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        idle time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprivilegedtime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        privileged time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprivilegedtime\"},{\"counter\":\"availablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availablememory\"},{\"counter\":\"percentusedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent used\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"},{\"counter\":\"usedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"counter\":\"pagesreadpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"counter\":\"availableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availableswap\"},{\"counter\":\"percentavailableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"},{\"counter\":\"percentavailablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem.
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"},{\"counter\":\"pagespersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"counter\":\"usedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedswap\"},{\"counter\":\"percentusedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        percentage\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"},{\"counter\":\"pageswrittenpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"}]},\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"__VM_RESOURCE_ID__\"}}},\"StorageAccount\":\"clitestdiagextsa20170510\"}\r\n
+        \           },\r\n            \"name\": \"LinuxDiagnostic\"\r\n          }\r\n
+        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"overprovision\": true,\r\n    \"uniqueId\": \"1ccfe592-bd33-4939-b208-fbc435404627\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
+        \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\",\r\n
+        \ \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:01:48 GMT']
+      Date: ['Fri, 29 Sep 2017 16:32:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['14477']
+      content-length: ['14513']
     status: {code: 200, message: OK}
 - request:
     body: '{"instanceIds": ["*"]}'
@@ -759,24 +496,25 @@ interactions:
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5a9561b6-9cc5-11e7-9b0f-a0b3ccf7272a]
+      x-ms-client-request-id: [bfd0bae6-a533-11e7-96f4-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss/manualupgrade?api-version=2017-03-30
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/a25f09b3-6c82-4ab5-8631-1bb372328aae?api-version=2017-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/06ff1a50-ac1e-45b4-8170-f62e7d0d490c?api-version=2017-03-30']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Mon, 18 Sep 2017 23:01:49 GMT']
+      Date: ['Fri, 29 Sep 2017 16:32:14 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/a25f09b3-6c82-4ab5-8631-1bb372328aae?monitor=true&api-version=2017-03-30']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/06ff1a50-ac1e-45b4-8170-f62e7d0d490c?monitor=true&api-version=2017-03-30']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -786,19 +524,49 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5a9561b6-9cc5-11e7-9b0f-a0b3ccf7272a]
+      x-ms-client-request-id: [bfd0bae6-a533-11e7-96f4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/a25f09b3-6c82-4ab5-8631-1bb372328aae?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/06ff1a50-ac1e-45b4-8170-f62e7d0d490c?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-09-18T23:01:48.3971648+00:00\",\r\
-        \n  \"endTime\": \"2017-09-18T23:02:17.2879782+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"a25f09b3-6c82-4ab5-8631-1bb372328aae\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-09-29T16:32:12.4199491+00:00\",\r\n
+        \ \"status\": \"InProgress\",\r\n  \"name\": \"06ff1a50-ac1e-45b4-8170-f62e7d0d490c\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:02:20 GMT']
+      Date: ['Fri, 29 Sep 2017 16:32:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bfd0bae6-a533-11e7-96f4-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/06ff1a50-ac1e-45b4-8170-f62e7d0d490c?api-version=2017-03-30
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-09-29T16:32:12.4199491+00:00\",\r\n
+        \ \"endTime\": \"2017-09-29T16:32:45.6161797+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"06ff1a50-ac1e-45b4-8170-f62e7d0d490c\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 29 Sep 2017 16:33:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -815,222 +583,96 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6d6af410-9cc5-11e7-9d87-a0b3ccf7272a]
+      x-ms-client-request-id: [e4967426-a533-11e7-b6c8-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
-        \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
-        : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
-        \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdc453\"\
-        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
-        : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
-        \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
-        \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
-        \       \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n  \
-        \          \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n   \
-        \     },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
-        ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\"\
-        ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdc453Nic\"\
-        ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
-        dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testdc453IPConfig\"\
-        ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
-        },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
-        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
-        }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
-        }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
-        \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
-        : \"Microsoft.Azure.Diagnostics\",\r\n              \"type\": \"LinuxDiagnostic\"\
-        ,\r\n              \"typeHandlerVersion\": \"3.0\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"ladCfg\":{\"sampleRateInSeconds\"\
-        :15,\"diagnosticMonitorConfiguration\":{\"syslogEvents\":{\"syslogEventConfiguration\"\
-        :{\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"\
-        LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\"\
-        :\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"\
-        LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\",\"LOG_UUCP\"\
-        :\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"\
-        LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\"\
-        :[{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read guest\
-        \ OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\"\
-        ,\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk writes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk transfer time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        averagetransfertime\",\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/averagetransfertime\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk transfers\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"writebytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"\
-        counterSpecifier\":\"/builtin/disk/writebytespersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read time\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"unit\"\
-        :\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\"\
-        ,\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk total bytes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        bytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/bytespersecond\",\"type\":\"builtin\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Disk reads\"}],\"condition\":\"IsAggregate=TRUE\"\
-        ,\"counter\":\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"disk\"\
-        ,\"counterSpecifier\":\"/builtin/disk/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk queue length\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\"\
-        ,\"unit\":\"Count\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Network in guest OS\"}],\"type\":\"builtin\",\"counter\":\"bytesreceived\"\
-        ,\"unit\":\"Bytes\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network total bytes\"\
-        }],\"type\":\"builtin\",\"counter\":\"bytestotal\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Network out guest OS\"}],\"type\"\
-        :\"builtin\",\"counter\":\"bytestransmitted\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"\
-        annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network collisions\"\
-        }],\"type\":\"builtin\",\"counter\":\"totalcollisions\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\
-        \ errors\"}],\"type\":\"builtin\",\"counter\":\"totalrxerrors\",\"unit\":\"\
-        Count\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetstransmitted\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetsreceived\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent errors\"\
-        }],\"type\":\"builtin\",\"counter\":\"totaltxerrors\",\"unit\":\"Count\",\"\
-        class\":\"network\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem transfers/sec\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"\
-        unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\":\"\
-        /builtin/filesystem/transferspersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem % free space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"unit\":\"Percent\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedspace\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedspace\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem used space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"unit\":\"Bytes\",\"class\"\
-        :\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\",\"\
-        type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem read bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"bytesreadpersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\"\
-        ,\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\",\"type\"\
-        :\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem\
-        \ free space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\"\
-        ,\"unit\":\"Bytes\",\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % free inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentfreeinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentfreeinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem bytes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem reads/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"\
-        counterSpecifier\":\"/builtin/filesystem/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem write\
-        \ bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/byteswrittenpersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem writes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"CPU IO wait time\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"unit\":\"Percent\"\
-        ,\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU user time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU nice time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU percentage guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprocessortime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprocessortime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU interrupt\
-        \ time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU idle time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU privileged time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprivilegedtime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprivilegedtime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory\
-        \ available\"}],\"type\":\"builtin\",\"counter\":\"availablememory\",\"unit\"\
-        :\"Bytes\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/availablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap percent used\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentusedswap\",\"unit\":\"Percent\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory used\"}],\"\
-        type\":\"builtin\",\"counter\":\"usedmemory\",\"unit\":\"Bytes\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Page reads\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"pagesreadpersec\",\"unit\":\"CountPerSecond\",\"class\":\"\
-        memory\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap available\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"availableswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"\
-        counterSpecifier\":\"/builtin/memory/availableswap\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Swap percent available\"}],\"type\":\"\
-        builtin\",\"counter\":\"percentavailableswap\",\"unit\":\"Percent\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem. percent available\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentavailablememory\",\"unit\":\"\
-        Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"type\"\
-        :\"builtin\",\"counter\":\"pagespersec\",\"unit\":\"CountPerSecond\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap used\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"usedswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"counterSpecifier\"\
-        :\"/builtin/memory/usedswap\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Memory percentage\"}],\"type\":\"builtin\",\"counter\":\"percentusedmemory\"\
-        ,\"unit\":\"Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page writes\"}],\"\
-        type\":\"builtin\",\"counter\":\"pageswrittenpersec\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"\
-        }]},\"metrics\":{\"resourceId\":\"__VM_RESOURCE_ID__\",\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"eventVolume\":\"Medium\"}},\"StorageAccount\":\"clitestdiagextsa20170510\"\
-        }\r\n            },\r\n            \"name\": \"LinuxDiagnostic\"\r\n     \
-        \     }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"\
-        Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"deb7ac41-9407-4579-aa3f-80b32600f1ab\"\
-        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
-        ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
+    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n    \"tier\":
+        \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
+        true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\":
+        false\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"testd4a52\",\r\n        \"adminUsername\":
+        \"user11\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\":
+        {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n
+        \         \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n
+        \           \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n
+        \       \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n
+        \         \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\",\r\n
+        \         \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\":
+        {\"networkInterfaceConfigurations\":[{\"name\":\"testd4a52Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"testd4a52IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"}]}}]}}]},\r\n
+        \     \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n
+        \           \"properties\": {\r\n              \"publisher\": \"Microsoft.Azure.Diagnostics\",\r\n
+        \             \"type\": \"LinuxDiagnostic\",\r\n              \"typeHandlerVersion\":
+        \"3.0\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\":
+        {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"eventVolume\":\"Medium\",\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagetransfertime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfer time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagetransfertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfers\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writebytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/writebytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        total bytes\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        queue length\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"},{\"counter\":\"bytesreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        in guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"},{\"counter\":\"bytestotal\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        total bytes\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"counter\":\"bytestransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        out guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"counter\":\"totalcollisions\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        collisions\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"},{\"counter\":\"totalrxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"},{\"counter\":\"packetstransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"},{\"counter\":\"packetsreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"},{\"counter\":\"totaltxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        transfers/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        used space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytesreadpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        read bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        free space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreeinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreeinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        bytes/sec\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        reads/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        write bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/byteswrittenpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        writes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        IO wait time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        user time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        nice time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprocessortime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        percentage guest OS\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprocessortime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        interrupt time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        idle time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprivilegedtime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        privileged time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprivilegedtime\"},{\"counter\":\"availablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availablememory\"},{\"counter\":\"percentusedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent used\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"},{\"counter\":\"usedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"counter\":\"pagesreadpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"counter\":\"availableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availableswap\"},{\"counter\":\"percentavailableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"},{\"counter\":\"percentavailablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem.
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"},{\"counter\":\"pagespersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"counter\":\"usedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedswap\"},{\"counter\":\"percentusedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        percentage\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"},{\"counter\":\"pageswrittenpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"}]},\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"__VM_RESOURCE_ID__\"}}},\"StorageAccount\":\"clitestdiagextsa20170510\"}\r\n
+        \           },\r\n            \"name\": \"LinuxDiagnostic\"\r\n          }\r\n
+        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"overprovision\": true,\r\n    \"uniqueId\": \"1ccfe592-bd33-4939-b208-fbc435404627\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
+        \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\",\r\n
+        \ \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:02:21 GMT']
+      Date: ['Fri, 29 Sep 2017 16:33:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['14477']
+      content-length: ['14513']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1040,210 +682,210 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6d8f9990-9cc5-11e7-83dd-a0b3ccf7272a]
+      x-ms-client-request-id: [e4c83824-a533-11e7-ae77-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2017-03-30&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"a1e80f6b-53dc-4dd4-b027-d041dbf28074\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
-        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
-        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
-        \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"osdisk_4de31bd4c6\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstorage4de31bd4c6b8c2.blob.core.windows.net/vhds/osdisk_4de31bd4c6.vhd\"\
-        \r\n        },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\"\
-        : 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"testdiagvm\",\r\n      \"adminUsername\"\
-        : \"user11\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
-        : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
-        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.17\",\r\n\
-        \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
-        Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n     \
-        \       \"time\": \"2017-09-18T23:02:21+00:00\"\r\n          }\r\n       \
-        \ ],\r\n        \"extensionHandlers\": []\r\n      },\r\n      \"disks\":\
-        \ [\r\n        {\r\n          \"name\": \"osdisk_4de31bd4c6\",\r\n       \
-        \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-09-18T22:59:35.848149+00:00\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"statuses\"\
-        : [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\
-        \n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2017-09-18T23:00:44.8498792+00:00\"\
-        \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
-        ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
-        \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\"\
-        ,\r\n  \"name\": \"testdiagvm\"\r\n}"}
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"214e660e-640e-4843-9a5b-b22fbfefaf54\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_32a651c70c\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\":
+        \"https://vhdstorage32a651c70ca5bb.blob.core.windows.net/vhds/osdisk_32a651c70c.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
+        {\r\n        \"vmAgentVersion\": \"2.2.17\",\r\n        \"statuses\": [\r\n
+        \         {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
+        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
+        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
+        \"2017-09-29T16:33:14+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_32a651c70c\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        succeeded\",\r\n              \"time\": \"2017-09-29T16:30:08.9514524+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"statuses\":
+        [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2017-09-29T16:31:14.5889048+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\",\r\n
+        \ \"name\": \"testdiagvm\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:02:22 GMT']
+      Date: ['Fri, 29 Sep 2017 16:33:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2608']
+      content-length: ['2609']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"autoUpgradeMinorVersion": true,
-      "settings": {"ladCfg": {"sampleRateInSeconds": 15, "diagnosticMonitorConfiguration":
-      {"syslogEvents": {"syslogEventConfiguration": {"LOG_KERN": "LOG_DEBUG", "LOG_LOCAL5":
-      "LOG_DEBUG", "LOG_LOCAL0": "LOG_DEBUG", "LOG_NEWS": "LOG_DEBUG", "LOG_LPR":
-      "LOG_DEBUG", "LOG_FTP": "LOG_DEBUG", "LOG_AUTH": "LOG_DEBUG", "LOG_DAEMON":
-      "LOG_DEBUG", "LOG_LOCAL3": "LOG_DEBUG", "LOG_LOCAL7": "LOG_DEBUG", "LOG_LOCAL1":
-      "LOG_DEBUG", "LOG_CRON": "LOG_DEBUG", "LOG_MAIL": "LOG_DEBUG", "LOG_UUCP": "LOG_DEBUG",
-      "LOG_LOCAL4": "LOG_DEBUG", "LOG_USER": "LOG_DEBUG", "LOG_LOCAL2": "LOG_DEBUG",
-      "LOG_SYSLOG": "LOG_DEBUG", "LOG_LOCAL6": "LOG_DEBUG", "LOG_AUTHPRIV": "LOG_DEBUG"}},
-      "performanceCounters": {"performanceCounterConfiguration": [{"annotation": [{"locale":
-      "en-us", "displayName": "Disk read guest OS"}], "condition": "IsAggregate=TRUE",
-      "counter": "readbytespersecond", "unit": "BytesPerSecond", "class": "disk",
-      "counterSpecifier": "/builtin/disk/readbytespersecond", "type": "builtin"},
-      {"annotation": [{"locale": "en-us", "displayName": "Disk writes"}], "condition":
-      "IsAggregate=TRUE", "counter": "writespersecond", "unit": "CountPerSecond",
-      "class": "disk", "counterSpecifier": "/builtin/disk/writespersecond", "type":
-      "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk transfer
-      time"}], "condition": "IsAggregate=TRUE", "counter": "averagetransfertime",
-      "unit": "Seconds", "class": "disk", "counterSpecifier": "/builtin/disk/averagetransfertime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      transfers"}], "condition": "IsAggregate=TRUE", "counter": "transferspersecond",
-      "unit": "CountPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/transferspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      write guest OS"}], "condition": "IsAggregate=TRUE", "counter": "writebytespersecond",
-      "unit": "BytesPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/writebytespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      read time"}], "condition": "IsAggregate=TRUE", "counter": "averagereadtime",
-      "unit": "Seconds", "class": "disk", "counterSpecifier": "/builtin/disk/averagereadtime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      write time"}], "condition": "IsAggregate=TRUE", "counter": "averagewritetime",
-      "unit": "Seconds", "class": "disk", "counterSpecifier": "/builtin/disk/averagewritetime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      total bytes"}], "condition": "IsAggregate=TRUE", "counter": "bytespersecond",
-      "unit": "BytesPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/bytespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      reads"}], "condition": "IsAggregate=TRUE", "counter": "readspersecond", "unit":
-      "CountPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/readspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      queue length"}], "condition": "IsAggregate=TRUE", "counter": "averagediskqueuelength",
-      "unit": "Count", "class": "disk", "counterSpecifier": "/builtin/disk/averagediskqueuelength",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Network
-      in guest OS"}], "type": "builtin", "counter": "bytesreceived", "unit": "Bytes",
-      "class": "network", "counterSpecifier": "/builtin/network/bytesreceived"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Network total bytes"}], "type": "builtin",
-      "counter": "bytestotal", "unit": "Bytes", "class": "network", "counterSpecifier":
-      "/builtin/network/bytestotal"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Network out guest OS"}], "type": "builtin", "counter": "bytestransmitted",
-      "unit": "Bytes", "class": "network", "counterSpecifier": "/builtin/network/bytestransmitted"},
-      {"annotation": [{"locale": "en-us", "displayName": "Network collisions"}], "type":
-      "builtin", "counter": "totalcollisions", "unit": "Count", "class": "network",
-      "counterSpecifier": "/builtin/network/totalcollisions"}, {"annotation": [{"locale":
-      "en-us", "displayName": "Packets received errors"}], "type": "builtin", "counter":
-      "totalrxerrors", "unit": "Count", "class": "network", "counterSpecifier": "/builtin/network/totalrxerrors"},
-      {"annotation": [{"locale": "en-us", "displayName": "Packets sent"}], "type":
-      "builtin", "counter": "packetstransmitted", "unit": "Count", "class": "network",
-      "counterSpecifier": "/builtin/network/packetstransmitted"}, {"annotation": [{"locale":
-      "en-us", "displayName": "Packets received"}], "type": "builtin", "counter":
-      "packetsreceived", "unit": "Count", "class": "network", "counterSpecifier":
-      "/builtin/network/packetsreceived"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Packets sent errors"}], "type": "builtin", "counter": "totaltxerrors", "unit":
-      "Count", "class": "network", "counterSpecifier": "/builtin/network/totaltxerrors"},
-      {"annotation": [{"locale": "en-us", "displayName": "Filesystem transfers/sec"}],
-      "condition": "IsAggregate=TRUE", "counter": "transferspersecond", "unit": "CountPerSecond",
-      "class": "filesystem", "counterSpecifier": "/builtin/filesystem/transferspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % free space"}], "condition": "IsAggregate=TRUE", "counter": "percentfreespace",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentfreespace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % used space"}], "condition": "IsAggregate=TRUE", "counter": "percentusedspace",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentusedspace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      used space"}], "condition": "IsAggregate=TRUE", "counter": "usedspace", "unit":
-      "Bytes", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/usedspace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      read bytes/sec"}], "condition": "IsAggregate=TRUE", "counter": "bytesreadpersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/bytesreadpersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      free space"}], "condition": "IsAggregate=TRUE", "counter": "freespace", "unit":
-      "Bytes", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/freespace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % free inodes"}], "condition": "IsAggregate=TRUE", "counter": "percentfreeinodes",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentfreeinodes",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      bytes/sec"}], "condition": "IsAggregate=TRUE", "counter": "bytespersecond",
-      "unit": "BytesPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/bytespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      reads/sec"}], "condition": "IsAggregate=TRUE", "counter": "readspersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/readspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      write bytes/sec"}], "condition": "IsAggregate=TRUE", "counter": "byteswrittenpersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/byteswrittenpersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      writes/sec"}], "condition": "IsAggregate=TRUE", "counter": "writespersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/writespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % used inodes"}], "condition": "IsAggregate=TRUE", "counter": "percentusedinodes",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentusedinodes",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      IO wait time"}], "condition": "IsAggregate=TRUE", "counter": "percentiowaittime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentiowaittime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      user time"}], "condition": "IsAggregate=TRUE", "counter": "percentusertime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentusertime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      nice time"}], "condition": "IsAggregate=TRUE", "counter": "percentnicetime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentnicetime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      percentage guest OS"}], "condition": "IsAggregate=TRUE", "counter": "percentprocessortime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentprocessortime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      interrupt time"}], "condition": "IsAggregate=TRUE", "counter": "percentinterrupttime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentinterrupttime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      idle time"}], "condition": "IsAggregate=TRUE", "counter": "percentidletime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentidletime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      privileged time"}], "condition": "IsAggregate=TRUE", "counter": "percentprivilegedtime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentprivilegedtime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Memory
-      available"}], "type": "builtin", "counter": "availablememory", "unit": "Bytes",
-      "class": "memory", "counterSpecifier": "/builtin/memory/availablememory"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Swap percent used"}], "type": "builtin",
-      "counter": "percentusedswap", "unit": "Percent", "class": "memory", "counterSpecifier":
-      "/builtin/memory/percentusedswap"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Memory used"}], "type": "builtin", "counter": "usedmemory", "unit": "Bytes",
-      "class": "memory", "counterSpecifier": "/builtin/memory/usedmemory"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Page reads"}], "type": "builtin", "counter":
-      "pagesreadpersec", "unit": "CountPerSecond", "class": "memory", "counterSpecifier":
-      "/builtin/memory/pagesreadpersec"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Swap available"}], "type": "builtin", "counter": "availableswap", "unit": "Bytes",
-      "class": "memory", "counterSpecifier": "/builtin/memory/availableswap"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Swap percent available"}], "type": "builtin",
-      "counter": "percentavailableswap", "unit": "Percent", "class": "memory", "counterSpecifier":
-      "/builtin/memory/percentavailableswap"}, {"annotation": [{"locale": "en-us",
-      "displayName": "Mem. percent available"}], "type": "builtin", "counter": "percentavailablememory",
-      "unit": "Percent", "class": "memory", "counterSpecifier": "/builtin/memory/percentavailablememory"},
-      {"annotation": [{"locale": "en-us", "displayName": "Pages"}], "type": "builtin",
-      "counter": "pagespersec", "unit": "CountPerSecond", "class": "memory", "counterSpecifier":
-      "/builtin/memory/pagespersec"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Swap used"}], "type": "builtin", "counter": "usedswap", "unit": "Bytes", "class":
-      "memory", "counterSpecifier": "/builtin/memory/usedswap"}, {"annotation": [{"locale":
-      "en-us", "displayName": "Memory percentage"}], "type": "builtin", "counter":
-      "percentusedmemory", "unit": "Percent", "class": "memory", "counterSpecifier":
-      "/builtin/memory/percentusedmemory"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Page writes"}], "type": "builtin", "counter": "pageswrittenpersec", "unit":
-      "CountPerSecond", "class": "memory", "counterSpecifier": "/builtin/memory/pageswrittenpersec"}]},
-      "metrics": {"resourceId": "__VM_RESOURCE_ID__", "metricAggregation": [{"scheduledTransferPeriod":
-      "PT1H"}, {"scheduledTransferPeriod": "PT1M"}]}, "eventVolume": "Medium"}}, "StorageAccount":
-      "clitestdiagextsa20170510"}, "type": "LinuxDiagnostic", "publisher": "Microsoft.OSTCExtensions",
-      "typeHandlerVersion": "2.3", "protectedSettings": {"storageAccountName": "clitestdiagextsa20170510",
-      "storageAccountSasToken": "123"}}}'
+    body: '{"properties": {"autoUpgradeMinorVersion": true, "publisher": "Microsoft.OSTCExtensions",
+      "protectedSettings": {"storageAccountName": "clitestdiagextsa20170510", "storageAccountSasToken":
+      "123"}, "type": "LinuxDiagnostic", "settings": {"ladCfg": {"sampleRateInSeconds":
+      15, "diagnosticMonitorConfiguration": {"eventVolume": "Medium", "syslogEvents":
+      {"syslogEventConfiguration": {"LOG_LOCAL2": "LOG_DEBUG", "LOG_LOCAL1": "LOG_DEBUG",
+      "LOG_NEWS": "LOG_DEBUG", "LOG_UUCP": "LOG_DEBUG", "LOG_AUTHPRIV": "LOG_DEBUG",
+      "LOG_LOCAL7": "LOG_DEBUG", "LOG_KERN": "LOG_DEBUG", "LOG_LOCAL4": "LOG_DEBUG",
+      "LOG_AUTH": "LOG_DEBUG", "LOG_CRON": "LOG_DEBUG", "LOG_LOCAL3": "LOG_DEBUG",
+      "LOG_DAEMON": "LOG_DEBUG", "LOG_LOCAL5": "LOG_DEBUG", "LOG_USER": "LOG_DEBUG",
+      "LOG_LOCAL6": "LOG_DEBUG", "LOG_LOCAL0": "LOG_DEBUG", "LOG_LPR": "LOG_DEBUG",
+      "LOG_FTP": "LOG_DEBUG", "LOG_SYSLOG": "LOG_DEBUG", "LOG_MAIL": "LOG_DEBUG"}},
+      "performanceCounters": {"performanceCounterConfiguration": [{"condition": "IsAggregate=TRUE",
+      "counter": "readbytespersecond", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk read guest OS"}], "unit": "BytesPerSecond",
+      "counterSpecifier": "/builtin/disk/readbytespersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "writespersecond", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk writes"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/disk/writespersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "averagetransfertime", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk transfer time"}], "unit": "Seconds",
+      "counterSpecifier": "/builtin/disk/averagetransfertime"}, {"condition": "IsAggregate=TRUE",
+      "counter": "transferspersecond", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk transfers"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/disk/transferspersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "writebytespersecond", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk write guest OS"}], "unit": "BytesPerSecond",
+      "counterSpecifier": "/builtin/disk/writebytespersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "averagereadtime", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk read time"}], "unit": "Seconds", "counterSpecifier":
+      "/builtin/disk/averagereadtime"}, {"condition": "IsAggregate=TRUE", "counter":
+      "averagewritetime", "type": "builtin", "class": "disk", "annotation": [{"locale":
+      "en-us", "displayName": "Disk write time"}], "unit": "Seconds", "counterSpecifier":
+      "/builtin/disk/averagewritetime"}, {"condition": "IsAggregate=TRUE", "counter":
+      "bytespersecond", "type": "builtin", "class": "disk", "annotation": [{"locale":
+      "en-us", "displayName": "Disk total bytes"}], "unit": "BytesPerSecond", "counterSpecifier":
+      "/builtin/disk/bytespersecond"}, {"condition": "IsAggregate=TRUE", "counter":
+      "readspersecond", "type": "builtin", "class": "disk", "annotation": [{"locale":
+      "en-us", "displayName": "Disk reads"}], "unit": "CountPerSecond", "counterSpecifier":
+      "/builtin/disk/readspersecond"}, {"condition": "IsAggregate=TRUE", "counter":
+      "averagediskqueuelength", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk queue length"}], "unit": "Count",
+      "counterSpecifier": "/builtin/disk/averagediskqueuelength"}, {"counter": "bytesreceived",
+      "type": "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Network in guest OS"}], "unit": "Bytes", "counterSpecifier": "/builtin/network/bytesreceived"},
+      {"counter": "bytestotal", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Network total bytes"}], "unit": "Bytes",
+      "counterSpecifier": "/builtin/network/bytestotal"}, {"counter": "bytestransmitted",
+      "type": "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Network out guest OS"}], "unit": "Bytes", "counterSpecifier": "/builtin/network/bytestransmitted"},
+      {"counter": "totalcollisions", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Network collisions"}], "unit": "Count",
+      "counterSpecifier": "/builtin/network/totalcollisions"}, {"counter": "totalrxerrors",
+      "type": "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Packets received errors"}], "unit": "Count", "counterSpecifier": "/builtin/network/totalrxerrors"},
+      {"counter": "packetstransmitted", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Packets sent"}], "unit": "Count", "counterSpecifier":
+      "/builtin/network/packetstransmitted"}, {"counter": "packetsreceived", "type":
+      "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Packets received"}], "unit": "Count", "counterSpecifier": "/builtin/network/packetsreceived"},
+      {"counter": "totaltxerrors", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Packets sent errors"}], "unit": "Count",
+      "counterSpecifier": "/builtin/network/totaltxerrors"}, {"condition": "IsAggregate=TRUE",
+      "counter": "transferspersecond", "type": "builtin", "class": "filesystem", "annotation":
+      [{"locale": "en-us", "displayName": "Filesystem transfers/sec"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/filesystem/transferspersecond"}, {"condition":
+      "IsAggregate=TRUE", "counter": "percentfreespace", "type": "builtin", "class":
+      "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      % free space"}], "unit": "Percent", "counterSpecifier": "/builtin/filesystem/percentfreespace"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentusedspace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      % used space"}], "unit": "Percent", "counterSpecifier": "/builtin/filesystem/percentusedspace"},
+      {"condition": "IsAggregate=TRUE", "counter": "usedspace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      used space"}], "unit": "Bytes", "counterSpecifier": "/builtin/filesystem/usedspace"},
+      {"condition": "IsAggregate=TRUE", "counter": "bytesreadpersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      read bytes/sec"}], "unit": "CountPerSecond", "counterSpecifier": "/builtin/filesystem/bytesreadpersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "freespace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      free space"}], "unit": "Bytes", "counterSpecifier": "/builtin/filesystem/freespace"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentfreeinodes", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      % free inodes"}], "unit": "Percent", "counterSpecifier": "/builtin/filesystem/percentfreeinodes"},
+      {"condition": "IsAggregate=TRUE", "counter": "bytespersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      bytes/sec"}], "unit": "BytesPerSecond", "counterSpecifier": "/builtin/filesystem/bytespersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "readspersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      reads/sec"}], "unit": "CountPerSecond", "counterSpecifier": "/builtin/filesystem/readspersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "byteswrittenpersecond", "type":
+      "builtin", "class": "filesystem", "annotation": [{"locale": "en-us", "displayName":
+      "Filesystem write bytes/sec"}], "unit": "CountPerSecond", "counterSpecifier":
+      "/builtin/filesystem/byteswrittenpersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "writespersecond", "type": "builtin", "class": "filesystem", "annotation":
+      [{"locale": "en-us", "displayName": "Filesystem writes/sec"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/filesystem/writespersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "percentusedinodes", "type": "builtin", "class": "filesystem", "annotation":
+      [{"locale": "en-us", "displayName": "Filesystem % used inodes"}], "unit": "Percent",
+      "counterSpecifier": "/builtin/filesystem/percentusedinodes"}, {"condition":
+      "IsAggregate=TRUE", "counter": "percentiowaittime", "type": "builtin", "class":
+      "processor", "annotation": [{"locale": "en-us", "displayName": "CPU IO wait
+      time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentiowaittime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentusertime", "type": "builtin",
+      "class": "processor", "annotation": [{"locale": "en-us", "displayName": "CPU
+      user time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentusertime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentnicetime", "type": "builtin",
+      "class": "processor", "annotation": [{"locale": "en-us", "displayName": "CPU
+      nice time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentnicetime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentprocessortime", "type":
+      "builtin", "class": "processor", "annotation": [{"locale": "en-us", "displayName":
+      "CPU percentage guest OS"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentprocessortime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentinterrupttime", "type":
+      "builtin", "class": "processor", "annotation": [{"locale": "en-us", "displayName":
+      "CPU interrupt time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentinterrupttime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentidletime", "type": "builtin",
+      "class": "processor", "annotation": [{"locale": "en-us", "displayName": "CPU
+      idle time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentidletime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentprivilegedtime", "type":
+      "builtin", "class": "processor", "annotation": [{"locale": "en-us", "displayName":
+      "CPU privileged time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentprivilegedtime"},
+      {"counter": "availablememory", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Memory available"}], "unit": "Bytes", "counterSpecifier":
+      "/builtin/memory/availablememory"}, {"counter": "percentusedswap", "type": "builtin",
+      "class": "memory", "annotation": [{"locale": "en-us", "displayName": "Swap percent
+      used"}], "unit": "Percent", "counterSpecifier": "/builtin/memory/percentusedswap"},
+      {"counter": "usedmemory", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Memory used"}], "unit": "Bytes", "counterSpecifier":
+      "/builtin/memory/usedmemory"}, {"counter": "pagesreadpersec", "type": "builtin",
+      "class": "memory", "annotation": [{"locale": "en-us", "displayName": "Page reads"}],
+      "unit": "CountPerSecond", "counterSpecifier": "/builtin/memory/pagesreadpersec"},
+      {"counter": "availableswap", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Swap available"}], "unit": "Bytes", "counterSpecifier":
+      "/builtin/memory/availableswap"}, {"counter": "percentavailableswap", "type":
+      "builtin", "class": "memory", "annotation": [{"locale": "en-us", "displayName":
+      "Swap percent available"}], "unit": "Percent", "counterSpecifier": "/builtin/memory/percentavailableswap"},
+      {"counter": "percentavailablememory", "type": "builtin", "class": "memory",
+      "annotation": [{"locale": "en-us", "displayName": "Mem. percent available"}],
+      "unit": "Percent", "counterSpecifier": "/builtin/memory/percentavailablememory"},
+      {"counter": "pagespersec", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Pages"}], "unit": "CountPerSecond", "counterSpecifier":
+      "/builtin/memory/pagespersec"}, {"counter": "usedswap", "type": "builtin", "class":
+      "memory", "annotation": [{"locale": "en-us", "displayName": "Swap used"}], "unit":
+      "Bytes", "counterSpecifier": "/builtin/memory/usedswap"}, {"counter": "percentusedmemory",
+      "type": "builtin", "class": "memory", "annotation": [{"locale": "en-us", "displayName":
+      "Memory percentage"}], "unit": "Percent", "counterSpecifier": "/builtin/memory/percentusedmemory"},
+      {"counter": "pageswrittenpersec", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Page writes"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/memory/pageswrittenpersec"}]}, "metrics": {"metricAggregation":
+      [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod": "PT1M"}],
+      "resourceId": "__VM_RESOURCE_ID__"}}}, "StorageAccount": "clitestdiagextsa20170510"},
+      "typeHandlerVersion": "2.3"}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1251,197 +893,77 @@ interactions:
       Content-Length: ['12865']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6de409f0-9cc5-11e7-b8c7-a0b3ccf7272a]
+      x-ms-client-request-id: [e4f30ce8-a533-11e7-a2b1-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.OSTCExtensions\"\
-        ,\r\n    \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"\
-        2.3\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"\
-        ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"\
-        syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_KERN\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\"\
-        ,\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\"\
-        ,\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_LOCAL7\"\
-        :\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"\
-        LOG_MAIL\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\"\
-        ,\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"\
-        LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\"}},\"\
-        performanceCounters\":{\"performanceCounterConfiguration\":[{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk read guest OS\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk writes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk transfer time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        averagetransfertime\",\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/averagetransfertime\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk transfers\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"writebytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"\
-        counterSpecifier\":\"/builtin/disk/writebytespersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read time\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"unit\"\
-        :\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\"\
-        ,\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk total bytes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        bytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/bytespersecond\",\"type\":\"builtin\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Disk reads\"}],\"condition\":\"IsAggregate=TRUE\"\
-        ,\"counter\":\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"disk\"\
-        ,\"counterSpecifier\":\"/builtin/disk/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk queue length\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\"\
-        ,\"unit\":\"Count\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Network in guest OS\"}],\"type\":\"builtin\",\"counter\":\"bytesreceived\"\
-        ,\"unit\":\"Bytes\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network total bytes\"\
-        }],\"type\":\"builtin\",\"counter\":\"bytestotal\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Network out guest OS\"}],\"type\"\
-        :\"builtin\",\"counter\":\"bytestransmitted\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"\
-        annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network collisions\"\
-        }],\"type\":\"builtin\",\"counter\":\"totalcollisions\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\
-        \ errors\"}],\"type\":\"builtin\",\"counter\":\"totalrxerrors\",\"unit\":\"\
-        Count\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetstransmitted\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetsreceived\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent errors\"\
-        }],\"type\":\"builtin\",\"counter\":\"totaltxerrors\",\"unit\":\"Count\",\"\
-        class\":\"network\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem transfers/sec\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"\
-        unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\":\"\
-        /builtin/filesystem/transferspersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem % free space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"unit\":\"Percent\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedspace\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedspace\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem used space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"unit\":\"Bytes\",\"class\"\
-        :\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\",\"\
-        type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem read bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"bytesreadpersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\"\
-        ,\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\",\"type\"\
-        :\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem\
-        \ free space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\"\
-        ,\"unit\":\"Bytes\",\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % free inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentfreeinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentfreeinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem bytes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem reads/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"\
-        counterSpecifier\":\"/builtin/filesystem/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem write\
-        \ bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/byteswrittenpersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem writes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"CPU IO wait time\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"unit\":\"Percent\"\
-        ,\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU user time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU nice time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU percentage guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprocessortime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprocessortime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU interrupt\
-        \ time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU idle time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU privileged time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprivilegedtime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprivilegedtime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory\
-        \ available\"}],\"type\":\"builtin\",\"counter\":\"availablememory\",\"unit\"\
-        :\"Bytes\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/availablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap percent used\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentusedswap\",\"unit\":\"Percent\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory used\"}],\"\
-        type\":\"builtin\",\"counter\":\"usedmemory\",\"unit\":\"Bytes\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Page reads\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"pagesreadpersec\",\"unit\":\"CountPerSecond\",\"class\":\"\
-        memory\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap available\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"availableswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"\
-        counterSpecifier\":\"/builtin/memory/availableswap\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Swap percent available\"}],\"type\":\"\
-        builtin\",\"counter\":\"percentavailableswap\",\"unit\":\"Percent\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem. percent available\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentavailablememory\",\"unit\":\"\
-        Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"type\"\
-        :\"builtin\",\"counter\":\"pagespersec\",\"unit\":\"CountPerSecond\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap used\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"usedswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"counterSpecifier\"\
-        :\"/builtin/memory/usedswap\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Memory percentage\"}],\"type\":\"builtin\",\"counter\":\"percentusedmemory\"\
-        ,\"unit\":\"Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page writes\"}],\"\
-        type\":\"builtin\",\"counter\":\"pageswrittenpersec\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"\
-        }]},\"metrics\":{\"resourceId\":\"__VM_RESOURCE_ID__\",\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"eventVolume\":\"Medium\"}},\"StorageAccount\":\"clitestdiagextsa20170510\"\
-        },\r\n    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
-        ,\r\n  \"name\": \"LinuxDiagnostic\"\r\n}"}
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.OSTCExtensions\",\r\n
+        \   \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"2.3\",\r\n
+        \   \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"eventVolume\":\"Medium\",\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagetransfertime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfer time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagetransfertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfers\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writebytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/writebytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        total bytes\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        queue length\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"},{\"counter\":\"bytesreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        in guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"},{\"counter\":\"bytestotal\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        total bytes\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"counter\":\"bytestransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        out guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"counter\":\"totalcollisions\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        collisions\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"},{\"counter\":\"totalrxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"},{\"counter\":\"packetstransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"},{\"counter\":\"packetsreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"},{\"counter\":\"totaltxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        transfers/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        used space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytesreadpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        read bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        free space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreeinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreeinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        bytes/sec\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        reads/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        write bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/byteswrittenpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        writes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        IO wait time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        user time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        nice time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprocessortime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        percentage guest OS\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprocessortime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        interrupt time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        idle time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprivilegedtime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        privileged time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprivilegedtime\"},{\"counter\":\"availablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availablememory\"},{\"counter\":\"percentusedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent used\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"},{\"counter\":\"usedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"counter\":\"pagesreadpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"counter\":\"availableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availableswap\"},{\"counter\":\"percentavailableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"},{\"counter\":\"percentavailablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem.
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"},{\"counter\":\"pagespersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"counter\":\"usedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedswap\"},{\"counter\":\"percentusedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        percentage\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"},{\"counter\":\"pageswrittenpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"}]},\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"__VM_RESOURCE_ID__\"}}},\"StorageAccount\":\"clitestdiagextsa20170510\"},\r\n
+        \   \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\",\r\n
+        \ \"name\": \"LinuxDiagnostic\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/bbb4b366-5cb6-425d-a3b3-885d4cfe391c?api-version=2017-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/58dd5faf-16cc-4a21-a862-922c587de663?api-version=2017-03-30']
       Cache-Control: [no-cache]
       Content-Length: ['12294']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:02:22 GMT']
+      Date: ['Fri, 29 Sep 2017 16:33:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1451,26 +973,27 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6de409f0-9cc5-11e7-b8c7-a0b3ccf7272a]
+      x-ms-client-request-id: [e4f30ce8-a533-11e7-a2b1-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/bbb4b366-5cb6-425d-a3b3-885d4cfe391c?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/58dd5faf-16cc-4a21-a862-922c587de663?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-09-18T23:02:21.1161485+00:00\",\r\
-        \n  \"endTime\": \"2017-09-18T23:02:51.553837+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"bbb4b366-5cb6-425d-a3b3-885d4cfe391c\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-09-29T16:33:14.8998602+00:00\",\r\n
+        \ \"endTime\": \"2017-09-29T16:33:34.9983877+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"58dd5faf-16cc-4a21-a862-922c587de663\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:02:53 GMT']
+      Date: ['Fri, 29 Sep 2017 16:33:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['183']
+      content-length: ['184']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1480,190 +1003,70 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6de409f0-9cc5-11e7-b8c7-a0b3ccf7272a]
+      x-ms-client-request-id: [e4f30ce8-a533-11e7-a2b1-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.OSTCExtensions\"\
-        ,\r\n    \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"\
-        2.3\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"\
-        ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"\
-        syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_KERN\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\"\
-        ,\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\"\
-        ,\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_LOCAL7\"\
-        :\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"\
-        LOG_MAIL\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\"\
-        ,\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"\
-        LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\"}},\"\
-        performanceCounters\":{\"performanceCounterConfiguration\":[{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk read guest OS\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk writes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk transfer time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        averagetransfertime\",\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/averagetransfertime\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk transfers\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"writebytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"\
-        counterSpecifier\":\"/builtin/disk/writebytespersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read time\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"unit\"\
-        :\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\"\
-        ,\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk total bytes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        bytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/bytespersecond\",\"type\":\"builtin\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Disk reads\"}],\"condition\":\"IsAggregate=TRUE\"\
-        ,\"counter\":\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"disk\"\
-        ,\"counterSpecifier\":\"/builtin/disk/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk queue length\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\"\
-        ,\"unit\":\"Count\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Network in guest OS\"}],\"type\":\"builtin\",\"counter\":\"bytesreceived\"\
-        ,\"unit\":\"Bytes\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network total bytes\"\
-        }],\"type\":\"builtin\",\"counter\":\"bytestotal\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Network out guest OS\"}],\"type\"\
-        :\"builtin\",\"counter\":\"bytestransmitted\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"\
-        annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network collisions\"\
-        }],\"type\":\"builtin\",\"counter\":\"totalcollisions\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\
-        \ errors\"}],\"type\":\"builtin\",\"counter\":\"totalrxerrors\",\"unit\":\"\
-        Count\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetstransmitted\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetsreceived\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent errors\"\
-        }],\"type\":\"builtin\",\"counter\":\"totaltxerrors\",\"unit\":\"Count\",\"\
-        class\":\"network\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem transfers/sec\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"\
-        unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\":\"\
-        /builtin/filesystem/transferspersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem % free space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"unit\":\"Percent\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedspace\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedspace\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem used space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"unit\":\"Bytes\",\"class\"\
-        :\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\",\"\
-        type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem read bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"bytesreadpersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\"\
-        ,\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\",\"type\"\
-        :\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem\
-        \ free space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\"\
-        ,\"unit\":\"Bytes\",\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % free inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentfreeinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentfreeinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem bytes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem reads/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"\
-        counterSpecifier\":\"/builtin/filesystem/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem write\
-        \ bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/byteswrittenpersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem writes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"CPU IO wait time\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"unit\":\"Percent\"\
-        ,\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU user time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU nice time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU percentage guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprocessortime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprocessortime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU interrupt\
-        \ time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU idle time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU privileged time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprivilegedtime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprivilegedtime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory\
-        \ available\"}],\"type\":\"builtin\",\"counter\":\"availablememory\",\"unit\"\
-        :\"Bytes\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/availablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap percent used\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentusedswap\",\"unit\":\"Percent\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory used\"}],\"\
-        type\":\"builtin\",\"counter\":\"usedmemory\",\"unit\":\"Bytes\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Page reads\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"pagesreadpersec\",\"unit\":\"CountPerSecond\",\"class\":\"\
-        memory\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap available\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"availableswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"\
-        counterSpecifier\":\"/builtin/memory/availableswap\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Swap percent available\"}],\"type\":\"\
-        builtin\",\"counter\":\"percentavailableswap\",\"unit\":\"Percent\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem. percent available\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentavailablememory\",\"unit\":\"\
-        Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"type\"\
-        :\"builtin\",\"counter\":\"pagespersec\",\"unit\":\"CountPerSecond\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap used\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"usedswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"counterSpecifier\"\
-        :\"/builtin/memory/usedswap\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Memory percentage\"}],\"type\":\"builtin\",\"counter\":\"percentusedmemory\"\
-        ,\"unit\":\"Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page writes\"}],\"\
-        type\":\"builtin\",\"counter\":\"pageswrittenpersec\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"\
-        }]},\"metrics\":{\"resourceId\":\"__VM_RESOURCE_ID__\",\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"eventVolume\":\"Medium\"}},\"StorageAccount\":\"clitestdiagextsa20170510\"\
-        },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
-        ,\r\n  \"name\": \"LinuxDiagnostic\"\r\n}"}
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.OSTCExtensions\",\r\n
+        \   \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"2.3\",\r\n
+        \   \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"eventVolume\":\"Medium\",\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagetransfertime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfer time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagetransfertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfers\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writebytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/writebytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        total bytes\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        queue length\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"},{\"counter\":\"bytesreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        in guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"},{\"counter\":\"bytestotal\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        total bytes\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"counter\":\"bytestransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        out guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"counter\":\"totalcollisions\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        collisions\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"},{\"counter\":\"totalrxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"},{\"counter\":\"packetstransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"},{\"counter\":\"packetsreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"},{\"counter\":\"totaltxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        transfers/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        used space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytesreadpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        read bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        free space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreeinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreeinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        bytes/sec\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        reads/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        write bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/byteswrittenpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        writes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        IO wait time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        user time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        nice time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprocessortime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        percentage guest OS\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprocessortime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        interrupt time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        idle time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprivilegedtime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        privileged time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprivilegedtime\"},{\"counter\":\"availablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availablememory\"},{\"counter\":\"percentusedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent used\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"},{\"counter\":\"usedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"counter\":\"pagesreadpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"counter\":\"availableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availableswap\"},{\"counter\":\"percentavailableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"},{\"counter\":\"percentavailablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem.
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"},{\"counter\":\"pagespersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"counter\":\"usedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedswap\"},{\"counter\":\"percentusedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        percentage\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"},{\"counter\":\"pageswrittenpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"}]},\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"__VM_RESOURCE_ID__\"}}},\"StorageAccount\":\"clitestdiagextsa20170510\"},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\",\r\n
+        \ \"name\": \"LinuxDiagnostic\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:02:53 GMT']
+      Date: ['Fri, 29 Sep 2017 16:33:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1680,239 +1083,115 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [80fed1ec-9cc5-11e7-8a8c-a0b3ccf7272a]
+      x-ms-client-request-id: [f7eb58dc-a533-11e7-9cf1-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2017-03-30&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"a1e80f6b-53dc-4dd4-b027-d041dbf28074\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
-        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
-        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
-        \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"osdisk_4de31bd4c6\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstorage4de31bd4c6b8c2.blob.core.windows.net/vhds/osdisk_4de31bd4c6.vhd\"\
-        \r\n        },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\"\
-        : 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"testdiagvm\",\r\n      \"adminUsername\"\
-        : \"user11\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
-        : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
-        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.17\",\r\n\
-        \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
-        Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n     \
-        \       \"time\": \"2017-09-18T23:02:51+00:00\"\r\n          }\r\n       \
-        \ ],\r\n        \"extensionHandlers\": [\r\n          {\r\n            \"\
-        type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n            \"typeHandlerVersion\"\
-        : \"2.3.9027\",\r\n            \"status\": {\r\n              \"code\": \"\
-        ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\n \
-        \             \"displayStatus\": \"Ready\",\r\n              \"message\":\
-        \ \"Plugin enabled\"\r\n            }\r\n          }\r\n        ]\r\n    \
-        \  },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_4de31bd4c6\"\
-        ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
-        : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
-        \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2017-09-18T23:02:21.2879864+00:00\"\r\n            }\r\
-        \n          ]\r\n        }\r\n      ],\r\n      \"extensions\": [\r\n    \
-        \    {\r\n          \"name\": \"LinuxDiagnostic\",\r\n          \"type\":\
-        \ \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n          \"typeHandlerVersion\"\
-        : \"2.3.9027\",\r\n          \"statuses\": [\r\n            {\r\n        \
-        \      \"code\": \"ProvisioningState/succeeded\",\r\n              \"level\"\
-        : \"Info\",\r\n              \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n              \"message\": \"Enable succeeded\"\r\n            }\r\n\
-        \          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n       \
-        \ {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"\
-        level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-09-18T23:02:51.553837+00:00\"\r\n        },\r\
-        \n        {\r\n          \"code\": \"PowerState/running\",\r\n          \"\
-        level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n    \
-        \    }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\n    \
-        \  \"properties\": {\r\n        \"publisher\": \"Microsoft.OSTCExtensions\"\
-        ,\r\n        \"type\": \"LinuxDiagnostic\",\r\n        \"typeHandlerVersion\"\
-        : \"2.3\",\r\n        \"autoUpgradeMinorVersion\": true,\r\n        \"settings\"\
-        : {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\"\
-        :{\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_KERN\":\"LOG_DEBUG\"\
-        ,\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_NEWS\":\"\
-        LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_AUTH\"\
-        :\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\"\
-        ,\"LOG_MAIL\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\"\
-        ,\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"\
-        LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\"}},\"\
-        performanceCounters\":{\"performanceCounterConfiguration\":[{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk read guest OS\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk writes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk transfer time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        averagetransfertime\",\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/averagetransfertime\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk transfers\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"writebytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"\
-        counterSpecifier\":\"/builtin/disk/writebytespersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read time\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"unit\"\
-        :\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\"\
-        ,\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk total bytes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        bytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/bytespersecond\",\"type\":\"builtin\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Disk reads\"}],\"condition\":\"IsAggregate=TRUE\"\
-        ,\"counter\":\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"disk\"\
-        ,\"counterSpecifier\":\"/builtin/disk/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk queue length\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\"\
-        ,\"unit\":\"Count\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Network in guest OS\"}],\"type\":\"builtin\",\"counter\":\"bytesreceived\"\
-        ,\"unit\":\"Bytes\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network total bytes\"\
-        }],\"type\":\"builtin\",\"counter\":\"bytestotal\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Network out guest OS\"}],\"type\"\
-        :\"builtin\",\"counter\":\"bytestransmitted\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"\
-        annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network collisions\"\
-        }],\"type\":\"builtin\",\"counter\":\"totalcollisions\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\
-        \ errors\"}],\"type\":\"builtin\",\"counter\":\"totalrxerrors\",\"unit\":\"\
-        Count\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetstransmitted\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetsreceived\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent errors\"\
-        }],\"type\":\"builtin\",\"counter\":\"totaltxerrors\",\"unit\":\"Count\",\"\
-        class\":\"network\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem transfers/sec\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"\
-        unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\":\"\
-        /builtin/filesystem/transferspersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem % free space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"unit\":\"Percent\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedspace\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedspace\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem used space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"unit\":\"Bytes\",\"class\"\
-        :\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\",\"\
-        type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem read bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"bytesreadpersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\"\
-        ,\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\",\"type\"\
-        :\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem\
-        \ free space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\"\
-        ,\"unit\":\"Bytes\",\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % free inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentfreeinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentfreeinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem bytes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem reads/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"\
-        counterSpecifier\":\"/builtin/filesystem/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem write\
-        \ bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/byteswrittenpersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem writes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"CPU IO wait time\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"unit\":\"Percent\"\
-        ,\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU user time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU nice time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU percentage guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprocessortime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprocessortime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU interrupt\
-        \ time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU idle time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU privileged time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprivilegedtime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprivilegedtime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory\
-        \ available\"}],\"type\":\"builtin\",\"counter\":\"availablememory\",\"unit\"\
-        :\"Bytes\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/availablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap percent used\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentusedswap\",\"unit\":\"Percent\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory used\"}],\"\
-        type\":\"builtin\",\"counter\":\"usedmemory\",\"unit\":\"Bytes\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Page reads\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"pagesreadpersec\",\"unit\":\"CountPerSecond\",\"class\":\"\
-        memory\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap available\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"availableswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"\
-        counterSpecifier\":\"/builtin/memory/availableswap\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Swap percent available\"}],\"type\":\"\
-        builtin\",\"counter\":\"percentavailableswap\",\"unit\":\"Percent\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem. percent available\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentavailablememory\",\"unit\":\"\
-        Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"type\"\
-        :\"builtin\",\"counter\":\"pagespersec\",\"unit\":\"CountPerSecond\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap used\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"usedswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"counterSpecifier\"\
-        :\"/builtin/memory/usedswap\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Memory percentage\"}],\"type\":\"builtin\",\"counter\":\"percentusedmemory\"\
-        ,\"unit\":\"Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page writes\"}],\"\
-        type\":\"builtin\",\"counter\":\"pageswrittenpersec\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"\
-        }]},\"metrics\":{\"resourceId\":\"__VM_RESOURCE_ID__\",\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"eventVolume\":\"Medium\"}},\"StorageAccount\":\"clitestdiagextsa20170510\"\
-        },\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"\
-        type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\"\
-        : \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
-        ,\r\n      \"name\": \"LinuxDiagnostic\"\r\n    }\r\n  ],\r\n  \"type\": \"\
-        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
-        tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\"\
-        ,\r\n  \"name\": \"testdiagvm\"\r\n}"}
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"214e660e-640e-4843-9a5b-b22fbfefaf54\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_32a651c70c\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\":
+        \"https://vhdstorage32a651c70ca5bb.blob.core.windows.net/vhds/osdisk_32a651c70c.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
+        {\r\n        \"vmAgentVersion\": \"2.2.17\",\r\n        \"statuses\": [\r\n
+        \         {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
+        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
+        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
+        \"2017-09-29T16:33:47+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        [\r\n          {\r\n            \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
+        \           \"typeHandlerVersion\": \"2.3.9027\",\r\n            \"status\":
+        {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n              \"level\":
+        \"Info\",\r\n              \"displayStatus\": \"Ready\",\r\n              \"message\":
+        \"Plugin enabled\"\r\n            }\r\n          }\r\n        ]\r\n      },\r\n
+        \     \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_32a651c70c\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        succeeded\",\r\n              \"time\": \"2017-09-29T16:33:15.009253+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"extensions\":
+        [\r\n        {\r\n          \"name\": \"LinuxDiagnostic\",\r\n          \"type\":
+        \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n          \"typeHandlerVersion\":
+        \"2.3.9027\",\r\n          \"statuses\": [\r\n            {\r\n              \"code\":
+        \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\n
+        \             \"displayStatus\": \"Provisioning succeeded\",\r\n              \"message\":
+        \"Enable succeeded\"\r\n            }\r\n          ]\r\n        }\r\n      ],\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2017-09-29T16:33:34.9827461+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\n      \"properties\":
+        {\r\n        \"publisher\": \"Microsoft.OSTCExtensions\",\r\n        \"type\":
+        \"LinuxDiagnostic\",\r\n        \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"eventVolume\":\"Medium\",\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagetransfertime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfer time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagetransfertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfers\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writebytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/writebytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        total bytes\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        queue length\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"},{\"counter\":\"bytesreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        in guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"},{\"counter\":\"bytestotal\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        total bytes\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"counter\":\"bytestransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        out guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"counter\":\"totalcollisions\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        collisions\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"},{\"counter\":\"totalrxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"},{\"counter\":\"packetstransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"},{\"counter\":\"packetsreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"},{\"counter\":\"totaltxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        transfers/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        used space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytesreadpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        read bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        free space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreeinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreeinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        bytes/sec\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        reads/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        write bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/byteswrittenpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        writes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        IO wait time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        user time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        nice time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprocessortime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        percentage guest OS\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprocessortime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        interrupt time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        idle time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprivilegedtime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        privileged time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprivilegedtime\"},{\"counter\":\"availablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availablememory\"},{\"counter\":\"percentusedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent used\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"},{\"counter\":\"usedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"counter\":\"pagesreadpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"counter\":\"availableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availableswap\"},{\"counter\":\"percentavailableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"},{\"counter\":\"percentavailablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem.
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"},{\"counter\":\"pagespersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"counter\":\"usedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedswap\"},{\"counter\":\"percentusedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        percentage\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"},{\"counter\":\"pageswrittenpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"}]},\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"__VM_RESOURCE_ID__\"}}},\"StorageAccount\":\"clitestdiagextsa20170510\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"westus\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\",\r\n
+        \     \"name\": \"LinuxDiagnostic\"\r\n    }\r\n  ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\",\r\n
+        \ \"name\": \"testdiagvm\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:02:54 GMT']
+      Date: ['Fri, 29 Sep 2017 16:33:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1930,24 +1209,25 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [811dd106-9cc5-11e7-94c5-a0b3ccf7272a]
+      x-ms-client-request-id: [f812dde8-a533-11e7-9009-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2017-03-30
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/2ee0f49e-bd10-45ee-b47f-6cae7cd80337?api-version=2017-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/861178b3-f96f-478c-be47-a98adc0275bd?api-version=2017-03-30']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Mon, 18 Sep 2017 23:02:54 GMT']
+      Date: ['Fri, 29 Sep 2017 16:33:48 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/2ee0f49e-bd10-45ee-b47f-6cae7cd80337?monitor=true&api-version=2017-03-30']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/861178b3-f96f-478c-be47-a98adc0275bd?monitor=true&api-version=2017-03-30']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1957,459 +1237,20 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [811dd106-9cc5-11e7-94c5-a0b3ccf7272a]
+      x-ms-client-request-id: [f812dde8-a533-11e7-9009-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/2ee0f49e-bd10-45ee-b47f-6cae7cd80337?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/861178b3-f96f-478c-be47-a98adc0275bd?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-09-18T23:02:53.0851002+00:00\",\r\
-        \n  \"endTime\": \"2017-09-18T23:03:07.11641+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"2ee0f49e-bd10-45ee-b47f-6cae7cd80337\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-09-29T16:33:46.8114521+00:00\",\r\n
+        \ \"endTime\": \"2017-09-29T16:34:06.8436503+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"861178b3-f96f-478c-be47-a98adc0275bd\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:03:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['182']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [93e4c2f0-9cc5-11e7-95d1-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2017-03-30&$expand=instanceView
-  response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"a1e80f6b-53dc-4dd4-b027-d041dbf28074\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
-        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
-        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
-        \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"osdisk_4de31bd4c6\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstorage4de31bd4c6b8c2.blob.core.windows.net/vhds/osdisk_4de31bd4c6.vhd\"\
-        \r\n        },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\"\
-        : 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"testdiagvm\",\r\n      \"adminUsername\"\
-        : \"user11\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
-        : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
-        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.17\",\r\n\
-        \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
-        Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n     \
-        \       \"time\": \"2017-09-18T23:03:24+00:00\"\r\n          }\r\n       \
-        \ ],\r\n        \"extensionHandlers\": []\r\n      },\r\n      \"disks\":\
-        \ [\r\n        {\r\n          \"name\": \"osdisk_4de31bd4c6\",\r\n       \
-        \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-09-18T23:02:53.1163376+00:00\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"statuses\"\
-        : [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\
-        \n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2017-09-18T23:03:07.1007732+00:00\"\
-        \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
-        ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
-        \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\"\
-        ,\r\n  \"name\": \"testdiagvm\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:03:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['2609']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "westus", "properties": {"autoUpgradeMinorVersion": true,
-      "settings": {"ladCfg": {"sampleRateInSeconds": 15, "diagnosticMonitorConfiguration":
-      {"syslogEvents": {"syslogEventConfiguration": {"LOG_KERN": "LOG_DEBUG", "LOG_LOCAL5":
-      "LOG_DEBUG", "LOG_LOCAL0": "LOG_DEBUG", "LOG_NEWS": "LOG_DEBUG", "LOG_LPR":
-      "LOG_DEBUG", "LOG_FTP": "LOG_DEBUG", "LOG_AUTH": "LOG_DEBUG", "LOG_DAEMON":
-      "LOG_DEBUG", "LOG_LOCAL3": "LOG_DEBUG", "LOG_LOCAL7": "LOG_DEBUG", "LOG_LOCAL1":
-      "LOG_DEBUG", "LOG_CRON": "LOG_DEBUG", "LOG_MAIL": "LOG_DEBUG", "LOG_UUCP": "LOG_DEBUG",
-      "LOG_LOCAL4": "LOG_DEBUG", "LOG_USER": "LOG_DEBUG", "LOG_LOCAL2": "LOG_DEBUG",
-      "LOG_SYSLOG": "LOG_DEBUG", "LOG_LOCAL6": "LOG_DEBUG", "LOG_AUTHPRIV": "LOG_DEBUG"}},
-      "performanceCounters": {"performanceCounterConfiguration": [{"annotation": [{"locale":
-      "en-us", "displayName": "Disk read guest OS"}], "condition": "IsAggregate=TRUE",
-      "counter": "readbytespersecond", "unit": "BytesPerSecond", "class": "disk",
-      "counterSpecifier": "/builtin/disk/readbytespersecond", "type": "builtin"},
-      {"annotation": [{"locale": "en-us", "displayName": "Disk writes"}], "condition":
-      "IsAggregate=TRUE", "counter": "writespersecond", "unit": "CountPerSecond",
-      "class": "disk", "counterSpecifier": "/builtin/disk/writespersecond", "type":
-      "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk transfer
-      time"}], "condition": "IsAggregate=TRUE", "counter": "averagetransfertime",
-      "unit": "Seconds", "class": "disk", "counterSpecifier": "/builtin/disk/averagetransfertime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      transfers"}], "condition": "IsAggregate=TRUE", "counter": "transferspersecond",
-      "unit": "CountPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/transferspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      write guest OS"}], "condition": "IsAggregate=TRUE", "counter": "writebytespersecond",
-      "unit": "BytesPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/writebytespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      read time"}], "condition": "IsAggregate=TRUE", "counter": "averagereadtime",
-      "unit": "Seconds", "class": "disk", "counterSpecifier": "/builtin/disk/averagereadtime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      write time"}], "condition": "IsAggregate=TRUE", "counter": "averagewritetime",
-      "unit": "Seconds", "class": "disk", "counterSpecifier": "/builtin/disk/averagewritetime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      total bytes"}], "condition": "IsAggregate=TRUE", "counter": "bytespersecond",
-      "unit": "BytesPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/bytespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      reads"}], "condition": "IsAggregate=TRUE", "counter": "readspersecond", "unit":
-      "CountPerSecond", "class": "disk", "counterSpecifier": "/builtin/disk/readspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Disk
-      queue length"}], "condition": "IsAggregate=TRUE", "counter": "averagediskqueuelength",
-      "unit": "Count", "class": "disk", "counterSpecifier": "/builtin/disk/averagediskqueuelength",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Network
-      in guest OS"}], "type": "builtin", "counter": "bytesreceived", "unit": "Bytes",
-      "class": "network", "counterSpecifier": "/builtin/network/bytesreceived"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Network total bytes"}], "type": "builtin",
-      "counter": "bytestotal", "unit": "Bytes", "class": "network", "counterSpecifier":
-      "/builtin/network/bytestotal"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Network out guest OS"}], "type": "builtin", "counter": "bytestransmitted",
-      "unit": "Bytes", "class": "network", "counterSpecifier": "/builtin/network/bytestransmitted"},
-      {"annotation": [{"locale": "en-us", "displayName": "Network collisions"}], "type":
-      "builtin", "counter": "totalcollisions", "unit": "Count", "class": "network",
-      "counterSpecifier": "/builtin/network/totalcollisions"}, {"annotation": [{"locale":
-      "en-us", "displayName": "Packets received errors"}], "type": "builtin", "counter":
-      "totalrxerrors", "unit": "Count", "class": "network", "counterSpecifier": "/builtin/network/totalrxerrors"},
-      {"annotation": [{"locale": "en-us", "displayName": "Packets sent"}], "type":
-      "builtin", "counter": "packetstransmitted", "unit": "Count", "class": "network",
-      "counterSpecifier": "/builtin/network/packetstransmitted"}, {"annotation": [{"locale":
-      "en-us", "displayName": "Packets received"}], "type": "builtin", "counter":
-      "packetsreceived", "unit": "Count", "class": "network", "counterSpecifier":
-      "/builtin/network/packetsreceived"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Packets sent errors"}], "type": "builtin", "counter": "totaltxerrors", "unit":
-      "Count", "class": "network", "counterSpecifier": "/builtin/network/totaltxerrors"},
-      {"annotation": [{"locale": "en-us", "displayName": "Filesystem transfers/sec"}],
-      "condition": "IsAggregate=TRUE", "counter": "transferspersecond", "unit": "CountPerSecond",
-      "class": "filesystem", "counterSpecifier": "/builtin/filesystem/transferspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % free space"}], "condition": "IsAggregate=TRUE", "counter": "percentfreespace",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentfreespace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % used space"}], "condition": "IsAggregate=TRUE", "counter": "percentusedspace",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentusedspace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      used space"}], "condition": "IsAggregate=TRUE", "counter": "usedspace", "unit":
-      "Bytes", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/usedspace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      read bytes/sec"}], "condition": "IsAggregate=TRUE", "counter": "bytesreadpersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/bytesreadpersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      free space"}], "condition": "IsAggregate=TRUE", "counter": "freespace", "unit":
-      "Bytes", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/freespace",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % free inodes"}], "condition": "IsAggregate=TRUE", "counter": "percentfreeinodes",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentfreeinodes",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      bytes/sec"}], "condition": "IsAggregate=TRUE", "counter": "bytespersecond",
-      "unit": "BytesPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/bytespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      reads/sec"}], "condition": "IsAggregate=TRUE", "counter": "readspersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/readspersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      write bytes/sec"}], "condition": "IsAggregate=TRUE", "counter": "byteswrittenpersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/byteswrittenpersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      writes/sec"}], "condition": "IsAggregate=TRUE", "counter": "writespersecond",
-      "unit": "CountPerSecond", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/writespersecond",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Filesystem
-      % used inodes"}], "condition": "IsAggregate=TRUE", "counter": "percentusedinodes",
-      "unit": "Percent", "class": "filesystem", "counterSpecifier": "/builtin/filesystem/percentusedinodes",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      IO wait time"}], "condition": "IsAggregate=TRUE", "counter": "percentiowaittime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentiowaittime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      user time"}], "condition": "IsAggregate=TRUE", "counter": "percentusertime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentusertime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      nice time"}], "condition": "IsAggregate=TRUE", "counter": "percentnicetime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentnicetime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      percentage guest OS"}], "condition": "IsAggregate=TRUE", "counter": "percentprocessortime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentprocessortime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      interrupt time"}], "condition": "IsAggregate=TRUE", "counter": "percentinterrupttime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentinterrupttime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      idle time"}], "condition": "IsAggregate=TRUE", "counter": "percentidletime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentidletime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "CPU
-      privileged time"}], "condition": "IsAggregate=TRUE", "counter": "percentprivilegedtime",
-      "unit": "Percent", "class": "processor", "counterSpecifier": "/builtin/processor/percentprivilegedtime",
-      "type": "builtin"}, {"annotation": [{"locale": "en-us", "displayName": "Memory
-      available"}], "type": "builtin", "counter": "availablememory", "unit": "Bytes",
-      "class": "memory", "counterSpecifier": "/builtin/memory/availablememory"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Swap percent used"}], "type": "builtin",
-      "counter": "percentusedswap", "unit": "Percent", "class": "memory", "counterSpecifier":
-      "/builtin/memory/percentusedswap"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Memory used"}], "type": "builtin", "counter": "usedmemory", "unit": "Bytes",
-      "class": "memory", "counterSpecifier": "/builtin/memory/usedmemory"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Page reads"}], "type": "builtin", "counter":
-      "pagesreadpersec", "unit": "CountPerSecond", "class": "memory", "counterSpecifier":
-      "/builtin/memory/pagesreadpersec"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Swap available"}], "type": "builtin", "counter": "availableswap", "unit": "Bytes",
-      "class": "memory", "counterSpecifier": "/builtin/memory/availableswap"}, {"annotation":
-      [{"locale": "en-us", "displayName": "Swap percent available"}], "type": "builtin",
-      "counter": "percentavailableswap", "unit": "Percent", "class": "memory", "counterSpecifier":
-      "/builtin/memory/percentavailableswap"}, {"annotation": [{"locale": "en-us",
-      "displayName": "Mem. percent available"}], "type": "builtin", "counter": "percentavailablememory",
-      "unit": "Percent", "class": "memory", "counterSpecifier": "/builtin/memory/percentavailablememory"},
-      {"annotation": [{"locale": "en-us", "displayName": "Pages"}], "type": "builtin",
-      "counter": "pagespersec", "unit": "CountPerSecond", "class": "memory", "counterSpecifier":
-      "/builtin/memory/pagespersec"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Swap used"}], "type": "builtin", "counter": "usedswap", "unit": "Bytes", "class":
-      "memory", "counterSpecifier": "/builtin/memory/usedswap"}, {"annotation": [{"locale":
-      "en-us", "displayName": "Memory percentage"}], "type": "builtin", "counter":
-      "percentusedmemory", "unit": "Percent", "class": "memory", "counterSpecifier":
-      "/builtin/memory/percentusedmemory"}, {"annotation": [{"locale": "en-us", "displayName":
-      "Page writes"}], "type": "builtin", "counter": "pageswrittenpersec", "unit":
-      "CountPerSecond", "class": "memory", "counterSpecifier": "/builtin/memory/pageswrittenpersec"}]},
-      "metrics": {"resourceId": "__VM_RESOURCE_ID__", "metricAggregation": [{"scheduledTransferPeriod":
-      "PT1H"}, {"scheduledTransferPeriod": "PT1M"}]}, "eventVolume": "Medium"}}, "StorageAccount":
-      "clitestdiagextsa20170510"}, "type": "LinuxDiagnostic", "publisher": "Microsoft.Azure.Diagnostics",
-      "typeHandlerVersion": "3.0", "protectedSettings": {"storageAccountName": "clitestdiagextsa20170510",
-      "storageAccountSasToken": "123"}}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['12868']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [940886dc-9cc5-11e7-8e64-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2017-03-30
-  response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Diagnostics\"\
-        ,\r\n    \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"\
-        3.0\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"\
-        ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"\
-        syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_KERN\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\"\
-        ,\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\"\
-        ,\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_LOCAL7\"\
-        :\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"\
-        LOG_MAIL\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\"\
-        ,\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"\
-        LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\"}},\"\
-        performanceCounters\":{\"performanceCounterConfiguration\":[{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk read guest OS\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk writes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk transfer time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        averagetransfertime\",\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/averagetransfertime\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk transfers\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"writebytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"\
-        counterSpecifier\":\"/builtin/disk/writebytespersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read time\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"unit\"\
-        :\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\"\
-        ,\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk total bytes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        bytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/bytespersecond\",\"type\":\"builtin\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Disk reads\"}],\"condition\":\"IsAggregate=TRUE\"\
-        ,\"counter\":\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"disk\"\
-        ,\"counterSpecifier\":\"/builtin/disk/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk queue length\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\"\
-        ,\"unit\":\"Count\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Network in guest OS\"}],\"type\":\"builtin\",\"counter\":\"bytesreceived\"\
-        ,\"unit\":\"Bytes\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network total bytes\"\
-        }],\"type\":\"builtin\",\"counter\":\"bytestotal\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Network out guest OS\"}],\"type\"\
-        :\"builtin\",\"counter\":\"bytestransmitted\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"\
-        annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network collisions\"\
-        }],\"type\":\"builtin\",\"counter\":\"totalcollisions\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\
-        \ errors\"}],\"type\":\"builtin\",\"counter\":\"totalrxerrors\",\"unit\":\"\
-        Count\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetstransmitted\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetsreceived\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent errors\"\
-        }],\"type\":\"builtin\",\"counter\":\"totaltxerrors\",\"unit\":\"Count\",\"\
-        class\":\"network\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem transfers/sec\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"\
-        unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\":\"\
-        /builtin/filesystem/transferspersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem % free space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"unit\":\"Percent\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedspace\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedspace\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem used space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"unit\":\"Bytes\",\"class\"\
-        :\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\",\"\
-        type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem read bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"bytesreadpersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\"\
-        ,\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\",\"type\"\
-        :\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem\
-        \ free space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\"\
-        ,\"unit\":\"Bytes\",\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % free inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentfreeinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentfreeinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem bytes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem reads/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"\
-        counterSpecifier\":\"/builtin/filesystem/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem write\
-        \ bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/byteswrittenpersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem writes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"CPU IO wait time\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"unit\":\"Percent\"\
-        ,\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU user time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU nice time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU percentage guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprocessortime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprocessortime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU interrupt\
-        \ time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU idle time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU privileged time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprivilegedtime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprivilegedtime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory\
-        \ available\"}],\"type\":\"builtin\",\"counter\":\"availablememory\",\"unit\"\
-        :\"Bytes\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/availablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap percent used\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentusedswap\",\"unit\":\"Percent\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory used\"}],\"\
-        type\":\"builtin\",\"counter\":\"usedmemory\",\"unit\":\"Bytes\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Page reads\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"pagesreadpersec\",\"unit\":\"CountPerSecond\",\"class\":\"\
-        memory\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap available\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"availableswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"\
-        counterSpecifier\":\"/builtin/memory/availableswap\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Swap percent available\"}],\"type\":\"\
-        builtin\",\"counter\":\"percentavailableswap\",\"unit\":\"Percent\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem. percent available\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentavailablememory\",\"unit\":\"\
-        Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"type\"\
-        :\"builtin\",\"counter\":\"pagespersec\",\"unit\":\"CountPerSecond\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap used\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"usedswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"counterSpecifier\"\
-        :\"/builtin/memory/usedswap\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Memory percentage\"}],\"type\":\"builtin\",\"counter\":\"percentusedmemory\"\
-        ,\"unit\":\"Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page writes\"}],\"\
-        type\":\"builtin\",\"counter\":\"pageswrittenpersec\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"\
-        }]},\"metrics\":{\"resourceId\":\"__VM_RESOURCE_ID__\",\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"eventVolume\":\"Medium\"}},\"StorageAccount\":\"clitestdiagextsa20170510\"\
-        },\r\n    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
-        ,\r\n  \"name\": \"LinuxDiagnostic\"\r\n}"}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/0fdded28-0f73-4976-a4a4-31db5dde05be?api-version=2017-03-30']
-      Cache-Control: [no-cache]
-      Content-Length: ['12297']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:03:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [940886dc-9cc5-11e7-8e64-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/0fdded28-0f73-4976-a4a4-31db5dde05be?api-version=2017-03-30
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-09-18T23:03:25.1946898+00:00\",\r\
-        \n  \"endTime\": \"2017-09-18T23:03:38.4447642+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"0fdded28-0f73-4976-a4a4-31db5dde05be\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:03:56 GMT']
+      Date: ['Fri, 29 Sep 2017 16:34:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2426,190 +1267,391 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [940886dc-9cc5-11e7-8e64-a0b3ccf7272a]
+      x-ms-client-request-id: [0ad72678-a534-11e7-ad9f-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2017-03-30&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Diagnostics\"\
-        ,\r\n    \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"\
-        3.0\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"\
-        ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"\
-        syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_KERN\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\"\
-        ,\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\"\
-        ,\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_LOCAL7\"\
-        :\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"\
-        LOG_MAIL\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\"\
-        ,\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"\
-        LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\"}},\"\
-        performanceCounters\":{\"performanceCounterConfiguration\":[{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk read guest OS\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk writes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk transfer time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        averagetransfertime\",\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/averagetransfertime\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk transfers\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"writebytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"\
-        counterSpecifier\":\"/builtin/disk/writebytespersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read time\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"unit\"\
-        :\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\"\
-        ,\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk total bytes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        bytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/bytespersecond\",\"type\":\"builtin\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Disk reads\"}],\"condition\":\"IsAggregate=TRUE\"\
-        ,\"counter\":\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"disk\"\
-        ,\"counterSpecifier\":\"/builtin/disk/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk queue length\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\"\
-        ,\"unit\":\"Count\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Network in guest OS\"}],\"type\":\"builtin\",\"counter\":\"bytesreceived\"\
-        ,\"unit\":\"Bytes\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network total bytes\"\
-        }],\"type\":\"builtin\",\"counter\":\"bytestotal\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Network out guest OS\"}],\"type\"\
-        :\"builtin\",\"counter\":\"bytestransmitted\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"\
-        annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network collisions\"\
-        }],\"type\":\"builtin\",\"counter\":\"totalcollisions\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\
-        \ errors\"}],\"type\":\"builtin\",\"counter\":\"totalrxerrors\",\"unit\":\"\
-        Count\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetstransmitted\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetsreceived\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent errors\"\
-        }],\"type\":\"builtin\",\"counter\":\"totaltxerrors\",\"unit\":\"Count\",\"\
-        class\":\"network\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem transfers/sec\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"\
-        unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\":\"\
-        /builtin/filesystem/transferspersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem % free space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"unit\":\"Percent\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedspace\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedspace\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem used space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"unit\":\"Bytes\",\"class\"\
-        :\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\",\"\
-        type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem read bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"bytesreadpersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\"\
-        ,\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\",\"type\"\
-        :\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem\
-        \ free space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\"\
-        ,\"unit\":\"Bytes\",\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % free inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentfreeinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentfreeinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem bytes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem reads/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"\
-        counterSpecifier\":\"/builtin/filesystem/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem write\
-        \ bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/byteswrittenpersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem writes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"CPU IO wait time\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"unit\":\"Percent\"\
-        ,\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU user time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU nice time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU percentage guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprocessortime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprocessortime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU interrupt\
-        \ time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU idle time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU privileged time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprivilegedtime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprivilegedtime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory\
-        \ available\"}],\"type\":\"builtin\",\"counter\":\"availablememory\",\"unit\"\
-        :\"Bytes\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/availablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap percent used\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentusedswap\",\"unit\":\"Percent\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory used\"}],\"\
-        type\":\"builtin\",\"counter\":\"usedmemory\",\"unit\":\"Bytes\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Page reads\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"pagesreadpersec\",\"unit\":\"CountPerSecond\",\"class\":\"\
-        memory\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap available\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"availableswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"\
-        counterSpecifier\":\"/builtin/memory/availableswap\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Swap percent available\"}],\"type\":\"\
-        builtin\",\"counter\":\"percentavailableswap\",\"unit\":\"Percent\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem. percent available\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentavailablememory\",\"unit\":\"\
-        Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"type\"\
-        :\"builtin\",\"counter\":\"pagespersec\",\"unit\":\"CountPerSecond\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap used\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"usedswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"counterSpecifier\"\
-        :\"/builtin/memory/usedswap\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Memory percentage\"}],\"type\":\"builtin\",\"counter\":\"percentusedmemory\"\
-        ,\"unit\":\"Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page writes\"}],\"\
-        type\":\"builtin\",\"counter\":\"pageswrittenpersec\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"\
-        }]},\"metrics\":{\"resourceId\":\"__VM_RESOURCE_ID__\",\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"eventVolume\":\"Medium\"}},\"StorageAccount\":\"clitestdiagextsa20170510\"\
-        },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
-        ,\r\n  \"name\": \"LinuxDiagnostic\"\r\n}"}
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"214e660e-640e-4843-9a5b-b22fbfefaf54\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_32a651c70c\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\":
+        \"https://vhdstorage32a651c70ca5bb.blob.core.windows.net/vhds/osdisk_32a651c70c.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
+        {\r\n        \"vmAgentVersion\": \"2.2.17\",\r\n        \"statuses\": [\r\n
+        \         {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
+        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
+        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
+        \"2017-09-29T16:34:17+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_32a651c70c\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        succeeded\",\r\n              \"time\": \"2017-09-29T16:33:46.8427031+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"statuses\":
+        [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2017-09-29T16:34:06.8124101+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\",\r\n
+        \ \"name\": \"testdiagvm\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:03:57 GMT']
+      Date: ['Fri, 29 Sep 2017 16:34:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2609']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"autoUpgradeMinorVersion": true, "publisher": "Microsoft.Azure.Diagnostics",
+      "protectedSettings": {"storageAccountName": "clitestdiagextsa20170510", "storageAccountSasToken":
+      "123"}, "type": "LinuxDiagnostic", "settings": {"ladCfg": {"sampleRateInSeconds":
+      15, "diagnosticMonitorConfiguration": {"eventVolume": "Medium", "syslogEvents":
+      {"syslogEventConfiguration": {"LOG_LOCAL2": "LOG_DEBUG", "LOG_LOCAL1": "LOG_DEBUG",
+      "LOG_NEWS": "LOG_DEBUG", "LOG_UUCP": "LOG_DEBUG", "LOG_AUTHPRIV": "LOG_DEBUG",
+      "LOG_LOCAL7": "LOG_DEBUG", "LOG_KERN": "LOG_DEBUG", "LOG_LOCAL4": "LOG_DEBUG",
+      "LOG_AUTH": "LOG_DEBUG", "LOG_CRON": "LOG_DEBUG", "LOG_LOCAL3": "LOG_DEBUG",
+      "LOG_DAEMON": "LOG_DEBUG", "LOG_LOCAL5": "LOG_DEBUG", "LOG_USER": "LOG_DEBUG",
+      "LOG_LOCAL6": "LOG_DEBUG", "LOG_LOCAL0": "LOG_DEBUG", "LOG_LPR": "LOG_DEBUG",
+      "LOG_FTP": "LOG_DEBUG", "LOG_SYSLOG": "LOG_DEBUG", "LOG_MAIL": "LOG_DEBUG"}},
+      "performanceCounters": {"performanceCounterConfiguration": [{"condition": "IsAggregate=TRUE",
+      "counter": "readbytespersecond", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk read guest OS"}], "unit": "BytesPerSecond",
+      "counterSpecifier": "/builtin/disk/readbytespersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "writespersecond", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk writes"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/disk/writespersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "averagetransfertime", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk transfer time"}], "unit": "Seconds",
+      "counterSpecifier": "/builtin/disk/averagetransfertime"}, {"condition": "IsAggregate=TRUE",
+      "counter": "transferspersecond", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk transfers"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/disk/transferspersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "writebytespersecond", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk write guest OS"}], "unit": "BytesPerSecond",
+      "counterSpecifier": "/builtin/disk/writebytespersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "averagereadtime", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk read time"}], "unit": "Seconds", "counterSpecifier":
+      "/builtin/disk/averagereadtime"}, {"condition": "IsAggregate=TRUE", "counter":
+      "averagewritetime", "type": "builtin", "class": "disk", "annotation": [{"locale":
+      "en-us", "displayName": "Disk write time"}], "unit": "Seconds", "counterSpecifier":
+      "/builtin/disk/averagewritetime"}, {"condition": "IsAggregate=TRUE", "counter":
+      "bytespersecond", "type": "builtin", "class": "disk", "annotation": [{"locale":
+      "en-us", "displayName": "Disk total bytes"}], "unit": "BytesPerSecond", "counterSpecifier":
+      "/builtin/disk/bytespersecond"}, {"condition": "IsAggregate=TRUE", "counter":
+      "readspersecond", "type": "builtin", "class": "disk", "annotation": [{"locale":
+      "en-us", "displayName": "Disk reads"}], "unit": "CountPerSecond", "counterSpecifier":
+      "/builtin/disk/readspersecond"}, {"condition": "IsAggregate=TRUE", "counter":
+      "averagediskqueuelength", "type": "builtin", "class": "disk", "annotation":
+      [{"locale": "en-us", "displayName": "Disk queue length"}], "unit": "Count",
+      "counterSpecifier": "/builtin/disk/averagediskqueuelength"}, {"counter": "bytesreceived",
+      "type": "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Network in guest OS"}], "unit": "Bytes", "counterSpecifier": "/builtin/network/bytesreceived"},
+      {"counter": "bytestotal", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Network total bytes"}], "unit": "Bytes",
+      "counterSpecifier": "/builtin/network/bytestotal"}, {"counter": "bytestransmitted",
+      "type": "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Network out guest OS"}], "unit": "Bytes", "counterSpecifier": "/builtin/network/bytestransmitted"},
+      {"counter": "totalcollisions", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Network collisions"}], "unit": "Count",
+      "counterSpecifier": "/builtin/network/totalcollisions"}, {"counter": "totalrxerrors",
+      "type": "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Packets received errors"}], "unit": "Count", "counterSpecifier": "/builtin/network/totalrxerrors"},
+      {"counter": "packetstransmitted", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Packets sent"}], "unit": "Count", "counterSpecifier":
+      "/builtin/network/packetstransmitted"}, {"counter": "packetsreceived", "type":
+      "builtin", "class": "network", "annotation": [{"locale": "en-us", "displayName":
+      "Packets received"}], "unit": "Count", "counterSpecifier": "/builtin/network/packetsreceived"},
+      {"counter": "totaltxerrors", "type": "builtin", "class": "network", "annotation":
+      [{"locale": "en-us", "displayName": "Packets sent errors"}], "unit": "Count",
+      "counterSpecifier": "/builtin/network/totaltxerrors"}, {"condition": "IsAggregate=TRUE",
+      "counter": "transferspersecond", "type": "builtin", "class": "filesystem", "annotation":
+      [{"locale": "en-us", "displayName": "Filesystem transfers/sec"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/filesystem/transferspersecond"}, {"condition":
+      "IsAggregate=TRUE", "counter": "percentfreespace", "type": "builtin", "class":
+      "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      % free space"}], "unit": "Percent", "counterSpecifier": "/builtin/filesystem/percentfreespace"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentusedspace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      % used space"}], "unit": "Percent", "counterSpecifier": "/builtin/filesystem/percentusedspace"},
+      {"condition": "IsAggregate=TRUE", "counter": "usedspace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      used space"}], "unit": "Bytes", "counterSpecifier": "/builtin/filesystem/usedspace"},
+      {"condition": "IsAggregate=TRUE", "counter": "bytesreadpersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      read bytes/sec"}], "unit": "CountPerSecond", "counterSpecifier": "/builtin/filesystem/bytesreadpersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "freespace", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      free space"}], "unit": "Bytes", "counterSpecifier": "/builtin/filesystem/freespace"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentfreeinodes", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      % free inodes"}], "unit": "Percent", "counterSpecifier": "/builtin/filesystem/percentfreeinodes"},
+      {"condition": "IsAggregate=TRUE", "counter": "bytespersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      bytes/sec"}], "unit": "BytesPerSecond", "counterSpecifier": "/builtin/filesystem/bytespersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "readspersecond", "type": "builtin",
+      "class": "filesystem", "annotation": [{"locale": "en-us", "displayName": "Filesystem
+      reads/sec"}], "unit": "CountPerSecond", "counterSpecifier": "/builtin/filesystem/readspersecond"},
+      {"condition": "IsAggregate=TRUE", "counter": "byteswrittenpersecond", "type":
+      "builtin", "class": "filesystem", "annotation": [{"locale": "en-us", "displayName":
+      "Filesystem write bytes/sec"}], "unit": "CountPerSecond", "counterSpecifier":
+      "/builtin/filesystem/byteswrittenpersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "writespersecond", "type": "builtin", "class": "filesystem", "annotation":
+      [{"locale": "en-us", "displayName": "Filesystem writes/sec"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/filesystem/writespersecond"}, {"condition": "IsAggregate=TRUE",
+      "counter": "percentusedinodes", "type": "builtin", "class": "filesystem", "annotation":
+      [{"locale": "en-us", "displayName": "Filesystem % used inodes"}], "unit": "Percent",
+      "counterSpecifier": "/builtin/filesystem/percentusedinodes"}, {"condition":
+      "IsAggregate=TRUE", "counter": "percentiowaittime", "type": "builtin", "class":
+      "processor", "annotation": [{"locale": "en-us", "displayName": "CPU IO wait
+      time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentiowaittime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentusertime", "type": "builtin",
+      "class": "processor", "annotation": [{"locale": "en-us", "displayName": "CPU
+      user time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentusertime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentnicetime", "type": "builtin",
+      "class": "processor", "annotation": [{"locale": "en-us", "displayName": "CPU
+      nice time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentnicetime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentprocessortime", "type":
+      "builtin", "class": "processor", "annotation": [{"locale": "en-us", "displayName":
+      "CPU percentage guest OS"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentprocessortime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentinterrupttime", "type":
+      "builtin", "class": "processor", "annotation": [{"locale": "en-us", "displayName":
+      "CPU interrupt time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentinterrupttime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentidletime", "type": "builtin",
+      "class": "processor", "annotation": [{"locale": "en-us", "displayName": "CPU
+      idle time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentidletime"},
+      {"condition": "IsAggregate=TRUE", "counter": "percentprivilegedtime", "type":
+      "builtin", "class": "processor", "annotation": [{"locale": "en-us", "displayName":
+      "CPU privileged time"}], "unit": "Percent", "counterSpecifier": "/builtin/processor/percentprivilegedtime"},
+      {"counter": "availablememory", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Memory available"}], "unit": "Bytes", "counterSpecifier":
+      "/builtin/memory/availablememory"}, {"counter": "percentusedswap", "type": "builtin",
+      "class": "memory", "annotation": [{"locale": "en-us", "displayName": "Swap percent
+      used"}], "unit": "Percent", "counterSpecifier": "/builtin/memory/percentusedswap"},
+      {"counter": "usedmemory", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Memory used"}], "unit": "Bytes", "counterSpecifier":
+      "/builtin/memory/usedmemory"}, {"counter": "pagesreadpersec", "type": "builtin",
+      "class": "memory", "annotation": [{"locale": "en-us", "displayName": "Page reads"}],
+      "unit": "CountPerSecond", "counterSpecifier": "/builtin/memory/pagesreadpersec"},
+      {"counter": "availableswap", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Swap available"}], "unit": "Bytes", "counterSpecifier":
+      "/builtin/memory/availableswap"}, {"counter": "percentavailableswap", "type":
+      "builtin", "class": "memory", "annotation": [{"locale": "en-us", "displayName":
+      "Swap percent available"}], "unit": "Percent", "counterSpecifier": "/builtin/memory/percentavailableswap"},
+      {"counter": "percentavailablememory", "type": "builtin", "class": "memory",
+      "annotation": [{"locale": "en-us", "displayName": "Mem. percent available"}],
+      "unit": "Percent", "counterSpecifier": "/builtin/memory/percentavailablememory"},
+      {"counter": "pagespersec", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Pages"}], "unit": "CountPerSecond", "counterSpecifier":
+      "/builtin/memory/pagespersec"}, {"counter": "usedswap", "type": "builtin", "class":
+      "memory", "annotation": [{"locale": "en-us", "displayName": "Swap used"}], "unit":
+      "Bytes", "counterSpecifier": "/builtin/memory/usedswap"}, {"counter": "percentusedmemory",
+      "type": "builtin", "class": "memory", "annotation": [{"locale": "en-us", "displayName":
+      "Memory percentage"}], "unit": "Percent", "counterSpecifier": "/builtin/memory/percentusedmemory"},
+      {"counter": "pageswrittenpersec", "type": "builtin", "class": "memory", "annotation":
+      [{"locale": "en-us", "displayName": "Page writes"}], "unit": "CountPerSecond",
+      "counterSpecifier": "/builtin/memory/pageswrittenpersec"}]}, "metrics": {"metricAggregation":
+      [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod": "PT1M"}],
+      "resourceId": "__VM_RESOURCE_ID__"}}}, "StorageAccount": "clitestdiagextsa20170510"},
+      "typeHandlerVersion": "3.0"}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['12868']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0b02df68-a534-11e7-9b70-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2017-03-30
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Diagnostics\",\r\n
+        \   \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"3.0\",\r\n
+        \   \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"eventVolume\":\"Medium\",\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagetransfertime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfer time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagetransfertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfers\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writebytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/writebytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        total bytes\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        queue length\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"},{\"counter\":\"bytesreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        in guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"},{\"counter\":\"bytestotal\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        total bytes\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"counter\":\"bytestransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        out guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"counter\":\"totalcollisions\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        collisions\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"},{\"counter\":\"totalrxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"},{\"counter\":\"packetstransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"},{\"counter\":\"packetsreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"},{\"counter\":\"totaltxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        transfers/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        used space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytesreadpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        read bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        free space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreeinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreeinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        bytes/sec\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        reads/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        write bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/byteswrittenpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        writes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        IO wait time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        user time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        nice time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprocessortime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        percentage guest OS\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprocessortime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        interrupt time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        idle time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprivilegedtime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        privileged time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprivilegedtime\"},{\"counter\":\"availablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availablememory\"},{\"counter\":\"percentusedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent used\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"},{\"counter\":\"usedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"counter\":\"pagesreadpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"counter\":\"availableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availableswap\"},{\"counter\":\"percentavailableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"},{\"counter\":\"percentavailablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem.
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"},{\"counter\":\"pagespersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"counter\":\"usedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedswap\"},{\"counter\":\"percentusedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        percentage\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"},{\"counter\":\"pageswrittenpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"}]},\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"__VM_RESOURCE_ID__\"}}},\"StorageAccount\":\"clitestdiagextsa20170510\"},\r\n
+        \   \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\",\r\n
+        \ \"name\": \"LinuxDiagnostic\"\r\n}"}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/9fc8cc01-8c60-4f7b-aec3-44fe2056b5e5?api-version=2017-03-30']
+      Cache-Control: [no-cache]
+      Content-Length: ['12297']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 29 Sep 2017 16:34:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0b02df68-a534-11e7-9b70-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9fc8cc01-8c60-4f7b-aec3-44fe2056b5e5?api-version=2017-03-30
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-09-29T16:34:18.6723882+00:00\",\r\n
+        \ \"endTime\": \"2017-09-29T16:34:38.4557354+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"9fc8cc01-8c60-4f7b-aec3-44fe2056b5e5\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 29 Sep 2017 16:34:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['184']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0b02df68-a534-11e7-9b70-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2017-03-30
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Diagnostics\",\r\n
+        \   \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"3.0\",\r\n
+        \   \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"eventVolume\":\"Medium\",\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagetransfertime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfer time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagetransfertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfers\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writebytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/writebytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        total bytes\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        queue length\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"},{\"counter\":\"bytesreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        in guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"},{\"counter\":\"bytestotal\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        total bytes\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"counter\":\"bytestransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        out guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"counter\":\"totalcollisions\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        collisions\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"},{\"counter\":\"totalrxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"},{\"counter\":\"packetstransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"},{\"counter\":\"packetsreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"},{\"counter\":\"totaltxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        transfers/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        used space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytesreadpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        read bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        free space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreeinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreeinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        bytes/sec\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        reads/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        write bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/byteswrittenpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        writes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        IO wait time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        user time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        nice time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprocessortime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        percentage guest OS\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprocessortime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        interrupt time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        idle time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprivilegedtime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        privileged time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprivilegedtime\"},{\"counter\":\"availablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availablememory\"},{\"counter\":\"percentusedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent used\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"},{\"counter\":\"usedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"counter\":\"pagesreadpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"counter\":\"availableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availableswap\"},{\"counter\":\"percentavailableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"},{\"counter\":\"percentavailablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem.
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"},{\"counter\":\"pagespersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"counter\":\"usedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedswap\"},{\"counter\":\"percentusedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        percentage\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"},{\"counter\":\"pageswrittenpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"}]},\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"__VM_RESOURCE_ID__\"}}},\"StorageAccount\":\"clitestdiagextsa20170510\"},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\",\r\n
+        \ \"name\": \"LinuxDiagnostic\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 29 Sep 2017 16:34:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2626,209 +1668,89 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
-          msrest_azure/0.4.14 computemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.16+dev]
+          msrest_azure/0.4.14 computemanagementclient/3.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.17+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a732b338-9cc5-11e7-b4a9-a0b3ccf7272a]
+      x-ms-client-request-id: [1dd39070-a534-11e7-a031-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"a1e80f6b-53dc-4dd4-b027-d041dbf28074\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
-        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
-        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
-        \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"osdisk_4de31bd4c6\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstorage4de31bd4c6b8c2.blob.core.windows.net/vhds/osdisk_4de31bd4c6.vhd\"\
-        \r\n        },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\"\
-        : 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"testdiagvm\",\r\n      \"adminUsername\"\
-        : \"user11\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
-        : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
-        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"resources\"\
-        : [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\": \"Microsoft.Azure.Diagnostics\"\
-        ,\r\n        \"type\": \"LinuxDiagnostic\",\r\n        \"typeHandlerVersion\"\
-        : \"3.0\",\r\n        \"autoUpgradeMinorVersion\": true,\r\n        \"settings\"\
-        : {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\"\
-        :{\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_KERN\":\"LOG_DEBUG\"\
-        ,\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_NEWS\":\"\
-        LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_AUTH\"\
-        :\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"\
-        LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\"\
-        ,\"LOG_MAIL\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\"\
-        ,\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"\
-        LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\"}},\"\
-        performanceCounters\":{\"performanceCounterConfiguration\":[{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk read guest OS\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk writes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk transfer time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        averagetransfertime\",\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/averagetransfertime\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Disk transfers\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"writebytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"\
-        counterSpecifier\":\"/builtin/disk/writebytespersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk read time\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"unit\"\
-        :\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk write time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\"\
-        ,\"unit\":\"Seconds\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Disk total bytes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"\
-        bytespersecond\",\"unit\":\"BytesPerSecond\",\"class\":\"disk\",\"counterSpecifier\"\
-        :\"/builtin/disk/bytespersecond\",\"type\":\"builtin\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Disk reads\"}],\"condition\":\"IsAggregate=TRUE\"\
-        ,\"counter\":\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"disk\"\
-        ,\"counterSpecifier\":\"/builtin/disk/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk queue length\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\"\
-        ,\"unit\":\"Count\",\"class\":\"disk\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Network in guest OS\"}],\"type\":\"builtin\",\"counter\":\"bytesreceived\"\
-        ,\"unit\":\"Bytes\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network total bytes\"\
-        }],\"type\":\"builtin\",\"counter\":\"bytestotal\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Network out guest OS\"}],\"type\"\
-        :\"builtin\",\"counter\":\"bytestransmitted\",\"unit\":\"Bytes\",\"class\"\
-        :\"network\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"\
-        annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network collisions\"\
-        }],\"type\":\"builtin\",\"counter\":\"totalcollisions\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\
-        \ errors\"}],\"type\":\"builtin\",\"counter\":\"totalrxerrors\",\"unit\":\"\
-        Count\",\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetstransmitted\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets received\"\
-        }],\"type\":\"builtin\",\"counter\":\"packetsreceived\",\"unit\":\"Count\"\
-        ,\"class\":\"network\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets sent errors\"\
-        }],\"type\":\"builtin\",\"counter\":\"totaltxerrors\",\"unit\":\"Count\",\"\
-        class\":\"network\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem transfers/sec\"\
-        }],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"\
-        unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\":\"\
-        /builtin/filesystem/transferspersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem % free space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"unit\":\"Percent\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedspace\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedspace\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem used space\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"unit\":\"Bytes\",\"class\"\
-        :\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\",\"\
-        type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem read bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"bytesreadpersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\"\
-        ,\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\",\"type\"\
-        :\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem\
-        \ free space\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\"\
-        ,\"unit\":\"Bytes\",\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % free inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentfreeinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentfreeinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem bytes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"unit\":\"BytesPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem reads/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"readspersecond\",\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"\
-        counterSpecifier\":\"/builtin/filesystem/readspersecond\",\"type\":\"builtin\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem write\
-        \ bytes/sec\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\"\
-        ,\"unit\":\"CountPerSecond\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/byteswrittenpersecond\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Filesystem writes/sec\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"filesystem\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Filesystem % used inodes\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentusedinodes\",\"unit\":\"Percent\",\"class\":\"filesystem\",\"counterSpecifier\"\
-        :\"/builtin/filesystem/percentusedinodes\",\"type\":\"builtin\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"CPU IO wait time\"}],\"condition\"\
-        :\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"unit\":\"Percent\"\
-        ,\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU user time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU nice time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU percentage guest OS\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprocessortime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprocessortime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU interrupt\
-        \ time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU idle time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\"\
-        ,\"unit\":\"Percent\",\"class\":\"processor\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"\
-        ,\"type\":\"builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"CPU privileged time\"}],\"condition\":\"IsAggregate=TRUE\",\"counter\"\
-        :\"percentprivilegedtime\",\"unit\":\"Percent\",\"class\":\"processor\",\"\
-        counterSpecifier\":\"/builtin/processor/percentprivilegedtime\",\"type\":\"\
-        builtin\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory\
-        \ available\"}],\"type\":\"builtin\",\"counter\":\"availablememory\",\"unit\"\
-        :\"Bytes\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/availablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap percent used\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentusedswap\",\"unit\":\"Percent\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory used\"}],\"\
-        type\":\"builtin\",\"counter\":\"usedmemory\",\"unit\":\"Bytes\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Page reads\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"pagesreadpersec\",\"unit\":\"CountPerSecond\",\"class\":\"\
-        memory\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap available\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"availableswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"\
-        counterSpecifier\":\"/builtin/memory/availableswap\"},{\"annotation\":[{\"\
-        locale\":\"en-us\",\"displayName\":\"Swap percent available\"}],\"type\":\"\
-        builtin\",\"counter\":\"percentavailableswap\",\"unit\":\"Percent\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem. percent available\"\
-        }],\"type\":\"builtin\",\"counter\":\"percentavailablememory\",\"unit\":\"\
-        Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"type\"\
-        :\"builtin\",\"counter\":\"pagespersec\",\"unit\":\"CountPerSecond\",\"class\"\
-        :\"memory\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"annotation\"\
-        :[{\"locale\":\"en-us\",\"displayName\":\"Swap used\"}],\"type\":\"builtin\"\
-        ,\"counter\":\"usedswap\",\"unit\":\"Bytes\",\"class\":\"memory\",\"counterSpecifier\"\
-        :\"/builtin/memory/usedswap\"},{\"annotation\":[{\"locale\":\"en-us\",\"displayName\"\
-        :\"Memory percentage\"}],\"type\":\"builtin\",\"counter\":\"percentusedmemory\"\
-        ,\"unit\":\"Percent\",\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"\
-        },{\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page writes\"}],\"\
-        type\":\"builtin\",\"counter\":\"pageswrittenpersec\",\"unit\":\"CountPerSecond\"\
-        ,\"class\":\"memory\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"\
-        }]},\"metrics\":{\"resourceId\":\"__VM_RESOURCE_ID__\",\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"eventVolume\":\"Medium\"}},\"StorageAccount\":\"clitestdiagextsa20170510\"\
-        },\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"\
-        type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\"\
-        : \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
-        ,\r\n      \"name\": \"LinuxDiagnostic\"\r\n    }\r\n  ],\r\n  \"type\": \"\
-        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
-        tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\"\
-        ,\r\n  \"name\": \"testdiagvm\"\r\n}"}
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"214e660e-640e-4843-9a5b-b22fbfefaf54\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_32a651c70c\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\":
+        \"https://vhdstorage32a651c70ca5bb.blob.core.windows.net/vhds/osdisk_32a651c70c.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"resources\": [\r\n
+        \   {\r\n      \"properties\": {\r\n        \"publisher\": \"Microsoft.Azure.Diagnostics\",\r\n
+        \       \"type\": \"LinuxDiagnostic\",\r\n        \"typeHandlerVersion\":
+        \"3.0\",\r\n        \"autoUpgradeMinorVersion\": true,\r\n        \"settings\":
+        {\"ladCfg\":{\"sampleRateInSeconds\":15,\"diagnosticMonitorConfiguration\":{\"eventVolume\":\"Medium\",\"syslogEvents\":{\"syslogEventConfiguration\":{\"LOG_LOCAL2\":\"LOG_DEBUG\",\"LOG_LOCAL1\":\"LOG_DEBUG\",\"LOG_NEWS\":\"LOG_DEBUG\",\"LOG_UUCP\":\"LOG_DEBUG\",\"LOG_AUTHPRIV\":\"LOG_DEBUG\",\"LOG_LOCAL7\":\"LOG_DEBUG\",\"LOG_KERN\":\"LOG_DEBUG\",\"LOG_LOCAL4\":\"LOG_DEBUG\",\"LOG_AUTH\":\"LOG_DEBUG\",\"LOG_CRON\":\"LOG_DEBUG\",\"LOG_LOCAL3\":\"LOG_DEBUG\",\"LOG_DAEMON\":\"LOG_DEBUG\",\"LOG_LOCAL5\":\"LOG_DEBUG\",\"LOG_USER\":\"LOG_DEBUG\",\"LOG_LOCAL6\":\"LOG_DEBUG\",\"LOG_LOCAL0\":\"LOG_DEBUG\",\"LOG_LPR\":\"LOG_DEBUG\",\"LOG_FTP\":\"LOG_DEBUG\",\"LOG_SYSLOG\":\"LOG_DEBUG\",\"LOG_MAIL\":\"LOG_DEBUG\"}},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readbytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/readbytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagetransfertime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfer time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagetransfertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        transfers\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writebytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write guest OS\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/writebytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagereadtime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        read time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagereadtime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagewritetime\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        write time\"}],\"unit\":\"Seconds\",\"counterSpecifier\":\"/builtin/disk/averagewritetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        total bytes\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/disk/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/disk/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"averagediskqueuelength\",\"type\":\"builtin\",\"class\":\"disk\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Disk
+        queue length\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/disk/averagediskqueuelength\"},{\"counter\":\"bytesreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        in guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytesreceived\"},{\"counter\":\"bytestotal\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        total bytes\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestotal\"},{\"counter\":\"bytestransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        out guest OS\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/network/bytestransmitted\"},{\"counter\":\"totalcollisions\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Network
+        collisions\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalcollisions\"},{\"counter\":\"totalrxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totalrxerrors\"},{\"counter\":\"packetstransmitted\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetstransmitted\"},{\"counter\":\"packetsreceived\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        received\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/packetsreceived\"},{\"counter\":\"totaltxerrors\",\"type\":\"builtin\",\"class\":\"network\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Packets
+        sent errors\"}],\"unit\":\"Count\",\"counterSpecifier\":\"/builtin/network/totaltxerrors\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"transferspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        transfers/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/transferspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used space\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"usedspace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        used space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/usedspace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytesreadpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        read bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytesreadpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"freespace\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        free space\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/filesystem/freespace\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentfreeinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % free inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentfreeinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"bytespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        bytes/sec\"}],\"unit\":\"BytesPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/bytespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"readspersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        reads/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/readspersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"byteswrittenpersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        write bytes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/byteswrittenpersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"writespersecond\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        writes/sec\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/filesystem/writespersecond\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusedinodes\",\"type\":\"builtin\",\"class\":\"filesystem\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Filesystem
+        % used inodes\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/filesystem/percentusedinodes\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentiowaittime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        IO wait time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentiowaittime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentusertime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        user time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentusertime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentnicetime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        nice time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentnicetime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprocessortime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        percentage guest OS\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprocessortime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentinterrupttime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        interrupt time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentinterrupttime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentidletime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        idle time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentidletime\"},{\"condition\":\"IsAggregate=TRUE\",\"counter\":\"percentprivilegedtime\",\"type\":\"builtin\",\"class\":\"processor\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"CPU
+        privileged time\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/processor/percentprivilegedtime\"},{\"counter\":\"availablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availablememory\"},{\"counter\":\"percentusedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent used\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedswap\"},{\"counter\":\"usedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedmemory\"},{\"counter\":\"pagesreadpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        reads\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagesreadpersec\"},{\"counter\":\"availableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        available\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/availableswap\"},{\"counter\":\"percentavailableswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailableswap\"},{\"counter\":\"percentavailablememory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Mem.
+        percent available\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentavailablememory\"},{\"counter\":\"pagespersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Pages\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pagespersec\"},{\"counter\":\"usedswap\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Swap
+        used\"}],\"unit\":\"Bytes\",\"counterSpecifier\":\"/builtin/memory/usedswap\"},{\"counter\":\"percentusedmemory\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Memory
+        percentage\"}],\"unit\":\"Percent\",\"counterSpecifier\":\"/builtin/memory/percentusedmemory\"},{\"counter\":\"pageswrittenpersec\",\"type\":\"builtin\",\"class\":\"memory\",\"annotation\":[{\"locale\":\"en-us\",\"displayName\":\"Page
+        writes\"}],\"unit\":\"CountPerSecond\",\"counterSpecifier\":\"/builtin/memory/pageswrittenpersec\"}]},\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"__VM_RESOURCE_ID__\"}}},\"StorageAccount\":\"clitestdiagextsa20170510\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"westus\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\",\r\n
+        \     \"name\": \"LinuxDiagnostic\"\r\n    }\r\n  ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\",\r\n
+        \ \"name\": \"testdiagvm\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 18 Sep 2017 23:03:58 GMT']
+      Date: ['Fri, 29 Sep 2017 16:34:51 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]


### PR DESCRIPTION
In PR #4579, @lmazuel is testing a change to msrest that rejects the default Python behavior of treating strings as iterables, which causes this test to fail. Instead of sending a string, we send the string wrapped in a list, which is what is intended. This causes no customer-facing changes. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [X] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
