### PR TITLE
Fixes #4953: Updating getSiteCredentials to get the correct credentials

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -2,13 +2,11 @@
 
 Release History
 ===============
-0.1.24
-++++++
-* `webapp log tail`: fixing a bug where support for slots was not working
 
 0.1.24
 ++++++
 * `webapp config ssl upload`: fix a bug where the hosting_environment_profile was null
+* `webapp log tail`: fixing a bug where support for slots was not working
 
 0.1.23
 ++++++

--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+0.1.24
+++++++
+* `webapp log tail`: fixing a bug where support for slots was not working
 
 0.1.24
 ++++++

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1220,7 +1220,7 @@ def get_streaming_log(cmd, resource_group_name, name, provider=None, slot=None):
         streaming_url += ('/' + provider.lstrip('/'))
 
     client = web_client_factory(cmd.cli_ctx)
-    user, password = _get_site_credential(client, resource_group_name, name, slot)
+    user, password = _get_site_credential(resource_group_name, name, slot)
     t = threading.Thread(target=_get_log, args=(streaming_url, user, password))
     t.daemon = True
     t.start()
@@ -1233,12 +1233,12 @@ def download_historical_logs(cmd, resource_group_name, name, log_file=None, slot
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
     url = scm_url.rstrip('/') + '/dump'
     client = web_client_factory(cmd.cli_ctx)
-    user_name, password = _get_site_credential(client, resource_group_name, name)
+    user_name, password = _get_site_credential(resource_group_name, name)
     _get_log(url, user_name, password, log_file)
     logger.warning('Downloaded logs to %s', log_file)
 
 
-def _get_site_credential(client, resource_group_name, name, slot=None):
+def _get_site_credential(resource_group_name, name, slot=None):
     creds = _generic_site_operation(resource_group_name, name, 'list_publishing_credentials', slot)
     creds = creds.result()
     return (creds.publishing_user_name, creds.publishing_password)
@@ -1603,10 +1603,9 @@ def list_locations(cmd, sku, linux_workers_enabled=None):
     return client.list_geo_regions(full_sku, linux_workers_enabled)
 
 
-def enable_zip_deploy(cmd, resource_group_name, name, src, slot=None):
-    client = web_client_factory(cmd.cli_ctx)
-    user_name, password = _get_site_credential(client, resource_group_name, name, slot)
-    scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
+def enable_zip_deploy(resource_group_name, name, src, slot=None):
+    user_name, password = _get_site_credential(resource_group_name, name, slot)
+    scm_url = _get_scm_url(resource_group_name, name, slot)
     zip_url = scm_url + '/api/zipdeploy'
 
     import urllib3

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1231,7 +1231,7 @@ def get_streaming_log(cmd, resource_group_name, name, provider=None, slot=None):
 def download_historical_logs(cmd, resource_group_name, name, log_file=None, slot=None):
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
     url = scm_url.rstrip('/') + '/dump'
-    user_name, password = _get_site_credential(resource_group_name, name)
+    user_name, password = _get_site_credential(resource_group_name, name, slot)
     _get_log(url, user_name, password, log_file)
     logger.warning('Downloaded logs to %s', log_file)
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1232,7 +1232,6 @@ def get_streaming_log(cmd, resource_group_name, name, provider=None, slot=None):
 def download_historical_logs(cmd, resource_group_name, name, log_file=None, slot=None):
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
     url = scm_url.rstrip('/') + '/dump'
-    client = web_client_factory(cmd.cli_ctx)
     user_name, password = _get_site_credential(resource_group_name, name)
     _get_log(url, user_name, password, log_file)
     logger.warning('Downloaded logs to %s', log_file)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1220,7 +1220,7 @@ def get_streaming_log(cmd, resource_group_name, name, provider=None, slot=None):
         streaming_url += ('/' + provider.lstrip('/'))
 
     client = web_client_factory(cmd.cli_ctx)
-    user, password = _get_site_credential(client, resource_group_name, name)
+    user, password = _get_site_credential(client, resource_group_name, name, slot)
     t = threading.Thread(target=_get_log, args=(streaming_url, user, password))
     t.daemon = True
     t.start()
@@ -1238,8 +1238,11 @@ def download_historical_logs(cmd, resource_group_name, name, log_file=None, slot
     logger.warning('Downloaded logs to %s', log_file)
 
 
-def _get_site_credential(client, resource_group_name, name):
-    creds = client.web_apps.list_publishing_credentials(resource_group_name, name)
+def _get_site_credential(client, resource_group_name, name, slot=None):
+    if slot:
+        creds = client.web_apps.list_publishing_credentials_slot(resource_group_name, name, slot)
+    else:
+        creds = client.web_apps.list_publishing_credentials(resource_group_name, name)
     creds = creds.result()
     return (creds.publishing_user_name, creds.publishing_password)
 
@@ -1605,7 +1608,7 @@ def list_locations(cmd, sku, linux_workers_enabled=None):
 
 def enable_zip_deploy(cmd, resource_group_name, name, src, slot=None):
     client = web_client_factory(cmd.cli_ctx)
-    user_name, password = _get_site_credential(client, resource_group_name, name)
+    user_name, password = _get_site_credential(client, resource_group_name, name, slot)
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
     zip_url = scm_url + '/api/zipdeploy'
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1219,7 +1219,6 @@ def get_streaming_log(cmd, resource_group_name, name, provider=None, slot=None):
     if provider:
         streaming_url += ('/' + provider.lstrip('/'))
 
-    client = web_client_factory(cmd.cli_ctx)
     user, password = _get_site_credential(resource_group_name, name, slot)
     t = threading.Thread(target=_get_log, args=(streaming_url, user, password))
     t.daemon = True

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1239,10 +1239,7 @@ def download_historical_logs(cmd, resource_group_name, name, log_file=None, slot
 
 
 def _get_site_credential(client, resource_group_name, name, slot=None):
-    if slot:
-        creds = client.web_apps.list_publishing_credentials_slot(resource_group_name, name, slot)
-    else:
-        creds = client.web_apps.list_publishing_credentials(resource_group_name, name)
+    creds = _generic_site_operation(resource_group_name, name, 'list_publishing_credentials', slot)
     creds = creds.result()
     return (creds.publishing_user_name, creds.publishing_password)
 


### PR DESCRIPTION
for a slot the publishing credentials is obtained using the list_publishing_credentials_slot, however the 
_get_site_credential was not supporting this logic updated this to obtain the right credentials & updated get _streaming_log & enable_zip_deploy to get the right credentials (NOTE: this however needs to be done to all places the _get_site_credentials is called
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
