### PR TITLE
Added detailed error to 'az sf cluster create' when template validiation fails

### DIFF
--- a/src/command_modules/azure-cli-servicefabric/HISTORY.rst
+++ b/src/command_modules/azure-cli-servicefabric/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.9
+++++++
+* Added detailed errors to validation response when creating cluster.
+
 0.0.8
 ++++++
 * Update for CLI core changes.
@@ -14,7 +18,6 @@ Release History
 0.0.6
 +++++
 * Minor fixes.
-* Added detailed errors to validation response when creating cluster.
 
 0.0.5
 +++++

--- a/src/command_modules/azure-cli-servicefabric/HISTORY.rst
+++ b/src/command_modules/azure-cli-servicefabric/HISTORY.rst
@@ -14,6 +14,7 @@ Release History
 0.0.6
 +++++
 * Minor fixes.
+* Added detailed errors to validation response when creating cluster.
 
 0.0.5
 +++++

--- a/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
@@ -263,9 +263,8 @@ def new_cluster(cmd,
         cli_ctx, resource_group_name, template, parameters, deployment_name, 'incremental', True)
     if validate_result.error is not None:
         errors_detailed = _build_detailed_error(validate_result.error, [])
-        error_message = "Error validating template. See below for more information. \n"
-        error_message += "".join(errors_detailed)
-        raise CLIError(error_message)
+        errors_detailed.insert(0, "Error validating template. See below for more information.")
+        raise CLIError('\n'.join(errors_detailed))
     logger.info("Deployment is valid, and begin to deploy")
     _deploy_arm_template_core(cli_ctx, resource_group_name, template,
                               parameters, deployment_name, 'incremental', False)
@@ -280,17 +279,19 @@ def new_cluster(cmd,
 
     return output_dict
 
-def _build_detailed_error(topError, outputList):
-    if outputList:
-        outputList.append(" Inner Error - Code: \"{}\" Message: \"{}\" \n".format(topError.code, topError.message))
-    else:
-        outputList.append("Error - Code: \"{}\" Message: \"{}\" \n".format(topError.code, topError.message))
-        
-    if topError.details:
-        for error in topError.details:
-            _build_detailed_error(error, outputList)
 
-    return outputList
+def _build_detailed_error(top_error, output_list):
+    if output_list:
+        output_list.append(' Inner Error - Code: "{}" Message: "{}"'.format(top_error.code, top_error.message))
+    else:
+        output_list.append('Error - Code: "{}" Message: "{}"'.format(top_error.code, top_error.message))
+
+    if top_error.details:
+        for error in top_error.details:
+            _build_detailed_error(error, output_list)
+
+    return output_list
+
 
 def add_app_cert(cmd,
                  client,

--- a/src/command_modules/azure-cli-servicefabric/setup.py
+++ b/src/command_modules/azure-cli-servicefabric/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.8"
+VERSION = "0.0.9"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This provides a fix for #4790 which is a frustration when deploying Service Fabric clusters. It's not easy to find out what caused a validation error as detailed error messages aren't emitted. The PR adds these messages into the output to assist users. 

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

I'm unsure if this change warrants an entry, what do you think?

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

I haven't modified any commands. 

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
