### PR TITLE
[Resource] Add --resource-group/-g alias to resource group commands

### DIFF
--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+unreleased
++++++++++++++++++++
+* group: permit --resource-group/-g options for resource group name.
+
+
 2.0.15 (2017-09-22)
 +++++++++++++++++++
 * policy: support to show built-in policy definition.

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -113,7 +113,7 @@ register_cli_argument('policy assignment', 'policy', help='name or id of the pol
 
 register_cli_argument('group', 'tag', tag_type)
 register_cli_argument('group', 'tags', tags_type)
-register_cli_argument('group', 'resource_group_name', resource_group_name_type, options_list=('--name', '-n'))
+register_cli_argument('group', 'resource_group_name', resource_group_name_type, options_list=['--name', '--resource-group', '-n', '-g'])
 
 register_cli_argument('group deployment', 'resource_group_name', arg_type=resource_group_name_type, completer=get_resource_group_completion_list)
 register_cli_argument('group deployment', 'deployment_name', options_list=('--name', '-n'), required=True, help='The deployment name.')


### PR DESCRIPTION
Allows the user to specify `--name/-n` or `--resource-group/-g` to specify resource group name for the `az group` commands. Since `-g` is used literally everywhere else in the CLI, this convention is more firmly cemented in users minds than the heuristic we use for names (at least for me).  This non-breaking change simply allows both conventions. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
