### PR TITLE
test: robustness fixes in azure-cli-core

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -707,6 +707,7 @@ class Test_Profile(unittest.TestCase):
             def __init__(self, *args, **kwargs):
                 self.subscriptions = mock.MagicMock()
                 self.subscriptions.list.return_value = [Test_Profile.subscription1]
+                self.config = mock.MagicMock()
 
         mock_get_client_class.return_value = ClientStub
 
@@ -1118,7 +1119,7 @@ class Test_Profile(unittest.TestCase):
         creds_cache = CredsCache(async_persist=False)
 
         # assert
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(CLIError) as context:
             creds_cache.load_adal_token_cache()
 
         self.assertTrue(re.findall(r'bad error for you', str(context.exception)))


### PR DESCRIPTION
2 things:
a. Fix a timing issues. The `test_connection_verify.py` changes the environment variable of `AZURE_CLI_DISABLE_CONNECTION_VERIFICATION` on the fly which could cause randomness on other tests running at the same time
b. More specific exception type check which I missed in #4647 

- [na] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na] Each command and parameter has a meaningful description.
- [na] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
