### PR TITLE
Use the actual extension name rather than the module name

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -162,7 +162,7 @@ class MainCommandsLoader(CLICommandsLoader):
 
                         for cmd_name, cmd in extension_command_table.items():
                             cmd.command_source = ExtensionCommandSource(
-                                extension_name=ext_mod,
+                                extension_name=ext_name,
                                 overrides_command=cmd_name in cmd_to_mod_map)
 
                         self.command_table.update(extension_command_table)


### PR DESCRIPTION
fixes knack regression

Fixes the following:

Actual:
```
$ az image copy -h
This command is from the following extension: azext_imagecopy
```

Expected:
```
$ az image copy -h
This command is from the following extension: azure-cli-image-copy-extension
```
