### PR TITLE
Remove some mock in ACS tests

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_custom.py
@@ -59,9 +59,9 @@ class AcsCustomCommandTest(unittest.TestCase):
 
         with mock.patch(
                 'azure.cli.command_modules.acs.custom.create_role_assignment') as create_role_assignment:
-            resp = mock.create_autospec(requests.Response)
+            resp = requests.Response()
             resp.status_code = 409
-            resp.text = 'Conflict'
+            resp._content = b'Conflict'
             err = CloudError(resp)
             err.message = 'The role assignment already exists.'
             create_role_assignment.side_effect = err
@@ -76,9 +76,9 @@ class AcsCustomCommandTest(unittest.TestCase):
 
         with mock.patch(
                 'azure.cli.command_modules.acs.custom.create_role_assignment') as create_role_assignment:
-            resp = mock.create_autospec(requests.Response)
+            resp = requests.Response()
             resp.status_code = 500
-            resp.text = 'Internal Error'
+            resp._content = b'Internal Error'
             err = CloudError(resp)
             err.message = 'Internal Error'
             create_role_assignment.side_effect = err


### PR DESCRIPTION
Already merged in "dev":
https://github.com/Azure/azure-cli/pull/4792

But if don't do it  in "master" as well, next msrest will break master.

@troydai please confirm you want this PR to master merged.