### PR TITLE
webapp: misc bug fixes(create command, log download)

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+(unreleased)
++++++++++++++++++++
+* webapp: fix a bug that downloaded log file might be invalid
+
 0.1.18 (2017-10-09)
 +++++++++++++++++++
 * webapp: added generic update with new command: 'az webapp update'

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -42,11 +42,11 @@ def _generic_site_operation(resource_group_name, name, operation_name, slot=None
 
 def _generic_settings_operation(resource_group_name, name, operation_name, setting_properties, slot=None, client=None):
     client = client or web_client_factory()
-    m = getattr(client.web_apps, operation_name if slot is None else operation_name + '_slot')
+    operation = getattr(client.web_apps, operation_name if slot is None else operation_name + '_slot')
     if slot is None:
-        return m(resource_group_name, name, str, setting_properties)
+        return operation(resource_group_name, name, str, setting_properties)
 
-    return m(resource_group_name, name, slot, str, setting_properties)
+    return operation(resource_group_name, name, slot, str, setting_properties)
 
 
 def get_hostname_completion_list(prefix, action, parsed_args, **kwargs):  # pylint: disable=unused-argument

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1197,7 +1197,8 @@ def _get_log(url, user_name, password, log_file=None):
         preload_content=False
     )
     if r.status != 200:
-        raise CLIError("Failed to connect to '{}' with status code '{}' and reason '{}'".format(url, r.status, r.reason))
+        raise CLIError("Failed to connect to '{}' with status code '{}' and reason '{}'".format(
+            url, r.status, r.reason))
     if log_file:  # download logs
         with open(log_file, 'wb') as f:
             while True:

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -76,9 +76,10 @@ def create_webapp(resource_group_name, name, plan, runtime=None, startup_file=No
         if not match:
             raise CLIError("Runtime '{}' is not supported. Please invoke 'list-runtimes' to cross check".format(runtime))  # pylint: disable=line-too-long
         match['setter'](match, site_config)
+        # Be consistent with portal: any windows webapp should have this even it doesn't have node in the stack
         if not match['displayName'].startswith('node'):
             site_config.app_settings.append(NameValuePair("WEBSITE_NODE_DEFAULT_VERSION", "6.9.1"))
-        
+
     if site_config.app_settings:
         for setting in site_config.app_settings:
             logger.info('Will set appsetting %s', setting)
@@ -813,10 +814,8 @@ def update_backup_schedule(resource_group_name, webapp_name, storage_account_url
                                      keep_at_least_one_backup, retention_period_in_days)
     backup_request = BackupRequest(location, backup_schedule=backup_schedule, enabled=True,
                                    storage_account_url=storage_account_url, databases=db_setting)
-    if slot:
-        return client.web_apps.update_backup_configuration_slot(resource_group_name, webapp_name, backup_request, slot)
-
-    return client.web_apps.update_backup_configuration(resource_group_name, webapp_name, backup_request)
+    return _generic_site_operation(resource_group_name, webapp_name, 'update_backup_configuration',
+                                   slot, backup_request)
 
 
 def restore_backup(resource_group_name, webapp_name, storage_account_url, backup_name,
@@ -1155,7 +1154,7 @@ def get_streaming_log(resource_group_name, name, provider=None, slot=None):
 
     client = web_client_factory()
     user, password = _get_site_credential(client, resource_group_name, name)
-    t = threading.Thread(target=_stream_trace, args=(streaming_url, user, password))
+    t = threading.Thread(target=_get_log, args=(streaming_url, user, password))
     t.daemon = True
     t.start()
 
@@ -1166,12 +1165,9 @@ def get_streaming_log(resource_group_name, name, provider=None, slot=None):
 def download_historical_logs(resource_group_name, name, log_file=None, slot=None):
     scm_url = _get_scm_url(resource_group_name, name, slot)
     url = scm_url.rstrip('/') + '/dump'
-    import requests
-    r = requests.get(url, stream=True)
-    with open(log_file, 'wb') as f:
-        for chunk in r.iter_content(chunk_size=1024):
-            if chunk:  # filter out keep-alive new chunks
-                f.write(chunk)
+    client = web_client_factory()
+    user_name, password = _get_site_credential(client, resource_group_name, name)
+    _get_log(url, user_name, password, log_file)
     logger.warning('Downloaded logs to %s', log_file)
 
 
@@ -1181,7 +1177,7 @@ def _get_site_credential(client, resource_group_name, name):
     return (creds.publishing_user_name, creds.publishing_password)
 
 
-def _stream_trace(streaming_url, user_name, password):
+def _get_log(url, user_name, password, log_file=None):
     import sys
     import certifi
     import urllib3
@@ -1196,16 +1192,26 @@ def _stream_trace(streaming_url, user_name, password):
     headers = urllib3.util.make_headers(basic_auth='{0}:{1}'.format(user_name, password))
     r = http.request(
         'GET',
-        streaming_url,
+        url,
         headers=headers,
         preload_content=False
     )
-    for chunk in r.stream():
-        if chunk:
-            # Extra encode() and decode for stdout which does not surpport 'utf-8'
-            print(chunk.decode(encoding='utf-8', errors='replace')
-                  .encode(std_encoding, errors='replace')
-                  .decode(std_encoding, errors='replace'), end='')  # each line of log has CRLF.
+    if r.status != 200:
+        raise CLIError("Failed to connect to '{}' with status code '{}'".format(url, r.status))
+    if log_file:  # download logs
+        with open(log_file, 'wb') as f:
+            while True:
+                data = r.read(1024)
+                if not data:
+                    break
+                f.write(data)
+    else:  # streaming
+        for chunk in r.stream():
+            if chunk:
+                # Extra encode() and decode for stdout which does not surpport 'utf-8'
+                print(chunk.decode(encoding='utf-8', errors='replace')
+                      .encode(std_encoding, errors='replace')
+                      .decode(std_encoding, errors='replace'), end='')  # each line of log has CRLF.
     r.release_conn()
 
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1197,7 +1197,7 @@ def _get_log(url, user_name, password, log_file=None):
         preload_content=False
     )
     if r.status != 200:
-        raise CLIError("Failed to connect to '{}' with status code '{}'".format(url, r.status))
+        raise CLIError("Failed to connect to '{}' with status code '{}' and reason '{}'".format(url, r.status, r.reason))
     if log_file:  # download logs
         with open(log_file, 'wb') as f:
             while True:

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -76,11 +76,9 @@ def create_webapp(resource_group_name, name, plan, runtime=None, startup_file=No
         if not match:
             raise CLIError("Runtime '{}' is not supported. Please invoke 'list-runtimes' to cross check".format(runtime))  # pylint: disable=line-too-long
         match['setter'](match, site_config)
-
-    # Be consistent with portal: any windows webapp should have this even it doesn't use node as the stack
-    if not is_linux:
-        site_config.app_settings.append(NameValuePair("WEBSITE_NODE_DEFAULT_VERSION", "6.9.1"))
-
+        if not match['displayName'].startswith('node'):
+            site_config.app_settings.append(NameValuePair("WEBSITE_NODE_DEFAULT_VERSION", "6.9.1"))
+        
     if site_config.app_settings:
         for setting in site_config.app_settings:
             logger.info('Will set appsetting %s', setting)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/latest/test_win_webapp_quick_create_cd.yaml
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/latest/test_win_webapp_quick_create_cd.yaml
@@ -8,9 +8,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -20,11 +20,11 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 03 Oct 2017 18:13:49 GMT']
+      date: ['Fri, 13 Oct 2017 20:59:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -34,9 +34,9 @@ interactions:
       CommandName: [appservice plan create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -46,15 +46,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 03 Oct 2017 18:13:49 GMT']
+      date: ['Fri, 13 Oct 2017 20:59:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"perSiteScaling": false, "name": "plan-quick000003"},
-      "sku": {"tier": "BASIC", "name": "B1", "capacity": 1}, "location": "westus"}'''
+    body: 'b''{"sku": {"capacity": 1, "tier": "BASIC", "name": "B1"}, "properties":
+      {"perSiteScaling": false, "name": "plan-quick000003"}, "location": "westus"}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -62,21 +62,21 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['154']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 websitemanagementclient/0.32.0 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 websitemanagementclient/0.32.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003?api-version=2016-09-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003","name":"plan-quick000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        US","properties":{"serverFarmId":0,"name":"plan-quick000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"0d3ae56c-deaf-4982-b514-33d016d4a683","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-083_5344","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
+        US","properties":{"serverFarmId":0,"name":"plan-quick000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-083_5885","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['1378']
       content-type: [application/json]
-      date: ['Tue, 03 Oct 2017 18:14:00 GMT']
+      date: ['Fri, 13 Oct 2017 20:59:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.0]
@@ -84,7 +84,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -95,21 +95,21 @@ interactions:
       CommandName: [webapp create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 websitemanagementclient/0.32.0 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 websitemanagementclient/0.32.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003?api-version=2016-09-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003","name":"plan-quick000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        US","properties":{"serverFarmId":0,"name":"plan-quick000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"0d3ae56c-deaf-4982-b514-33d016d4a683","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-083_5344","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
+        US","properties":{"serverFarmId":0,"name":"plan-quick000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-083_5885","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['1378']
       content-type: [application/json]
-      date: ['Tue, 03 Oct 2017 18:14:01 GMT']
+      date: ['Fri, 13 Oct 2017 20:59:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.0]
@@ -127,9 +127,9 @@ interactions:
       CommandName: [webapp create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 websitemanagementclient/0.32.0 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 websitemanagementclient/0.32.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/providers/Microsoft.Web/availableStacks?api-version=2016-03-01
@@ -145,7 +145,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12513']
       content-type: [application/json]
-      date: ['Tue, 03 Oct 2017 18:14:01 GMT']
+      date: ['Fri, 13 Oct 2017 20:59:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.0]
@@ -156,11 +156,11 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''b\''{"properties": {"reserved": false, "siteConfig": {"appSettings":
-      [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "6.1.0"}], "localMySqlEnabled":
-      false, "netFrameworkVersion": "v4.6"}, "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003",
-      "microService": "WebSites", "scmSiteAlsoStopped": false}, "location": "West
-      US"}\'''''
+    body: 'b''b\''{"location": "West US", "properties": {"scmSiteAlsoStopped": false,
+      "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003",
+      "microService": "WebSites", "reserved": false, "siteConfig": {"localMySqlEnabled":
+      false, "netFrameworkVersion": "v4.6", "appSettings": [{"value": "6.1.0", "name":
+      "WEBSITE_NODE_DEFAULT_VERSION"}]}}}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -168,21 +168,21 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['490']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 websitemanagementclient/0.32.0 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 websitemanagementclient/0.32.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-quick-cd000002?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-quick-cd000002","name":"webapp-quick-cd000002","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"webapp-quick-cd000002","state":"Running","hostNames":["webapp-quick-cd000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-083.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/webapp-quick-cd000002","repositorySiteName":"webapp-quick-cd000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-quick-cd000002.azurewebsites.net","webapp-quick-cd000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-quick-cd000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-quick-cd000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003","reserved":false,"lastModifiedTimeUtc":"2017-10-03T18:14:06.7366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-quick-cd000002","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.118.246.51,40.78.98.75,40.86.187.157,40.78.101.192,40.78.97.93","possibleOutboundIpAddresses":"40.118.246.51,40.78.98.75,40.86.187.157,40.78.101.192,40.78.97.93,40.85.159.5,13.91.108.158","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-083","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"webapp-quick-cd000002.azurewebsites.net","slotSwapStatus":null}}'}
+        US","properties":{"name":"webapp-quick-cd000002","state":"Running","hostNames":["webapp-quick-cd000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-083.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/webapp-quick-cd000002","repositorySiteName":"webapp-quick-cd000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-quick-cd000002.azurewebsites.net","webapp-quick-cd000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-quick-cd000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-quick-cd000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003","reserved":false,"lastModifiedTimeUtc":"2017-10-13T20:59:49.0133333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-quick-cd000002","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.118.246.51,40.78.98.75,40.86.187.157,40.78.101.192,40.78.97.93","possibleOutboundIpAddresses":"40.118.246.51,40.78.98.75,40.86.187.157,40.78.101.192,40.78.97.93,40.85.159.5,13.91.108.158","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-083","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"webapp-quick-cd000002.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['3111']
       content-type: [application/json]
-      date: ['Tue, 03 Oct 2017 18:14:18 GMT']
-      etag: ['"1D33C7367089E40"']
+      date: ['Fri, 13 Oct 2017 20:59:51 GMT']
+      etag: ['"1D344663539A6C0"']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.0]
@@ -190,7 +190,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -201,44 +201,41 @@ interactions:
       CommandName: [webapp create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 websitemanagementclient/0.32.0 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 websitemanagementclient/0.32.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-quick-cd000002?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-quick-cd000002","name":"webapp-quick-cd000002","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"webapp-quick-cd000002","state":"Running","hostNames":["webapp-quick-cd000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-083.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/webapp-quick-cd000002","repositorySiteName":"webapp-quick-cd000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-quick-cd000002.azurewebsites.net","webapp-quick-cd000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-quick-cd000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-quick-cd000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003","reserved":false,"lastModifiedTimeUtc":"2017-10-03T18:14:07.14","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-quick-cd000002","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.118.246.51,40.78.98.75,40.86.187.157,40.78.101.192,40.78.97.93","possibleOutboundIpAddresses":"40.118.246.51,40.78.98.75,40.86.187.157,40.78.101.192,40.78.97.93,40.85.159.5,13.91.108.158","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-083","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"webapp-quick-cd000002.azurewebsites.net","slotSwapStatus":null}}'}
+        US","properties":{"name":"webapp-quick-cd000002","state":"Running","hostNames":["webapp-quick-cd000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-083.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/webapp-quick-cd000002","repositorySiteName":"webapp-quick-cd000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-quick-cd000002.azurewebsites.net","webapp-quick-cd000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-quick-cd000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-quick-cd000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/plan-quick000003","reserved":false,"lastModifiedTimeUtc":"2017-10-13T20:59:49.42","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-quick-cd000002","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.118.246.51,40.78.98.75,40.86.187.157,40.78.101.192,40.78.97.93","possibleOutboundIpAddresses":"40.118.246.51,40.78.98.75,40.86.187.157,40.78.101.192,40.78.97.93,40.85.159.5,13.91.108.158","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-083","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"webapp-quick-cd000002.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['3106']
       content-type: [application/json]
-      date: ['Tue, 03 Oct 2017 18:14:18 GMT']
-      etag: ['"1D33C7367089E40"']
+      date: ['Fri, 13 Oct 2017 20:59:53 GMT']
+      etag: ['"1D344663539A6C0"']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"repoUrl": "https://github.com/yugangw-msft/azure-site-test.git",
-      "isMercurial": false, "isManualIntegration": true, "branch": "master"}, "kind":
-      "West US"}'
+    body: '{"location": "West US", "properties": {"branch": "master", "isManualIntegration":
+      true, "isMercurial": false, "repoUrl": "https://github.com/yugangw-msft/azure-site-test.git"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [webapp create]
       Connection: [keep-alive]
-      Content-Length: ['172']
+      Content-Length: ['176']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 websitemanagementclient/0.32.0 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 websitemanagementclient/0.32.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-quick-cd000002/sourcecontrols/web?api-version=2016-08-01
@@ -249,14 +246,14 @@ interactions:
       cache-control: [no-cache]
       content-length: ['535']
       content-type: [application/json]
-      date: ['Tue, 03 Oct 2017 18:14:26 GMT']
-      etag: ['"1D33C737136D1C0"']
+      date: ['Fri, 13 Oct 2017 21:00:02 GMT']
+      etag: ['"1D344663C5DA780"']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
       x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
@@ -267,22 +264,22 @@ interactions:
       CommandName: [webapp create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 websitemanagementclient/0.32.0 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 websitemanagementclient/0.32.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-quick-cd000002/sourcecontrols/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-quick-cd000002/sourcecontrols/web","name":"webapp-quick-cd000002","type":"Microsoft.Web/sites/sourcecontrols","location":"West
-        US","properties":{"repoUrl":"https://github.com/yugangw-msft/azure-site-test.git","branch":"master","isManualIntegration":true,"deploymentRollbackEnabled":false,"isMercurial":false,"provisioningState":"InProgress","provisioningDetails":"2017-10-03T18:14:50.6861458
-        https://webapp-quick-cd000002.scm.azurewebsites.net/api/deployments/latest?deployer=GitHub&time=2017-10-03_18-14-37Z"}}'}
+        US","properties":{"repoUrl":"https://github.com/yugangw-msft/azure-site-test.git","branch":"master","isManualIntegration":true,"deploymentRollbackEnabled":false,"isMercurial":false,"provisioningState":"InProgress","provisioningDetails":"2017-10-13T21:00:31.9843577
+        https://webapp-quick-cd000002.scm.azurewebsites.net/api/deployments/latest?deployer=GitHub&time=2017-10-13_21-00-20Z"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['707']
       content-type: [application/json]
-      date: ['Tue, 03 Oct 2017 18:14:56 GMT']
-      etag: ['"1D33C737136D1C0"']
+      date: ['Fri, 13 Oct 2017 21:00:33 GMT']
+      etag: ['"1D344663C5DA780"']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.0]
@@ -298,9 +295,9 @@ interactions:
       CommandName: [webapp create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 websitemanagementclient/0.32.0 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 websitemanagementclient/0.32.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-quick-cd000002/sourcecontrols/web?api-version=2016-08-01
@@ -311,8 +308,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['534']
       content-type: [application/json]
-      date: ['Tue, 03 Oct 2017 18:15:27 GMT']
-      etag: ['"1D33C737136D1C0"']
+      date: ['Fri, 13 Oct 2017 21:01:10 GMT']
+      etag: ['"1D344663C5DA780"']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.0]
@@ -331,22 +328,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['2']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 websitemanagementclient/0.32.0 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 websitemanagementclient/0.32.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-quick-cd000002/publishxml?api-version=2016-08-01
   response:
     body: {string: '<publishData><publishProfile profileName="webapp-quick-cd000002
         - Web Deploy" publishMethod="MSDeploy" publishUrl="webapp-quick-cd000002.scm.azurewebsites.net:443"
-        msdeploySite="webapp-quick-cd000002" userName="$webapp-quick-cd000002" userPWD="Kjou7ZmehgJEgjilJFMXb5f6mfblDHGCxEqtxfHA94u8B1jFsJmwodWBxuE8"
+        msdeploySite="webapp-quick-cd000002" userName="$webapp-quick-cd000002" userPWD="K2smgkjSxcRkmtNQZYrCPuixzZ8lqhk3cWiw5H25zkwHvlH69zYAi7Esr3Xy"
         destinationAppUrl="http://webapp-quick-cd000002.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="webapp-quick-cd000002
         - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-083.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="webapp-quick-cd000002\$webapp-quick-cd000002"
-        userPWD="Kjou7ZmehgJEgjilJFMXb5f6mfblDHGCxEqtxfHA94u8B1jFsJmwodWBxuE8" destinationAppUrl="http://webapp-quick-cd000002.azurewebsites.net"
+        userPWD="K2smgkjSxcRkmtNQZYrCPuixzZ8lqhk3cWiw5H25zkwHvlH69zYAi7Esr3Xy" destinationAppUrl="http://webapp-quick-cd000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile></publishData>'}
@@ -354,7 +351,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1150']
       content-type: [application/xml]
-      date: ['Tue, 03 Oct 2017 18:15:28 GMT']
+      date: ['Fri, 13 Oct 2017 21:01:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.0]
@@ -369,7 +366,7 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.9.1]
+      User-Agent: [python-requests/2.18.4]
     method: GET
     uri: http://webapp-quick-cd000002.azurewebsites.net/
   response:
@@ -377,10 +374,10 @@ interactions:
     headers:
       content-length: ['31']
       content-type: [text/html; charset=utf-8]
-      date: ['Tue, 03 Oct 2017 18:16:05 GMT']
+      date: ['Fri, 13 Oct 2017 21:01:47 GMT']
       etag: [W/"1f-H44L5SX3tzFL9aR6KafVKYde584"]
       server: [Microsoft-IIS/8.0]
-      set-cookie: [ARRAffinity=cb746de7feae5ed56d84908bd14643b305b420ae2364a3aac4c66c125daaeb9d;Path=/;HttpOnly;Domain=webapp-quick-cdcvr2mezpg.azurewebsites.net]
+      set-cookie: [ARRAffinity=acb38b1716f087c4ca1d9e513679a6d21aedb6a620596b768e271b9551691e67;Path=/;HttpOnly;Domain=webapp-quick-cdtsqyjhear.azurewebsites.net]
       vary: [Accept-Encoding]
       x-powered-by: [Express, ASP.NET]
     status: {code: 200, message: OK}
@@ -393,9 +390,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.15
-          msrest_azure/0.4.14 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.17+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.15
+          msrest_azure/0.4.11 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -404,11 +401,11 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Tue, 03 Oct 2017 18:16:05 GMT']
+      date: ['Fri, 13 Oct 2017 21:01:46 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdUV05ZUERRRU43Mlk2QUYzWlZQRUtEU0o1TExMUk4zNTVWUHw2Mzc5RDA3NzM5MUMyOEI0LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdEWjdCRFJYVjZPRVZGTTNVQllSTlpWN1pVQ0k3NEFSMkZHT3xFNUU3MUQ5RTVDMERFMzc0LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
@@ -5,8 +5,10 @@
 import unittest
 import os
 import time
+import tempfile
+import requests
 
-from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
+from azure.cli.testsdk import ScenarioTest, LiveScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
 from azure.cli.testsdk import JMESPathCheck as JMESPathCheckV2
 from azure.cli.testsdk.vcr_test_base import (ResourceGroupVCRTestBase,
                                              JMESPathCheck, NoneCheck)
@@ -107,9 +109,7 @@ class WebappQuickCreateTest(ScenarioTest):
         plan = self.create_random_name(prefix='plan-quick', length=24)
         self.cmd('appservice plan create -g {} -n {}'.format(resource_group, plan))
         self.cmd('webapp create -g {} -n {} --plan {} --deployment-source-url https://github.com/yugangw-msft/azure-site-test.git -r "node|6.1"'.format(resource_group, webapp_name, plan))
-        import time
         time.sleep(30)  # 30 seconds should be enough for the deployment finished(Skipped under playback mode)
-        import requests
         r = requests.get('http://{}.azurewebsites.net'.format(webapp_name))
         # verify the web page
         self.assertTrue('Hello world' in str(r.content))
@@ -121,7 +121,6 @@ class WebappQuickCreateTest(ScenarioTest):
 
         self.cmd('appservice plan create -g {} -n {} --is-linux'.format(resource_group, plan))
         self.cmd('webapp create -g {} -n {} --plan {} -i naziml/ruby-hello'.format(resource_group, webapp_name, plan))
-        import requests
         r = requests.get('http://{}.azurewebsites.net'.format(webapp_name), timeout=240)
         # verify the web page
         self.assertTrue('Ruby on Rails in Web Apps on Linux' in str(r.content))
@@ -137,9 +136,7 @@ class WebappQuickCreateTest(ScenarioTest):
         plan = 'plan-quick-linux-cd'
         self.cmd('appservice plan create -g {} -n {} --is-linux'.format(resource_group, plan))
         self.cmd('webapp create -g {} -n {} --plan {} -u https://github.com/yugangw-msft/azure-site-test.git -r "node|6.10"'.format(resource_group, webapp_name, plan))
-        import time
         time.sleep(30)  # 30 seconds should be enough for the deployment finished(Skipped under playback mode)
-        import requests
         r = requests.get('http://{}.azurewebsites.net'.format(webapp_name), timeout=240)
         # verify the web page
         self.assertTrue('Hello world' in str(r.content))
@@ -153,6 +150,50 @@ class WebappQuickCreateTest(ScenarioTest):
         self.cmd('webapp create -g {} -n webInOtherRG --plan {}'.format(resource_group2, plan_id), checks=[
             JMESPathCheckV2('name', 'webInOtherRG')
         ])
+
+
+# Test Framework is not able to handle binary file format, hence, only run live
+class AppServiceLogTest(LiveScenarioTest):
+    @ResourceGroupPreparer()
+    def test_download_win_web_log(self, resource_group):
+        import zipfile
+        from pathlib import Path
+        webapp_name = self.create_random_name(prefix='webapp-win-log', length=24)
+        plan = self.create_random_name(prefix='win-log', length=24)
+        self.cmd('appservice plan create -g {} -n {}'.format(resource_group, plan))
+        self.cmd('webapp create -g {} -n {} --plan {} --deployment-source-url https://github.com/yugangw-msft/azure-site-test.git -r "node|6.1"'.format(resource_group, webapp_name, plan))
+        time.sleep(30)  # 30 seconds should be enough for the deployment finished(Skipped under playback mode)
+
+        # sanity check the traces
+        _, log_file = tempfile.mkstemp()
+        log_dir = log_file + '-dir'
+        log_file = log_file.replace('\\', '\\\\')
+        self.cmd('webapp log download -g {} -n {} --log-file {}'.format(resource_group, webapp_name, log_file))
+        zip_ref = zipfile.ZipFile(log_file, 'r')
+        zip_ref.extractall(log_dir)
+        p = Path(log_dir, r'LogFiles\kudu\trace')
+        self.assertTrue(p.is_dir())
+
+    @ResourceGroupPreparer()
+    def test_download_linux_web_log(self, resource_group):
+        import zipfile
+        from pathlib import Path
+        webapp_name = self.create_random_name(prefix='webapp-linux-log', length=24)
+        plan = self.create_random_name(prefix='linux-log', length=24)
+        self.cmd('appservice plan create -g {} -n {} --is-linux'.format(resource_group, plan))
+        self.cmd('webapp create -g {} -n {} --plan {} -i naziml/ruby-hello'.format(resource_group, webapp_name, plan))
+        # load the site to produce a few traces
+        requests.get('http://{}.azurewebsites.net'.format(webapp_name), timeout=240)
+
+        # sanity check the traces
+        _, log_file = tempfile.mkstemp()
+        log_dir = log_file + '-dir'
+        log_file = log_file.replace('\\', '\\\\')
+        self.cmd('webapp log download -g {} -n {} --log-file {}'.format(resource_group, webapp_name, log_file))
+        zip_ref = zipfile.ZipFile(log_file, 'r')
+        zip_ref.extractall(log_dir)
+        p = Path(log_dir, r'LogFiles\kudu\trace')
+        self.assertTrue(p.is_dir())
 
 
 class AppServicePlanSceanrioTest(ScenarioTest):
@@ -682,7 +723,6 @@ class WebappBackupRestoreScenarioTest(ResourceGroupVCRTestBase):
             JMESPathCheck('[-1].databases[0].name', database_name)
         ]
         self.cmd('webapp config backup list -g {} --webapp-name {}'.format(self.resource_group, self.webapp_name), checks=list_checks)
-        import time
         time.sleep(900)  # Allow plenty of time for a backup to finish -- database backup takes a while (skipped in playback)
         self.cmd('webapp config backup restore -g {} --webapp-name {} --container-url "{}" --backup-name {} --db-connection-string "{}" --db-name {} --db-type {} --ignore-hostname-conflict --overwrite'
                  .format(self.resource_group, self.webapp_name, sas_url, backup_name, db_conn_str, database_name, database_type), checks=JMESPathCheck('name', self.webapp_name))

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
@@ -167,12 +167,10 @@ class AppServiceLogTest(LiveScenarioTest):
         # sanity check the traces
         _, log_file = tempfile.mkstemp()
         log_dir = log_file + '-dir'
-        log_file = log_file.replace('\\', '\\\\')
-        self.cmd('webapp log download -g {} -n {} --log-file {}'.format(resource_group, webapp_name, log_file))
+        self.cmd('webapp log download -g {} -n {} --log-file "{}"'.format(resource_group, webapp_name, log_file))
         zip_ref = zipfile.ZipFile(log_file, 'r')
         zip_ref.extractall(log_dir)
-        p = Path(log_dir, r'LogFiles\kudu\trace')
-        self.assertTrue(p.is_dir())
+        self.assertTrue(os.path.isdir(os.path.join(log_dir, 'LogFiles', 'kudu', 'trace')))
 
     @ResourceGroupPreparer()
     def test_download_linux_web_log(self, resource_group):
@@ -188,12 +186,10 @@ class AppServiceLogTest(LiveScenarioTest):
         # sanity check the traces
         _, log_file = tempfile.mkstemp()
         log_dir = log_file + '-dir'
-        log_file = log_file.replace('\\', '\\\\')
-        self.cmd('webapp log download -g {} -n {} --log-file {}'.format(resource_group, webapp_name, log_file))
+        self.cmd('webapp log download -g {} -n {} --log-file "{}"'.format(resource_group, webapp_name, log_file))
         zip_ref = zipfile.ZipFile(log_file, 'r')
         zip_ref.extractall(log_dir)
-        p = Path(log_dir, r'LogFiles\kudu\trace')
-        self.assertTrue(p.is_dir())
+        self.assertTrue(os.path.isdir(os.path.join(log_dir, 'LogFiles', 'kudu', 'trace')))
 
 
 class AppServicePlanSceanrioTest(ScenarioTest):


### PR DESCRIPTION
1. Fix #3598. 
2. Fix a recent regression that creating node js web would fail for redundant app-setting `WEBSITE_NODE_DEFAULT_VERSION`
3. code clean ups

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
