### PR TITLE
ad sp reset-credentials: support to add credentials instead of overwriting 

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.15
+++++++
+* 'ad sp reset-credentials': support to add credentials instead of overwriting
 
 2.0.14
 ++++++

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -33,6 +33,7 @@ register_cli_argument('ad sp create-for-rbac', 'scopes', nargs='+')
 register_cli_argument('ad sp create-for-rbac', 'role', completer=get_role_definition_name_completion_list)
 register_cli_argument('ad sp create-for-rbac', 'skip_assignment', action='store_true', help='do not create default assignment')
 register_cli_argument('ad sp create-for-rbac', 'show_auth_for_sdk', options_list='--sdk-auth', action='store_true', help='output result in compatible with Azure SDK auth file')
+register_cli_argument('ad sp reset-credentials', 'append', action='store_true', help='append the new credential instead of overwriting')
 
 for item in ['create-for-rbac', 'reset-credentials']:
     register_cli_argument('ad sp {}'.format(item), 'name', name_arg_type)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -846,7 +846,7 @@ def _get_public(x509):
 
 
 def reset_service_principal_credential(name, password=None, create_cert=False,
-                                       cert=None, years=None, keyvault=None):
+                                       cert=None, years=None, keyvault=None, append=False):
     import pytz
     client = _graph_client_factory()
 
@@ -883,26 +883,28 @@ def reset_service_principal_credential(name, password=None, create_cert=False,
     cert_creds = None
 
     if password:
-        app_creds = [
-            PasswordCredential(
-                start_date=app_start_date,
-                end_date=app_end_date,
-                key_id=str(uuid.uuid4()),
-                value=password
-            )
-        ]
+        app_creds = []
+        if append:
+            app_creds = list(client.applications.list_password_credentials(app.object_id))
+        app_creds.append(PasswordCredential(
+            start_date=app_start_date,
+            end_date=app_end_date,
+            key_id=str(uuid.uuid4()),
+            value=password
+        ))
 
     if public_cert_string:
-        cert_creds = [
-            KeyCredential(
-                start_date=app_start_date,
-                end_date=app_end_date,
-                value=public_cert_string,
-                key_id=str(uuid.uuid4()),
-                usage='Verify',
-                type='AsymmetricX509Cert'
-            )
-        ]
+        cert_creds = []
+        if append:
+            cert_creds = list(client.applications.list_key_credentials(app.object_id))
+        cert_creds.append(KeyCredential(
+            start_date=app_start_date,
+            end_date=app_end_date,
+            value=public_cert_string,
+            key_id=str(uuid.uuid4()),
+            usage='Verify',
+            type='AsymmetricX509Cert'
+        ))
 
     app_create_param = ApplicationUpdateParameters(password_credentials=app_creds, key_credentials=cert_creds)
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role_commands_thru_mock.py
@@ -13,7 +13,9 @@ from azure.mgmt.authorization.models import RoleDefinition, RoleDefinitionProper
 from azure.graphrbac.models import Application, ServicePrincipal
 from azure.cli.command_modules.role.custom import (create_role_definition,
                                                    update_role_definition,
-                                                   create_service_principal_for_rbac)
+                                                   create_service_principal_for_rbac,
+                                                   reset_service_principal_credential,
+                                                   _try_x509_pem)
 
 # pylint: disable=line-too-long
 
@@ -156,6 +158,92 @@ class TestRoleMocked(unittest.TestCase):
         self.assertEqual(result['appId'], test_app_id)
         self.assertTrue(logger_mock.warning.called)  # we should warn 'years' will be dropped
         self.assertTrue(faked_graph_client.applications.create.called)
+
+    @mock.patch('azure.cli.command_modules.role.custom._graph_client_factory', autospec=True)
+    def test_reset_credentials_password(self, graph_client_mock):
+        patch_invoked = [False]
+        test_object_id = 'app_object_id'
+        test_pwd = 'verySecret'
+        name = 'http://mysp'
+
+        def test_patch(id, param):
+            patch_invoked[0] = True
+            self.assertEqual(id, test_object_id)
+            self.assertEqual(1, len(param.password_credentials))
+            self.assertEqual(param.password_credentials[0].value, test_pwd)
+
+        faked_graph_client = mock.MagicMock()
+        sp_object = mock.MagicMock()
+        sp_object.app_id = 'app_id'
+        app_object = mock.MagicMock()
+        app_object.object_id = test_object_id
+
+        graph_client_mock.return_value = faked_graph_client
+        faked_graph_client.service_principals.list.return_value = [sp_object]
+        faked_graph_client.applications.list.return_value = [app_object]
+        faked_graph_client.applications.get.side_effect = [app_object, app_object]
+        faked_graph_client.applications.patch = test_patch
+        faked_graph_client.applications.list_password_credentials.side_effect = [ValueError('should not invoke')]
+
+        # action
+        reset_service_principal_credential(name, test_pwd, append=False)
+
+        # assert
+        self.assertTrue(patch_invoked[0])
+
+    @mock.patch('azure.cli.command_modules.role.custom._graph_client_factory', autospec=True)
+    def test_reset_credentials_certificate_append_option(self, graph_client_mock):
+        patch_invoked = [False]
+        test_object_id = 'app_object_id'
+        test_cert = _try_x509_pem('\n'.join(['-----BEGIN CERTIFICATE-----',
+                                             'MIICoTCCAYkCAgPoMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCUNMSS1Mb2dp',
+                                             'bjAiGA8yMDE3MTExMzIxMjQyMloYDzIwMTgxMTEzMjEyNDI0WjAUMRIwEAYDVQQD',
+                                             'DAlDTEktTG9naW4wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCtyRA6',
+                                             'mbUtByQBODMlp3r5fGpnYCfRhAzp2U29KRVTOQK1ntMIo3FWR19ceqK6T0UM+BFb',
+                                             'XGn28hGhgz5Y1lrbqyKrAcF10/3y42wmiMyPWjmXJ+WOEKjckKKzPMm2KBsn/ePV',
+                                             'qsr5UwlnHh2rGFR0PF1qjC0IU/SI0UQN0KJKpVp0OB8+lRlIAcsLUTveTXbdFDlp',
+                                             'k5AA8w3TTo7pT5sKNZr3+qv1o4ogDfDEx0bCYtlm4L1HvGer4pbX7q35ucZY9BWq',
+                                             'VjHQ/MjiuAyxZoyY5xVoULMWJupRyMT3wP1Hb+oJ9/tTBZbpNTv1ed9OswCc2W1l',
+                                             'MQzLwE10Ev0LJkhlAgMBAAEwDQYJKoZIhvcNAQEFBQADggEBAF+RP+7uzmf4u4+l',
+                                             'xjS+lXd3O0tqTNOVe8RR+GXl1s2Un6UhwmP3SKs2RNcXkb9+6Q4Zvg7GODK7Z8th',
+                                             't/enpTcvLmPmq2ow1hFGWJk/lONZtVKU2mikTY/ICnQrbhf3WYr1cuf98CRqoG71',
+                                             'ldrjgSsM1Ut7Gee1Tpc2eamRtHTm07AUQhqGnS5wVp6s1HUd43nvu/lVx+j2hjEB',
+                                             'y63BSuD3aSUweVne4roBNcBJjLU1wvYl+3cLgnZ9///3y/C4pKebsKHljkejRaer',
+                                             'nvbPfW9hy7BqMem7t0Qk2D84VzaK+6x9EnnsXy+90nfvTLUSqpU1MjpdWhuWyxDL',
+                                             'p4oYS5Q=',
+                                             '-----END CERTIFICATE-----']))
+        key_id_of_existing_cert = 'existing cert'
+        name = 'http://mysp'
+
+        def test_patch(id, param):
+            patch_invoked[0] = True
+            self.assertEqual(id, test_object_id)
+            self.assertEqual(2, len(param.key_credentials))
+            self.assertTrue(len(param.key_credentials[1].value) > 0)
+            self.assertEqual(param.key_credentials[1].type, 'AsymmetricX509Cert')
+            self.assertEqual(param.key_credentials[1].usage, 'Verify')
+            self.assertEqual(param.key_credentials[0].key_id, key_id_of_existing_cert)
+
+        faked_graph_client = mock.MagicMock()
+        sp_object = mock.MagicMock()
+        sp_object.app_id = 'app_id'
+        app_object = mock.MagicMock()
+        app_object.object_id = test_object_id
+        key_cred = mock.MagicMock()
+        key_cred.key_id = key_id_of_existing_cert
+
+        graph_client_mock.return_value = faked_graph_client
+        faked_graph_client.service_principals.list.return_value = [sp_object]
+        faked_graph_client.applications.list.return_value = [app_object]
+        faked_graph_client.applications.get.side_effect = [app_object, app_object]
+        faked_graph_client.applications.patch = test_patch
+        faked_graph_client.applications.list_key_credentials.return_value = [key_cred]
+
+        # action
+        reset_service_principal_credential(name, cert=test_cert, append=True)
+
+        # assert
+        self.assertTrue(patch_invoked[0])
 
 
 class FakedResponse(object):  # pylint: disable=too-few-public-methods

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role_commands_thru_mock.py
@@ -161,7 +161,7 @@ class TestRoleMocked(unittest.TestCase):
 
     @mock.patch('azure.cli.command_modules.role.custom._graph_client_factory', autospec=True)
     def test_reset_credentials_password(self, graph_client_mock):
-        patch_invoked = [False]
+        patch_invoked = [False]  # to be used in a nested function below, array type is needed to get scoping work
         test_object_id = 'app_object_id'
         test_pwd = 'verySecret'
         name = 'http://mysp'
@@ -181,7 +181,7 @@ class TestRoleMocked(unittest.TestCase):
         graph_client_mock.return_value = faked_graph_client
         faked_graph_client.service_principals.list.return_value = [sp_object]
         faked_graph_client.applications.list.return_value = [app_object]
-        faked_graph_client.applications.get.side_effect = [app_object, app_object]
+        faked_graph_client.applications.get.side_effect = [app_object]
         faked_graph_client.applications.patch = test_patch
         faked_graph_client.applications.list_password_credentials.side_effect = [ValueError('should not invoke')]
 
@@ -193,7 +193,7 @@ class TestRoleMocked(unittest.TestCase):
 
     @mock.patch('azure.cli.command_modules.role.custom._graph_client_factory', autospec=True)
     def test_reset_credentials_certificate_append_option(self, graph_client_mock):
-        patch_invoked = [False]
+        patch_invoked = [False]  # to be used in a nested function below, array type is needed to get scoping work
         test_object_id = 'app_object_id'
         test_cert = _try_x509_pem('\n'.join(['-----BEGIN CERTIFICATE-----',
                                              'MIICoTCCAYkCAgPoMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCUNMSS1Mb2dp',
@@ -235,7 +235,7 @@ class TestRoleMocked(unittest.TestCase):
         graph_client_mock.return_value = faked_graph_client
         faked_graph_client.service_principals.list.return_value = [sp_object]
         faked_graph_client.applications.list.return_value = [app_object]
-        faked_graph_client.applications.get.side_effect = [app_object, app_object]
+        faked_graph_client.applications.get.side_effect = [app_object]
         faked_graph_client.applications.patch = test_patch
         faked_graph_client.applications.list_key_credentials.return_value = [key_cred]
 

--- a/src/command_modules/azure-cli-role/setup.py
+++ b/src/command_modules/azure-cli-role/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.14"
+VERSION = "2.0.15"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fix #3996 
### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
