### PR TITLE
Fixes#4988:Certificates uploaded through CLI is not useable to bind to an app

### DIFF
--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -14,7 +14,8 @@
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <InterpreterId>MSBuild|{54f4b6dc-0859-46dc-99bb-b275c9d0aca3}|$(MSBuildProjectFullPath)</InterpreterId>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <CommandLineArguments>mysql server-logs download -h</CommandLineArguments>
+    <CommandLineArguments>
+    </CommandLineArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />

--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.24
+++++++
+* `webapp config ssl upload`: fix a bug where the hosting_environment_profile was null
+
 0.1.23
 ++++++
 * Minor fixes.
@@ -10,6 +14,7 @@ Release History
 0.1.22
 ++++++
 * Minor fixes.
+* `webapp config ssl upload`: fix a bug where the hosting_environment_profile was null
 
 0.1.21
 ++++++

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1296,7 +1296,7 @@ def upload_ssl_cert(cmd, resource_group_name, name, certificate_password, certif
     cert_name = _generate_cert_name(thumb_print, hosting_environment_profile_param,
                                     webapp.location, cert_resource_group_name)
     cert = Certificate(password=certificate_password, pfx_blob=cert_contents,
-                       location=webapp.location)
+                       location=webapp.location, server_farm_id=webapp.server_farm_id)
     return client.certificates.create_or_update(cert_resource_group_name, cert_name, cert)
 
 

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.23"
+VERSION = "0.1.24"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fix #4988

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
