### PR TITLE
dev setup: pin to newer versions of requests and adal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-adal==0.4.3
+adal==0.4.7
 applicationinsights==0.10.0
 argcomplete==1.8.0
 colorama==0.3.7
@@ -10,7 +10,7 @@ pip==9.0.1
 pygments==2.1.3
 pyOpenSSL==16.2.0
 pyyaml==3.11
-requests==2.9.1
+requests==2.18.4
 setuptools==30.4.0
 six==1.10.0
 vcrpy==1.10.3

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -50,7 +50,7 @@ CLASSIFIERS = [
 
 # TODO These dependencies should be updated to reflect only what this package needs
 DEPENDENCIES = [
-    'adal>=0.4.3',
+    'adal>=0.4.7',
     'applicationinsights',
     'argcomplete>=1.8.0',
     'colorama',

--- a/src/command_modules/azure-cli-profile/setup.py
+++ b/src/command_modules/azure-cli-profile/setup.py
@@ -30,7 +30,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'adal>=0.4.3',
+    'adal>=0.4.7',
     'azure-cli-core',
 ]
 


### PR DESCRIPTION
Mainly for dev set up.
1. Older `requests` versions have caused test recordings to fail in my box with errors like 'ConnectionError' , so it is time to refresh.
2. `Adal-0.4.7` contains a fix for the Stack environment. I also updated setup.py to ensure it always gets picked up

Those newer versions have been used in our installers, and tested by customers. The change here is just to get things all sync'd

### General Guidelines

- [na] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na] Each command and parameter has a meaningful description.
- [na] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
