### PR TITLE
Fix bug with read_file_content.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -132,16 +132,16 @@ def read_file_content(file_path, allow_binary=False):
             with codecs_open(file_path, encoding=encoding) as f:
                 logger.debug("attempting to read file %s as %s", file_path, encoding)
                 return f.read()
-        except UnicodeDecodeError:
-            if allow_binary:
-                with open(file_path, 'rb') as input_file:
-                    logger.debug("attempting to read file %s as binary", file_path)
-                    return base64.b64encode(input_file.read()).decode("utf-8")
-            else:
-                raise
-        except UnicodeError:
+        except (UnicodeError, UnicodeDecodeError):
             pass
 
+    if allow_binary:
+        try:
+            with open(file_path, 'rb') as input_file:
+                logger.debug("attempting to read file %s as binary", file_path)
+                return base64.b64encode(input_file.read()).decode("utf-8")
+        except:  # pylint: disable=bare-except
+            pass
     raise CLIError('Failed to decode file {} - unknown decoding'.format(file_path))
 
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -140,7 +140,7 @@ def read_file_content(file_path, allow_binary=False):
             with open(file_path, 'rb') as input_file:
                 logger.debug("attempting to read file %s as binary", file_path)
                 return base64.b64encode(input_file.read()).decode("utf-8")
-        except:  # pylint: disable=bare-except
+        except Exception:  # pylint: disable=broad-except
             pass
     raise CLIError('Failed to decode file {} - unknown decoding'.format(file_path))
 


### PR DESCRIPTION
In the old logic, if the first encoding failed, but binary was allowed, then the method would immediately return binary and the other encodings didn't get checked. Now it will cycle through all encodings and then, if binary is allowed, return the binary. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
