### PR TITLE
Extensions: Call pip as subprocess instead of importing directly

### DIFF
--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
@@ -33,7 +33,7 @@ OUT_KEY_METADATA = 'metadata'
 
 
 def _run_pip(pip_exec_args):
-    cmd = [sys.executable, '-m', 'pip'] + pip_exec_args + ['-vv']
+    cmd = [sys.executable, '-m', 'pip'] + pip_exec_args + ['-vv', '--disable-pip-version-check', '--no-cache-dir']
     logger.debug('Running: %s', cmd)
     try:
         log_output = check_output(cmd, stderr=STDOUT, universal_newlines=True)

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
@@ -2,17 +2,17 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+import sys
 import os
 import tempfile
 import shutil
-import logging
 import zipfile
 import traceback
+from subprocess import check_output, STDOUT, CalledProcessError
 
 import requests
 from wheel.install import WHEEL_INFO_RE
 
-from six import StringIO
 from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
 
 from azure.cli.core.util import CLIError
@@ -32,23 +32,18 @@ OUT_KEY_TYPE = 'extensionType'
 OUT_KEY_METADATA = 'metadata'
 
 
-def _run_pip(pip, pip_exec_args):
-    log_stream = StringIO()
-    log_handler = logging.StreamHandler(log_stream)
-    log_handler.setFormatter(logging.Formatter('%(name)s : %(message)s'))
-
-    pip.logger.handlers = []
-    pip.logger.addHandler(log_handler)
-
-    # Don't propagate to root logger as we catch the pip logs in our own log stream
-    pip.logger.propagate = False
-    logger.debug('Running pip: %s %s', pip, pip_exec_args)
-    status_code = pip.main(pip_exec_args)
-
-    log_output = log_stream.getvalue()
-    logger.debug(log_output)
-    log_stream.close()
-    return status_code
+def _run_pip(pip_exec_args):
+    cmd = [sys.executable, '-m', 'pip'] + pip_exec_args + ['-vv']
+    logger.debug('Running: %s', cmd)
+    try:
+        log_output = check_output(cmd, stderr=STDOUT, universal_newlines=True)
+        logger.debug(log_output)
+        returncode = 0
+    except CalledProcessError as e:
+        logger.debug(e.output)
+        logger.debug(e)
+        returncode = e.returncode
+    return returncode
 
 
 def _whl_download_from_url(url_parse_result, ext_file):
@@ -90,7 +85,6 @@ def _validate_whl_extension(ext_file):
 
 
 def _add_whl_ext(source):  # pylint: disable=too-many-statements
-    import pip
     url_parse_result = urlparse(source)
     is_url = (url_parse_result.scheme == 'http' or url_parse_result.scheme == 'https')
     logger.debug('Extension source is url? %s', is_url)
@@ -132,7 +126,7 @@ def _add_whl_ext(source):  # pylint: disable=too-many-statements
     pip_args = ['install', '--target', extension_path, ext_file]
     logger.debug('Executing pip with args: %s', pip_args)
     with HomebrewPipPatch():
-        pip_status_code = _run_pip(pip, pip_args)
+        pip_status_code = _run_pip(pip_args)
     if pip_status_code > 0:
         logger.debug('Pip failed so deleting anything we might have installed at %s', extension_path)
         shutil.rmtree(extension_path, ignore_errors=True)


### PR DESCRIPTION
The source code of pip is not provided as an API so we should be calling pip through their command line interface instead.

Closes https://github.com/Azure/azure-cli/issues/4571

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [n/a] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [n/a] Each command and parameter has a meaningful description.
- [n/a] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
