### PR TITLE
[Resource] Add --resource-group/-g alias to RG create...

### DIFF
--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -130,7 +130,7 @@ register_cli_argument('group deployment operation show', 'operation_ids', nargs=
 
 register_cli_argument('group export', 'include_comments', action='store_true')
 register_cli_argument('group export', 'include_parameter_default_value', action='store_true')
-register_cli_argument('group create', 'rg_name', options_list=('--name', '-n'), help='name of the new resource group', completer=None)
+register_cli_argument('group create', 'rg_name', options_list=['--name', '--resource-group', '-n', '-g'], help='name of the new resource group', completer=None)
 
 register_cli_argument('tag', 'tag_name', options_list=('--name', '-n'))
 register_cli_argument('tag', 'tag_value', options_list=('--value',))


### PR DESCRIPTION
For some reason, this command doesn't use `resource_group_name` for the param, so I need this alias here too.  Sorry for blaming @williexu!
