### PR TITLE
[Prototype] Refactor the api version

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -274,13 +274,14 @@ class AzCommandsLoader(CLICommandsLoader):
         resource_type = resource_type or self._get_resource_type()
         return get_api_version(self.cli_ctx, resource_type)
 
-    def supported_api_version(self, resource_type=None, min_api=None, max_api=None):
+    def supported_api_version(self, resource_type=None, min_api=None, max_api=None, operation_group=None):
         from azure.cli.core.profiles import supported_api_version, PROFILE_TYPE
         return supported_api_version(
             cli_ctx=self.cli_ctx,
             resource_type=resource_type or self._get_resource_type() or PROFILE_TYPE,
             min_api=min_api or self.min_profile,
-            max_api=max_api or self.max_profile)
+            max_api=max_api or self.max_profile,
+            operation_group=operation_group)
 
     def get_sdk(self, *attr_args, **kwargs):
         from azure.cli.core.profiles import get_sdk
@@ -344,10 +345,9 @@ class AzCommandsLoader(CLICommandsLoader):
 
         if self.supported_api_version(resource_type=kwargs.get('resource_type'),
                                       min_api=kwargs.get('min_api'),
-                                      max_api=kwargs.get('max_api')):
-            self.command_table[name] = self.command_cls(self, name,
-                                                        handler or default_command_handler,
-                                                        **kwargs)
+                                      max_api=kwargs.get('max_api'),
+                                      operation_group=kwargs.get('operation_group', None)):
+            self.command_table[name] = self.command_cls(self, name, handler or default_command_handler, **kwargs)
 
     def get_op_handler(self, operation):
         """ Import and load the operation handler """

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -640,7 +640,7 @@ class SubscriptionFinder(object):
             from azure.cli.core._debug import change_ssl_cert_verification
             client_type = get_client_class(ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS)
             api_version = get_api_version(cli_ctx, ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS)
-            return change_ssl_cert_verification(client_type(credentials, api_version=api_version,
+            return change_ssl_cert_verification(client_type(credentials, api_version=str(api_version),
                                                             base_url=self.cli_ctx.cloud.endpoints.resource_manager))
 
         self._arm_client_factory = create_arm_client_factory

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -176,9 +176,10 @@ class AzCliCommand(CLICommand):
         resource_type = resource_type or self.command_kwargs.get('resource_type', None)
         return self.loader.get_api_version(resource_type=resource_type)
 
-    def supported_api_version(self, resource_type=None, min_api=None, max_api=None):
+    def supported_api_version(self, resource_type=None, min_api=None, max_api=None, operation_group=None):
         resource_type = resource_type or self.command_kwargs.get('resource_type', None)
-        return self.loader.supported_api_version(resource_type=resource_type, min_api=min_api, max_api=max_api)
+        return self.loader.supported_api_version(resource_type=resource_type, min_api=min_api, max_api=max_api,
+                                                 operation_group=operation_group)
 
     def get_models(self, *attr_args, **kwargs):
         resource_type = kwargs.get('resource_type', self.command_kwargs.get('resource_type', None))

--- a/src/azure-cli-core/azure/cli/core/profiles/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/__init__.py
@@ -4,40 +4,43 @@
 # --------------------------------------------------------------------------------------------
 
 #  pylint: disable=unused-import
-from azure.cli.core.profiles._shared import AZURE_API_PROFILES, ResourceType, PROFILE_TYPE
+from azure.cli.core.profiles._shared import AZURE_API_PROFILES, ResourceType, PROFILE_TYPE, get_client_class
+from azure.cli.core.profiles._apiversions import ApiVersions
 
 
-def get_api_version(cli_ctx, resource_type, as_sdk_profile=False):
+def get_api_version(cli_ctx, resource_type):
     """ Get the current API version for a given resource_type.
 
+    :param cli_ctx: The CLI context
     :param resource_type: The resource type.
     :type resource_type: ResourceType.
-    :param bool as_sdk_profile: Return SDKProfile instance.
     :returns: The API version
-     Can return a tuple<operation_group, str> if the resource_type supports SDKProfile.
-    :rtype: str or tuple[str]
+    :rtype: ApiVersions
     """
     from azure.cli.core.profiles._shared import get_api_version as _sdk_get_api_version
-    return _sdk_get_api_version(cli_ctx.cloud.profile, resource_type, as_sdk_profile)
+    return _sdk_get_api_version(cli_ctx.cloud.profile, resource_type)
 
 
-def supported_api_version(cli_ctx, resource_type, min_api=None, max_api=None):
+def supported_api_version(cli_ctx, resource_type, min_api=None, max_api=None, operation_group=None):
     """ Method to check if the current API version for a given resource_type is supported.
         If resource_type is set to None, the current profile version will be used as the basis of
         the comparison.
 
+    :param cli_ctx: The CLI context
     :param resource_type: The resource type.
     :type resource_type: ResourceType.
     :param min_api: The minimum API that is supported (inclusive). Omit for no minimum constraint.
     "type min_api: str
     :param max_api: The maximum API that is supported (inclusive). Omit for no maximum constraint.
     :type max_api: str
+    :param operation_group: The operation group to be tested.
+    :type operation_group: str
     :returns: True if the current API version of resource_type satisfies the min/max constraints. False otherwise.
      Can return a tuple<operation_group, bool> if the resource_type supports SDKProfile.
     :rtype: bool or tuple[bool]
     """
     from azure.cli.core.profiles._shared import supported_api_version as _sdk_supported_api_version
-    return _sdk_supported_api_version(cli_ctx.cloud.profile, resource_type, min_api, max_api)
+    return _sdk_supported_api_version(cli_ctx.cloud.profile, resource_type, min_api, max_api, operation_group)
 
 
 def get_sdk(cli_ctx, resource_type, *attr_args, **kwargs):
@@ -67,6 +70,7 @@ def get_sdk(cli_ctx, resource_type, *attr_args, **kwargs):
                                      mod='models',
                                      operation_group='virtual_machines')
 
+    :param cli_ctx: The CLI context
     :param resource_type: The resource type.
     :type resource_type: ResourceType.
     :param attr_args: Positional arguments for paths to objects to get.

--- a/src/azure-cli-core/azure/cli/core/profiles/_apiversions.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_apiversions.py
@@ -1,0 +1,114 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from functools import total_ordering
+from ._shared import SDKProfile, get_client_class, ResourceType
+
+
+class ApiVersions(object):
+    def __init__(self, api_version_data, resource_type=None):
+        self._resource_type=resource_type
+        self._sdk_profile = None
+        self._op_groups = set()
+
+        if isinstance(api_version_data, str):
+            self._default_version = api_version_data
+
+        elif isinstance(api_version_data, SDKProfile):
+            if not resource_type:
+                raise ValueError('The resource_type is missing.')
+            self._sdk_profile = api_version_data
+            self._default_version = self._sdk_profile.default_api_version
+            self._op_groups = set(
+                [op for op, t in get_client_class(resource_type).__dict__.items() if isinstance(t, property)])
+
+        else:
+            raise ValueError('The given api version data is neither a str or {}'.format(SDKProfile.__name__))
+
+    def __str__(self):
+        return self.get_version()
+
+    def is_operation_group_required(self):
+        return self._sdk_profile is not None
+
+    def get_version(self, operation_group=None):
+        if self.is_operation_group_required():
+            if not operation_group:
+                raise ValueError("operation group is required for resource type '{}'".format(self._resource_type))
+
+            if operation_group not in self._op_groups:
+                raise KeyError("operation group {} is not defined for resource type '{}'".format(operation_group, self._resource_type))
+
+            return self._sdk_profile.profile.get(operation_group, self._default_version)
+        else:
+            return self._default_version
+
+    def get_default_version(self):
+        return self._default_version
+
+    def get_sdk_profile(self):
+        return self._sdk_profile
+
+    def is_supported(self, min_api=None, max_api=None, operation_group=None):
+        if not operation_group:
+            api_version = _DateAPIFormat(self._default_version)
+        else:
+            if not self.is_operation_group_required():
+                raise ValueError("operation group is not supported for resource type '{}'".format(self._resource_type))
+            api_version = _DateAPIFormat(self.get_version(operation_group))
+
+        if min_api and api_version < _DateAPIFormat(min_api):
+            return False
+        if max_api and api_version > _DateAPIFormat(max_api):
+            return False
+        return True
+
+
+@total_ordering  # pylint: disable=too-few-public-methods
+class _DateAPIFormat(object):
+    """ Class to support comparisons for API versions in
+        YYYY-MM-DD, YYYY-MM-DD-preview, YYYY-MM-DD-profile, YYYY-MM-DD-profile-preview
+        or any string that starts with YYYY-MM-DD format. A special case is made for 'latest'.
+    """
+
+    def __init__(self, api_version_str):
+        try:
+            self.latest = self.preview = False
+            self.yyyy = self.mm = self.dd = None
+            if api_version_str == 'latest':
+                self.latest = True
+            else:
+                if 'preview' in api_version_str:
+                    self.preview = True
+                parts = api_version_str.split('-')
+                self.yyyy = int(parts[0])
+                self.mm = int(parts[1])
+                self.dd = int(parts[2])
+        except (ValueError, TypeError):
+            raise ValueError('The API version {} is not in a '
+                             'supported format'.format(api_version_str))
+
+    def __eq__(self, other):
+        return self.latest == other.latest and self.yyyy == other.yyyy and self.mm == other.mm and \
+               self.dd == other.dd and self.preview == other.preview
+
+    def __lt__(self, other):  # pylint: disable=too-many-return-statements
+        if self.latest or other.latest:
+            if not self.latest and other.latest:
+                return True
+            if self.latest and not other.latest:
+                return False
+            return False
+        if self.yyyy < other.yyyy:
+            return True
+        if self.yyyy == other.yyyy:
+            if self.mm < other.mm:
+                return True
+            if self.mm == other.mm:
+                if self.dd < other.dd:
+                    return True
+                if self.dd == other.dd:
+                    if self.preview and not other.preview:
+                        return True

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_template_builder.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_template_builder.py
@@ -201,7 +201,7 @@ def build_application_gateway_resource(cmd, name, location, tags, sku_name, sku_
         'name': name,
         'location': location,
         'tags': tags,
-        'apiVersion': cmd.get_api_version(),
+        'apiVersion': str(cmd.get_api_version()),
         'dependsOn': [],
         'properties': ag_properties
     }
@@ -226,7 +226,7 @@ def build_load_balancer_resource(cmd, name, location, tags, backend_pool_name, f
         'name': name,
         'location': location,
         'tags': tags,
-        'apiVersion': cmd.get_api_version(),
+        'apiVersion': str(cmd.get_api_version()),
         'dependsOn': [],
         'properties': lb_properties
     }
@@ -242,7 +242,7 @@ def build_public_ip_resource(cmd, name, location, tags, address_allocation, dns_
         public_ip_properties['dnsSettings'] = {'domainNameLabel': dns_name}
 
     public_ip = {
-        'apiVersion': cmd.get_api_version(),
+        'apiVersion': str(cmd.get_api_version()),
         'type': 'Microsoft.Network/publicIPAddresses',
         'name': name,
         'location': location,

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -771,7 +771,7 @@ def get_network_watcher_from_vm(namespace):
 def get_network_watcher_from_resource(namespace):
     resource_client = get_mgmt_service_client(namespace.cmd.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES).resources
     resource = resource_client.get_by_id(namespace.resource,
-                                         namespace.cmd.get_api_version(ResourceType.MGMT_NETWORK))
+                                         str(namespace.cmd.get_api_version(ResourceType.MGMT_NETWORK)))
     namespace.location = resource.location  # pylint: disable=no-member
     get_network_watcher_from_location(remove=True)(namespace)
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -135,7 +135,7 @@ def build_public_ip_resource(cmd, name, location, tags, address_allocation, dns_
         public_ip_properties['dnsSettings'] = {'domainNameLabel': dns_name}
 
     public_ip = {
-        'apiVersion': cmd.get_api_version(ResourceType.MGMT_NETWORK),
+        'apiVersion': str(cmd.get_api_version(ResourceType.MGMT_NETWORK)),
         'type': 'Microsoft.Network/publicIPAddresses',
         'name': name,
         'location': location,
@@ -294,7 +294,7 @@ def build_vm_msi_extension(cmd, vm_name, location, role_assignment_guid, port, i
     return {
         'type': 'Microsoft.Compute/virtualMachines/extensions',
         'name': vm_name + '/' + ext_type_name,
-        'apiVersion': cmd.get_api_version(ResourceType.MGMT_COMPUTE).virtual_machine_extensions,
+        'apiVersion': cmd.get_api_version(ResourceType.MGMT_COMPUTE).get_version('virtual_machine_extensions'),
         'location': location,
         'dependsOn': [role_assignment_guid or 'Microsoft.Compute/virtualMachines/' + vm_name],
         'properties': {
@@ -440,7 +440,7 @@ def build_vm_resource(  # pylint: disable=too-many-locals
         vm_properties['licenseType'] = license_type
 
     vm = {
-        'apiVersion': cmd.get_api_version(ResourceType.MGMT_COMPUTE).virtual_machines,
+        'apiVersion': cmd.get_api_version(ResourceType.MGMT_COMPUTE).get_version('virtual_machines'),
         'type': 'Microsoft.Compute/virtualMachines',
         'name': name,
         'location': location,
@@ -655,7 +655,7 @@ def build_load_balancer_resource(cmd, name, location, tags, backend_pool_name, n
         'name': name,
         'location': location,
         'tags': tags,
-        'apiVersion': cmd.get_api_version(ResourceType.MGMT_NETWORK),
+        'apiVersion': str(cmd.get_api_version(ResourceType.MGMT_NETWORK)),
         'dependsOn': [],
         'properties': lb_properties
     }
@@ -804,7 +804,7 @@ def build_vmss_resource(cmd, name, naming_prefix, location, tags, overprovision,
         }
     }
 
-    if cmd.supported_api_version(min_api='2017-03-30').virtual_machine_scale_sets:  # pylint: disable=no-member
+    if cmd.supported_api_version(min_api='2017-03-30', operation_group='virtual_machine_scale_sets'):
         if dns_servers:
             nic_config['properties']['dnsSettings'] = {'dnsServers': dns_servers}
 
@@ -831,10 +831,10 @@ def build_vmss_resource(cmd, name, naming_prefix, location, tags, overprovision,
     if license_type:
         vmss_properties['virtualMachineProfile']['licenseType'] = license_type
 
-    if health_probe and cmd.supported_api_version(min_api='2017-03-30').virtual_machine_scale_sets:  # pylint: disable=no-member
+    if health_probe and cmd.supported_api_version(min_api='2017-03-30', operation_group='virtual_machine_scale_sets'):
         vmss_properties['virtualMachineProfile']['networkProfile']['healthProbe'] = {'id': health_probe}
 
-    if cmd.supported_api_version(min_api='2016-04-30-preview').virtual_machine_scale_sets:  # pylint: disable=no-member
+    if cmd.supported_api_version(min_api='2016-04-30-preview', operation_group='virtual_machine_scale_sets'):
         vmss_properties['singlePlacementGroup'] = single_placement_group
 
     vmss = {
@@ -842,7 +842,7 @@ def build_vmss_resource(cmd, name, naming_prefix, location, tags, overprovision,
         'name': name,
         'location': location,
         'tags': tags,
-        'apiVersion': cmd.get_api_version(ResourceType.MGMT_COMPUTE).virtual_machine_scale_sets,  # pylint: disable=no-member
+        'apiVersion': cmd.get_api_version(ResourceType.MGMT_COMPUTE).get_version('virtual_machine_scale_sets'),
         'dependsOn': [],
         'sku': {
             'name': vm_sku,
@@ -862,13 +862,13 @@ def build_av_set_resource(cmd, name, location, tags,
         'name': name,
         'location': location,
         'tags': tags,
-        'apiVersion': cmd.get_api_version(ResourceType.MGMT_COMPUTE).availability_sets,  # pylint: disable=no-member
+        'apiVersion': cmd.get_api_version(ResourceType.MGMT_COMPUTE).get_version('availability_sets'),
         "properties": {
             'platformFaultDomainCount': platform_fault_domain_count,
         }
     }
 
-    if cmd.supported_api_version(min_api='2016-04-30-preview').availability_sets:  # pylint: disable=no-member
+    if cmd.supported_api_version(min_api='2016-04-30-preview', operation_group='availability_sets'):
         av_set['sku'] = {
             'name': 'Classic' if unmanaged else 'Aligned'
         }


### PR DESCRIPTION
This change addresses multiple issues:
1. Performance: the VM module spends 80% of the loading time constructing a `namedtuple`. It is as expensive as it can get. This PR eliminate the `namedtuple`.
2. Regression: the PR #4983 is not fully merged back to `KnackFinal` branch. The `AzCliCommand` and `AzCommandLoader` ignores the `operation_group` in the API version comparison.
3. Design: the `get_api_version` is confusing, it may return one of the following three types: `str`, `namedtuple`, and `SDKProfile`. Three types are consumed differently and `isinstance` is widely used to alter the downstream consumer behavior. It is a bad design. This change concentrate the usage to single `ApiVersions` type.

Follow up:
This PR is not complete, but design opinion and advice are welcome. Some unit tests need to be updated.