### PR TITLE
appservice: support assign managed service identity to webapp/functionapp

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -801,6 +801,7 @@ def resolve_role_id(role, scope):
             role_id = role_defs[0].id
     return role_id
 
+
 def _gen_guid():
     import uuid
     return uuid.uuid4()

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -780,7 +780,7 @@ def resolve_role_id(role, scope):
     client = get_mgmt_service_client(AuthorizationManagementClient).role_definitions
 
     role_id = None
-    if re.match(r'/subscriptions/.+/providers/Microsoft.Authorization/roleDefinitions/',
+    if re.match(r'/subscriptions/[^/]+/providers/Microsoft.Authorization/roleDefinitions/',
                 role, re.I):
         role_id = role
     else:

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -44,6 +44,20 @@ helps['webapp auth update'] = """
           --facebook-oauth-scopes public_profile email
 """
 
+helps['webapp assign-identity'] = """
+    type: command
+    short-summary: (PREVIEW)assign managed service identity to the webapp
+    examples:
+        - name: assign local identity and assign a reader role to the current resource group.
+          text: >
+            az webapp assign-identity -g MyResourceGroup -n MyUniqueApp --role reader --scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/MyResourceGroup
+        - name: disable the identity when there is need.
+          text: >
+            az webapp config appsettings set -g MyResourceGroup -n MyUniqueApp --settings WEBSITE_DISABLE_MSI=true
+"""
+
+helps['functionapp assign-identity'] = helps['webapp assign-identity'].replace('webapp', 'functionapp')
+
 helps['webapp config'] = """
 type: group
 short-summary: Configure a web app.

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -46,7 +46,7 @@ helps['webapp auth update'] = """
 
 helps['webapp assign-identity'] = """
     type: command
-    short-summary: (PREVIEW)assign managed service identity to the webapp
+    short-summary: (PREVIEW) assign managed service identity to the webapp
     examples:
         - name: assign local identity and assign a reader role to the current resource group.
           text: >

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -144,6 +144,8 @@ for scope in ['webapp', 'functionapp']:
     register_cli_argument(scope + ' create', 'deployment_source_url', options_list=('--deployment-source-url', '-u'), help='Git repository URL to link with manual integration')
     register_cli_argument(scope + ' create', 'deployment_source_branch', options_list=('--deployment-source-branch', '-b'), help='the branch to deploy')
     register_cli_argument(scope + ' assign-identity', 'disable_msi', action='store_true', help='disable the identity')
+    register_cli_argument(scope + ' assign-identity', 'scope', help="The scope the managed identity has access to")
+    register_cli_argument(scope + ' assign-identity', 'role', help="Role name or id the managed identity will be assigned")
 
 register_cli_argument('webapp config hostname', 'webapp_name', help="webapp name. You can configure the default using 'az configure --defaults web=<name>'", configured_default='web',
                       completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -143,6 +143,7 @@ for scope in ['webapp', 'functionapp']:
     register_cli_argument(scope + ' create', 'deployment_zip', options_list=('--deployment-zip', '-z'), help='perform deployment using zip file')
     register_cli_argument(scope + ' create', 'deployment_source_url', options_list=('--deployment-source-url', '-u'), help='Git repository URL to link with manual integration')
     register_cli_argument(scope + ' create', 'deployment_source_branch', options_list=('--deployment-source-branch', '-b'), help='the branch to deploy')
+    register_cli_argument(scope + ' assign-identity', 'disable_msi', action='store_true', help='disable the identity')
 
 register_cli_argument('webapp config hostname', 'webapp_name', help="webapp name. You can configure the default using 'az configure --defaults web=<name>'", configured_default='web',
                       completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -188,3 +188,4 @@ if not supported_api_version(PROFILE_TYPE, max_api='2017-03-09-profile'):
     cli_command(__name__, 'functionapp deployment list-publishing-profiles',
                 custom_path + 'list_publish_profiles')
     cli_command(__name__, 'functionapp deployment user show', 'azure.mgmt.web.web_site_management_client#WebSiteManagementClient.get_publishing_user', cf_web_client, exception_handler=empty_on_404)
+    cli_command(__name__, 'functionapp assign-identity', custom_path + 'assign_identity')

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -144,6 +144,7 @@ cli_command(__name__, 'webapp list-runtimes', custom_path + 'list_runtimes')
 cli_command(__name__, 'webapp auth show', custom_path + 'get_auth_settings')
 cli_command(__name__, 'webapp auth update', custom_path + 'update_auth_settings')
 
+cli_command(__name__, 'webapp assign-identity', custom_path + 'assign_identity')
 
 if not supported_api_version(PROFILE_TYPE, max_api='2017-03-09-profile'):
     cli_command(__name__, 'appservice plan create', custom_path + 'create_app_service_plan', exception_handler=ex_handler_factory(creating_plan=True))

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/latest/test_assign_identity.yaml
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/latest/test_assign_identity.yaml
@@ -1,0 +1,1486 @@
+interactions:
+- request:
+    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 03 Nov 2017 20:28:54 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [appservice plan create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 03 Nov 2017 20:28:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"sku": {"capacity": 1, "name": "B1", "tier": "BASIC"}, "location":
+      "westus", "properties": {"name": "web-msi-plan000002", "perSiteScaling": false}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [appservice plan create]
+      Connection: [keep-alive]
+      Content-Length: ['150']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 websitemanagementclient/0.34.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","name":"web-msi-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        US","properties":{"serverFarmId":0,"name":"web-msi-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-085_3483","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1366']
+      content-type: [application/json]
+      date: ['Fri, 03 Nov 2017 20:29:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 websitemanagementclient/0.34.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","name":"web-msi-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        US","properties":{"serverFarmId":0,"name":"web-msi-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-085_3483","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1366']
+      content-type: [application/json]
+      date: ['Fri, 03 Nov 2017 20:29:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''b\''{"location": "West US", "properties": {"scmSiteAlsoStopped": false,
+      "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002",
+      "siteConfig": {"appSettings": [], "netFrameworkVersion": "v4.6", "localMySqlEnabled":
+      false}, "reserved": false}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp create]
+      Connection: [keep-alive]
+      Content-Length: ['400']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 websitemanagementclient/0.34.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-085.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2017-11-03T20:29:34.6566667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.53.219,104.42.226.43,104.42.227.57,104.42.228.164,104.42.230.5","possibleOutboundIpAddresses":"104.40.53.219,104.42.226.43,104.42.227.57,104.42.228.164,104.42.230.5,104.42.229.180,104.42.227.131","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-085","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3089']
+      content-type: [application/json]
+      date: ['Fri, 03 Nov 2017 20:29:37 GMT']
+      etag: ['"1D354E27670F795"']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp create]
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 websitemanagementclient/0.34.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/publishxml?api-version=2016-08-01
+  response:
+    body: {string: '<publishData><publishProfile profileName="web-msi000003 - Web
+        Deploy" publishMethod="MSDeploy" publishUrl="web-msi000003.scm.azurewebsites.net:443"
+        msdeploySite="web-msi000003" userName="$web-msi000003" userPWD="L3kvu2x8QRuHA14dBrAkzYvpDSJk9jA8ljKmdEl0ycMGwYoYlG27suLviK7M"
+        destinationAppUrl="http://web-msi000003.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-msi000003
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-085.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-msi000003\$web-msi000003" userPWD="L3kvu2x8QRuHA14dBrAkzYvpDSJk9jA8ljKmdEl0ycMGwYoYlG27suLviK7M"
+        destinationAppUrl="http://web-msi000003.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile></publishData>'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1114']
+      content-type: [application/xml]
+      date: ['Fri, 03 Nov 2017 20:29:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp assign-identity]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 websitemanagementclient/0.34.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-085.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2017-11-03T20:29:35.0333333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.53.219,104.42.226.43,104.42.227.57,104.42.228.164,104.42.230.5","possibleOutboundIpAddresses":"104.40.53.219,104.42.226.43,104.42.227.57,104.42.228.164,104.42.230.5,104.42.229.180,104.42.227.131","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-085","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3089']
+      content-type: [application/json]
+      date: ['Fri, 03 Nov 2017 20:29:40 GMT']
+      etag: ['"1D354E27670F795"']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''b\''b\\\''{"kind": "app", "location": "West US", "properties": {"httpsOnly":
+      false, "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002",
+      "enabled": true, "containerSize": 0, "hostNamesDisabled": false, "scmSiteAlsoStopped":
+      false, "clientCertEnabled": false, "reserved": false, "hostNameSslStates": [{"hostType":
+      "Standard", "name": "web-msi000003.azurewebsites.net", "sslState": "Disabled"},
+      {"hostType": "Repository", "name": "web-msi000003.scm.azurewebsites.net", "sslState":
+      "Disabled"}], "clientAffinityEnabled": true, "dailyMemoryTimeQuota": 0}, "identity":
+      {"type": "SystemAssigned"}}\\\''\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp assign-identity]
+      Connection: [keep-alive]
+      Content-Length: ['761']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 websitemanagementclient/0.34.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-085.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2017-11-03T20:29:43.4233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.53.219,104.42.226.43,104.42.227.57,104.42.228.164,104.42.230.5","possibleOutboundIpAddresses":"104.40.53.219,104.42.226.43,104.42.227.57,104.42.228.164,104.42.230.5,104.42.229.180,104.42.227.131","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-085","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false},"identity":{"type":"SystemAssigned","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3229']
+      content-type: [application/json]
+      date: ['Fri, 03 Nov 2017 20:29:43 GMT']
+      etag: ['"1D354E27B712DF5"']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp assign-identity]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27reader%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
+        you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-08-19T00:03:56.0652623Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['578']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 03 Nov 2017 20:29:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"principalId": "7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c",
+      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp assign-identity]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46667?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 7e98bce88f3b4aaeaad1c4bb3e07a25c
+        does not exist in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 03 Nov 2017 20:29:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"properties": {"principalId": "7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c",
+      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp assign-identity]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46667?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 7e98bce88f3b4aaeaad1c4bb3e07a25c
+        does not exist in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 03 Nov 2017 20:29:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"properties": {"principalId": "7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c",
+      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp assign-identity]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46667?api-version=2015-07-01
+  response:
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001","createdOn":"2017-11-03T20:30:02.1302435Z","updatedOn":"2017-11-03T20:30:02.1302435Z","createdBy":null,"updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46667","type":"Microsoft.Authorization/roleAssignments","name":"88daaf5a-ea86-4a68-9d45-477538d46667"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['868']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 03 Nov 2017 20:30:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp assign-identity]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 websitemanagementclient/0.34.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","properties":{}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['315']
+      content-type: [application/json]
+      date: ['Fri, 03 Nov 2017 20:30:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"kind": "<class ''str''>", "properties": {"WEBSITE_DISABLE_MSI": "False"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp assign-identity]
+      Connection: [keep-alive]
+      Content-Length: ['73']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 websitemanagementclient/0.34.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","properties":{"WEBSITE_DISABLE_MSI":"False"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['344']
+      content-type: [application/json]
+      date: ['Fri, 03 Nov 2017 20:30:09 GMT']
+      etag: ['"1D354E28AFEB4CB"']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [role assignment list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%277e98bce8-8f3b-4aae-aad1-c4bb3e07a25c%27%29&api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['166']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Fri, 03 Nov 2017 20:30:09 GMT']
+      duration: ['615345']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [SwKd16gk0qQHqjuDH5ZMkxgOMor4FyG3yLeRoPVHqag=]
+      ocp-aad-session-key: [6TOPP0qsVgaM5L-uLHZMYACB-rwESmieAo68ksOFTnxuI8A_yxal2rQvFC6vfu4SrhW22BK1hq1Qmz_2gFJRpjZZipfgAJLPFue6_-0UvOJCc60SstTEFH2utpHcvRX9.3jaKBff8LUU_J2nMBITE4VJYm1D7tVQaAfa3ozZLjrU]
+      pragma: [no-cache]
+      request-id: [c16d0fdd-27e3-4a16-8cf5-7e19d126f657]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"objectIds": ["7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c"], "includeDirectoryObjectReferences":
+      true}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [role assignment list]
+      Connection: [keep-alive]
+      Content-Length: ['97']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003"],"appDisplayName":null,"appId":"d6cb63e1-1fa8-4f8e-a00e-b2bacb693d03","appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"web-msi000003","errorUrl":null,"homepage":null,"keyCredentials":[{"customKeyIdentifier":null,"endDate":"2018-02-01T20:24:00Z","keyId":"885c798c-388f-4b02-a7d1-c8ca8f4eedff","startDate":"2017-11-03T20:24:00Z","type":"AsymmetricX509Cert","usage":"Verify","value":null}],"logoutUrl":null,"oauth2Permissions":[],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["d6cb63e1-1fa8-4f8e-a00e-b2bacb693d03","https://identity.azure.net/+C/xZ+jmHnAl4EXdYCSPYZWldZ+w6Iva3oNBw8zA2kk="],"servicePrincipalType":"ServiceAccount","tags":[],"tokenEncryptionKeyId":null}]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1354']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Fri, 03 Nov 2017 20:30:10 GMT']
+      duration: ['826458']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [2/OO1DBlsN9Tt3bUcO4UhTMA41ZH6bC9vTECDGTrVeQ=]
+      ocp-aad-session-key: [PoIT_t3yqC1PJdrau5EhHYah1pQxcibThswFyTOMA_VtInr2THY7RsgUQFB0jejnWBlT6BTe0UdrfzS6IHEU_Q12brrjEtZO4smngdi_XIYP7OEgmXoic_KxR_LCxn6u.e5HKZlEzlfH1Z7bAsioWlIxkf80XIJYKiN1sb1QDpXM]
+      pragma: [no-cache]
+      request-id: [ef7fa073-fe10-47ff-851f-ab6a38099843]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [role assignment list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%277e98bce8-8f3b-4aae-aad1-c4bb3e07a25c%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001","createdOn":"2017-11-03T20:30:06.2086686Z","updatedOn":"2017-11-03T20:30:06.2086686Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46667","type":"Microsoft.Authorization/roleAssignments","name":"88daaf5a-ea86-4a68-9d45-477538d46667"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['914']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 03 Nov 2017 20:30:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [role assignment list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01
+  response:
+    body: {string: "{\"value\":[{\"properties\":{\"roleName\":\"API Management Service\
+        \ Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can manage service\
+        \ and the APIs\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.ApiManagement/service/*\",\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2017-01-23T23:12:00.5823195Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/312a565d-c81f-4fd8-895a-4e21e48d571c\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"312a565d-c81f-4fd8-895a-4e21e48d571c\"\
+        },{\"properties\":{\"roleName\":\"API Management Service Operator Role\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Can manage service but not the APIs\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ApiManagement/service/*/read\"\
+        ,\"Microsoft.ApiManagement/service/backup/action\",\"Microsoft.ApiManagement/service/delete\"\
+        ,\"Microsoft.ApiManagement/service/managedeployments/action\",\"Microsoft.ApiManagement/service/read\"\
+        ,\"Microsoft.ApiManagement/service/restore/action\",\"Microsoft.ApiManagement/service/updatecertificate/action\"\
+        ,\"Microsoft.ApiManagement/service/updatehostname/action\",\"Microsoft.ApiManagement/service/write\"\
+        ,\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[\"Microsoft.ApiManagement/service/users/keys/read\"]}],\"\
+        createdOn\":\"2016-11-09T00:03:42.1194019Z\",\"updatedOn\":\"2016-11-18T23:56:25.4682649Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e022efe7-f5ba-4159-bbe4-b44f577e9b61\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e022efe7-f5ba-4159-bbe4-b44f577e9b61\"\
+        },{\"properties\":{\"roleName\":\"API Management Service Reader Role\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Read-only access to service and APIs\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ApiManagement/service/*/read\"\
+        ,\"Microsoft.ApiManagement/service/read\",\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.ApiManagement/service/users/keys/read\"\
+        ]}],\"createdOn\":\"2016-11-09T00:26:45.1540473Z\",\"updatedOn\":\"2017-01-23T23:10:34.8876776Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/71522526-b88f-4d52-b57f-d31fc3546d0d\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"71522526-b88f-4d52-b57f-d31fc3546d0d\"\
+        },{\"properties\":{\"roleName\":\"Application Insights Component Contributor\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Can manage Application Insights\
+        \ components\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.Insights/components/*\",\"Microsoft.Insights/webtests/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-11-29T20:30:34.2313394Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ae349356-3a1b-4a5e-921d-050484c6347e\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ae349356-3a1b-4a5e-921d-050484c6347e\"\
+        },{\"properties\":{\"roleName\":\"Application Insights Snapshot Debugger\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Gives user permission to use Application\
+        \ Insights Snapshot Debugger features\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Insights/components/*/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-19T21:25:12.3728747Z\",\"updatedOn\"\
+        :\"2017-04-19T23:34:59.9511581Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/08954f03-6346-4c2e-81c0-ec3a5cfae23b\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"08954f03-6346-4c2e-81c0-ec3a5cfae23b\"\
+        },{\"properties\":{\"roleName\":\"Automation Job Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Create and Manage Jobs using Automation Runbooks.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/read\",\"Microsoft.Automation/automationAccounts/jobs/resume/action\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/stop/action\",\"Microsoft.Automation/automationAccounts/jobs/streams/read\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/suspend/action\",\"Microsoft.Automation/automationAccounts/jobs/write\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-19T20:52:41.0020018Z\",\"updatedOn\"\
+        :\"2017-04-25T01:02:08.3049604Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4fe576fe-1146-4730-92eb-48519fa6bf9f\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4fe576fe-1146-4730-92eb-48519fa6bf9f\"\
+        },{\"properties\":{\"roleName\":\"Automation Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Automation Operators are able to start, stop, suspend,\
+        \ and resume jobs\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Automation/automationAccounts/jobs/read\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/resume/action\",\"Microsoft.Automation/automationAccounts/jobs/stop/action\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/streams/read\",\"Microsoft.Automation/automationAccounts/jobs/suspend/action\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/write\",\"Microsoft.Automation/automationAccounts/jobSchedules/read\"\
+        ,\"Microsoft.Automation/automationAccounts/jobSchedules/write\",\"Microsoft.Automation/automationAccounts/read\"\
+        ,\"Microsoft.Automation/automationAccounts/runbooks/read\",\"Microsoft.Automation/automationAccounts/schedules/read\"\
+        ,\"Microsoft.Automation/automationAccounts/schedules/write\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2015-08-18T01:05:03.3916130Z\",\"updatedOn\"\
+        :\"2016-05-31T23:13:38.5728496Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/d3881f73-407a-4167-8283-e981cbba0404\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"d3881f73-407a-4167-8283-e981cbba0404\"\
+        },{\"properties\":{\"roleName\":\"Automation Runbook Operator\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Read Runbook properties - to be able to create\
+        \ Jobs of the runbook.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Automation/automationAccounts/runbooks/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-19T20:47:49.5640674Z\",\"updatedOn\"\
+        :\"2017-04-25T01:00:45.6444999Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5fb5aef8-1081-4b8e-bb16-9d5d0385bab5\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5fb5aef8-1081-4b8e-bb16-9d5d0385bab5\"\
+        },{\"properties\":{\"roleName\":\"Backup Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage backup service,but can't create vaults\
+        \ and give access to others\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Network/virtualNetworks/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/operationResults/*\",\"\
+        Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/*\",\"\
+        Microsoft.RecoveryServices/Vaults/backupJobs/*\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupManagementMetaData/*\",\"Microsoft.RecoveryServices/Vaults/backupOperationResults/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/*\",\"Microsoft.RecoveryServices/Vaults/backupProtectableItems/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupProtectedItems/*\",\"Microsoft.RecoveryServices/Vaults/backupProtectionContainers/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/certificates/*\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/*\",\"Microsoft.RecoveryServices/Vaults/usages/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupUsageSummaries/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.RecoveryServices/locations/allocatedStamp/read\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupconfig/vaultconfig/*\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupSecurityPIN/*\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-01-03T13:12:15.7321344Z\",\"updatedOn\"\
+        :\"2017-07-07T06:22:36.4530284Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5e467623-bb1f-42f4-a55d-6e525e11384b\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5e467623-bb1f-42f4-a55d-6e525e11384b\"\
+        },{\"properties\":{\"roleName\":\"Backup Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage backup services, except removal of backup,\
+        \ vault creation and giving access to others\",\"assignableScopes\":[\"/\"\
+        ],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Network/virtualNetworks/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/backup/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationsStatus/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/restore/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupJobs/*\",\"Microsoft.RecoveryServices/Vaults/backupJobs/cancel/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupJobs/operationResults/read\",\"\
+        Microsoft.RecoveryServices/Vaults/backupJobs/read\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupManagementMetaData/read\",\"Microsoft.RecoveryServices/Vaults/backupOperationResults/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectableItems/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupProtectableItems/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupProtectionContainers/read\",\"\
+        Microsoft.RecoveryServices/Vaults/backupUsageSummaries/read\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/extendedInformation/write\",\"Microsoft.RecoveryServices/Vaults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/refreshContainers/*\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/provisionInstantItemRecovery/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/revokeInstantItemRecovery/action\"\
+        ,\"Microsoft.RecoveryServices/locations/allocatedStamp/read\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupconfig/vaultconfig/*\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/operationStatus/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/certificates/write\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-01-03T13:21:11.8947640Z\",\"updatedOn\"\
+        :\"2017-09-13T10:34:41.5049784Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00c29273-979b-4161-815c-10b084fb9324\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"00c29273-979b-4161-815c-10b084fb9324\"\
+        },{\"properties\":{\"roleName\":\"Backup Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can view backup services, but can't make changes\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationsStatus/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupJobs/operationResults/read\",\"\
+        Microsoft.RecoveryServices/Vaults/backupJobs/read\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupManagementMetaData/read\",\"Microsoft.RecoveryServices/Vaults/backupOperationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupProtectionContainers/read\",\"\
+        Microsoft.RecoveryServices/Vaults/backupUsageSummaries/read\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupconfig/vaultconfig/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupJobsExport/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/usages/read\"],\"notActions\":[]}],\"\
+        createdOn\":\"2017-01-03T13:18:41.3893065Z\",\"updatedOn\":\"2017-09-13T10:33:25.5814653Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/a795c7a0-d4a2-40c1-ae25-d81f01202912\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"a795c7a0-d4a2-40c1-ae25-d81f01202912\"\
+        },{\"properties\":{\"roleName\":\"Billing Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Allows read access to billing data\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Billing/*/read\",\"Microsoft.Consumption/*/read\",\"Microsoft.Commerce/*/read\"\
+        ,\"Microsoft.Management/managementGroups/read\",\"Microsoft.Support/*\"],\"\
+        notActions\":[]}],\"createdOn\":\"2017-04-25T02:13:38.9054151Z\",\"updatedOn\"\
+        :\"2017-09-19T17:36:32.7624564Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64\"\
+        },{\"properties\":{\"roleName\":\"BizTalk Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage BizTalk services, but not access to them.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.BizTalkServices/BizTalk/*\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\"\
+        :\"2016-05-31T23:13:55.8430061Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5e3c6656-6cfa-4708-81fe-0de47ac73342\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5e3c6656-6cfa-4708-81fe-0de47ac73342\"\
+        },{\"properties\":{\"roleName\":\"CDN Endpoint Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can manage CDN endpoints, but can\u2019t grant access to\
+        \ other users.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\"\
+        ,\"Microsoft.Cdn/profiles/endpoints/*\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:52.6231539Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/426e0c7f-0c7e-4658-b36f-ff54d6c29b45\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"426e0c7f-0c7e-4658-b36f-ff54d6c29b45\"\
+        },{\"properties\":{\"roleName\":\"CDN Endpoint Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can view CDN endpoints, but can\u2019t make changes.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\",\"\
+        Microsoft.Cdn/profiles/endpoints/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:53.1585846Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/871e35f6-b5c1-49cc-a043-bde969a0f2cd\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"871e35f6-b5c1-49cc-a043-bde969a0f2cd\"\
+        },{\"properties\":{\"roleName\":\"CDN Profile Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can manage CDN profiles and their endpoints, but can\u2019\
+        t grant access to other users.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\"\
+        ,\"Microsoft.Cdn/operationresults/*\",\"Microsoft.Cdn/profiles/*\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:53.7051278Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ec156ff8-a8d1-4d15-830c-5b80698ca432\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ec156ff8-a8d1-4d15-830c-5b80698ca432\"\
+        },{\"properties\":{\"roleName\":\"CDN Profile Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can view CDN profiles and their endpoints, but can\u2019\
+        t make changes.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\"\
+        ,\"Microsoft.Cdn/profiles/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:54.2283001Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8f96442b-4075-438f-813d-ad51ab4019af\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8f96442b-4075-438f-813d-ad51ab4019af\"\
+        },{\"properties\":{\"roleName\":\"Classic Network Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage classic networks, but not\
+        \ access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicNetwork/*\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\"\
+        :\"2016-05-31T23:13:56.3934954Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b34d265f-36f7-4a0d-a4d4-e158ca92e90f\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b34d265f-36f7-4a0d-a4d4-e158ca92e90f\"\
+        },{\"properties\":{\"roleName\":\"Classic Storage Account Contributor\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Lets you manage classic storage accounts,\
+        \ but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicStorage/storageAccounts/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:56.9379206Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/86e8f5dc-a6e9-4c67-9d15-de283e8eac25\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"86e8f5dc-a6e9-4c67-9d15-de283e8eac25\"\
+        },{\"properties\":{\"roleName\":\"Classic Storage Account Key Operator Service\
+        \ Role\",\"type\":\"BuiltInRole\",\"description\":\"Classic Storage Account\
+        \ Key Operators are allowed to list and regenerate keys on Classic Storage\
+        \ Accounts\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.ClassicStorage/storageAccounts/listkeys/action\",\"Microsoft.ClassicStorage/storageAccounts/regeneratekey/action\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-13T18:22:52.1461100Z\",\"updatedOn\"\
+        :\"2017-04-13T20:54:03.0505986Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/985d6b00-f706-48f5-a6fe-d0ca12fb668d\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"985d6b00-f706-48f5-a6fe-d0ca12fb668d\"\
+        },{\"properties\":{\"roleName\":\"Classic Virtual Machine Contributor\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Lets you manage classic virtual machines,\
+        \ but not access to them, and not the virtual network or storage account they\u2019\
+        re connected to.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicCompute/domainNames/*\"\
+        ,\"Microsoft.ClassicCompute/virtualMachines/*\",\"Microsoft.ClassicNetwork/networkSecurityGroups/join/action\"\
+        ,\"Microsoft.ClassicNetwork/reservedIps/link/action\",\"Microsoft.ClassicNetwork/reservedIps/read\"\
+        ,\"Microsoft.ClassicNetwork/virtualNetworks/join/action\",\"Microsoft.ClassicNetwork/virtualNetworks/read\"\
+        ,\"Microsoft.ClassicStorage/storageAccounts/disks/read\",\"Microsoft.ClassicStorage/storageAccounts/images/read\"\
+        ,\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.ClassicStorage/storageAccounts/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:57.4788684Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/d73bb868-a0df-4d4d-bd69-98a00b01fccb\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"d73bb868-a0df-4d4d-bd69-98a00b01fccb\"\
+        },{\"properties\":{\"roleName\":\"ClearDB MySQL DB Contributor\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Lets you manage ClearDB MySQL databases,\
+        \ but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ,\"successbricks.cleardb/databases/*\"],\"notActions\":[]}],\"createdOn\"\
+        :\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:13:58.1393839Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9106cda0-8a86-4e81-b686-29a22c54effe\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9106cda0-8a86-4e81-b686-29a22c54effe\"\
+        },{\"properties\":{\"roleName\":\"Contributor\",\"type\":\"BuiltInRole\",\"\
+        description\":\"Lets you manage everything except access to resources.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*\"],\"notActions\"\
+        :[\"Microsoft.Authorization/*/Delete\",\"Microsoft.Authorization/*/Write\"\
+        ,\"Microsoft.Authorization/elevateAccess/Action\"]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-12-14T02:04:45.1393855Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b24988ac-6180-42a0-ab88-20f7382dd24c\"\
+        },{\"properties\":{\"roleName\":\"Cosmos DB Account Reader Role\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Can read Azure Cosmos DB Accounts data\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.DocumentDB/databaseAccounts/*/read\",\"Microsoft.DocumentDB/databaseAccounts/readonlykeys/action\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2017-10-30T17:53:54.6005577Z\"\
+        ,\"updatedOn\":\"2017-10-30T18:07:15.7673112Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fbdf93bf-df7d-467e-a4d2-9458aa1360c8\"\
+        },{\"properties\":{\"roleName\":\"Data Factory Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Create and manage data factories, as well as child resources\
+        \ within them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.DataFactory/dataFactories/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-09-12T19:16:42.3441035Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/673868aa-7521-48a0-acc6-0f60742d39f5\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"673868aa-7521-48a0-acc6-0f60742d39f5\"\
+        },{\"properties\":{\"roleName\":\"Data Lake Analytics Developer\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Lets you submit, monitor, and manage your\
+        \ own jobs but not create or delete Data Lake Analytics accounts.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.BigAnalytics/accounts/*\",\"Microsoft.DataLakeAnalytics/accounts/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.BigAnalytics/accounts/Delete\"\
+        ,\"Microsoft.BigAnalytics/accounts/TakeOwnership/action\",\"Microsoft.BigAnalytics/accounts/Write\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/Delete\",\"Microsoft.DataLakeAnalytics/accounts/TakeOwnership/action\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/Write\",\"Microsoft.DataLakeAnalytics/accounts/dataLakeStoreAccounts/Write\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/dataLakeStoreAccounts/Delete\",\"\
+        Microsoft.DataLakeAnalytics/accounts/storageAccounts/Write\",\"Microsoft.DataLakeAnalytics/accounts/storageAccounts/Delete\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/firewallRules/Write\",\"Microsoft.DataLakeAnalytics/accounts/firewallRules/Delete\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/computePolicies/Write\",\"Microsoft.DataLakeAnalytics/accounts/computePolicies/Delete\"\
+        ]}],\"createdOn\":\"2015-10-20T00:33:29.3115234Z\",\"updatedOn\":\"2017-08-18T00:00:17.0411642Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/47b7735b-770e-4598-a7da-8b91488b4c88\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"47b7735b-770e-4598-a7da-8b91488b4c88\"\
+        },{\"properties\":{\"roleName\":\"DevTest Labs User\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you connect, start, restart, and shutdown your virtual\
+        \ machines in your Azure DevTest Labs.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Compute/availabilitySets/read\"\
+        ,\"Microsoft.Compute/virtualMachines/*/read\",\"Microsoft.Compute/virtualMachines/deallocate/action\"\
+        ,\"Microsoft.Compute/virtualMachines/read\",\"Microsoft.Compute/virtualMachines/restart/action\"\
+        ,\"Microsoft.Compute/virtualMachines/start/action\",\"Microsoft.DevTestLab/*/read\"\
+        ,\"Microsoft.DevTestLab/labs/createEnvironment/action\",\"Microsoft.DevTestLab/labs/claimAnyVm/action\"\
+        ,\"Microsoft.DevTestLab/labs/formulas/delete\",\"Microsoft.DevTestLab/labs/formulas/read\"\
+        ,\"Microsoft.DevTestLab/labs/formulas/write\",\"Microsoft.DevTestLab/labs/policySets/evaluatePolicies/action\"\
+        ,\"Microsoft.DevTestLab/labs/virtualMachines/claim/action\",\"Microsoft.Network/loadBalancers/backendAddressPools/join/action\"\
+        ,\"Microsoft.Network/loadBalancers/inboundNatRules/join/action\",\"Microsoft.Network/networkInterfaces/*/read\"\
+        ,\"Microsoft.Network/networkInterfaces/join/action\",\"Microsoft.Network/networkInterfaces/read\"\
+        ,\"Microsoft.Network/networkInterfaces/write\",\"Microsoft.Network/publicIPAddresses/*/read\"\
+        ,\"Microsoft.Network/publicIPAddresses/join/action\",\"Microsoft.Network/publicIPAddresses/read\"\
+        ,\"Microsoft.Network/virtualNetworks/subnets/join/action\",\"Microsoft.Resources/deployments/operations/read\"\
+        ,\"Microsoft.Resources/deployments/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Storage/storageAccounts/listKeys/action\"],\"notActions\":[\"\
+        Microsoft.Compute/virtualMachines/vmSizes/read\"]}],\"createdOn\":\"2015-06-08T21:52:45.0657582Z\"\
+        ,\"updatedOn\":\"2017-02-02T02:38:38.2961026Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/76283e04-6283-4c54-8f91-bcf1374a3c64\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"76283e04-6283-4c54-8f91-bcf1374a3c64\"\
+        },{\"properties\":{\"roleName\":\"DNS Zone Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage DNS zones and record sets in Azure DNS,\
+        \ but does not let you control who has access to them.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/dnsZones/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2015-10-15T23:33:25.9730842Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:40.3710365Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/befefa01-2a29-4197-83a8-272ff33ce314\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"befefa01-2a29-4197-83a8-272ff33ce314\"\
+        },{\"properties\":{\"roleName\":\"DocumentDB Account Contributor\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Lets you manage DocumentDB accounts, but\
+        \ not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.DocumentDb/databaseAccounts/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:07.2132374Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5bd9cd88-fe45-4216-938b-f97437e15450\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5bd9cd88-fe45-4216-938b-f97437e15450\"\
+        },{\"properties\":{\"roleName\":\"Intelligent Systems Account Contributor\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Lets you manage Intelligent Systems\
+        \ accounts, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.IntelligentSystems/accounts/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:59.7946586Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/03a6d094-3444-4b3d-88af-7477090a9e5e\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"03a6d094-3444-4b3d-88af-7477090a9e5e\"\
+        },{\"properties\":{\"roleName\":\"Key Vault Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage key vaults, but not access to them.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.KeyVault/*\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[\"Microsoft.KeyVault/locations/deletedVaults/purge/action\"\
+        ]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2017-07-31T21:29:27.9634288Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/f25e0fa2-a7c8-4377-a976-54943a77a395\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"f25e0fa2-a7c8-4377-a976-54943a77a395\"\
+        },{\"properties\":{\"roleName\":\"Log Analytics Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Log Analytics Contributor can read all monitoring\
+        \ data and edit monitoring settings. Editing monitoring settings includes\
+        \ adding the VM extension to VMs; reading storage account keys to be able\
+        \ to configure collection of logs from Azure Storage; creating and configuring\
+        \ Automation accounts; adding solutions; and configuring Azure diagnostics\
+        \ on all Azure resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Automation/automationAccounts/*\",\"*/read\",\"Microsoft.ClassicCompute/virtualMachines/extensions/*\"\
+        ,\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.Compute/virtualMachines/extensions/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/diagnosticSettings/*\"\
+        ,\"Microsoft.OperationalInsights/*\",\"Microsoft.OperationsManagement/*\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourcegroups/deployments/*\"\
+        ,\"Microsoft.Storage/storageAccounts/listKeys/action\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-25T21:51:45.3174711Z\",\"updatedOn\"\
+        :\"2017-05-19T04:00:50.7280454Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\
+        },{\"properties\":{\"roleName\":\"Log Analytics Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Log Analytics Reader can view and search all monitoring\
+        \ data as well as and view monitoring settings, including viewing the configuration\
+        \ of Azure diagnostics on all Azure resources.\",\"assignableScopes\":[\"\
+        /\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.OperationalInsights/workspaces/analytics/query/action\"\
+        ,\"Microsoft.OperationalInsights/workspaces/search/action\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[\"Microsoft.OperationalInsights/workspaces/sharedKeys/read\"\
+        ]}],\"createdOn\":\"2017-05-02T00:20:28.1449012Z\",\"updatedOn\":\"2017-05-02T22:36:45.2104697Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/73c42c96-874c-492b-b04d-ab87d138a893\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"73c42c96-874c-492b-b04d-ab87d138a893\"\
+        },{\"properties\":{\"roleName\":\"Logic App Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage logic app, but not access to them.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.ClassicStorage/storageAccounts/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/diagnosticSettings/*\"\
+        ,\"Microsoft.Insights/logdefinitions/*\",\"Microsoft.Insights/metricDefinitions/*\"\
+        ,\"Microsoft.Logic/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/operationresults/read\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/listkeys/action\"\
+        ,\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.Support/*\",\"Microsoft.Web/connections/*\"\
+        ,\"Microsoft.Web/connectionGateways/*\",\"Microsoft.Web/serverFarms/join/action\"\
+        ,\"Microsoft.Web/serverFarms/read\",\"Microsoft.Web/sites/functions/listSecrets/action\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2016-04-28T21:33:30.4656007Z\",\"updatedOn\"\
+        :\"2016-11-09T20:20:11.3665904Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/87a39d53-fc1b-424a-814c-f7e04687dc9e\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"87a39d53-fc1b-424a-814c-f7e04687dc9e\"\
+        },{\"properties\":{\"roleName\":\"Logic App Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you read, enable and disable logic app.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*/read\",\"Microsoft.Insights/diagnosticSettings/*/read\"\
+        ,\"Microsoft.Insights/metricDefinitions/*/read\",\"Microsoft.Logic/*/read\"\
+        ,\"Microsoft.Logic/workflows/disable/action\",\"Microsoft.Logic/workflows/enable/action\"\
+        ,\"Microsoft.Logic/workflows/validate/action\",\"Microsoft.Resources/deployments/operations/read\"\
+        ,\"Microsoft.Resources/subscriptions/operationresults/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.Web/connections/*/read\",\"Microsoft.Web/connectionGateways/*/read\"\
+        ,\"Microsoft.Web/serverFarms/read\"],\"notActions\":[]}],\"createdOn\":\"\
+        2016-04-28T21:33:30.4656007Z\",\"updatedOn\":\"2016-11-09T20:26:07.8911630Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/515c2055-d9d4-4321-b1b9-bd0c9a0f79fe\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"515c2055-d9d4-4321-b1b9-bd0c9a0f79fe\"\
+        },{\"properties\":{\"roleName\":\"Monitoring Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can read all monitoring data and update monitoring settings.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"\
+        Microsoft.Insights/AlertRules/*\",\"Microsoft.Insights/components/*\",\"Microsoft.Insights/DiagnosticSettings/*\"\
+        ,\"Microsoft.Insights/eventtypes/*\",\"Microsoft.Insights/LogDefinitions/*\"\
+        ,\"Microsoft.Insights/MetricDefinitions/*\",\"Microsoft.Insights/Metrics/*\"\
+        ,\"Microsoft.Insights/Register/Action\",\"Microsoft.Insights/webtests/*\"\
+        ,\"Microsoft.OperationalInsights/workspaces/intelligencepacks/*\",\"Microsoft.OperationalInsights/workspaces/savedSearches/*\"\
+        ,\"Microsoft.OperationalInsights/workspaces/search/action\",\"Microsoft.OperationalInsights/workspaces/sharedKeys/action\"\
+        ,\"Microsoft.OperationalInsights/workspaces/storageinsightconfigs/*\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2016-09-21T19:21:08.4345976Z\",\"updatedOn\"\
+        :\"2017-07-28T19:50:48.0869081Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"749f88d5-cbae-40b8-bcfc-e573ddc772fa\"\
+        },{\"properties\":{\"roleName\":\"Monitoring Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can read all monitoring data.\",\"assignableScopes\":[\"\
+        /\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.OperationalInsights/workspaces/search/action\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-09-21T19:19:52.4939376Z\"\
+        ,\"updatedOn\":\"2017-07-07T20:00:57.2225683Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/43d0d8ad-25c7-4714-9337-8ba259a9fe05\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"43d0d8ad-25c7-4714-9337-8ba259a9fe05\"\
+        },{\"properties\":{\"roleName\":\"Network Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage networks, but not access to them.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2015-06-02T00:18:27.3542698Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:00.3326359Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4d97b98b-1d4f-4787-a291-c67834d212e7\"\
+        },{\"properties\":{\"roleName\":\"New Relic APM Account Contributor\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Lets you manage New Relic Application Performance\
+        \ Management accounts and applications, but not access to them.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\",\"NewRelic.APM/accounts/*\"],\"notActions\":[]}],\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:07.7538043Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5d28c62d-5b37-4476-8438-e587778df237\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5d28c62d-5b37-4476-8438-e587778df237\"\
+        },{\"properties\":{\"roleName\":\"Owner\",\"type\":\"BuiltInRole\",\"description\"\
+        :\"Lets you manage everything, including access to resources.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"*\"],\"notActions\":[]}],\"createdOn\"\
+        :\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:00.9179619Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8e3af657-a8ff-443c-a75c-2fe8c4bcb635\"\
+        },{\"properties\":{\"roleName\":\"Reader\",\"type\":\"BuiltInRole\",\"description\"\
+        :\"Lets you view everything, but not make any changes.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"*/read\"],\"notActions\":[]}],\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-08-19T00:03:56.0652623Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"acdd72a7-3385-48ef-bd42-f606fba81ae7\"\
+        },{\"properties\":{\"roleName\":\"Redis Cache Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage Redis caches, but not access to them.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Cache/redis/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:01.9877071Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e0f68234-74aa-48ed-b826-c38b57376e17\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e0f68234-74aa-48ed-b826-c38b57376e17\"\
+        },{\"properties\":{\"roleName\":\"Resource Policy Contributor (Preview)\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"(Preview) Backfilled users from\
+        \ EA, with rights to create/modify resource policy, create support ticket\
+        \ and read resources/hierarchy.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"*/read\",\"Microsoft.Authorization/policyassignments/*\"\
+        ,\"Microsoft.Authorization/policydefinitions/*\",\"Microsoft.Support/*\",\"\
+        Microsoft.PolicyInsights/*\"],\"notActions\":[]}],\"createdOn\":\"2017-08-25T19:08:01.3861639Z\"\
+        ,\"updatedOn\":\"2017-10-06T23:09:34.7662094Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/36243c78-bf99-498c-9df9-86d9f8d28608\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"36243c78-bf99-498c-9df9-86d9f8d28608\"\
+        },{\"properties\":{\"roleName\":\"Scheduler Job Collections Contributor\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Lets you manage Scheduler job\
+        \ collections, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Scheduler/jobcollections/*\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:02.5343995Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/188a0f2f-5c9e-469b-ae67-2aa5ce574b94\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"188a0f2f-5c9e-469b-ae67-2aa5ce574b94\"\
+        },{\"properties\":{\"roleName\":\"Search Service Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage Search services, but not access\
+        \ to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Search/searchServices/*\",\"Microsoft.Support/*\"],\"notActions\"\
+        :[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:03.0463472Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7ca78c08-252a-4471-8644-bb5ff32d4ba0\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"7ca78c08-252a-4471-8644-bb5ff32d4ba0\"\
+        },{\"properties\":{\"roleName\":\"Security Admin\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Security Admin Role\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Insights/alertRules/*\",\"Microsoft.operationalInsights/workspaces/*/read\"\
+        ,\"Microsoft.Authorization/*/read\",\"Microsoft.Support/*\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Security/*/read\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-05-03T07:51:23.0917487Z\",\"updatedOn\"\
+        :\"2017-05-03T18:44:05.2089574Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fb1c8493-542b-48eb-b624-b4c8fea62acd\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fb1c8493-542b-48eb-b624-b4c8fea62acd\"\
+        },{\"properties\":{\"roleName\":\"Security Manager\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage security components, security policies\
+        \ and virtual machines\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicCompute/*/read\"\
+        ,\"Microsoft.ClassicCompute/virtualMachines/*/write\",\"Microsoft.ClassicNetwork/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Security/*\",\"Microsoft.Support/*\"],\"notActions\":[]}],\"\
+        createdOn\":\"2015-06-22T17:45:15.8986455Z\",\"updatedOn\":\"2016-05-31T23:14:03.5656122Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e3d13bf0-dd5a-482e-ba6b-9b8433878d10\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e3d13bf0-dd5a-482e-ba6b-9b8433878d10\"\
+        },{\"properties\":{\"roleName\":\"Security Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Security Reader Role\",\"assignableScopes\":[\"/\"],\"\
+        permissions\":[{\"actions\":[\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.operationalInsights/workspaces/*/read\",\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Security/*/read\"],\"notActions\":[]}],\"createdOn\":\"2017-05-03T07:48:49.0516559Z\"\
+        ,\"updatedOn\":\"2017-05-03T18:42:54.9787380Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"39bc4728-0917-49c7-9d2c-d95423bc2eb4\"\
+        },{\"properties\":{\"roleName\":\"Site Recovery Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage Site Recovery sservice except\
+        \ vault creation and role assignment\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\"\
+        ,\"Microsoft.RecoveryServices/locations/allocateStamp/action\",\"Microsoft.RecoveryServices/Vaults/certificates/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/extendedInformation/*\",\"Microsoft.RecoveryServices/Vaults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/*\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationAlertSettings/*\",\"Microsoft.RecoveryServices/vaults/replicationEvents/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/*\",\"Microsoft.RecoveryServices/vaults/replicationJobs/*\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationPolicies/*\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/storageConfig/*\",\"Microsoft.RecoveryServices/Vaults/tokenInfo/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.RecoveryServices/Vaults/vaultTokens/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/*\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2017-05-19T13:46:17.4592776Z\"\
+        ,\"updatedOn\":\"2017-06-29T05:31:19.7240473Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6670b86e-a3f7-4917-ac9b-5d6ab1be4567\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6670b86e-a3f7-4917-ac9b-5d6ab1be4567\"\
+        },{\"properties\":{\"roleName\":\"Site Recovery Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you failover and failback but not perform other Site\
+        \ Recovery management operations\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\"\
+        ,\"Microsoft.RecoveryServices/locations/allocateStamp/action\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/vaults/replicationAlertSettings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationEvents/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/checkConsistency/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/reassociateGateway/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/renewcertificate/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/replicationNetworkMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectableItems/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/applyRecoveryPoint/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/failoverCommit/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/plannedFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/recoveryPoints/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/repairReplication/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/reProtect/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/testFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/testFailoverCleanup/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/unplannedFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/updateMobilityService/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionContainerMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders/refreshProvider/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/replicationStorageClassificationMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationvCenters/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationJobs/*\",\"Microsoft.RecoveryServices/vaults/replicationPolicies/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/failoverCommit/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/plannedFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/read\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/reProtect/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/testFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/testFailoverCleanup/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/unplannedFailover/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/*\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/storageConfig/read\",\"Microsoft.RecoveryServices/Vaults/tokenInfo/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.RecoveryServices/Vaults/vaultTokens/read\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2017-05-19T13:47:50.1341148Z\"\
+        ,\"updatedOn\":\"2017-06-29T05:42:27.1715639Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/494ae006-db33-4328-bf46-533a6560a3ca\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"494ae006-db33-4328-bf46-533a6560a3ca\"\
+        },{\"properties\":{\"roleName\":\"Site Recovery Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you view Site Recovery status but not perform other\
+        \ management operations\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/vaults/replicationAlertSettings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationEvents/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/replicationNetworkMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectableItems/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/recoveryPoints/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionContainerMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/replicationStorageClassificationMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationvCenters/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationJobs/read\",\"Microsoft.RecoveryServices/vaults/replicationPolicies/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/tokenInfo/read\",\"Microsoft.RecoveryServices/Vaults/usages/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/vaultTokens/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-05-19T13:35:40.0093634Z\",\"updatedOn\"\
+        :\"2017-05-26T19:54:51.3933250Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/dbaa88c4-0c30-4179-9fb3-46319faa6149\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"dbaa88c4-0c30-4179-9fb3-46319faa6149\"\
+        },{\"properties\":{\"roleName\":\"SQL DB Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage SQL databases, but not access to them.\
+        \ Also, you can't manage their security-related policies or their parent SQL\
+        \ servers.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Sql/servers/databases/*\",\"Microsoft.Sql/servers/read\",\"Microsoft.Support/*\"\
+        ,\"Microsoft.Sql/locations/*/read\"],\"notActions\":[\"Microsoft.Sql/servers/databases/auditingPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditRecords/read\"\
+        ,\"Microsoft.Sql/servers/databases/connectionPolicies/*\",\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/securityMetrics/*\"\
+        ]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2017-06-16T21:40:03.7331761Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9b7fa17d-e63e-47b0-bb0a-15c516ac86ec\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9b7fa17d-e63e-47b0-bb0a-15c516ac86ec\"\
+        },{\"properties\":{\"roleName\":\"SQL Security Manager\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage the security-related policies of SQL servers\
+        \ and databases, but not access to them.\",\"assignableScopes\":[\"/\"],\"\
+        permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Network/virtualNetworks/subnets/joinViaServiceEndpoint/action\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Sql/servers/auditingPolicies/*\"\
+        ,\"Microsoft.Sql/servers/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditingPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditRecords/read\"\
+        ,\"Microsoft.Sql/servers/databases/connectionPolicies/*\",\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/read\",\"Microsoft.Sql/servers/databases/schemas/read\"\
+        ,\"Microsoft.Sql/servers/databases/schemas/tables/columns/read\",\"Microsoft.Sql/servers/databases/schemas/tables/read\"\
+        ,\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/securityMetrics/*\"\
+        ,\"Microsoft.Sql/servers/firewallRules/*\",\"Microsoft.Sql/servers/read\"\
+        ,\"Microsoft.Sql/servers/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\"\
+        ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/operationResults/*\"\
+        ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\",\"\
+        Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2017-08-24T16:52:56.9679438Z\",\"createdBy\":null,\"updatedBy\"\
+        :\"yaiyun\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"056cd41c-7e88-42e1-933e-88ba6a50c9c3\"\
+        },{\"properties\":{\"roleName\":\"SQL Server Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage SQL servers and databases, but not access\
+        \ to them, and not their security -related policies.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Sql/servers/*\",\"Microsoft.Support/*\",\"Microsoft.Sql/locations/*/read\"\
+        ],\"notActions\":[\"Microsoft.Sql/servers/auditingPolicies/*\",\"Microsoft.Sql/servers/auditingSettings/*\"\
+        ,\"Microsoft.Sql/servers/databases/auditingPolicies/*\",\"Microsoft.Sql/servers/databases/auditingSettings/*\"\
+        ,\"Microsoft.Sql/servers/databases/auditRecords/read\",\"Microsoft.Sql/servers/databases/connectionPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/securityMetrics/*\",\"Microsoft.Sql/servers/securityAlertPolicies/*\"\
+        ]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2017-06-16T21:33:44.5854549Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437\"\
+        },{\"properties\":{\"roleName\":\"Storage Account Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage storage accounts, but not\
+        \ access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.Insights/diagnosticSettings/*\",\"Microsoft.Network/virtualNetworks/subnets/joinViaServiceEndpoint/action\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/*\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2015-06-02T00:18:27.3542698Z\"\
+        ,\"updatedOn\":\"2017-08-21T07:43:20.3060994Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"17d1049b-9a84-46fb-8f53-869881c3d3ab\"\
+        },{\"properties\":{\"roleName\":\"Storage Account Key Operator Service Role\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Storage Account Key Operators\
+        \ are allowed to list and regenerate keys on Storage Accounts\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/listkeys/action\"\
+        ,\"Microsoft.Storage/storageAccounts/regeneratekey/action\"],\"notActions\"\
+        :[]}],\"createdOn\":\"2017-04-13T18:26:11.5770570Z\",\"updatedOn\":\"2017-04-13T20:57:14.5990198Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/81a9662b-bebf-436f-a333-f67b29880f12\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"81a9662b-bebf-436f-a333-f67b29880f12\"\
+        },{\"properties\":{\"roleName\":\"Support Request Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you create and manage Support requests\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-06-22T22:25:37.8053068Z\",\"updatedOn\"\
+        :\"2017-06-23T01:06:24.2399631Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e\"\
+        },{\"properties\":{\"roleName\":\"Traffic Manager Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage Traffic Manager profiles,\
+        \ but does not let you control who has access to them.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/trafficManagerProfiles/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2015-10-15T23:33:25.9730842Z\",\"updatedOn\"\
+        :\"2016-05-31T23:13:44.1458854Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/a4b10055-b0c7-44c2-b00f-c7b5b3550cf7\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"a4b10055-b0c7-44c2-b00f-c7b5b3550cf7\"\
+        },{\"properties\":{\"roleName\":\"User Access Administrator\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage user access to Azure resources.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"\
+        Microsoft.Authorization/*\",\"Microsoft.Support/*\"],\"notActions\":[]}],\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:04.6964687Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"18d7d88d-d35e-4fb5-a5c3-7773c20a72d9\"\
+        },{\"properties\":{\"roleName\":\"Virtual Machine Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage virtual machines, but not\
+        \ access to them, and not the virtual network or storage account they\uFFFD\
+        re connected to.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Compute/availabilitySets/*\"\
+        ,\"Microsoft.Compute/locations/*\",\"Microsoft.Compute/virtualMachines/*\"\
+        ,\"Microsoft.Compute/virtualMachineScaleSets/*\",\"Microsoft.DevTestLab/schedules/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/applicationGateways/backendAddressPools/join/action\"\
+        ,\"Microsoft.Network/loadBalancers/backendAddressPools/join/action\",\"Microsoft.Network/loadBalancers/inboundNatPools/join/action\"\
+        ,\"Microsoft.Network/loadBalancers/inboundNatRules/join/action\",\"Microsoft.Network/loadBalancers/read\"\
+        ,\"Microsoft.Network/loadBalancers/probes/join/action\",\"Microsoft.Network/locations/*\"\
+        ,\"Microsoft.Network/networkInterfaces/*\",\"Microsoft.Network/networkSecurityGroups/join/action\"\
+        ,\"Microsoft.Network/networkSecurityGroups/read\",\"Microsoft.Network/publicIPAddresses/join/action\"\
+        ,\"Microsoft.Network/publicIPAddresses/read\",\"Microsoft.Network/virtualNetworks/read\"\
+        ,\"Microsoft.Network/virtualNetworks/subnets/join/action\",\"Microsoft.RecoveryServices/locations/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/*/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/read\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/usages/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/write\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Storage/storageAccounts/listKeys/action\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2015-06-02T00:18:27.3542698Z\"\
+        ,\"updatedOn\":\"2017-08-28T05:53:14.5251750Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9980e02c-c2be-4d73-94e8-173b1dc7cf3c\"\
+        },{\"properties\":{\"roleName\":\"Web Plan Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage the web plans for websites, but not access\
+        \ to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.Web/serverFarms/*\"],\"notActions\":[]}],\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:05.9401651Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b\"\
+        },{\"properties\":{\"roleName\":\"Website Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage websites (not web plans), but not access\
+        \ to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/components/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ,\"Microsoft.Web/certificates/*\",\"Microsoft.Web/listSitesAssignedToHostName/read\"\
+        ,\"Microsoft.Web/serverFarms/join/action\",\"Microsoft.Web/serverFarms/read\"\
+        ,\"Microsoft.Web/sites/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:06.5272742Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"de139f84-1756-47ae-9be6-808fbbe84772\"\
+        }]}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['75402']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 03 Nov 2017 20:30:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"objectIds": ["7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c"], "includeDirectoryObjectReferences":
+      true}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [role assignment list]
+      Connection: [keep-alive]
+      Content-Length: ['97']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"7e98bce8-8f3b-4aae-aad1-c4bb3e07a25c","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003"],"appDisplayName":null,"appId":"d6cb63e1-1fa8-4f8e-a00e-b2bacb693d03","appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"web-msi000003","errorUrl":null,"homepage":null,"keyCredentials":[{"customKeyIdentifier":null,"endDate":"2018-02-01T20:24:00Z","keyId":"885c798c-388f-4b02-a7d1-c8ca8f4eedff","startDate":"2017-11-03T20:24:00Z","type":"AsymmetricX509Cert","usage":"Verify","value":null}],"logoutUrl":null,"oauth2Permissions":[],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["d6cb63e1-1fa8-4f8e-a00e-b2bacb693d03","https://identity.azure.net/+C/xZ+jmHnAl4EXdYCSPYZWldZ+w6Iva3oNBw8zA2kk="],"servicePrincipalType":"ServiceAccount","tags":[],"tokenEncryptionKeyId":null}]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1354']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Fri, 03 Nov 2017 20:30:11 GMT']
+      duration: ['760643']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [LY/yJbtWyuhbIWwwzINxuwIEezUchbj+/ceSqG17f24=]
+      ocp-aad-session-key: [Tgr0Hs85ft7CX0mM8jRsMKR5MN4ToAuHl_yjiyzHVxy_AaXzi_6Nu-5bN3bj3M258swjqxow18LRjwyCROz5FgCdbQjBwfc817Ow_Nvl389GuDO1BPsyOhZ97RjJymn_.mgLfuAZfGpD13wOuFiH0uCpjxpyK3qcqgAKnrx5bw1A]
+      pragma: [no-cache]
+      request-id: [a607b3d3-32ff-4237-bb31-c69e6d4fe2c6]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.17
+          msrest_azure/0.4.15 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 03 Nov 2017 20:30:12 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdLTjMzVEI2T1lUNUlEWTJMM0hUVU1VUkc2RFlGVVk0S0xUS3wwRjhGODRBNEYxQzQ5NzMzLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
+import mock
+import uuid
 import os
 import time
 import tempfile
@@ -842,6 +844,24 @@ class WebappZipDeployScenarioTest(LiveScenarioTest):
             JMESPathCheckV2('deployer', 'Zip-Push'),
             JMESPathCheckV2('message', 'Created via zip push deployment'),
             JMESPathCheckV2('complete', True)])
+
+
+class WebappImplictIdentityTest(ScenarioTest):
+    @ResourceGroupPreparer()
+    def test_assign_identity(self, resource_group):
+        scope = '/subscriptions/{}/resourcegroups/{}'.format(self.get_subscription_id(), resource_group)
+        role = 'Reader'
+        plan_name = self.create_random_name('web-msi-plan', 20)
+        webapp_name = self.create_random_name('web-msi', 20)
+        self.cmd('appservice plan create -g {} -n {}'.format(resource_group, plan_name))
+        self.cmd('webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
+        guids = [uuid.UUID('88DAAF5A-EA86-4A68-9D45-477538D46667')]
+        with mock.patch('azure.cli.core.commands.arm._gen_guid', side_effect=guids, autospec=True):
+            result = self.cmd('webapp assign-identity -g {} -n {} --role {} --scope {}'.format(resource_group, webapp_name, role, scope)).get_output_in_json()
+        self.cmd('role assignment list -g {} --assignee {}'.format(resource_group, result['principalId']), checks=[
+            JMESPathCheckV2('length([])', 1),
+            JMESPathCheckV2('[0].properties.roleDefinitionName', role)
+        ])
 
 
 if __name__ == '__main__':

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -2007,11 +2007,9 @@ class MSIScenarioTest(ScenarioTest):
 
         # Fixing the role assignment guids so test can run under playback. The assignments will
         # be auto-deleted when the RG gets recycled, so the same ids can be reused.
-        guids = [uuid.UUID('CD58500A-F421-4815-B5CF-A36A1E16C1A0'),
-                 uuid.UUID('C1E7FC22-CB48-407E-BE6A-19F0F1ED9C81'),
-                 uuid.UUID('88DAAF5A-EA86-4A68-9D45-477538D41732'),
+        guids = [uuid.UUID('88DAAF5A-EA86-4A68-9D45-477538D41732'),
                  uuid.UUID('13ECC8E1-A3AA-40CE-95E9-1313957D6CF3')]
-        with mock.patch('azure.cli.command_modules.vm.custom._gen_guid', side_effect=guids, autospec=True):
+        with mock.patch('azure.cli.core.commands.arm._gen_guid', side_effect=guids, autospec=True):
             # create a linux vm with default configuration
             self.cmd('vm create -g {} -n {} --image debian --assign-identity --admin-username admin123 --admin-password PasswordPassword1! --scope {}'.format(resource_group, vm1, default_scope), checks=[
                 JMESPathCheckV2('identity.role', 'Contributor'),


### PR DESCRIPTION
For less code redundancy, I extracted some common role assignments logic and moved to azure-cli-core.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
