### PR TITLE
Fix metadata, update base image version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,14 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-FROM python:3.5.2-alpine
+FROM python:3.6.3-alpine
 
 ARG CLI_VERSION
 
 # Metadata as defined at http://label-schema.org
 ARG BUILD_DATE
-LABEL org.label-schema.schema-version="1.0" \
+LABEL maintainer="Microsoft" \
+      org.label-schema.schema-version="1.0" \
       org.label-schema.vendor="Microsoft" \
       org.label-schema.name="Azure CLI 2.0" \
       org.label-schema.version=$CLI_VERSION \
@@ -19,7 +20,7 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.usage="https://docs.microsoft.com/en-us/cli/azure/install-az-cli2#docker" \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/Azure/azure-cli.git" \
-      org.label-schema.docker.cmd="docker run -v ${HOME}:/root -it azuresdk/azure-cli-python:<version>"
+      org.label-schema.docker.cmd="docker run -v \${HOME}/.azure:/root/.azure -it azuresdk/azure-cli-python:$CLI_VERSION"
 
 WORKDIR azure-cli
 COPY . /azure-cli


### PR DESCRIPTION
This PR updates the container image metadata to include the **version** value in the `org.label-schema.docker.cmd` label and also correctly render the `${HOME}` variable in that label.

**Existing:**
```powershell
PS> docker image inspect azuresdk/azure-cli-python:2.0.20 --format "{{json .Config.Labels}}" | ConvertFrom-Json | ConvertTo-Json
{
    "org.label-schema.build-date":  "2017-10-19T18:26:52Z",
    "org.label-schema.description":  "The Azure CLI 2.0 is the new Azure CLI and is applicable when you use the Resource Manager deployment model.",
    "org.label-schema.docker.cmd":  "docker run -v :/root -it azuresdk/azure-cli-python:\u003cversion\u003e",
    "org.label-schema.license":  "MIT",
    "org.label-schema.name":  "Azure CLI 2.0",
    "org.label-schema.schema-version":  "1.0",
    "org.label-schema.url":  "https://docs.microsoft.com/en-us/cli/azure/overview",
    "org.label-schema.usage":  "https://docs.microsoft.com/en-us/cli/azure/install-az-cli2#docker",
    "org.label-schema.vcs-url":  "https://github.com/Azure/azure-cli.git",
    "org.label-schema.vendor":  "Microsoft",
    "org.label-schema.version":  "2.0.20"
}
```
**Updated:**
```powershell
PS> docker image inspect azuresdk/azure-cli-python:2.0.20-test --format "{{json .Config.Labels}}" | ConvertFrom-Json | ConvertTo-Json
{
    "maintainer":  "Microsoft",
    "org.label-schema.build-date":  "2017-10-26T00:38:26Z",
    "org.label-schema.description":  "The Azure CLI 2.0 is the new Azure CLI and is applicable when you use the Resource Manager deployment model.",
    "org.label-schema.docker.cmd":  "docker run -v ${HOME}/.azure:/root/.azure -it azuresdk/azure-cli-python:2.0.20-test",
    "org.label-schema.license":  "MIT",
    "org.label-schema.name":  "Azure CLI 2.0",
    "org.label-schema.schema-version":  "1.0",
    "org.label-schema.url":  "https://docs.microsoft.com/en-us/cli/azure/overview",
    "org.label-schema.usage":  "https://docs.microsoft.com/en-us/cli/azure/install-az-cli2#docker",
    "org.label-schema.vcs-url":  "https://github.com/Azure/azure-cli.git",
    "org.label-schema.vendor":  "Microsoft",
    "org.label-schema.version":  "2.0.20-test"
}
```

This PR also updates the container base image version to `python:3.6.3-alpine`.