### PR TITLE
Knack bug fixes

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -36,6 +36,7 @@ class AzCli(CLI):
         from azure.cli.core._session import ACCOUNT, CONFIG, SESSION
 
         import knack.events as events
+        from knack.util import ensure_dir
 
         self.data['headers'] = {}
         self.data['command'] = 'unknown'
@@ -44,8 +45,7 @@ class AzCli(CLI):
         self.data['query_active'] = False
 
         azure_folder = self.config.config_dir
-        if not os.path.exists(azure_folder):
-            os.mkdir(azure_folder)
+        ensure_dir(azure_folder)
         ACCOUNT.load(os.path.join(azure_folder, 'azureProfile.json'))
         CONFIG.load(os.path.join(azure_folder, 'az.json'))
         SESSION.load(os.path.join(azure_folder, 'az.sess'), max_age=3600)

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -80,6 +80,10 @@ class AzCli(CLI):
         from azure.cli.core.util import get_az_version_string
         print(get_az_version_string())
 
+    def exception_handler(self, ex):  # pylint: disable=no-self-use
+        from azure.cli.core.util import handle_exception
+        return handle_exception(ex)
+
 
 class MainCommandsLoader(CLICommandsLoader):
 

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -32,11 +32,11 @@ You can change your telemetry settings with `az configure`.
 """
 
 WELCOME_MESSAGE = r"""
-    /\\
-   /  \\    _____   _ _ __ ___
-  / /\ \\  |_  / | | | \'__/ _ \\
- / ____ \\  / /| |_| | | |  __/
-/_/    \_\\/___|\__,_|_|  \___|
+     /\\
+    /  \\    _____   _ _  ___ _
+   / /\ \\  |_  / | | | \'__/ _\
+  / ____ \\  / /| |_| | | |  __/
+ /_/    \_\\/___|\__,_|_|  \___|
 
 
 Welcome to the cool new Azure CLI!

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -32,11 +32,11 @@ You can change your telemetry settings with `az configure`.
 """
 
 WELCOME_MESSAGE = r"""
-     /\\
-    /  \\    _____   _ _  ___ _
-   / /\ \\  |_  / | | | \'__/ _\
-  / ____ \\  / /| |_| | | |  __/
- /_/    \_\\/___|\__,_|_|  \___|
+     /\
+    /  \    _____   _ _  ___ _
+   / /\ \  |_  / | | | \'__/ _\
+  / ____ \  / /| |_| | | |  __/
+ /_/    \_\/___|\__,_|_|  \___|
 
 
 Welcome to the cool new Azure CLI!

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -9,6 +9,7 @@ import platform
 
 from azure.cli.core.commands.validators import validate_tag, validate_tags
 from azure.cli.core.commands.validators import generate_deployment_name
+from azure.cli.core.decorators import Completer
 from azure.cli.core.profiles import ResourceType
 
 from knack.arguments import CLIArgumentType, CaseInsensitiveList
@@ -24,8 +25,9 @@ def get_subscription_locations(cli_ctx):
     return list(subscription_client.subscriptions.list_locations(subscription_id))
 
 
-def get_location_completion_list(cli_ctx, prefix, **kwargs):  # pylint: disable=unused-argument
-    result = get_subscription_locations(cli_ctx)
+@Completer
+def get_location_completion_list(cmd, prefix, namespace,**kwargs):  # pylint: disable=unused-argument
+    result = get_subscription_locations(cmd.cli_ctx)
     return [l.name for l in result]
 
 
@@ -58,8 +60,9 @@ def get_resource_groups(cli_ctx):
     return list(rcf.resource_groups.list())
 
 
-def get_resource_group_completion_list(cli_ctx, prefix, **kwargs):  # pylint: disable=unused-argument
-    result = get_resource_groups(cli_ctx)
+@Completer
+def get_resource_group_completion_list(cmd, prefix, namespace, **kwargs):  # pylint: disable=unused-argument
+    result = get_resource_groups(cmd.cli_ctx)
     return [l.name for l in result]
 
 
@@ -93,7 +96,9 @@ def get_resource_name_completion_list(resource_type=None):
 
 
 def get_generic_completion_list(generic_list):
-    def completer(prefix, action, parsed_args, **kwargs):  # pylint: disable=unused-argument
+
+    @Completer
+    def completer(cmd, prefix, namespace, **kwargs):  # pylint: disable=unused-argument
         return generic_list
     return completer
 


### PR DESCRIPTION
- Fixes #4993. Cloud Errors should no longer produce a stack trace.
- Fixes #4943. ASCII art no longer looks wonky.
- Fixes #5001. Uses the `ensure_dirs` stuff from the latest Knack.
- Fixes #4999. Resource group and location completers now work. Also updated generic_completer even though nothing uses it today.