### PR TITLE
Change default VM for AKS to D1_v2.

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -5,8 +5,9 @@ Release History
 
 2.0.19
 ++++++
-* Call "agent" a "node" in AKS to match documentation.
-* Deprecate --orchestrator-release option in acs create
+* call "agent" a "node" in AKS to match documentation
+* deprecate --orchestrator-release option in acs create
+* change default VM size for AKS to Standard_D1_v2
 
 2.0.18
 ++++++

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1146,7 +1146,7 @@ def aks_create(client, resource_group_name, name, ssh_key_value,  # pylint: disa
                location=None,
                admin_username="azureuser",
                kubernetes_version="1.7.7",
-               node_vm_size="Standard_D2_v2",
+               node_vm_size="Standard_D1_v2",
                node_osdisk_size=0,
                node_count=3,
                service_principal=None, client_secret=None,


### PR DESCRIPTION
Tested interactively as well to verify we actually get Standard_D1_v2 VMs by default.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
