### PR TITLE
`storage blob/file delete-batch` commands

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * `storage account create`: defaults --sku to 'Standard_RAGRS'
 * Fixed bugs when dealing with file/blob names that include non-ascii chars.
 * `storage blob/file copy start-batch`: Fixed bug that prevented using --source-uri.
+* `storage blob/file delete-batch`: Added commands to glob and delete multiple blobs/files.
 
 2.0.18
 ++++++

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -220,7 +220,7 @@ helps['storage blob upload-batch'] = """
           type: string
           short-summary: The blob container where the files will be uploaded.
           long-summary: The destination can be the container URL or the container name. When the destination is the container URL, the storage
-            account name will parsed from the URL.
+                        account name will be parsed from the URL.
         - name: --pattern
           type: string
           short-summary: The pattern used for globbing files or blobs in the source. The supported patterns are '*', '?', '[seq]', and '[!seq]'.
@@ -229,13 +229,13 @@ helps['storage blob upload-batch'] = """
           short-summary: Show the summary of the operations to be taken instead of actually uploading the file(s).
         - name: --if-match
           type: string
-          short-summary: An ETag value, or the wildcard character (*). Specify this header to perform the operation \
-only if the resource's ETag matches the value specified.
+          short-summary: An ETag value, or the wildcard character (*). Specify this header to perform the operation
+                         only if the resource's ETag matches the value specified.
         - name: --if-none-match
           type: string
           short-summary: An ETag value, or the wildcard character (*).
           long-summary: Specify this header to perform the operation only if the resource's ETag does not match the value specified.
-            Specify the wildcard character (*) to perform the operation only if the resource does not exist, and fail the operation if it does exist.
+                        Specify the wildcard character (*) to perform the operation only if the resource does not exist, and fail the operation if it does exist.
 """
 helps['storage blob download-batch'] = """
     type: command
@@ -245,7 +245,7 @@ helps['storage blob download-batch'] = """
           type: string
           short-summary: The blob container from where the files will be downloaded.
           long-summary: The source can be the container URL or the container name. When the source is the container URL, the storage
-            account name will parsed from the URL.
+                        account name will parsed from the URL.
         - name: --destination -d
           type: string
           short-summary: The existing destination folder for this download operation.
@@ -264,7 +264,7 @@ helps['storage blob delete-batch'] = """
           type: string
           short-summary: The blob container from where the files will be deleted.
           long-summary: The source can be the container URL or the container name. When the source is the container URL, the storage
-            account name will parsed from the URL.
+                        account name will parsed from the URL.
         - name: --pattern
           type: string
           short-summary: The pattern used for globbing files or blobs in the source. The supported patterns are '*', '?', '[seq]', and '[!seq]'.
@@ -273,13 +273,13 @@ helps['storage blob delete-batch'] = """
           short-summary: Show the summary of the operations to be taken instead of actually deleting the file(s).
         - name: --if-match
           type: string
-          short-summary: An ETag value, or the wildcard character (*). Specify this header to perform the operation \
-only if the resource's ETag matches the value specified.
+          short-summary: An ETag value, or the wildcard character (*). Specify this header to perform the operation
+                         only if the resource's ETag matches the value specified.
         - name: --if-none-match
           type: string
           short-summary: An ETag value, or the wildcard character (*).
           long-summary: Specify this header to perform the operation only if the resource's ETag does not match the value specified.
-            Specify the wildcard character (*) to perform the operation only if the resource does not exist, and fail the operation if it does exist.
+                        Specify the wildcard character (*) to perform the operation only if the resource does not exist, and fail the operation if it does exist.
 
 """
 helps['storage blob copy start-batch'] = """
@@ -516,7 +516,7 @@ helps['storage file delete-batch'] = """
           short-summary: The pattern used for file globbing. The supported patterns are '*', '?', '[seq]', and '[!seq]'.
         - name: --dryrun
           type: bool
-          short-summary: List the files and blobs to be deleted. No actual data transfer will occur.
+          short-summary: List the files and blobs to be deleted. No actual data deletion will occur.
 """
 
 helps['storage file copy start-batch'] = """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -209,6 +209,79 @@ helps['storage blob set-tier'] = """
         For block blob this command only supports block blob on standard storage accounts.
         For page blob, this command only supports for page blobs on premium accounts.
 """
+helps['storage blob upload-batch'] = """
+    type: command
+    short-summary: Upload files from a local directory to a blob container.
+    parameters:
+        - name: --source -s
+          type: string
+          short-summary: The directory where the files to be uploaded are located.
+        - name: --destination -d
+          type: string
+          short-summary: The blob container where the files will be uploaded.
+          long-summary: The destination can be the container URL or the container name. When the destination is the container URL, the storage
+            account name will parsed from the URL.
+        - name: --pattern
+          type: string
+          short-summary: The pattern used for globbing files or blobs in the source. The supported patterns are '*', '?', '[seq]', and '[!seq]'.
+        - name: --dryrun
+          type: bool
+          short-summary: Show the summary of the operations to be taken instead of actually uploading the file(s).
+        - name: --if-match
+          type: string
+          short-summary: An ETag value, or the wildcard character (*). Specify this header to perform the operation \
+only if the resource's ETag matches the value specified.
+        - name: --if-none-match
+          type: string
+          short-summary: An ETag value, or the wildcard character (*).
+          long-summary: Specify this header to perform the operation only if the resource's ETag does not match the value specified.
+            Specify the wildcard character (*) to perform the operation only if the resource does not exist, and fail the operation if it does exist.
+"""
+helps['storage blob download-batch'] = """
+    type: command
+    short-summary: Download blobs from a blob container recursively.
+    parameters:
+        - name: --source -s
+          type: string
+          short-summary: The blob container from where the files will be downloaded.
+          long-summary: The source can be the container URL or the container name. When the source is the container URL, the storage
+            account name will parsed from the URL.
+        - name: --destination -d
+          type: string
+          short-summary: The existing destination folder for this download operation.
+        - name: --pattern
+          type: string
+          short-summary: The pattern used for globbing files or blobs in the source. The supported patterns are '*', '?', '[seq]', and '[!seq]'.
+        - name: --dryrun
+          type: bool
+          short-summary: Show the summary of the operations to be taken instead of actually downloading the file(s).
+"""
+helps['storage blob delete-batch'] = """
+    type: command
+    short-summary: Delete blobs from a blob container recursively.
+    parameters:
+        - name: --source -s
+          type: string
+          short-summary: The blob container from where the files will be deleted.
+          long-summary: The source can be the container URL or the container name. When the source is the container URL, the storage
+            account name will parsed from the URL.
+        - name: --pattern
+          type: string
+          short-summary: The pattern used for globbing files or blobs in the source. The supported patterns are '*', '?', '[seq]', and '[!seq]'.
+        - name: --dryrun
+          type: bool
+          short-summary: Show the summary of the operations to be taken instead of actually deleting the file(s).
+        - name: --if-match
+          type: string
+          short-summary: An ETag value, or the wildcard character (*). Specify this header to perform the operation \
+only if the resource's ETag matches the value specified.
+        - name: --if-none-match
+          type: string
+          short-summary: An ETag value, or the wildcard character (*).
+          long-summary: Specify this header to perform the operation only if the resource's ETag does not match the value specified.
+            Specify the wildcard character (*) to perform the operation only if the resource does not exist, and fail the operation if it does exist.
+
+"""
 helps['storage blob copy start-batch'] = """
     type: command
     short-summary: Copy multiple blobs or files to a blob container.
@@ -416,7 +489,7 @@ helps['storage file download-batch'] = """
           short-summary: The local directory where the files are downloaded to. This directory must already exist.
         - name: --pattern
           type: string
-          short-summary: The pattern used for file globbing. The supported patterns are '*', '?', '[seq', and '[!seq]'.
+          short-summary: The pattern used for file globbing. The supported patterns are '*', '?', '[seq]', and '[!seq]'.
         - name: --dryrun
           type: bool
           short-summary: List the files and blobs to be downloaded. No actual data transfer will occur.
@@ -429,6 +502,21 @@ helps['storage file download-batch'] = """
           long-summary: >
             The storage service checks the hash of the content that has arrived is identical to the hash that was sent.
             This is mostly valuable for detecting bitflips during transfer if using HTTP instead of HTTPS. This hash is not stored.
+"""
+
+helps['storage file delete-batch'] = """
+    type: command
+    short-summary: Delete files from an Azure Storage File Share.
+    parameters:
+        - name: --source -s
+          type: string
+          short-summary: The source of the file delete operation. The source can be the file share URL or the share name.
+        - name: --pattern
+          type: string
+          short-summary: The pattern used for file globbing. The supported patterns are '*', '?', '[seq]', and '[!seq]'.
+        - name: --dryrun
+          type: bool
+          short-summary: List the files and blobs to be deleted. No actual data transfer will occur.
 """
 
 helps['storage file copy start-batch'] = """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -31,6 +31,7 @@ from ._validators import \
      validate_custom_domain, validate_public_access,
      process_blob_upload_batch_parameters, process_blob_download_batch_parameters,
      process_file_upload_batch_parameters, process_file_download_batch_parameters,
+     process_blob_delete_batch_parameters,
      get_content_setting_validator, validate_encryption_services, validate_accept,
      validate_key, storage_account_key_options, validate_encryption_source,
      process_file_download_namespace,
@@ -450,6 +451,14 @@ register_cli_argument('storage blob download-batch', 'source', options_list=('--
                       validator=process_blob_download_batch_parameters)
 
 register_cli_argument('storage blob download-batch', 'source_container_name', ignore_type)
+
+
+# BLOB DELETE-BATCH PARAMETERS
+register_cli_argument('storage blob delete-batch', 'source', options_list=('--source', '-s'),
+                      validator=process_blob_delete_batch_parameters)
+
+register_cli_argument('storage blob delete-batch', 'source_container_name', ignore_type)
+
 
 # BLOB UPLOAD-BATCH PARAMETERS
 register_cli_argument('storage blob upload-batch', 'destination', options_list=('--destination', '-d'))

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -31,7 +31,7 @@ from ._validators import \
      validate_custom_domain, validate_public_access,
      process_blob_upload_batch_parameters, process_blob_download_batch_parameters,
      process_file_upload_batch_parameters, process_file_download_batch_parameters,
-     process_blob_delete_batch_parameters,
+     process_blob_batch_source_parameters, process_file_batch_source_parameters,
      get_content_setting_validator, validate_encryption_services, validate_accept,
      validate_key, storage_account_key_options, validate_encryption_source,
      process_file_download_namespace,
@@ -455,9 +455,10 @@ register_cli_argument('storage blob download-batch', 'source_container_name', ig
 
 # BLOB DELETE-BATCH PARAMETERS
 register_cli_argument('storage blob delete-batch', 'source', options_list=('--source', '-s'),
-                      validator=process_blob_delete_batch_parameters)
+                      validator=process_blob_batch_source_parameters)
 
 register_cli_argument('storage blob delete-batch', 'source_container_name', ignore_type)
+register_cli_argument('storage blob delete-batch', 'delete_snapshots', **enum_choice_list(list(delete_snapshot_types.keys())))
 
 
 # BLOB UPLOAD-BATCH PARAMETERS
@@ -527,6 +528,10 @@ with CommandContext('storage file download-batch') as c:
 
         with VersionConstraint(ResourceType.DATA_STORAGE, min_api='2016-05-31') as vc:
             vc.register_cli_argument('storage file download-batch', 'validate_content')
+
+# FILE DELETE-BATCH PARAMETERS
+with CommandContext('storage file delete-batch') as c:
+    c.reg_arg('source', options_list=('--source', '-s'), validator=process_file_batch_source_parameters)
 
 # FILE COPY-BATCH PARAMETERS
 with CommandContext('storage file copy start-batch') as c:

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -686,6 +686,23 @@ def process_blob_download_batch_parameters(namespace):
             namespace.account_name = identifier.account_name
 
 
+def process_blob_delete_batch_parameters(namespace):
+    """Process the parameters for storage blob download command"""
+
+    # try to extract account name and container name from source string
+    from .storage_url_helpers import StorageResourceIdentifier
+    identifier = StorageResourceIdentifier(namespace.source)
+
+    if not identifier.is_url():
+        namespace.source_container_name = namespace.source
+    elif identifier.blob:
+        raise ValueError('incorrect usage: source should be either container URL or name')
+    else:
+        namespace.source_container_name = identifier.container
+        if namespace.account_name is None:
+            namespace.account_name = identifier.account_name
+
+
 def process_blob_upload_batch_parameters(namespace):
     """Process the source and destination of storage blob upload command"""
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -673,20 +673,10 @@ def process_blob_download_batch_parameters(namespace):
         raise ValueError('incorrect usage: destination must be an existing directory')
 
     # 2. try to extract account name and container name from source string
-    from .storage_url_helpers import StorageResourceIdentifier
-    identifier = StorageResourceIdentifier(namespace.source)
-
-    if not identifier.is_url():
-        namespace.source_container_name = namespace.source
-    elif identifier.blob:
-        raise ValueError('incorrect usage: source should be either container URL or name')
-    else:
-        namespace.source_container_name = identifier.container
-        if namespace.account_name is None:
-            namespace.account_name = identifier.account_name
+    process_blob_batch_source_parameters(namespace)
 
 
-def process_blob_delete_batch_parameters(namespace):
+def process_blob_batch_source_parameters(namespace):
     """Process the parameters for storage blob download command"""
 
     # try to extract account name and container name from source string
@@ -800,6 +790,10 @@ def process_file_download_batch_parameters(namespace):
         raise ValueError('incorrect usage: destination must be an existing directory')
 
     # 2. try to extract account name and share name from source string
+    process_file_batch_source_parameters(namespace)
+
+
+def process_file_batch_source_parameters(namespace):
     from .storage_url_helpers import StorageResourceIdentifier
     identifier = StorageResourceIdentifier(namespace.source)
     if identifier.is_url():

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
@@ -90,25 +90,6 @@ def storage_blob_copy_batch(client, source_client,
 
 # pylint: disable=unused-argument
 def storage_blob_download_batch(client, source, destination, source_container_name, pattern=None, dryrun=False):
-    """
-    Download blobs in a container recursively
-
-    :param str source:
-        The string represents the source of this download operation. The source can be the
-        container URL or the container name. When the source is the container URL, the storage
-        account name will parsed from the URL.
-
-    :param str destination:
-        The string represents the destination folder of this download operation. The folder must
-        exist.
-
-    :param bool dryrun:
-        Show the summary of the operations to be taken instead of actually download the file(s)
-
-    :param str pattern:
-        The pattern is used for files globbing. The supported patterns are '*', '?', '[seq]',
-        and '[!seq]'.
-    """
     source_blobs = list(collect_blobs(client, source_container_name, pattern))
 
     if dryrun:
@@ -131,34 +112,6 @@ def storage_blob_upload_batch(client, source, destination, pattern=None, source_
                               maxsize_condition=None, max_connections=2, lease_id=None,
                               if_modified_since=None, if_unmodified_since=None, if_match=None,
                               if_none_match=None, timeout=None, dryrun=False):
-    """
-    Upload files to storage container as blobs
-
-    :param str source:
-        The directory where the files to be uploaded.
-
-    :param str destination:
-        The string represents the destination of this upload operation. The source can be the
-        container URL or the container name. When the source is the container URL, the storage
-        account name will parsed from the URL.
-
-    :param str pattern:
-        The pattern is used for files globbing. The supported patterns are '*', '?', '[seq]',
-        and '[!seq]'.
-
-    :param bool dryrun:
-        Show the summary of the operations to be taken instead of actually upload the file(s)
-
-    :param string if_match:
-        An ETag value, or the wildcard character (*). Specify this header to perform the operation
-        only if the resource's ETag matches the value specified.
-
-    :param string if_none_match:
-        An ETag value, or the wildcard character (*). Specify this header to perform the
-        operation only if the resource's ETag does not match the value specified. Specify the
-        wildcard character (*) to perform the operation only if the resource does not exist,
-        and fail the operation if it does exist.
-    """
 
     def _append_blob(file_path, blob_name, blob_content_settings):
         if not client.exists(destination_container_name, blob_name):
@@ -244,21 +197,6 @@ def storage_blob_upload_batch(client, source, destination, pattern=None, source_
 def storage_blob_delete_batch(client, source, source_container_name, pattern=None, lease_id=None,
                               delete_snapshots=None, if_modified_since=None, if_unmodified_since=None, if_match=None,
                               if_none_match=None, timeout=None, dryrun=False):
-    """
-    Delete blobs in a container recursively
-
-    :param str source:
-        The string represents the source of this delete operation. The source can be the
-        container URL or the container name. When the source is the container URL, the storage
-        account name will parsed from the URL.
-
-    :param bool dryrun:
-        Show the summary of the operations to be taken instead of actually delete the file(s)
-
-    :param str pattern:
-        The pattern is used for files globbing. The supported patterns are '*', '?', '[seq]',
-        and '[!seq]'.
-    """
 
     def _delete_blob(blob_name):
         delete_blob_args = {
@@ -274,6 +212,7 @@ def storage_blob_delete_batch(client, source, source_container_name, pattern=Non
         }
         response = client.delete_blob(**delete_blob_args)
         return response
+
     source_blobs = list(collect_blobs(client, source_container_name, pattern))
 
     if dryrun:

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
@@ -99,7 +99,7 @@ def storage_blob_download_batch(client, source, destination, source_container_na
         logger.warning('  container %s', source_container_name)
         logger.warning('      total %d', len(source_blobs))
         logger.warning(' operations')
-        for b in source_blobs or []:
+        for b in source_blobs:
             logger.warning('  - %s', b)
         return []
 
@@ -222,7 +222,7 @@ def storage_blob_delete_batch(client, source, source_container_name, pattern=Non
         logger.warning('  container %s', source_container_name)
         logger.warning('      total %d', len(source_blobs))
         logger.warning(' operations')
-        for blob in source_blobs or []:
+        for blob in source_blobs:
             logger.warning('  - %s', blob)
         return []
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -183,6 +183,7 @@ cli_storage_data_plane_command('storage file copy start', file_service_path + 'c
 cli_storage_data_plane_command('storage file copy cancel', file_service_path + 'abort_copy_file', factory)
 cli_storage_data_plane_command('storage file upload-batch', 'azure.cli.command_modules.storage.file#storage_file_upload_batch', factory)
 cli_storage_data_plane_command('storage file download-batch', 'azure.cli.command_modules.storage.file#storage_file_download_batch', factory)
+cli_storage_data_plane_command('storage file delete-batch', 'azure.cli.command_modules.storage.file#storage_file_delete_batch', factory)
 cli_storage_data_plane_command('storage file copy start-batch', 'azure.cli.command_modules.storage.file#storage_file_copy_batch', factory)
 
 # table commands

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -129,6 +129,7 @@ cli_storage_data_plane_command('storage blob copy start-batch', 'azure.cli.comma
 cli_storage_data_plane_command('storage blob copy cancel', block_blob_path + 'abort_copy_blob', factory)
 cli_storage_data_plane_command('storage blob upload-batch', 'azure.cli.command_modules.storage.blob#storage_blob_upload_batch', factory)
 cli_storage_data_plane_command('storage blob download-batch', 'azure.cli.command_modules.storage.blob#storage_blob_download_batch', factory)
+cli_storage_data_plane_command('storage blob delete-batch', 'azure.cli.command_modules.storage.blob#storage_blob_delete_batch', factory)
 cli_storage_data_plane_command('storage blob set-tier', custom_path + 'set_blob_tier', factory)
 
 # page blob commands

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/file.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/file.py
@@ -211,11 +211,9 @@ def storage_file_delete_batch(client, source, pattern=None, dryrun=False, timeou
         return client.delete_file(**delete_file_args)
 
     from .util import glob_files_remotely
-    source_files = glob_files_remotely(client, source, pattern)
+    source_files = list(glob_files_remotely(client, source, pattern))
 
     if dryrun:
-        # source_files_list = list(source_files)
-
         logger = get_az_logger(__name__)
         logger.warning('delete files from %s', source)
         logger.warning('    pattern %s', pattern)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/file.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/file.py
@@ -32,7 +32,7 @@ def storage_file_upload_batch(client, destination, source, pattern=None, dryrun=
         logger.info('upload files to file share')
         logger.info('    account %s', client.account_name)
         logger.info('      share %s', destination)
-        logger.info('      total %d', len(source_files or []))
+        logger.info('      total %d', len(source_files))
         return [{'File': client.make_file_url(destination, os.path.dirname(src), os.path.basename(dst)),
                  'Type': guess_content_type(src, content_settings, settings_class).content_type}
                 for src, dst in source_files]

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_batch_operations.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_batch_operations.py
@@ -245,11 +245,7 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
             src_container = self.create_container(storage_account_info)
 
             # upload test files to storage account
-            self.storage_cmd('storage blob upload-batch -s "{}"',
-                            storage_account_info, test_dir, src_container)
-            self.storage_cmd('storage blob list -c {}', storage_account_info, src_container) \
-                .assert_with_checks(JMESPathCheck('length(@)', 41))
-            
+            self.storage_cmd('storage blob upload-batch -s "{}" -d {}', storage_account_info, test_dir, src_container)
             return src_container
 
         # delete recursively without pattern
@@ -268,13 +264,58 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
 
         # delete recursively with wild card after dir
         src_container = create_and_populate_container()
-        self.storage_cmd('storage blob delete-batch -s {} --pattern {}', storage_account_info, src_container,
-                         'apple/*').assert_with_checks(JMESPathCheck('length(@)', 10))
+        self.storage_cmd('storage blob delete-batch -s {} --pattern apple/*', storage_account_info,
+                         src_container).assert_with_checks(JMESPathCheck('length(@)', 10))
 
         # delete recursively with wild card before name
         src_container = create_and_populate_container()
-        self.storage_cmd('storage blob delete-batch -s {} --pattern {}', storage_account_info, src_container,
-                         '*/file_0').assert_with_checks(JMESPathCheck('length(@)', 4))
+        self.storage_cmd('storage blob delete-batch -s {} --pattern */file_0', storage_account_info,
+                         src_container).assert_with_checks(JMESPathCheck('length(@)', 4))
+
+        # delete recursively with non-existing pattern
+        src_container = create_and_populate_container()
+        self.storage_cmd('storage blob delete-batch -s {} --pattern nonexists/*', storage_account_info,
+                         src_container).assert_with_checks(JMESPathCheck('length(@)', 0))
+
+    @ResourceGroupPreparer()
+    @StorageAccountPreparer()
+    @StorageTestFilesPreparer()
+    def test_storage_file_batch_delete_scenarios(self, test_dir, storage_account_info):
+        def create_and_populate_share():
+            src_share = self.create_share(storage_account_info)
+
+            # upload test files to storage account
+            self.storage_cmd('storage file upload-batch -s "{}" -d {}', storage_account_info, test_dir, src_share)
+            return src_share
+
+        # delete recursively without pattern
+        src_share = create_and_populate_share()
+        cmd = 'storage file delete-batch -s {}'.format(src_share)
+        self.storage_cmd(cmd, storage_account_info).assert_with_checks(JMESPathCheck('length(@)', 41))
+
+        # delete recursively with wild card *, and use URL as source
+        src_share = create_and_populate_share()
+        src_url = self.storage_cmd('storage file url -s {} -p readme -otsv', storage_account_info, src_share).output
+        src_url = src_url[:src_url.rfind('/')]
+
+        self.storage_cmd('storage file delete-batch -s {} --pattern *', storage_account_info,
+                         src_url).assert_with_checks(JMESPathCheck('length(@)', 41))
+
+        # delete recursively with wild card after dir
+        src_share = create_and_populate_share()
+        self.storage_cmd('storage file delete-batch -s {} --pattern apple/*', storage_account_info,
+                         src_share).assert_with_checks(JMESPathCheck('length(@)', 10))
+
+        # delete recursively with wild card before name
+        src_share = create_and_populate_share()
+        self.storage_cmd('storage file delete-batch -s {} --pattern */file_0', storage_account_info,
+                         src_share).assert_with_checks(JMESPathCheck('length(@)', 4))
+
+        # delete recursively with non-existing pattern
+        src_share = create_and_populate_share()
+        self.storage_cmd('storage file delete-batch -s {} --pattern nonexists/*', storage_account_info,
+                         src_share).assert_with_checks(JMESPathCheck('length(@)', 0))
+
 
 if __name__ == '__main__':
     import unittest

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_batch_operations.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_batch_operations.py
@@ -237,6 +237,44 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
                          local_folder)
         self.assertEqual(expect_file_count, sum(len(f) for r, d, f in os.walk(local_folder)))
 
+    @ResourceGroupPreparer()
+    @StorageAccountPreparer()
+    @StorageTestFilesPreparer()
+    def test_storage_blob_batch_delete_scenarios(self, test_dir, storage_account_info):
+        def create_and_populate_container():
+            src_container = self.create_container(storage_account_info)
+
+            # upload test files to storage account
+            self.storage_cmd('storage blob upload-batch -s "{}"',
+                            storage_account_info, test_dir, src_container)
+            self.storage_cmd('storage blob list -c {}', storage_account_info, src_container) \
+                .assert_with_checks(JMESPathCheck('length(@)', 41))
+            
+            return src_container
+
+        # delete recursively without pattern
+        src_container = create_and_populate_container()
+        cmd = 'storage blob delete-batch -s {}'.format(src_container)
+        self.storage_cmd(cmd, storage_account_info).assert_with_checks(JMESPathCheck('length(@)', 41))
+
+        # delete recursively with wild card *, and use URL as source
+        src_container = create_and_populate_container()
+        src_url = self.storage_cmd('storage blob url -c {} -n readme -otsv', storage_account_info,
+                                   src_container).output
+        src_url = src_url[:src_url.rfind('/')]
+
+        self.storage_cmd('storage blob delete-batch -s {} --pattern *',
+                         storage_account_info, src_url).assert_with_checks(JMESPathCheck('length(@)', 41))
+
+        # delete recursively with wild card after dir
+        src_container = create_and_populate_container()
+        self.storage_cmd('storage blob delete-batch -s {} --pattern {}', storage_account_info, src_container,
+                         'apple/*').assert_with_checks(JMESPathCheck('length(@)', 10))
+
+        # delete recursively with wild card before name
+        src_container = create_and_populate_container()
+        self.storage_cmd('storage blob delete-batch -s {} --pattern {}', storage_account_info, src_container,
+                         '*/file_0').assert_with_checks(JMESPathCheck('length(@)', 4))
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
---
Closes: https://github.com/Azure/azure-cli/issues/3757

delete-batch commands will delete multiple files/blobs using a pattern to glob
deletes will use the same connection and hence be faster then running a delete command for each file/blob.

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [y ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [y ] Each command and parameter has a meaningful description.
- [y ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
