### PR TITLE
Add monitor action-group commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/sdk/util.py
+++ b/src/azure-cli-core/azure/cli/core/sdk/util.py
@@ -89,7 +89,7 @@ class CommandGroup(object):
                     no_wait_param=no_wait_param)
 
     def custom_command(self, name, custom_func_name, confirmation=None,
-                       exception_handler=None, deprecate_info=None, no_wait_param=None):
+                       exception_handler=None, deprecate_info=None, no_wait_param=None, table_transformer=None):
         cli_command(self._scope,
                     '{} {}'.format(self._group_name, name),
                     self._custom_path.format(custom_func_name),
@@ -97,10 +97,11 @@ class CommandGroup(object):
                     confirmation=confirmation,
                     deprecate_info=deprecate_info,
                     exception_handler=exception_handler or self._exception_handler,
-                    no_wait_param=no_wait_param)
+                    no_wait_param=no_wait_param,
+                    table_transformer=table_transformer)
 
     def generic_update_command(self, name, getter_op, setter_op, custom_func_name=None,
-                               setter_arg_name='parameters', no_wait_param=None):
+                               setter_arg_name='parameters', no_wait_param=None, **kwargs):
         if custom_func_name:
             custom_function_op = self._custom_path.format(custom_func_name)
         else:
@@ -114,7 +115,7 @@ class CommandGroup(object):
             factory=self._client_factory,
             custom_function_op=custom_function_op,
             setter_arg_name=setter_arg_name,
-            no_wait_param=no_wait_param)
+            no_wait_param=no_wait_param, **kwargs)
 
 
 # PARAMETERS UTILITIES
@@ -155,6 +156,10 @@ class ParametersContext(object):
 
     def register(self, argument_name, options_list, **kwargs):
         register_cli_argument(self._commmand, argument_name, options_list=options_list, **kwargs)
+
+    def extra(self, argument_name, **kwargs):
+        from azure.cli.core.commands import register_extra_cli_argument
+        register_extra_cli_argument(self._commmand, argument_name, **kwargs)
 
     def expand(self, argument_name, model_type, group_name=None, patches=None):
         # TODO:

--- a/src/command_modules/azure-cli-monitor/HISTORY.rst
+++ b/src/command_modules/azure-cli-monitor/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+unreleased
+++++++++++
+* Add action-group commands
+
 0.0.10 (2017-09-22)
 +++++++++++++++++++
 * minor fixes

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_client_factory.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_client_factory.py
@@ -31,6 +31,10 @@ def cf_log_profiles(kwargs):
     return cf_monitor(kwargs).log_profiles
 
 
+def cf_action_groups(kwargs):
+    return cf_monitor(kwargs).action_groups
+
+
 # DATA CLIENT FACTORIES
 def cf_monitor_data(_):
     from azure.monitor import MonitorClient

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
@@ -207,3 +207,57 @@ helps['monitor activity-log'] = """
     type: group
     short-summary: Manage activity logs.
 """
+
+helps['monitor action-group'] = """
+    type: group
+    short-summary: Manage action groups
+"""
+
+helps['monitor action-group list'] = """
+    type: command
+    short-summary: List action groups under a resource group or the current subscription
+    parameters:
+        - name: --resource-group -g
+          type: string
+          short-summary: Name of the resource group under which the action groups are being listed. If it is omitted,
+                         all the action groups under the current subscription are listed.
+"""
+
+helps['monitor action-group show'] = """
+    type: command
+    short-summary: Show the details of an action group
+"""
+
+helps['monitor action-group create'] = """
+    type: command
+    short-summary: Create a new action group
+    parameters:
+        - name: --action -a
+          short-summary: Add receivers to the action group during the creation
+          long-summary: |
+            Usage:   --action TYPE NAME [ARG ...]
+            Email:   --action email bob bob@contoso.com
+            SMS:     --action sms charli 1 5551234567
+            Webhook: --action webhook alert_hook https://www.contoso.com/alert
+            Multiple actions can be specified by using more than one `--action` argument.
+        - name: --short-name
+          short-summary: The short name of the action group
+"""
+
+helps['monitor action-group update'] = """
+    type: command
+    short-summary: Update an action group
+    parameters:
+        - name: --short-name
+          short-summary: Update the group short name of the action group
+        - name: --add-action -a
+          short-summary: Add receivers to the action group
+          long-summary: |
+            Usage:   --add-action TYPE NAME [ARG ...]
+            Email:   --add-action email bob bob@contoso.com
+            SMS:     --add-action sms charli 1 5551234567
+            Webhook: --add-action https://www.contoso.com/alert
+            Multiple actions can be specified by using more than one `--add-action` argument.
+        - name: --remove-action -r
+          short-summary: Remove receivers from the action group. Accept space separated list of receiver names.
+"""

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/action_groups.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/action_groups.py
@@ -1,0 +1,40 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+def list_action_groups(client, resource_group_name=None):
+    if resource_group_name:
+        return client.list_by_resource_group(resource_group_name)
+    return client.list_by_subscription_id()
+
+
+def update_action_groups(instance, tags=None, short_name=None, add_receivers=None, remove_receivers=None):
+    if tags:
+        instance.tags = tags
+
+    if short_name:
+        instance.group_short_name = short_name
+
+    if remove_receivers:
+        remove_receivers = set(remove_receivers)
+
+        def filter_receivers(collection):
+            return [receiver for receiver in collection if receiver.name not in remove_receivers]
+
+        instance.email_receivers = filter_receivers(instance.email_receivers)
+        instance.sms_receivers = filter_receivers(instance.sms_receivers)
+        instance.webhook_receivers = filter_receivers(instance.webhook_receivers)
+
+    if add_receivers:
+        from azure.mgmt.monitor.models import EmailReceiver, SmsReceiver, WebhookReceiver
+        for r in add_receivers:
+            if isinstance(r, EmailReceiver):
+                instance.email_receivers.append(r)
+            elif isinstance(r, SmsReceiver):
+                instance.sms_receivers.append(r)
+            elif isinstance(r, WebhookReceiver):
+                instance.webhook_receivers.append(r)
+
+    return instance

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
@@ -153,3 +153,26 @@ with ParametersContext(command='monitor activity-log list') as c:
     c.argument('end_time', arg_group=filter_arg_group_name)
     c.argument('caller', arg_group=filter_arg_group_name)
     c.argument('status', arg_group=filter_arg_group_name)
+
+
+register_cli_argument('monitor action-group', 'action_group_name', options_list=('--name', '-n'), id_part='name')
+
+with ParametersContext(command='monitor action-group create') as c:
+    from .validators import process_action_group_detail_for_creation
+    from .actions import ActionGroupReceiverParameterAction
+
+    c.extra('receivers', options_list=('--action', '-a'), nargs='+', arg_group='Actions',
+            action=ActionGroupReceiverParameterAction, validator=process_action_group_detail_for_creation)
+    c.extra('short_name')
+    c.extra('tags')
+    c.ignore('action_group')
+
+with ParametersContext(command='monitor action-group update') as c:
+    c.extra('add_receivers', options_list=('--add-action', '-a'), nargs='+', arg_group='Actions',
+            action=ActionGroupReceiverParameterAction)
+    c.extra('remove_receivers', options_list=('--remove-action', '-r'), nargs='+', arg_group='Actions')
+    c.ignore('action_group')
+
+with ParametersContext(command='monitor action-group enable-receiver') as c:
+    c.register_alias('receiver_name', ('--name', '-n'))
+    c.register_alias('action_group_name', options_list='--action-group')

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/recordings/latest/test_monitor_action_group_basic_scenario.yaml
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/recordings/latest/test_monitor_action_group_basic_scenario.yaml
@@ -1,0 +1,407 @@
+interactions:
+- request:
+    body: '{"location": "southcentralus", "tags": {"use": "az-test"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['58']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"southcentralus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['336']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"location": "global", "properties": {"groupShortName": "cliactiongro",
+      "enabled": true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers":
+      []}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group create]
+      Connection: [keep-alive]
+      Content-Length: ['155']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['537']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups?api-version=2017-04-01
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['549']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:16 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['537']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "Global", "tags": {"owner": "alice"}, "properties": {"groupShortName":
+      "new_name", "enabled": true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers":
+      []}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Length: ['179']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":{"owner":"alice"},"properties":{"groupShortName":"new_name","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['546']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['537']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "Global", "properties": {"groupShortName": "cliactiongro",
+      "enabled": true, "emailReceivers": [{"name": "alice", "emailAddress": "alice@example.com"}],
+      "smsReceivers": [{"name": "alice_sms", "countryCode": "1", "phoneNumber": "5551234567"}],
+      "webhookReceivers": [{"name": "alice_web", "serviceUri": "https://www.example.com/alert?name=alice"}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Length: ['358']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[{"name":"alice","emailAddress":"alice@example.com","status":"Enabled"}],"smsReceivers":[{"name":"alice_sms","countryCode":"1","phoneNumber":"5551234567","status":"Enabled"}],"webhookReceivers":[{"name":"alice_web","serviceUri":"https://www.example.com/alert?name=alice"}],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[{"name":"alice","emailAddress":"alice@example.com","status":"Enabled"}],"smsReceivers":[{"name":"alice_sms","countryCode":"1","phoneNumber":"5551234567","status":"Enabled"}],"webhookReceivers":[{"name":"alice_web","serviceUri":"https://www.example.com/alert?name=alice"}],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "Global", "properties": {"groupShortName": "cliactiongro",
+      "enabled": true, "emailReceivers": [{"name": "alice", "emailAddress": "alice@example.com"}],
+      "smsReceivers": [{"name": "alice_sms", "countryCode": "1", "phoneNumber": "5551234567"}],
+      "webhookReceivers": []}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Length: ['279']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[{"name":"alice","emailAddress":"alice@example.com","status":"Enabled"}],"smsReceivers":[{"name":"alice_sms","countryCode":"1","phoneNumber":"5551234567","status":"Enabled"}],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['691']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"receiverName": "nonexist"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group enable-receiver]
+      Connection: [keep-alive]
+      Content-Length: ['28']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002/subscribe?api-version=2017-04-01
+  response:
+    body: {string: '{"Code":"ReceiverNotFound","Message":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['42']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"receiverName": "alice"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group enable-receiver]
+      Connection: [keep-alive]
+      Content-Length: ['25']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002/subscribe?api-version=2017-04-01
+  response:
+    body: {string: '{"Code":"ReceiverAlreadyEnabled","Message":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['48']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Mon, 16 Oct 2017 18:10:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups?api-version=2017-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 16 Oct 2017 18:10:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Mon, 16 Oct 2017 18:10:29 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdWM1hKSkJJUEVTTzZZUzZaTFpGNjU1VDZMRENBM0ZBUjZXRHxCNjc1NDE1N0VDN0Y2RUM4LVNPVVRIQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJzb3V0aGNlbnRyYWx1cyJ9?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/recordings/latest/test_monitor_create_empty_action_group.yaml
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/recordings/latest/test_monitor_create_empty_action_group.yaml
@@ -1,0 +1,290 @@
+interactions:
+- request:
+    body: '{"location": "southcentralus", "tags": {"use": "az-test"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['58']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"southcentralus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['336']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 13 Oct 2017 22:29:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"location": "global", "properties": {"groupShortName": "cliactiongro",
+      "enabled": true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers":
+      []}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group create]
+      Connection: [keep-alive]
+      Content-Length: ['155']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['537']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 13 Oct 2017 22:30:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups?api-version=2017-04-01
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['549']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 13 Oct 2017 22:30:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['537']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 13 Oct 2017 22:30:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "Global", "tags": {"owner": "alice"}, "properties": {"groupShortName":
+      "new_name", "enabled": true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers":
+      []}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Length: ['179']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":{"owner":"alice"},"properties":{"groupShortName":"new_name","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['546']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 13 Oct 2017 22:30:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['537']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 13 Oct 2017 22:30:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "Global", "properties": {"groupShortName": "cliactiongro",
+      "enabled": true, "emailReceivers": [{"name": "alice", "emailAddress": "alice@example.com"}],
+      "smsReceivers": [{"name": "alice_sms", "countryCode": "1", "phoneNumber": "5551234567"}],
+      "webhookReceivers": [{"name": "alice_web", "serviceUri": "https://www.example.com/alert?name=alice"}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group update]
+      Connection: [keep-alive]
+      Content-Length: ['358']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002","type":"Microsoft.Insights/ActionGroups","name":"cliactiongrouptest000002","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"cliactiongro","enabled":true,"emailReceivers":[{"name":"alice","emailAddress":"alice@example.com","status":"Enabled"}],"smsReceivers":[{"name":"alice_sms","countryCode":"1","phoneNumber":"5551234567","status":"Enabled"}],"webhookReceivers":[{"name":"alice_web","serviceUri":"https://www.example.com/alert?name=alice"}],"itsmReceivers":[],"azureAppPushReceivers":[]},"identity":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 13 Oct 2017 22:30:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/cliactiongrouptest000002?api-version=2017-04-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 13 Oct 2017 22:30:16 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [monitor action-group list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 monitormanagementclient/0.3.0 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups?api-version=2017-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 13 Oct 2017 22:30:16 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.16 msrest_azure/0.4.14 resourcemanagementclient/1.2.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.18+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 13 Oct 2017 22:30:18 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdJNjdYN05LR05TM0hVRzNaUFRLVENWVlBZN1k2UTNCMjVRR3wwQUMzREIzMzYyQjVGNkI3LVNPVVRIQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJzb3V0aGNlbnRyYWx1cyJ9?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/test_monitor_action_groups.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/test_monitor_action_groups.py
@@ -1,0 +1,56 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, JMESPathCheck
+
+
+class TestActionGroupScenarios(ScenarioTest):
+    @ResourceGroupPreparer(location='southcentralus')
+    def test_monitor_action_group_basic_scenario(self, resource_group):
+        # the prefix is intentionally keep long so as to test the default short name conversion
+        action_group_name = self.create_random_name('cliactiongrouptest', 32)
+        self.cmd('monitor action-group create -n {} -g {} -ojson'.format(action_group_name, resource_group), checks=[
+            JMESPathCheck('length(emailReceivers)', 0),
+            JMESPathCheck('length(smsReceivers)', 0),
+            JMESPathCheck('length(webhookReceivers)', 0),
+            JMESPathCheck('location', 'Global'),
+            JMESPathCheck('name', action_group_name),
+            JMESPathCheck('groupShortName', action_group_name[:12]),
+            JMESPathCheck('enabled', True),
+            JMESPathCheck('resourceGroup', resource_group),
+            JMESPathCheck('tags', None)
+        ])
+
+        self.cmd('monitor action-group list -g {} -ojson'.format(resource_group),
+                 checks=[JMESPathCheck('type(@)', 'array'),
+                         JMESPathCheck('length(@)', 1),
+                         JMESPathCheck('[0].name', action_group_name)])
+
+        self.cmd('monitor action-group update -n {} -g {} -ojson --short-name new_name --tag owner=alice'
+                 .format(action_group_name, resource_group), checks=[JMESPathCheck('tags.owner', 'alice'),
+                                                                     JMESPathCheck('groupShortName', 'new_name')])
+
+        self.cmd('monitor action-group update -n {} -g {} -ojson -a email alice alice@example.com '
+                 '-a sms alice_sms 1 5551234567 -a webhook alice_web https://www.example.com/alert?name=alice'
+                 .format(action_group_name, resource_group), checks=[JMESPathCheck('length(emailReceivers)', 1),
+                                                                     JMESPathCheck('length(smsReceivers)', 1),
+                                                                     JMESPathCheck('length(webhookReceivers)', 1)])
+
+        self.cmd('monitor action-group update -n {} -g {} -ojson -r alice_web'
+                 .format(action_group_name, resource_group), checks=[JMESPathCheck('length(emailReceivers)', 1),
+                                                                     JMESPathCheck('length(smsReceivers)', 1),
+                                                                     JMESPathCheck('length(webhookReceivers)', 0)])
+
+        self.cmd('monitor action-group enable-receiver -n nonexist --action-group {} -g {}'
+                 .format(action_group_name, resource_group))
+
+        self.cmd('monitor action-group enable-receiver -n alice --action-group {} -g {}'
+                 .format(action_group_name, resource_group))
+
+        self.cmd('monitor action-group delete -n {} -g {} -ojson'.format(action_group_name, resource_group))
+
+        self.cmd('monitor action-group list -g {} -ojson'.format(resource_group),
+                 checks=[JMESPathCheck('type(@)', 'array'),
+                         JMESPathCheck('length(@)', 0)])

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/transformers.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/transformers.py
@@ -1,0 +1,44 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""The output transformers for monitor commands. The global import should be limited to improve performance."""
+
+
+def _item_to_ordered_dict(item, *properties):
+    from collections import OrderedDict
+    result = OrderedDict()
+
+    for p in properties:
+        if isinstance(p, tuple):
+            property_name, display_name = p
+        else:
+            property_name = display_name = str(p)
+
+        value = item.get(property_name)
+
+        if isinstance(value, str):
+            result[display_name] = value
+        elif isinstance(value, list):
+            result[display_name] = str(len(value))
+        elif value is not None:
+            result[display_name] = str(value)
+
+    return result
+
+
+def action_group_list_table(results):
+    if not isinstance(results, list):
+        results = [results]
+
+    output_results = []
+    for result in results:
+        data = _item_to_ordered_dict(result, 'name', 'resourceGroup', 'groupShortName', 'enabled', 'location',
+                                     ('emailReceivers', 'email'),
+                                     ('smsReceivers', 'sms'),
+                                     ('webhookReceivers', 'webhook'))
+
+        output_results.append(data)
+
+    return output_results

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/util.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/util.py
@@ -1,0 +1,12 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+def get_resource_group_location(name):
+    from azure.cli.core.commands.client_factory import get_mgmt_service_client
+    from azure.cli.core.profiles import ResourceType
+
+    # pylint: disable=no-member
+    return get_mgmt_service_client(ResourceType.MGMT_RESOURCE_RESOURCES).resource_groups.get(name).location

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
@@ -109,3 +109,23 @@ def _validate_tag(string):
         comps = string.split('=', 1)
         result = {comps[0]: comps[1]} if len(comps) > 1 else {string: ''}
     return result
+
+
+def process_action_group_detail_for_creation(namespace):
+    from azure.mgmt.monitor.models import ActionGroupResource, EmailReceiver, SmsReceiver, WebhookReceiver
+
+    _validate_tags(namespace)
+
+    ns = vars(namespace)
+    name = ns['action_group_name']
+    receivers = ns.pop('receivers') or []
+    action_group_resource_properties = {
+        'location': 'global',  # as of now, 'global' is the only available location for action group
+        'group_short_name': ns.pop('short_name') or name[:12],  # '12' is the short name length limitation
+        'email_receivers': [r for r in receivers if isinstance(r, EmailReceiver)],
+        'sms_receivers': [r for r in receivers if isinstance(r, SmsReceiver)],
+        'webhook_receivers': [r for r in receivers if isinstance(r, WebhookReceiver)],
+        'tags': ns.get('tags') or None
+    }
+
+    ns['action_group'] = ActionGroupResource(**action_group_resource_properties)

--- a/src/command_modules/azure-cli-monitor/setup.py
+++ b/src/command_modules/azure-cli-monitor/setup.py
@@ -30,7 +30,8 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-cli-core',
     'azure-monitor==0.3.0',
-    'azure-mgmt-monitor==0.2.1'
+    'azure-mgmt-monitor==0.3.0',
+    'azure-mgmt-resource==1.2.1'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
```
Group
    az monitor action-group: Manage action groups.

Commands:
    create: Create a new action group.
    delete: Delete an action group.
    list  : List action groups under a resource group or the current subscription.
    show  : Show the details of an action group.
    update: Update an action group.
```

### az monitor action-group list
```
Command
    az monitor action-group list: List action groups under a resource group or the current
    subscription.

Arguments
    --resource-group -g: Name of the resource ground under which the action groups are being listed.
                         If it is omitted, all the action groups under the current subscription are
                         listed.

Global Arguments
    --debug            : Increase logging verbosity to show all debug logs.
    --help -h          : Show this help message and exit.
    --output -o        : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
    --query            : JMESPath query string. See http://jmespath.org/ for more information and
                         examples.
    --verbose          : Increase logging verbosity. Use --debug for full debug logs.

16:26 $ az monitor action-group list -otable
Name       ResourceGroup    GroupShortName    Enabled    Location      Email    Sms    Webhook
---------  ---------------  ----------------  ---------  ----------  -------  -----  ---------
trdaag01   troy-permanent   new1              True       Global            3      0          0
trdaiag02  troy-permanent   trdaiag02         True       Global            0      0          2
trdaiag03  troy-permanent   trdaiag03         True       Global            0      0          0
```

### az monitor action-group show
```
Command
    az monitor action-group show: Show the details of an action group.

Arguments
    --name -n           [Required]: The name of the action group.
    --resource-group -g [Required]: Name of resource group. You can configure the default group
                                    using `az configure --defaults group=<name>`.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: json.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
```

### az monitor action-group create
```
Command
    az monitor action-group create: Create a new action group.

Arguments
    --name -n           [Required]: The name of the action group.
    --resource-group -g [Required]: Name of resource group. You can configure the default group
                                    using `az configure --defaults group=<name>`.
    --short-name                  : The short name of the action group.
    --tags                        : Space separated tags in 'key[=value]' format. Use '' to clear
                                    existing tags.

Receivers Arguments
    --add-receiver -a             : Add receivers to the action group during the creation.
        Usage:   --add-receiver TYPE NAME [ARG ...]
        Email:   --add-receiver email bob bob@contoso.com
        SMS:     --add-receiver sms charli 1 5551234567
        Webhook: --add-receiver webhook alert_hook https://www.contoso.com/alert
        Multiple actions can be specified by using more than one `--add-receiver` argument.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: json.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
```
### az monitor action-group delete
```
Command
    az monitor action-group delete: Delete an action group.

Arguments
    --name -n           [Required]: The name of the action group.
    --resource-group -g [Required]: Name of resource group. You can configure the default group
                                    using `az configure --defaults group=<name>`.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: json.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
```

### az monitor action-group update
```
Command
    az monitor action-group update: Update an action group.

Arguments
    --name -n           [Required]: The name of the action group.
    --resource-group -g [Required]: Name of resource group. You can configure the default group
                                    using `az configure --defaults group=<name>`.
    --short-name                  : Update the group short name of the action group.
    --tags                        : Space separated tags in 'key[=value]' format. Use '' to clear
                                    existing tags.

Receivers Arguments
    --add-receiver -a             : Add receivers to the action group.
        Usage:   --add-receiver TYPE NAME [ARG ...]
        Email:   --add-receiver email bob bob@contoso.com
        SMS:     --add-receiver sms charli 1 5551234567
        Webhook: --add-receiver webhook alert_hook https://www.contoso.com/alert
        Multiple actions can be specified by using more than one `--add-receiver` argument.
    --remove-receiver -r          : Remove receivers from the action group. Accept space separated
                                    list of receiver names.

Generic Update Arguments
    --add                         : Add an object to a list of objects by specifying a path and key
                                    value pairs.  Example: --add property.listProperty <key=value,
                                    string or JSON string>.
    --remove                      : Remove a property or an element from a list.  Example: --remove
                                    property.list <indexToRemove> OR --remove propertyToRemove.
    --set                         : Update an object by specifying a property path and value to set.
                                    Example: --set property1.property2=<value>.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: json.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
```

### az monitor action-group enable-receiver 

```
0:21 $ az monitor action-group enable-receiver -h

Command
    az monitor action-group enable-receiver: Enable a receiver in an action group.
        This changes the receiver's status from Disabled to Enabled.

Arguments
    --action-group      [Required]: The name of the action group.
    --name -n           [Required]: The name of the receiver to resubscribe.
    --resource-group -g [Required]: Name of resource group. You can configure the default group
                                    using `az configure --defaults group=<name>`.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: json.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
