### PR TITLE
Allow user to specify custom client_arg_name

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,6 +2,15 @@
 
 Release History
 ===============
+
+2.0.24
+++++++
+* Minor fixes
+
+2.0.23
+++++++
+* Minor fixes
+
 2.0.22
 ++++++
 * Minor fixes

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -319,7 +319,8 @@ class AzCommandsLoader(CLICommandsLoader):
 
             client = client_factory(self.cli_ctx, command_args) if client_factory else None
             if client:
-                client_arg_name = kwargs.get('client_arg_name', 'client' if operation.startswith(('azure.cli', 'azext')) else 'self')
+                client_arg_name = kwargs.get('client_arg_name',
+                                             'client' if operation.startswith(('azure.cli', 'azext')) else 'self')
                 if client_arg_name in op_args:
                     command_args[client_arg_name] = client
             result = op(**command_args)

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 from __future__ import print_function
 
-__version__ = "2.0.22"
+__version__ = "2.0.24"
 
 import os
 import sys

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -319,7 +319,7 @@ class AzCommandsLoader(CLICommandsLoader):
 
             client = client_factory(self.cli_ctx, command_args) if client_factory else None
             if client:
-                client_arg_name = 'client' if operation.startswith(('azure.cli', 'azext')) else 'self'
+                client_arg_name = kwargs.get('client_arg_name', 'client' if operation.startswith(('azure.cli', 'azext')) else 'self')
                 if client_arg_name in op_args:
                     command_args[client_arg_name] = client
             result = op(**command_args)

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -26,7 +26,7 @@ import azure.cli.core.telemetry as telemetry
 logger = get_logger(__name__)
 
 CLI_COMMAND_KWARGS = ['transform', 'table_transformer', 'confirmation', 'exception_handler', 'min_api', 'max_api',
-                      'client_factory', 'operations_tmpl', 'no_wait_param', 'validator', 'resource_type']
+                      'client_factory', 'operations_tmpl', 'no_wait_param', 'validator', 'resource_type', 'client_arg_name']
 
 CONFIRM_PARAM_NAME = 'yes'
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -26,7 +26,8 @@ import azure.cli.core.telemetry as telemetry
 logger = get_logger(__name__)
 
 CLI_COMMAND_KWARGS = ['transform', 'table_transformer', 'confirmation', 'exception_handler', 'min_api', 'max_api',
-                      'client_factory', 'operations_tmpl', 'no_wait_param', 'validator', 'resource_type', 'client_arg_name']
+                      'client_factory', 'operations_tmpl', 'no_wait_param', 'validator', 'resource_type',
+                      'client_arg_name']
 
 CONFIRM_PARAM_NAME = 'yes'
 

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.22"
+VERSION = "2.0.24"
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ===============
 
+2.0.24
+++++++
+* Minor fixes
+
+2.0.23
+++++++
+* Minor fixes
+
 2.0.22
 ++++++
 * Remove `az component` commands. Use `az extension` instead. `az component` has been deprecated for several months now.

--- a/src/azure-cli/azure/cli/__init__.py
+++ b/src/azure-cli/azure/cli/__init__.py
@@ -11,4 +11,4 @@ import pkg_resources
 pkg_resources.declare_namespace(__name__)
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "2.0.22"
+__version__ = "2.0.24"

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.22"
+VERSION = "2.0.24"
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:


### PR DESCRIPTION
For vendored SDKs, the dynamic smartness of `client_arg_name = 'client' if operation.startswith(('azure.cli', 'azext')) else 'self'` is not reliable.

This PR allows the user to override this.