### PR TITLE
Fix `az aks browse` on Windows

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * call "agent" a "node" in AKS to match documentation
 * deprecate --orchestrator-release option in acs create
 * change default VM size for AKS to Standard_D1_v2
+* fix "az aks browse" on Windows
 
 2.0.18
 ++++++

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1122,10 +1122,13 @@ def aks_browse(client, resource_group_name, name, disable_browser=False):
     # TODO: need to add an --admin option?
     aks_get_credentials(client, resource_group_name, name, admin=False, path=browse_path)
     # find the dashboard pod's name
-    dashboard_pod = subprocess.check_output(
-        ["kubectl", "get", "pods", "--kubeconfig", browse_path, "--namespace", "kube-system", "--output", "name",
-         "--selector", "k8s-app=kubernetes-dashboard"],
-        universal_newlines=True)
+    try:
+        dashboard_pod = subprocess.check_output(
+            ["kubectl", "get", "pods", "--kubeconfig", browse_path, "--namespace", "kube-system", "--output", "name",
+             "--selector", "k8s-app=kubernetes-dashboard"],
+            universal_newlines=True)
+    except subprocess.CalledProcessError as err:
+        raise CLIError('Could not find dashboard pod: {}'.format(err))
     if dashboard_pod:
         # remove the "pods/" prefix from the name
         dashboard_pod = str(dashboard_pod)[5:].strip()


### PR DESCRIPTION
`NamedTemporaryFile` has limitations on Windows, so this uses [`mkstemp`](https://docs.python.org/3/library/tempfile.html). Tested interactively on Windows 10, macOS, and Ubuntu Linux.