### PR TITLE
Azure Stack: handle adfs authority url with a trailing slash

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+(unreleased)
++++++++++++++++++++
+* Azure Stack: handle adfs authority url with a trailing slash
+
 2.0.17 (2017-09-22)
 +++++++++++++++++++
 * minor fixes

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -61,9 +61,10 @@ _TENANT_LEVEL_ACCOUNT_NAME = 'N/A(tenant level account)'
 
 
 def _authentication_context_factory(tenant, cache):
+    import re
     import adal
     authority_url = CLOUD.endpoints.active_directory
-    is_adfs = authority_url.lower().endswith('/adfs')
+    is_adfs = bool(re.match('.+(/adfs|/adfs/)$', authority_url, re.I))
     if not is_adfs:
         authority_url = authority_url + '/' + (tenant or _COMMON_TENANT)
     return adal.AuthenticationContext(authority_url, cache=cache, api_version=None,

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1130,7 +1130,7 @@ class Test_Profile(unittest.TestCase):
         mock_get_cloud.endpoints.active_directory = adfs_url_1
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock, use_global_creds_cache=False)
-        
+
         # test w/ trailing slash
         r = profile.auth_ctx_factory('common', None)
         self.assertEqual(r.authority.url, adfs_url_1)

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1124,6 +1124,29 @@ class Test_Profile(unittest.TestCase):
             'thumbprint': 'F0:6A:53:84:8B:BE:71:4A:42:90:D6:9D:33:52:79:C1:D0:10:73:FD'
         })
 
+    @mock.patch('azure.cli.core._profile.CLOUD', autospec=True)
+    def test_detect_adfs_authority_url(self, mock_get_cloud):
+        adfs_url_1 = 'https://adfs.redmond.ext-u15f2402.masd.stbtest.microsoft.com/adfs/'
+        mock_get_cloud.endpoints.active_directory = adfs_url_1
+        storage_mock = {'subscriptions': None}
+        profile = Profile(storage_mock, use_global_creds_cache=False)
+        
+        # test w/ trailing slash
+        r = profile.auth_ctx_factory('common', None)
+        self.assertEqual(r.authority.url, adfs_url_1)
+
+        # test w/o trailing slash
+        adfs_url_2 = 'https://adfs.redmond.ext-u15f2402.masd.stbtest.microsoft.com/adfs'
+        mock_get_cloud.endpoints.active_directory = adfs_url_2
+        r = profile.auth_ctx_factory('common', None)
+        self.assertEqual(r.authority.url, adfs_url_2)
+
+        # test w/ regular aad
+        aad_url = 'https://login.microsoftonline.com'
+        mock_get_cloud.endpoints.active_directory = aad_url
+        r = profile.auth_ctx_factory('common', None)
+        self.assertEqual(r.authority.url, aad_url + '/common')
+
 
 class FileHandleStub(object):  # pylint: disable=too-few-public-methods
 


### PR DESCRIPTION
Fix #4213 
//cc @bganapa @viananth 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
