### PR TITLE
Skip two types of style errors in flake8.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,8 @@ max-complexity = 10
 ignore =
     E126,
     E501,
+    E722,
+    E741,
     F401,
     F811,
     C901

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -25,7 +25,7 @@ DEPENDENCIES = [
     'autopep8>=1.2.4',
     'pylint>=1.7.1'
     'coverage>=4.2',
-    'flake8>=3.2.1',
+    'flake8==3.5.0',
     'pycodestyle>=2.2.0',
     'nose>=1.3.7',
     'readme_renderer>=17.2',


### PR DESCRIPTION
This is temporary. We must upgrade to 3.5 and newly introduced fix style issues in near future.