### PR TITLE
Prevent using "extra" on a non-command argument context.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -893,6 +893,10 @@ class AzArgumentContext(ArgumentsContext):
         if not self._applicable():
             return
 
+        if self.scope not in self.command_loader.command_table:
+            raise ValueError("command authoring error: extra argument '{}' cannot be registered to a group-level "\
+                             "scope '{}'. It must be registered to a specific command.".format(dest, self.scope))
+
         merged_kwargs = self.group_kwargs.copy()
         merged_kwargs.update(kwargs)
         if self.command_loader.supported_api_version(resource_type=merged_kwargs.get('resource_type'),


### PR DESCRIPTION
Example:
```
command authoring error: extra argument 'noodle' cannot be registered to a group-level scope 'resource'. It must be registered to a specific command.
Traceback (most recent call last):
  File "C:\Users\trpresco\Documents\github\azure-cli\env\lib\site-packages\knack\cli.py", line 193, in invoke
    cmd_result = self.invocation.execute(args)
  File "c:\users\trpresco\documents\github\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 241, in execute
    self.commands_loader.load_arguments(command)
  File "c:\users\trpresco\documents\github\azure-cli\src\azure-cli-core\azure\cli\core\__init__.py", line 204, in load_arguments
    loader.load_arguments(command)  # this adds entries to the argument registries
  File "c:\users\trpresco\documents\github\azure-cli\src\command_modules\azure-cli-resource\azure\cli\command_modules\resource\__init__.py", line 26, in load_arguments
    load_arguments(self, command)
  File "c:\users\trpresco\documents\github\azure-cli\src\command_modules\azure-cli-resource\azure\cli\command_modules\resource\_params.py", line 39, in load_arguments
    c.extra('noodle')
  File "c:\users\trpresco\documents\github\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 898, in extra
    "scope '{}'. It must be registered to a specific command.".format(dest, self.scope))
ValueError: command authoring error: extra argument 'noodle' cannot be registered to a group-level scope 'resource'. It must be registered to a specific command.
```

I opted for ValueError instead of CLIError because the stack trace pinpoints the exact problem line.