### PR TITLE
Add az sql show-usage/list-usages

### DIFF
--- a/src/command_modules/azure-cli-sql/HISTORY.rst
+++ b/src/command_modules/azure-cli-sql/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+unreleased
+++++++++++
+* Added az sql db list-usages and az sql db show-usage commands.
+
 2.0.15
 ++++++
 * Added --ignore-missing-vnet-service-endpoint param to az sql server vnet-rule create and update commands

--- a/src/command_modules/azure-cli-sql/HISTORY.rst
+++ b/src/command_modules/azure-cli-sql/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 
-unreleased
+2.0.16
 ++++++++++
 * Added az sql db list-usages and az sql db show-usage commands.
 

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
@@ -96,5 +96,9 @@ def get_sql_server_usages_operations(kwargs):
     return get_sql_management_client(kwargs).server_usages
 
 
+def get_sql_subscription_usages_operations(kwargs):
+    return get_sql_management_client(kwargs).subscription_usages
+
+
 def get_sql_virtual_network_rules_operations(kwargs):
     return get_sql_management_client(kwargs).virtual_network_rules

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
@@ -26,6 +26,7 @@ from ._util import (
     get_sql_server_keys_operations,
     get_sql_servers_operations,
     get_sql_server_usages_operations,
+    get_sql_subscription_usages_operations,
     get_sql_virtual_network_rules_operations
 )
 
@@ -46,6 +47,20 @@ if not supported_api_version(PROFILE_TYPE, max_api='2017-03-09-profile'):
 
         with s.group('sql elastic-pool') as c:
             c.custom_command('list-editions', 'elastic_pool_list_capabilities')
+
+    ###############################################
+    #                sql list-usages              #
+    ###############################################
+
+    subscription_usages_operations = create_service_adapter(
+        'azure.mgmt.sql.operations.subscription_usages_operations',
+        'SubscriptionUsagesOperations')
+
+    with ServiceGroup(__name__, get_sql_subscription_usages_operations,
+                      subscription_usages_operations, custom_path) as s:
+        with s.group('sql') as c:
+            c.command('list-usages', 'list_by_location')
+            c.command('show-usage', 'get')
 
     ###############################################
     #                sql db                       #

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
@@ -10,6 +10,7 @@ from azure.cli.core.commands.parameters import (
     enum_choice_list,
     ignore_type,
     get_resource_name_completion_list,
+    location_type,
     three_state_flag)
 from azure.cli.core.sdk.util import ParametersContext, patch_arg_make_required, patch_arg_make_optional
 from azure.mgmt.sql.models.database import Database
@@ -45,6 +46,7 @@ server_param_type = CliArgumentType(
     options_list=('--server', '-s'),
     help='Name of the Azure SQL server.')
 
+
 #####
 #        SizeWithUnitConverter - consider moving to common code (azure.cli.core.commands.parameters)
 #####
@@ -77,6 +79,11 @@ class SizeWithUnitConverter(object):  # pylint: disable=too-few-public-methods
         return 'Size (in {}) - valid units are {}.'.format(
             self.unit,
             ', '.join(sorted(self.unit_map, key=self.unit_map.__getitem__)))
+
+
+with ParametersContext(command='sql') as c:
+    c.argument('location_name', arg_type=location_type)
+    c.argument('usage_name', options_list=('--usage', '-u'))
 
 
 ###############################################

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/recordings/latest/test_sql_subscription_usages.yaml
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/recordings/latest/test_sql_subscription_usages.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [sql list-usages]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.18
+          msrest_azure/0.4.16 sqlmanagementclient/0.8.3 Azure-SDK-For-Python AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Sql/locations/westus/usages?api-version=2015-05-01-preview
+  response:
+    body: {string: '{"value":[{"properties":{"displayName":"Regional Server Quota
+        for westus","currentValue":2.0,"limit":20.0,"unit":"Count"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Sql/locations/westus/usages/ServerQuota","name":"ServerQuota","type":"Microsoft.Sql/locations/usages"},{"properties":{"displayName":"Free
+        Database Count per Subscription for westus","currentValue":0.0,"limit":1.0,"unit":"Count"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Sql/locations/westus/usages/SubscriptionFreeDatabaseCount","name":"SubscriptionFreeDatabaseCount","type":"Microsoft.Sql/locations/usages"},{"properties":{"displayName":"Free
+        to Basic Database Upgrade count-down in westus","currentValue":136.0,"limit":365.0,"unit":"Count"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Sql/locations/westus/usages/SubscriptionFreeDatabaseDaysLeft","name":"SubscriptionFreeDatabaseDaysLeft","type":"Microsoft.Sql/locations/usages"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1004']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 14 Nov 2017 07:56:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [sql show-usage]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.18
+          msrest_azure/0.4.16 sqlmanagementclient/0.8.3 Azure-SDK-For-Python AZURECLI/2.0.21]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Sql/locations/westus/usages/SubscriptionFreeDatabaseDaysLeft?api-version=2015-05-01-preview
+  response:
+    body: {string: '{"properties":{"displayName":"Free to Basic Database Upgrade count-down
+        in westus","currentValue":136.0,"limit":365.0,"unit":"Count"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Sql/locations/westus/usages/SubscriptionFreeDatabaseDaysLeft","name":"SubscriptionFreeDatabaseDaysLeft","type":"Microsoft.Sql/locations/usages"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['356']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 14 Nov 2017 07:56:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/test_sql_commands.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/test_sql_commands.py
@@ -1723,3 +1723,14 @@ class SqlServerVnetMgmtScenarioTest(ScenarioTest):
         # test sql server vnet-rule delete rule 2
         self.cmd('sql server vnet-rule delete --name {} -g {} --server {}'.format(vnet_rule_2, rg, server),
                  checks=NoneCheck())
+
+
+class SqlSubscriptionUsagesScenarioTest(ScenarioTest):
+    def test_sql_subscription_usages(self):
+        self.cmd('sql list-usages -l westus',
+                 checks=[JMESPathCheckGreaterThan('length(@)', 2)])
+
+        self.cmd('sql show-usage -l westus -u SubscriptionFreeDatabaseDaysLeft',
+                 checks=[
+                     JMESPathCheck('name', 'SubscriptionFreeDatabaseDaysLeft'),
+                     JMESPathCheckGreaterThan('limit', 0)])

--- a/src/command_modules/azure-cli-sql/setup.py
+++ b/src/command_modules/azure-cli-sql/setup.py
@@ -29,7 +29,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-mgmt-sql==0.8.3',
+    'azure-mgmt-sql==0.8.4',
     'azure-mgmt-storage==1.4.0',
     'six'
 ]

--- a/src/command_modules/azure-cli-sql/setup.py
+++ b/src/command_modules/azure-cli-sql/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.15"
+VERSION = "2.0.16"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
```
(env) D:\git\azure-cli [subscriptionUsages ≡]> az sql show-usage -h

Command
    az sql show-usage: Gets a subscription usage metric.

Arguments
    --location -l [Required]: Location. You can configure the default location using `az configure
                              --defaults location=<location>`.
    --usage -u    [Required]: Name of usage metric to return.

Global Arguments
    --debug                 : Increase logging verbosity to show all debug logs.
    --help -h               : Show this help message and exit.
    --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                              json.
    --query                 : JMESPath query string. See http://jmespath.org/ for more information
                              and examples.
    --verbose               : Increase logging verbosity. Use --debug for full debug logs.

(env) D:\git\azure-cli [subscriptionUsages ≡]> az sql list-usages -h

Command
    az sql list-usages: Gets all subscription usage metrics in a given location.

Arguments
    --location -l [Required]: Location. You can configure the default location using `az configure
                              --defaults location=<location>`.

Global Arguments
    --debug                 : Increase logging verbosity to show all debug logs.
    --help -h               : Show this help message and exit.
    --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                              json.
    --query                 : JMESPath query string. See http://jmespath.org/ for more information
                              and examples.
    --verbose               : Increase logging verbosity. Use --debug for full debug logs.
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
