### PR TITLE
resource-level locks support using the id of the resource to be locked

### DIFF
--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+unreleased
+++++++++++
+* --resource parameter, resource-level locks now support resource-ids
+
 2.0.17
 ++++++
 * `group export`: Fixed incompatibility with most recent version of msrest dependency.

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -3,14 +3,11 @@
 Release History
 ===============
 
-unreleased
-++++++++++
-* --resource parameter, resource-level locks now support resource-ids
-
 2.0.17
 ++++++
 * `group export`: Fixed incompatibility with most recent version of msrest dependency.
 * `az policy assignment create`: policy assignment create command to work with built in policy definitions and policy set definitions.
+* --resource parameter, resource-level locks now support resource-ids
 
 2.0.16 (2017-10-09)
 +++++++++++++++++++

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -3,11 +3,14 @@
 Release History
 ===============
 
+2.0.18
+++++++
+* --resource parameter, resource-level locks now support resource-ids.
+
 2.0.17
 ++++++
 * `group export`: Fixed incompatibility with most recent version of msrest dependency.
 * `az policy assignment create`: policy assignment create command to work with built in policy definitions and policy set definitions.
-* --resource parameter, resource-level locks now support resource-ids
 
 2.0.16 (2017-10-09)
 +++++++++++++++++++

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -73,7 +73,7 @@ helps['lock'] = """
         - name: --parent-resource-path
           type: string
           text: The path to the parent resource of the resource being locked.
-        - name: --resource-name
+        - name: --resource
           type: string
           text: The name of the resource this lock applies to.
 """
@@ -100,7 +100,7 @@ helps['lock list'] = """
     examples:
         - name: List out the locks on a vnet resource. Includes locks in the associated group and subscription.
           text: >
-            az lock list --resource-name myvnet --resource-type Microsoft.Network/virtualNetworks -g group
+            az lock list --resource myvnet --resource-type Microsoft.Network/virtualNetworks -g group
         - name: List out all locks on the subscription level
           text: >
             az lock list
@@ -665,7 +665,10 @@ helps['resource lock create'] = """
     examples:
         - name: Create a read-only resource level lock on a vnet.
           text: >
-            az resource lock create --lock-type ReadOnly -n lockName -g MyResourceGroup --resource-name myvnet --resource-type Microsoft.Network/virtualNetworks
+            az resource lock create --lock-type ReadOnly -n lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
+        - name: Create a read-only resource level lock on a vnet using a vnet id.
+          text: >
+            az resource lock create --lock-type ReadOnly -n lockName --resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/myvnet
     """
 helps['resource lock delete'] = """
     type: command
@@ -673,7 +676,10 @@ helps['resource lock delete'] = """
     examples:
         - name: Delete a resource level lock
           text: >
-            az resource lock delete --name lockName -g MyResourceGroup --resource-name myvnet --resource-type Microsoft.Network/virtualNetworks
+            az resource lock delete --name lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
+        - name: Delete a resource level lock on a vnet using a vnet id.
+          text: >
+            az resource lock create --lock-type ReadOnly -n lockName --resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/myvnet
     """
 helps['resource lock list'] = """
     type: command
@@ -681,7 +687,7 @@ helps['resource lock list'] = """
     examples:
         - name: List out all locks on a vnet
           text: >
-            az resource lock list -g MyResourceGroup --resource-name myvnet --resource-type Microsoft.Network/virtualNetworks
+            az resource lock list -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
     """
 helps['resource lock show'] = """
     type: command
@@ -689,7 +695,7 @@ helps['resource lock show'] = """
     examples:
         - name: Show a resource level lock
           text: >
-            az resource lock show -n lockname -g MyResourceGroup --resource-name myvnet --resource-type Microsoft.Network/virtualNetworks
+            az resource lock show -n lockname -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
     """
 helps['resource lock update'] = """
     type: command
@@ -697,5 +703,5 @@ helps['resource lock update'] = """
     examples:
         - name: Update a resource level lock with new notes and type
           text: >
-            az resource lock update --name lockName -g MyResourceGroup --resource-name myvnet --resource-type Microsoft.Network/virtualNetworks --notes newNotesHere --lock-type CanNotDelete
+            az resource lock update --name lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks --notes newNotesHere --lock-type CanNotDelete
     """

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -679,7 +679,7 @@ helps['resource lock delete'] = """
             az resource lock delete --name lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
         - name: Delete a resource level lock on a vnet using a vnet id.
           text: >
-            az resource lock create --lock-type ReadOnly -n lockName --resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/myvnet
+            az resource lock delete -n lockName --resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/myvnet
     """
 helps['resource lock list'] = """
     type: command

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -63,19 +63,6 @@ helps['managedapp list'] = """
 helps['lock'] = """
     type: group
     short-summary: Manage Azure locks.
-    parameters:
-        - name: --resource-type
-          type: string
-          text: The name of the resource type. May have a provider namespace.
-        - name: --resource-provider-namespace
-          type: string
-          text: The name of the resource provider.
-        - name: --parent-resource-path
-          type: string
-          text: The path to the parent resource of the resource being locked.
-        - name: --resource
-          type: string
-          text: The name of the resource this lock applies to.
 """
 helps['lock create'] = """
     type: command

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -159,7 +159,7 @@ register_cli_argument('lock', 'resource_name', options_list=('--resource', '--re
 register_cli_argument('lock', 'resource_group', resource_group_name_type, validator=validate_lock_parameters)
 
 register_cli_argument('resource lock', 'resource_group', resource_group_name_type)
-register_cli_argument('resource lock', 'resource_name', options_list=('--resource-name'), validator=validate_resource_lock)
+register_cli_argument('resource lock', 'resource_name', options_list=('--resource', '--resource-name'), validator=validate_resource_lock)
 
 register_cli_argument('group lock', 'resource_group', resource_group_name_type, validator=validate_group_lock)
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -159,7 +159,7 @@ register_cli_argument('lock', 'resource_name', options_list=('--resource', '--re
 register_cli_argument('lock', 'resource_group', resource_group_name_type, validator=validate_lock_parameters)
 
 register_cli_argument('resource lock', 'resource_group', resource_group_name_type)
-register_cli_argument('resource lock', 'resource_name', options_list=('--resource', '--resource-name'), validator=validate_resource_lock)
+register_cli_argument('resource lock', 'resource_name', options_list=('--resource', '--resource-name'), help='Name or ID of the resource being locked. If an ID is given, other resource arguments should not be given.', validator=validate_resource_lock)
 
 register_cli_argument('group lock', 'resource_group', resource_group_name_type, validator=validate_group_lock)
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -155,7 +155,7 @@ register_cli_argument('managedapp definition create', 'mainTemplate', options_li
 register_cli_argument('lock', 'parent_resource_path', resource_parent_type)
 register_cli_argument('lock', 'resource_provider_namespace', resource_namespace_type)
 register_cli_argument('lock', 'resource_type', arg_type=resource_type_type, completer=get_resource_types_completion_list)
-register_cli_argument('lock', 'resource_name', options_list=('--resource-name'), help='Name of the resource being locked.')
+register_cli_argument('lock', 'resource_name', options_list=('--resource', '--resource-name'), help='Name or ID of the resource being locked. If an ID is given, other resource arguments should not be given.')
 register_cli_argument('lock', 'resource_group', resource_group_name_type, validator=validate_lock_parameters)
 
 register_cli_argument('resource lock', 'resource_group', resource_group_name_type)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_validators.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_validators.py
@@ -50,7 +50,7 @@ def internal_validate_lock_parameters(namespace, resource_group, resource_provid
                 setattr(namespace, id_part, id_dict.get(id_part))
             setattr(namespace, 'resource_provider_namespace', id_dict.get('resource_namespace'))
             setattr(namespace, 'parent_resource_path', id_dict.get('resource_parent').strip('/'))
-            
+
         if resource_type is not None:
             raise CLIError('--resource-type is ignored if --resource-group is not given.')
         if resource_provider_namespace is not None:

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_validators.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_validators.py
@@ -36,11 +36,22 @@ def process_deployment_create_namespace(namespace):
     _validate_deployment_name(namespace)
 
 
-def internal_validate_lock_parameters(resource_group, resource_provider_namespace,
+def internal_validate_lock_parameters(namespace, resource_group, resource_provider_namespace,
                                       parent_resource_path, resource_type, resource_name):
     if resource_group is None:
         if resource_name is not None:
-            raise CLIError('--resource-name is ignored if --resource-group is not given.')
+            from msrestazure.tools import parse_resource_id, is_valid_resource_id
+            if not is_valid_resource_id(resource_name):
+                print(namespace)
+                raise CLIError('--resource is not a valid resource ID. '
+                               '--resource as a resource name is ignored if --resource-group is not given.')
+            # resource-name is an ID, populate namespace
+            id_dict = parse_resource_id(resource_name)
+            for id_part in ['resource_name', 'resource_type', 'resource_group']:
+                setattr(namespace, id_part, id_dict.get(id_part))
+            setattr(namespace, 'resource_provider_namespace', id_dict.get('resource_namespace'))
+            setattr(namespace, 'parent_resource_path', id_dict.get('resource_parent'))
+            
         if resource_type is not None:
             raise CLIError('--resource-type is ignored if --resource-group is not given.')
         if resource_provider_namespace is not None:
@@ -51,27 +62,28 @@ def internal_validate_lock_parameters(resource_group, resource_provider_namespac
 
     if resource_name is None:
         if resource_type is not None:
-            raise CLIError('--resource-type is ignored if --resource-name is not given.')
+            raise CLIError('--resource-type is ignored if --resource is not given.')
         if resource_provider_namespace is not None:
-            raise CLIError('--namespace is ignored if --resource-name is not given.')
+            raise CLIError('--namespace is ignored if --resource is not given.')
         if parent_resource_path is not None:
-            raise CLIError('--parent is ignored if --resource-name is not given.')
+            raise CLIError('--parent is ignored if --resource is not given.')
         return
 
     if not resource_type:
-        raise CLIError('--resource-type is required if --resource-name is present')
+        raise CLIError('--resource-type is required if the name, --resource, is present')
 
     parts = resource_type.split('/')
     if resource_provider_namespace is None:
         if len(parts) == 1:
-            raise CLIError('A resource namespace is required if --resource-name is present.'
+            raise CLIError('A resource namespace is required if the name, --resource, is present.'
                            'Expected <namespace>/<type> or --namespace=<namespace>')
     elif len(parts) != 1:
         raise CLIError('Resource namespace specified in both --resource-type and --namespace')
 
 
 def validate_lock_parameters(namespace):
-    internal_validate_lock_parameters(getattr(namespace, 'resource_group', None),
+    internal_validate_lock_parameters(namespace,
+                                      getattr(namespace, 'resource_group', None),
                                       getattr(namespace, 'resource_provider_namespace', None),
                                       getattr(namespace, 'parent_resource_path', None),
                                       getattr(namespace, 'resource_type', None),
@@ -106,11 +118,10 @@ def validate_resource_lock(namespace):
                                                                'resource_name']):
                 raise CLIError('{} is not a valid resource-level lock id.'.format(lock_id))
     else:
+        if not getattr(namespace, 'resource_type', None):
+            raise CLIError('Missing required {} parameter.'.format('resource_type'))
         kwargs = {}
-        for param in ['resource_group', 'resource_type', 'resource_name']:
-            if not getattr(namespace, param, None):
-                raise CLIError('Missing required {} parameter.'.format(param))
-            kwargs[param] = getattr(namespace, param)
-        kwargs['resource_provider_namespace'] = getattr(namespace, 'resource_provider_namespace', None)
-        kwargs['parent_resource_path'] = getattr(namespace, 'parent_resource_path', None)
-        internal_validate_lock_parameters(**kwargs)
+        for param in ['resource_group', 'resource_name', 'resource_provider_namespace', 'parent_resource_path',
+                      'resource_type']:
+            kwargs[param] = getattr(namespace, param, None)
+        internal_validate_lock_parameters(namespace, **kwargs)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_validators.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_validators.py
@@ -42,7 +42,6 @@ def internal_validate_lock_parameters(namespace, resource_group, resource_provid
         if resource_name is not None:
             from msrestazure.tools import parse_resource_id, is_valid_resource_id
             if not is_valid_resource_id(resource_name):
-                print(namespace)
                 raise CLIError('--resource is not a valid resource ID. '
                                '--resource as a resource name is ignored if --resource-group is not given.')
             # resource-name is an ID, populate namespace
@@ -50,7 +49,7 @@ def internal_validate_lock_parameters(namespace, resource_group, resource_provid
             for id_part in ['resource_name', 'resource_type', 'resource_group']:
                 setattr(namespace, id_part, id_dict.get(id_part))
             setattr(namespace, 'resource_provider_namespace', id_dict.get('resource_namespace'))
-            setattr(namespace, 'parent_resource_path', id_dict.get('resource_parent'))
+            setattr(namespace, 'parent_resource_path', id_dict.get('resource_parent').strip('/'))
             
         if resource_type is not None:
             raise CLIError('--resource-type is ignored if --resource-group is not given.')
@@ -118,8 +117,8 @@ def validate_resource_lock(namespace):
                                                                'resource_name']):
                 raise CLIError('{} is not a valid resource-level lock id.'.format(lock_id))
     else:
-        if not getattr(namespace, 'resource_type', None):
-            raise CLIError('Missing required {} parameter.'.format('resource_type'))
+        if not getattr(namespace, 'resource_name', None):
+            raise CLIError('Missing required {} parameter.'.format('resource_name'))
         kwargs = {}
         for param in ['resource_group', 'resource_name', 'resource_provider_namespace', 'parent_resource_path',
                       'resource_type']:

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/recordings/latest/test_lock_with_resource_id.yaml
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/recordings/latest/test_lock_with_resource_id.yaml
@@ -1,0 +1,601 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001","name":"cli_test_lock_with_resource_id000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001","name":"cli_test_lock_with_resource_id000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "dhcpOptions": {}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Length: ['123']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 networkmanagementclient/1.5.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002?api-version=2017-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"cli-lock-vnet000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002\"\
+        ,\r\n  \"etag\": \"W/\\\"0eff6d09-cde7-4167-be82-2f37516597db\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"d4ee3e9d-a44f-4221-aa86-02b2a188aa1d\"\
+        ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
+        10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
+        : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
+        \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
+        : false\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/20768e59-a63f-4990-8533-9d809f0dba49?api-version=2017-09-01']
+      cache-control: [no-cache]
+      content-length: ['816']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 networkmanagementclient/1.5.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/20768e59-a63f-4990-8533-9d809f0dba49?api-version=2017-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 networkmanagementclient/1.5.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002?api-version=2017-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"cli-lock-vnet000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002\"\
+        ,\r\n  \"etag\": \"W/\\\"71477e1b-cddd-422c-b58e-3fa2948a30bc\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"d4ee3e9d-a44f-4221-aa86-02b2a188aa1d\"\
+        ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
+        10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
+        : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
+        \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
+        : false\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['817']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:26 GMT']
+      etag: [W/"71477e1b-cddd-422c-b58e-3fa2948a30bc"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"properties": {"addressPrefix": "10.0.0.0/16"}, "name": "cli-lock-subnet000003"}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet subnet create]
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 networkmanagementclient/1.5.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003?api-version=2017-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"cli-lock-subnet000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003\"\
+        ,\r\n  \"etag\": \"W/\\\"efe866ff-79a2-48d9-953f-5ec8c8a2cb52\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
+        addressPrefix\": \"10.0.0.0/16\"\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f9436f3a-f37f-45ea-9358-45620ec09ca8?api-version=2017-09-01']
+      cache-control: [no-cache]
+      content-length: ['473']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet subnet create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 networkmanagementclient/1.5.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f9436f3a-f37f-45ea-9358-45620ec09ca8?api-version=2017-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet subnet create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 networkmanagementclient/1.5.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003?api-version=2017-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"cli-lock-subnet000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003\"\
+        ,\r\n  \"etag\": \"W/\\\"db2db899-c58c-403b-815d-90de471815da\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.0.0.0/16\"\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['474']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:31 GMT']
+      etag: [W/"db2db899-c58c-403b-815d-90de471815da"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"properties": {"level": "CanNotDelete"}, "name": "cli-test-lock000004"}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [resource lock create]
+      Connection: [keep-alive]
+      Content-Length: ['103']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/providers/Microsoft.Authorization/locks/cli-test-lock000004?api-version=2016-09-01
+  response:
+    body: {string: '{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/providers/Microsoft.Authorization/locks/cli-test-lock000004","type":"Microsoft.Authorization/locks","name":"cli-test-lock000004"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['454']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 201, message: Created}
+- request:
+    body: 'b''{"properties": {"level": "CanNotDelete"}, "name": "cli-test-lock000005"}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [lock create]
+      Connection: [keep-alive]
+      Content-Length: ['73']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003/providers/Microsoft.Authorization/locks/cli-test-lock000005?api-version=2016-09-01
+  response:
+    body: {string: '{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003/providers/Microsoft.Authorization/locks/cli-test-lock000005","type":"Microsoft.Authorization/locks","name":"cli-test-lock000005"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['433']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [resource lock show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/locks?api-version=2016-09-01
+  response:
+    body: {string: '{"value":[{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/wilx-group/providers/Microsoft.Authorization/locks/mylock","type":"Microsoft.Authorization/locks","name":"mylock"},{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/providers/Microsoft.Authorization/locks/cli-test-lock000004","type":"Microsoft.Authorization/locks","name":"cli-test-lock000004"},{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003/providers/Microsoft.Authorization/locks/cli-test-lock000005","type":"Microsoft.Authorization/locks","name":"cli-test-lock000005"},{"properties":{"level":"CanNotDelete","notes":"please
+        keep"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sdk-test/providers/Microsoft.Authorization/locks/sdk-test-lock","type":"Microsoft.Authorization/locks","name":"sdk-test-lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.Storage/storageAccounts/acliautomationlab2987/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Pending
+        support ticket: REG:117080316140410"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2del/providers/Microsoft.Authorization/locks/nottodelete","type":"Microsoft.Authorization/locks","name":"nottodelete"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.Storage/storageAccounts/acliautomationlab2281/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3926']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [resource lock show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/providers/Microsoft.Authorization/locks/cli-test-lock000004?api-version=2016-09-01
+  response:
+    body: {string: '{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/providers/Microsoft.Authorization/locks/cli-test-lock000004","type":"Microsoft.Authorization/locks","name":"cli-test-lock000004"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['454']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [lock show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/locks?api-version=2016-09-01
+  response:
+    body: {string: '{"value":[{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/wilx-group/providers/Microsoft.Authorization/locks/mylock","type":"Microsoft.Authorization/locks","name":"mylock"},{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/providers/Microsoft.Authorization/locks/cli-test-lock000004","type":"Microsoft.Authorization/locks","name":"cli-test-lock000004"},{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003/providers/Microsoft.Authorization/locks/cli-test-lock000005","type":"Microsoft.Authorization/locks","name":"cli-test-lock000005"},{"properties":{"level":"CanNotDelete","notes":"please
+        keep"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sdk-test/providers/Microsoft.Authorization/locks/sdk-test-lock","type":"Microsoft.Authorization/locks","name":"sdk-test-lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.Storage/storageAccounts/acliautomationlab2987/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Pending
+        support ticket: REG:117080316140410"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2del/providers/Microsoft.Authorization/locks/nottodelete","type":"Microsoft.Authorization/locks","name":"nottodelete"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.Storage/storageAccounts/acliautomationlab2281/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3926']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [lock show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003/providers/Microsoft.Authorization/locks/cli-test-lock000005?api-version=2016-09-01
+  response:
+    body: {string: '{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003/providers/Microsoft.Authorization/locks/cli-test-lock000005","type":"Microsoft.Authorization/locks","name":"cli-test-lock000005"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['433']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [resource lock delete]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/locks?api-version=2016-09-01
+  response:
+    body: {string: '{"value":[{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/wilx-group/providers/Microsoft.Authorization/locks/mylock","type":"Microsoft.Authorization/locks","name":"mylock"},{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/providers/Microsoft.Authorization/locks/cli-test-lock000004","type":"Microsoft.Authorization/locks","name":"cli-test-lock000004"},{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003/providers/Microsoft.Authorization/locks/cli-test-lock000005","type":"Microsoft.Authorization/locks","name":"cli-test-lock000005"},{"properties":{"level":"CanNotDelete","notes":"please
+        keep"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sdk-test/providers/Microsoft.Authorization/locks/sdk-test-lock","type":"Microsoft.Authorization/locks","name":"sdk-test-lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.Storage/storageAccounts/acliautomationlab2987/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Pending
+        support ticket: REG:117080316140410"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2del/providers/Microsoft.Authorization/locks/nottodelete","type":"Microsoft.Authorization/locks","name":"nottodelete"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.Storage/storageAccounts/acliautomationlab2281/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3926']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [resource lock delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/providers/Microsoft.Authorization/locks/cli-test-lock000004?api-version=2016-09-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 19 Oct 2017 19:55:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [lock delete]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/locks?api-version=2016-09-01
+  response:
+    body: {string: '{"value":[{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/wilx-group/providers/Microsoft.Authorization/locks/mylock","type":"Microsoft.Authorization/locks","name":"mylock"},{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/providers/Microsoft.Authorization/locks/cli-test-lock000004","type":"Microsoft.Authorization/locks","name":"cli-test-lock000004"},{"properties":{"level":"CanNotDelete"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003/providers/Microsoft.Authorization/locks/cli-test-lock000005","type":"Microsoft.Authorization/locks","name":"cli-test-lock000005"},{"properties":{"level":"CanNotDelete","notes":"please
+        keep"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sdk-test/providers/Microsoft.Authorization/locks/sdk-test-lock","type":"Microsoft.Authorization/locks","name":"sdk-test-lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.Storage/storageAccounts/acliautomationlab2987/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Pending
+        support ticket: REG:117080316140410"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2del/providers/Microsoft.Authorization/locks/nottodelete","type":"Microsoft.Authorization/locks","name":"nottodelete"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.Storage/storageAccounts/acliautomationlab2281/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"},{"properties":{"level":"CanNotDelete","notes":"Reserved
+        resource locked by ''cliautomationlab'' lab."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliautomation01/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/providers/Microsoft.Authorization/locks/DevTestLabs
+        Lock","type":"Microsoft.Authorization/locks","name":"DevTestLabs Lock"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3926']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 19 Oct 2017 19:55:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [lock delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 managementlockclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001/providers/Microsoft.Network/virtualNetworks/cli-lock-vnet000002/subnets/cli-lock-subnet000003/providers/Microsoft.Authorization/locks/cli-test-lock000005?api-version=2016-09-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 19 Oct 2017 19:55:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.2 (Darwin-16.7.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.17 msrest_azure/0.4.15 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.20]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_lock_with_resource_id000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 19 Oct 2017 19:55:48 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGTE9DSzo1RldJVEg6NUZSRVNPVVJDRTo1RklER0VEN0ZTQnxBMDAyODQ1MzBCODFBRjJBLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_locks.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_locks.py
@@ -268,14 +268,18 @@ class ResourceLockTests(ScenarioTest):
                                      vnet_name, resource_group)).get_output_in_json().get('id')
 
 
-        self.cmd('lock create -n {} --resource {} --lock-type CanNotDelete'.format(vnet_lock_name, vnet_id))
+        self.cmd('resource lock create -n {} --resource {} --lock-type CanNotDelete'.format(vnet_lock_name, vnet_id))
         self.cmd('lock create -n {} --resource {} --lock-type CanNotDelete'.format(subnet_lock_name, subnet_id))
 
-        print(self.cmd('resource lock show --name {} --resource {}'
-                 .format(vnet_lock_name, vnet_id)).assert_with_checks([
-                     JMESPathCheck('name', vnet_lock_name)]).get_output_in_json())
+        self.cmd('resource lock show --name {} --resource {}'
+                 .format(vnet_lock_name, vnet_id)).assert_with_checks([JMESPathCheck('name', vnet_lock_name)])
+        self.cmd('lock show --name {} --resource {}'
+                 .format(subnet_lock_name, subnet_id)).assert_with_checks([JMESPathCheck('name', subnet_lock_name)])
 
-
+        self.cmd('resource lock delete --name {} --resource {}'.format(vnet_lock_name, vnet_id))
+        self.cmd('lock delete --name {} --resource {}'.format(subnet_lock_name, subnet_id))
+        
+        self._sleep_for_lock_operation()
 
     def _sleep_for_lock_operation(self):
         if self.is_live:

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_locks.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_locks.py
@@ -267,7 +267,6 @@ class ResourceLockTests(ScenarioTest):
                              .format(subnet_name, subnetaddress,
                                      vnet_name, resource_group)).get_output_in_json().get('id')
 
-
         self.cmd('resource lock create -n {} --resource {} --lock-type CanNotDelete'.format(vnet_lock_name, vnet_id))
         self.cmd('lock create -n {} --resource {} --lock-type CanNotDelete'.format(subnet_lock_name, subnet_id))
 
@@ -278,7 +277,7 @@ class ResourceLockTests(ScenarioTest):
 
         self.cmd('resource lock delete --name {} --resource {}'.format(vnet_lock_name, vnet_id))
         self.cmd('lock delete --name {} --resource {}'.format(subnet_lock_name, subnet_id))
-        
+
         self._sleep_for_lock_operation()
 
     def _sleep_for_lock_operation(self):

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_locks.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_locks.py
@@ -253,6 +253,30 @@ class ResourceLockTests(ScenarioTest):
         my_locks = self.cmd("az lock list -g {} -ojson".format(resource_group)).get_output_in_json()
         self.assertFalse(my_locks)
 
+    @ResourceGroupPreparer(name_prefix='cli_test_lock_with_resource_id')
+    def test_lock_with_resource_id(self, resource_group):
+        vnet_name = self.create_random_name('cli-lock-vnet', 30)
+        subnet_name = self.create_random_name('cli-lock-subnet', 30)
+        vnet_lock_name = self.create_random_name('cli-test-lock', 50)
+        subnet_lock_name = self.create_random_name('cli-test-lock', 20)
+
+        vnet = self.cmd('network vnet create -n {} -g {}'.format(vnet_name, resource_group)).get_output_in_json()
+        vnet_id = vnet.get('newVNet').get('id')
+        subnetaddress = vnet.get('newVNet').get('addressSpace').get('addressPrefixes')[0]
+        subnet_id = self.cmd('network vnet subnet create -n {} --address-prefix {} --vnet-name {} -g {}'
+                             .format(subnet_name, subnetaddress,
+                                     vnet_name, resource_group)).get_output_in_json().get('id')
+
+
+        self.cmd('lock create -n {} --resource {} --lock-type CanNotDelete'.format(vnet_lock_name, vnet_id))
+        self.cmd('lock create -n {} --resource {} --lock-type CanNotDelete'.format(subnet_lock_name, subnet_id))
+
+        print(self.cmd('resource lock show --name {} --resource {}'
+                 .format(vnet_lock_name, vnet_id)).assert_with_checks([
+                     JMESPathCheck('name', vnet_lock_name)]).get_output_in_json())
+
+
+
     def _sleep_for_lock_operation(self):
         if self.is_live:
             sleep(5)

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.17"
+VERSION = "2.0.18"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
---
`--resource` argument
old `--resource-name` arg still allowed

`az resource lock delete -n lockName --resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/myvnet`

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [y ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [y ] Each command and parameter has a meaningful description.
- [y ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
