### PR TITLE
Fix Batch tests

### DIFF
--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/data/batchUpdatePool.json
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/data/batchUpdatePool.json
@@ -3,7 +3,7 @@
     "commandLine": "cmd /c echo updated",
     "waitForSuccess": true
   },
-  "certificateReferences": {},
-  "metadata": {},
-  "applicationPackageReferences": {}
+  "certificateReferences": [],
+  "metadata": [],
+  "applicationPackageReferences": []
 }


### PR DESCRIPTION
Batch tests uses an incorrect JSON  data for the "PoolUpdatePropertiesParameter", since these three fields are supposed to be an array, not a dict:
https://github.com/Azure/azure-sdk-for-python/blob/master/azure-batch/azure/batch/models/pool_update_properties_parameter.py#L64-L66

new version of msrest refuses this, and then the file needs to be fixed.

Discussed with @tjprescott and @annatisch.