### PR TITLE
feature: fix table output of show & list command to show "state"

### DIFF
--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -93,7 +93,7 @@ cli_command(__name__, 'provider operation show', 'azure.cli.command_modules.reso
 if supported_api_version(ResourceType.MGMT_RESOURCE_RESOURCES, min_api='2017-05-10'):
     # Resource feature commands
     feature_table_transform = '{Name:name, RegistrationState:properties.state}'
-    cli_command(__name__, 'feature list', 'azure.cli.command_modules.resource.custom#list_features', cf_features, table_transformer='[].'+feature_table_transform)
+    cli_command(__name__, 'feature list', 'azure.cli.command_modules.resource.custom#list_features', cf_features, table_transformer='[].' + feature_table_transform)
     cli_command(__name__, 'feature show', 'azure.mgmt.resource.features.operations.features_operations#FeaturesOperations.get', cf_features, exception_handler=empty_on_404, table_transformer=feature_table_transform)
     cli_command(__name__, 'feature register', 'azure.cli.command_modules.resource.custom#register_feature', cf_features)
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -92,8 +92,9 @@ cli_command(__name__, 'provider operation show', 'azure.cli.command_modules.reso
 
 if supported_api_version(ResourceType.MGMT_RESOURCE_RESOURCES, min_api='2017-05-10'):
     # Resource feature commands
-    cli_command(__name__, 'feature list', 'azure.cli.command_modules.resource.custom#list_features', cf_features)
-    cli_command(__name__, 'feature show', 'azure.mgmt.resource.features.operations.features_operations#FeaturesOperations.get', cf_features, exception_handler=empty_on_404)
+    feature_table_transform = '{Name:name, RegistrationState:properties.state}'
+    cli_command(__name__, 'feature list', 'azure.cli.command_modules.resource.custom#list_features', cf_features, table_transformer='[].'+feature_table_transform)
+    cli_command(__name__, 'feature show', 'azure.mgmt.resource.features.operations.features_operations#FeaturesOperations.get', cf_features, exception_handler=empty_on_404, table_transformer=feature_table_transform)
     cli_command(__name__, 'feature register', 'azure.cli.command_modules.resource.custom#register_feature', cf_features)
 
 # Tag commands


### PR DESCRIPTION
Before the output is not useful as the state is missing
```
Name                      
------------------------ 
Microsoft.AAD/betaAccess
```
Now, we display it
```
Name                      RegistrationState
------------------------  -------------------
Microsoft.AAD/betaAccess  NotRegistered
```
//cc: @christiankuhtz 
### General Guidelines

- [na] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na] Each command and parameter has a meaningful description.
- [na] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
