### PR TITLE
cloud console: make sure the expiration time is 45 minutes away from local time

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -186,7 +186,7 @@ class Profile(object):
         for t in tokens[1:]:
             decoded_tokens.append(jwt.decode(t, verify=False, algorithms=['RS256']))
         final_tokens = []
-        # Note, setting expiration time at 2700 seconds is bit arbitrary, but should not matter 
+        # Note, setting expiration time at 2700 seconds is bit arbitrary, but should not matter
         # as shell should update us with new ones every 10~15 minutes
         for t in decoded_tokens:
             final_tokens.append({

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -186,11 +186,13 @@ class Profile(object):
         for t in tokens[1:]:
             decoded_tokens.append(jwt.decode(t, verify=False, algorithms=['RS256']))
         final_tokens = []
+        # Note, setting expiration time at 2700 seconds is bit arbitrary, but should not matter 
+        # as shell should update us with new ones every 10~15 minutes
         for t in decoded_tokens:
             final_tokens.append({
                 '_clientId': _CLIENT_ID,
-                'expiresIn': '3600',
-                'expiresOn': str(datetime.utcnow() + timedelta(seconds=3600 * 24)),
+                'expiresIn': '2700',
+                'expiresOn': str(datetime.now() + timedelta(seconds=2700)),
                 'userId': t['unique_name'].split('#')[-1],
                 '_authority': CLOUD.endpoints.active_directory.rstrip('/') + '/' + t['tid'],
                 'resource': t['aud'],

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -536,6 +536,8 @@ class Test_Profile(unittest.TestCase):
 
     def test_cloud_console_login(self):
         import tempfile
+        from datetime import datetime, timedelta
+        from dateutil import parser
         from azure.cli.core.util import get_file_json
         from azure.cli.core._session import Session
 
@@ -543,7 +545,7 @@ class Test_Profile(unittest.TestCase):
         test_dir = tempfile.mkdtemp()
         test_account_file = os.path.join(test_dir, 'azureProfile.json')
         test_account.load(test_account_file)
-        # test_token_file = os.path.join(test_dir, 'accessTokens.json')
+        test_token_file = os.path.join(test_dir, 'accessTokens.json')
 
         os.environ['AZURE_CONFIG_DIR'] = test_dir
 
@@ -574,7 +576,12 @@ class Test_Profile(unittest.TestCase):
             "environmentName": "AzureCloud",
             "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"
         }
+
+        actual = get_file_json(test_token_file)
+
         self.assertEqual([expected_subscription], result_accounts)
+        # sanity check that the expiration time is about 45 minutes away
+        self.assertTrue(parser.parse(actual[0]['expiresOn']) < datetime.now() + timedelta(minutes=45))
 
         # verify the token file
         # expected_arm_token_entry = {


### PR DESCRIPTION
2 changes to get token expiration time a bit accurate inside the cloud shell so we have a better chance to capture #4333
1. Be consistent with ADAL, use local time
2. Set expiration time be 2700 seconds

- [na] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
