### PR TITLE
Debian Build: Remove the cryptography workaround

### DIFF
--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -64,8 +64,6 @@ done;
 all_modules=`find $tmp_pkg_dir -name "*.whl"`
 $source_dir/python_env/bin/pip3 install $all_modules
 $source_dir/python_env/bin/pip3 install --force-reinstall --upgrade azure-nspkg azure-mgmt-nspkg
-# WORKAROUND: Newer versions of cryptography do not work on Bash on Windows / WSL - see https://github.com/Azure/azure-cli/issues/4154
-# If you *have* to use a newer version of cryptography in the future, verify that it works on WSL also.
 # Add the debian files
 mkdir $source_dir/debian
 # Create temp dir for the debian/ directory used for CLI build.

--- a/build_scripts/debian/build.sh
+++ b/build_scripts/debian/build.sh
@@ -66,7 +66,6 @@ $source_dir/python_env/bin/pip3 install $all_modules
 $source_dir/python_env/bin/pip3 install --force-reinstall --upgrade azure-nspkg azure-mgmt-nspkg
 # WORKAROUND: Newer versions of cryptography do not work on Bash on Windows / WSL - see https://github.com/Azure/azure-cli/issues/4154
 # If you *have* to use a newer version of cryptography in the future, verify that it works on WSL also.
-$source_dir/python_env/bin/pip3 install cryptography==2.0
 # Add the debian files
 mkdir $source_dir/debian
 # Create temp dir for the debian/ directory used for CLI build.


### PR DESCRIPTION
Remove the cryptography workaround as it works in WSL now and we had to update cryptography