### PR TITLE
Fix `az aks get-credentials` on Windows

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -9,6 +9,7 @@ Release History
 * deprecate --orchestrator-release option in acs create
 * change default VM size for AKS to Standard_D1_v2
 * fix "az aks browse" on Windows
+* fix "az aks get-credentials" on Windows
 
 2.0.18
 ++++++


### PR DESCRIPTION
`NamedTemporaryFile` can't be opened more than once on Windows, so this uses [`mkstemp`](https://docs.python.org/3/library/tempfile.html). Tested interactively on Windows 10, macOS, and Ubuntu Linux.
