### PR TITLE
Support extensions that later become command modules

### DIFF
--- a/doc/extensions/faq.md
+++ b/doc/extensions/faq.md
@@ -28,4 +28,5 @@ FAQ
 - Add a dependency on `azure-cli-core` to your `setup.py`.
 - Rename your package to start with `azure-cli-*`.
 - If you rely on an Azure autorest SDK, release the SDK at [azure-sdk-for-python](https://github.com/Azure/azure-sdk-for-python) and add it as a dependency.
+- If you no longer want your extension to be loaded, modify `BLACKLISTED_EXTENSIONS` in azure.cli.core.commands.__init__.py.
 - Create a PR to [Azure/azure-cli](https://github.com/Azure/azure-cli/).


### PR DESCRIPTION
e.g. after moved from extension to inside CLI

Looking for feedback at this stage: @troydai @tjprescott @yugangw-msft @johanste 
We may have an ask for this feature in the future.

**This is not for Connect()**

You can try it out in the prompt.ws preview.
```
az extension add -n image-copy-extension
az image copy -h --debug
(You'll see a debug message saying this extension has been skipped)
```