### PR TITLE
vmss: ensure app-gateway has a name when defaults to it for large scalesets

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.21
+++++++
+vmss: ensure app-gateway has a name when defaults to it for large scalesets
 
 2.0.19
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1685,7 +1685,6 @@ def create_vmss(cmd, vmss_name, resource_group_name, image,
         master_template.add_resource(lb_resource)
 
     # Or handle application gateway creation
-    app_gateway = application_gateway
     if app_gateway_type == 'new':
         vmss_dependencies.append('Microsoft.Network/applicationGateways/{}'.format(app_gateway))
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vmss_create_default_app_gateway.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vmss_create_default_app_gateway.yaml
@@ -1,0 +1,258 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.21
+          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.22]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 19 Dec 2017 19:25:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.21
+          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.22]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 19 Dec 2017 19:25:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [raw.githubusercontent.com]
+      User-Agent: [Python-urllib/3.5]
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
+        ,\n  \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\"\
+        :{},\n  \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"\
+        type\":\"object\",\n      \"value\":{\n\n        \"Linux\":{\n          \"\
+        CentOS\":{\n            \"publisher\":\"OpenLogic\",\n            \"offer\"\
+        :\"CentOS\",\n            \"sku\":\"7.3\",\n            \"version\":\"latest\"\
+        \n          },\n          \"CoreOS\":{\n            \"publisher\":\"CoreOS\"\
+        ,\n            \"offer\":\"CoreOS\",\n            \"sku\":\"Stable\",\n  \
+        \          \"version\":\"latest\"\n          },\n          \"Debian\":{\n\
+        \            \"publisher\":\"credativ\",\n            \"offer\":\"Debian\"\
+        ,\n            \"sku\":\"8\",\n            \"version\":\"latest\"\n      \
+        \    },\n          \"openSUSE-Leap\": {\n            \"publisher\":\"SUSE\"\
+        ,\n            \"offer\":\"openSUSE-Leap\",\n            \"sku\":\"42.2\"\
+        ,\n            \"version\": \"latest\"\n          },\n          \"RHEL\":{\n\
+        \            \"publisher\":\"RedHat\",\n            \"offer\":\"RHEL\",\n\
+        \            \"sku\":\"7.3\",\n            \"version\":\"latest\"\n      \
+        \    },\n          \"SLES\":{\n            \"publisher\":\"SUSE\",\n     \
+        \       \"offer\":\"SLES\",\n            \"sku\":\"12-SP2\",\n           \
+        \ \"version\":\"latest\"\n          },\n          \"UbuntuLTS\":{\n      \
+        \      \"publisher\":\"Canonical\",\n            \"offer\":\"UbuntuServer\"\
+        ,\n            \"sku\":\"16.04-LTS\",\n            \"version\":\"latest\"\n\
+        \          }\n        },\n\n        \"Windows\":{\n          \"Win2016Datacenter\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2016-Datacenter\",\n   \
+        \         \"version\":\"latest\"\n          },\n          \"Win2012R2Datacenter\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2012-R2-Datacenter\",\n\
+        \            \"version\":\"latest\"\n          },\n          \"Win2012Datacenter\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2012-Datacenter\",\n   \
+        \         \"version\":\"latest\"\n          },\n          \"Win2008R2SP1\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2008-R2-SP1\",\n       \
+        \     \"version\":\"latest\"\n          }\n        }\n      }\n    }\n  }\n\
+        }\n"}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['*']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['2235']
+      content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
+      content-type: [text/plain; charset=utf-8]
+      date: ['Tue, 19 Dec 2017 19:25:39 GMT']
+      etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
+      expires: ['Tue, 19 Dec 2017 19:30:39 GMT']
+      source-age: ['116']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [HIT]
+      x-cache-hits: ['1']
+      x-content-type-options: [nosniff]
+      x-fastly-request-id: [6c8e8e582f5fa1ac886aca47b4b1dedb743f9081]
+      x-frame-options: [deny]
+      x-geo-block-list: ['']
+      x-github-request-id: ['DC80:5F7A:2F69:4973:5A39673F']
+      x-served-by: [cache-sea1023-SEA]
+      x-timer: ['S1513711539.156160,VS0,VE1']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.21
+          msrest_azure/0.4.19 networkmanagementclient/1.5.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.22]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-09-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 19 Dec 2017 19:25:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"properties": {"template": {"contentVersion": "1.0.0.0", "outputs":
+      {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
+      "type": "object"}}, "parameters": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "resources": [{"name": "vmss1VNET", "type": "Microsoft.Network/virtualNetworks",
+      "tags": {}, "dependsOn": [], "properties": {"subnets": [{"name": "vmss1Subnet",
+      "properties": {"addressPrefix": "10.0.0.0/24"}}, {"name": "appGwSubnet", "properties":
+      {"addressPrefix": "10.0.1.0/24"}}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}},
+      "location": "westus", "apiVersion": "2015-06-15"}, {"apiVersion": "2017-09-01",
+      "type": "Microsoft.Network/publicIPAddresses", "tags": {}, "dependsOn": [],
+      "name": "vmss1AGPublicIP", "properties": {"publicIPAllocationMethod": "Dynamic"},
+      "location": "westus"}, {"name": "vmss1AG", "type": "Microsoft.Network/applicationGateways",
+      "tags": {}, "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/publicIpAddresses/vmss1AGPublicIP"],
+      "properties": {"backendHttpSettingsCollection": [{"name": "appGwBackendHttpSettings",
+      "properties": {"Protocol": "Http", "CookieBasedAffinity": "Disabled", "Port":
+      80}}], "frontendPorts": [{"name": "appGwFrontendPort", "properties": {"Port":
+      80}}], "httpListeners": [{"name": "appGwHttpListener", "properties": {"Protocol":
+      "Http", "FrontendPort": {"Id": "[concat(variables(\''appGwID\''), \''/frontendPorts/appGwFrontendPort\'')]"},
+      "FrontendIPConfiguration": {"Id": "[concat(variables(\''appGwID\''), \''/frontendIPConfigurations/appGwFrontendIP\'')]"},
+      "SslCertificate": null}}], "sku": {"name": "Standard_Large", "capacity": 10,
+      "tier": "Standard"}, "frontendIPConfigurations": [{"name": "appGwFrontendIP",
+      "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1AGPublicIP"}}}],
+      "requestRoutingRules": [{"Name": "rule1", "properties": {"backendHttpSettings":
+      {"id": "[concat(variables(\''appGwID\''), \''/backendHttpSettingsCollection/appGwBackendHttpSettings\'')]"},
+      "httpListener": {"id": "[concat(variables(\''appGwID\''), \''/httpListeners/appGwHttpListener\'')]"},
+      "RuleType": "Basic", "backendAddressPool": {"id": "[concat(variables(\''appGwID\''),
+      \''/backendAddressPools/vmss1LBBEPool\'')]"}}}], "backendAddressPools": [{"name":
+      "vmss1LBBEPool"}], "gatewayIPConfigurations": [{"name": "appGwIpConfig", "properties":
+      {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/appGwSubnet"}}}]},
+      "location": "westus", "apiVersion": "2015-06-15"}, {"name": "vmss1", "type":
+      "Microsoft.Compute/virtualMachineScaleSets", "sku": {"name": "Standard_D1_v2",
+      "capacity": 101}, "tags": {}, "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
+      "Microsoft.Network/applicationGateways/vmss1AG"], "properties": {"singlePlacementGroup":
+      false, "virtualMachineProfile": {"storageProfile": {"imageReference": {"sku":
+      "16.04-LTS", "publisher": "Canonical", "offer": "UbuntuServer", "version": "latest"},
+      "osDisk": {"caching": "ReadWrite", "createOption": "FromImage", "managedDisk":
+      {"storageAccountType": null}}}, "osProfile": {"computerNamePrefix": "vmss197db",
+      "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh": {"publicKeys":
+      [{"path": "/home/yugangw2/.ssh/authorized_keys", "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==
+      yugangw2@YUGANGLP2\\n"}]}}, "adminUsername": "yugangw2"}, "networkProfile":
+      {"networkInterfaceConfigurations": [{"name": "vmss197dbNic", "properties": {"primary":
+      "true", "ipConfigurations": [{"name": "vmss197dbIPConfig", "properties": {"subnet":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
+      "ApplicationGatewayBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/applicationGateways/vmss1AG/backendAddressPools/vmss1LBBEPool"}]}}]}}]}},
+      "upgradePolicy": {"mode": "manual"}, "overprovision": false}, "location": "westus",
+      "apiVersion": "2017-03-30"}], "variables": {"appGwID": "[resourceId(\''Microsoft.Network/applicationGateways\'',
+      \''vmss1AG\'')]"}}, "mode": "Incremental", "parameters": {}}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Length: ['5089']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.21
+          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.22]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2017-05-10
+  response:
+    body: {string: '{"error":{"code":"InvalidTemplateDeployment","message":"The template
+        deployment ''vmss_deploy_Dv3yH8HWDAEV4KBDtihEXIg54WK7X8T6'' is not valid according
+        to the validation procedure. The tracking id is ''4826f764-79b6-46b8-9ff2-bc4224ef7b92''.
+        See inner errors for details. Please see https://aka.ms/arm-deploy for usage
+        details.","details":[{"code":"QuotaExceeded","message":"Operation results
+        in exceeding quota limits of Core. Maximum allowed: 100, Current in use: 5,
+        Additional requested: 101. Please read more about quota increase at http://aka.ms/corequotaincrease."}]}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['570']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 19 Dec 2017 19:25:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-failure-cause: [gateway]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.18.4 msrest/0.4.21
+          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.22]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Tue, 19 Dec 2017 19:25:43 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdRQjNXUUtNRUhPU1JSNUtUV1pGN01DMkY1TFBZN09XMzZFT3xGNUUxNjg2MEJEMzUyNjBCLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -1355,6 +1355,14 @@ class VMSSCreateBalancerOptionsTest(ScenarioTest):  # pylint: disable=too-many-i
             self.check('virtualMachineProfile.networkProfile.networkInterfaceConfigurations[0].ipConfigurations[0].applicationGatewayBackendAddressPools[0].resourceGroup', '{rg}')
         ])
 
+    @ResourceGroupPreparer()
+    def test_vmss_create_default_app_gateway(self, resource_group):
+        vmss_name = 'vmss1'
+        res = self.cmd("vmss create -g {} --name {} --image UbuntuLTS --disable-overprovision --instance-count 101 "
+                       "--single-placement-group false --validate".format(resource_group, vmss_name)).get_output_in_json()
+        # Ensure generated template is valid. "Quota Exceeding" is expected on most subscriptions, so we allow that.
+        self.assertTrue(not res['error'] or (res['error']['details'][0]['code'] == 'QuotaExceeded'))
+
     @ResourceGroupPreparer(name_prefix='cli_test_vmss_create_w_ips')
     def test_vmss_public_ip_per_vm_custom_domain_name(self, resource_group):
 

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.19"
+VERSION = "2.0.21"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Same with #5137, but target to the `KnackConversion` branch.
As long as this PR can catch up with the Jan 17 release, I am fine with any branch to target. Looks like KnackConversion is lagging behind, so the CI failure at this moment is not caused by this PR  

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
