### PR TITLE
Updates to avoid breaking azure.common dependencies.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -380,3 +380,20 @@ class AzCommandsLoader(CLICommandsLoader):
             return six.get_method_function(op)
         except (ValueError, AttributeError):
             raise ValueError("The operation '{}' is invalid.".format(operation))
+
+
+def get_default_cli():
+    from azure.cli.core.azlogging import AzCliLogging
+    from azure.cli.core.commands import AzCliCommandInvoker
+    from azure.cli.core.parser import AzCliCommandParser
+    from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
+    from azure.cli.core._help import AzCliHelp
+
+    return AzCli(cli_name='az',
+                 config_dir=GLOBAL_CONFIG_DIR,
+                 config_env_var_prefix=ENV_VAR_PREFIX,
+                 commands_loader_cls=MainCommandsLoader,
+                 invocation_cls=AzCliCommandInvoker,
+                 parser_cls=AzCliCommandParser,
+                 logging_cls=AzCliLogging,
+                 help_cls=AzCliHelp)

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -104,8 +104,11 @@ def get_credential_types(cli_ctx):
 
 
 class Profile(object):
-    def __init__(self, cli_ctx, storage=None, auth_ctx_factory=None, use_global_creds_cache=True):
-        self.cli_ctx = cli_ctx
+
+    def __init__(self, storage=None, auth_ctx_factory=None, use_global_creds_cache=True, cli_ctx=None):
+        from azure.cli.core import get_default_cli
+
+        self.cli_ctx = cli_ctx or get_default_cli()
         self._storage = storage or ACCOUNT
         self.auth_ctx_factory = auth_ctx_factory or _AUTH_CTX_FACTORY
         if use_global_creds_cache:
@@ -160,7 +163,7 @@ class Profile(object):
         if allow_no_subscriptions:
             t_list = [s.tenant_id for s in subscriptions]
             bare_tenants = [t for t in subscription_finder.tenants if t not in t_list]
-            profile = Profile(self.cli_ctx)
+            profile = Profile(cli_ctx=self.cli_ctx)
             subscriptions = profile._build_tenant_level_accounts(bare_tenants)  # pylint: disable=protected-access
             if not subscriptions:
                 return []

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -286,7 +286,10 @@ def get_cloud(cli_ctx, cloud_name):
     return cloud
 
 
-def get_active_cloud(cli_ctx):
+def get_active_cloud(cli_ctx=None):
+    if not cli_ctx:
+        from azure.cli.core import get_default_cli
+        cli_ctx = get_default_cli()
     try:
         return get_cloud(cli_ctx, get_active_cloud_name(cli_ctx))
     except CloudNotRegisteredException as err:
@@ -330,7 +333,7 @@ def set_cloud_subscription(cli_ctx, cloud_name, subscription):
 def _set_active_subscription(cli_ctx, cloud_name):
     from azure.cli.core._profile import (Profile, _ENVIRONMENT_NAME, _SUBSCRIPTION_ID,
                                          _STATE, _SUBSCRIPTION_NAME)
-    profile = Profile(cli_ctx)
+    profile = Profile(cli_ctx=cli_ctx)
     subscription_to_use = get_cloud_subscription(cloud_name) or \
                           next((s[_SUBSCRIPTION_ID] for s in profile.load_cached_subscriptions()  # noqa
                                 if s[_STATE] == 'Enabled'),

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -81,7 +81,7 @@ def _get_mgmt_service_client(cli_ctx,
     from azure.cli.core._profile import Profile
     logger.debug('Getting management service client client_type=%s', client_type.__name__)
     resource = resource or cli_ctx.cloud.endpoints.active_directory_resource_id
-    profile = Profile(cli_ctx)
+    profile = Profile(cli_ctx=cli_ctx)
     cred, subscription_id, _ = profile.get_login_credentials(subscription_id=subscription_id, resource=resource)
 
     client_kwargs = {}
@@ -129,7 +129,7 @@ def get_data_service_client(cli_ctx, service_type, account_name, account_key, co
 
 def get_subscription_id(cli_ctx):
     from azure.cli.core._profile import Profile
-    _, subscription_id, _ = Profile(cli_ctx).get_login_credentials()
+    _, subscription_id, _ = Profile(cli_ctx=cli_ctx).get_login_credentials()
     return subscription_id
 
 

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -292,7 +292,7 @@ def _get_installation_id():
 @decorators.suppress_all_exceptions(fallback_return=None)
 def _get_profile():
     from azure.cli.core._profile import Profile
-    return Profile(_session.application)
+    return Profile(cli_ctx=_session.application)
 
 
 @decorators.suppress_all_exceptions(fallback_return='')

--- a/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
@@ -43,7 +43,7 @@ class TestCloud(unittest.TestCase):
         with self.assertRaises(CloudEndpointNotSetException):
             cli = TestCli()
             cli.cloud = Cloud('AzureCloud')
-            profile = Profile(cli)
+            profile = Profile(cli_ctx=cli)
             profile.get_login_credentials()
 
     @mock.patch('azure.cli.core.cloud.get_custom_clouds', lambda: [])

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -85,7 +85,7 @@ class TestProfile(unittest.TestCase):
     def test_normalize(self):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1,
                                                      [self.subscription1],
                                                      False)
@@ -108,7 +108,7 @@ class TestProfile(unittest.TestCase):
     def test_update_add_two_different_subscriptions(self):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         # add the first and verify
         consolidated = profile._normalize_properties(self.user1,
@@ -160,7 +160,7 @@ class TestProfile(unittest.TestCase):
     def test_update_with_same_subscription_added_twice(self):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         # add one twice and verify we will have one but with new token
         consolidated = profile._normalize_properties(self.user1,
@@ -183,7 +183,7 @@ class TestProfile(unittest.TestCase):
     def test_set_active_subscription(self):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         consolidated = profile._normalize_properties(self.user1,
                                                      [self.subscription1],
@@ -204,7 +204,7 @@ class TestProfile(unittest.TestCase):
     def test_default_active_subscription_to_non_disabled_one(self):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         subscriptions = profile._normalize_properties(
             self.user2, [self.subscription2, self.subscription1], False)
@@ -218,7 +218,7 @@ class TestProfile(unittest.TestCase):
     def test_get_subscription(self):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         consolidated = profile._normalize_properties(self.user1,
                                                      [self.subscription1],
@@ -237,7 +237,7 @@ class TestProfile(unittest.TestCase):
     def test_get_auth_info_fail_on_user_account(self):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         consolidated = profile._normalize_properties(self.user1,
                                                      [self.subscription1],
@@ -265,7 +265,7 @@ class TestProfile(unittest.TestCase):
         finder = SubscriptionFinder(cli, lambda _, _1, _2: mock_auth_context, None, lambda _: mock_arm_client)
 
         storage_mock = {'subscriptions': []}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         profile._management_resource_uri = 'https://management.core.windows.net/'
         profile.find_subscriptions_on_login(False, '1234', 'my-secret', True, self.tenant_id, False, finder)
         # action
@@ -280,7 +280,7 @@ class TestProfile(unittest.TestCase):
     def test_get_auth_info_for_newly_created_service_principal(self):
         cli = TestCli()
         storage_mock = {'subscriptions': []}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1, [self.subscription1], False)
         profile._set_subscriptions(consolidated)
         # action
@@ -303,7 +303,7 @@ class TestProfile(unittest.TestCase):
         finder = SubscriptionFinder(cli, lambda _, _1, _2: mock_auth_context, None, lambda _: mock_arm_client)
 
         storage_mock = {'subscriptions': []}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         profile._management_resource_uri = 'https://management.core.windows.net/'
 
         # action
@@ -337,7 +337,7 @@ class TestProfile(unittest.TestCase):
         finder = SubscriptionFinder(cli, lambda _, _1, _2: mock_auth_context, None, lambda _: mock_arm_client)
 
         storage_mock = {'subscriptions': []}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         profile._management_resource_uri = 'https://management.core.windows.net/'
 
         # action
@@ -362,7 +362,7 @@ class TestProfile(unittest.TestCase):
         finder = mock.MagicMock()
         finder.find_through_interactive_flow.return_value = []
         storage_mock = {'subscriptions': []}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         # action
         result = profile.find_subscriptions_on_login(True,
@@ -383,7 +383,7 @@ class TestProfile(unittest.TestCase):
         mock_read_cred_file.return_value = [TestProfile.token_entry1]
 
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1,
                                                      [self.subscription1],
                                                      False)
@@ -398,7 +398,7 @@ class TestProfile(unittest.TestCase):
     def test_create_token_cache(self, mock_read_file):
         cli = TestCli()
         mock_read_file.return_value = []
-        profile = Profile(cli, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, use_global_creds_cache=False)
         cache = profile._creds_cache.adal_token_cache
         self.assertFalse(cache.read_items())
         self.assertTrue(mock_read_file.called)
@@ -407,7 +407,7 @@ class TestProfile(unittest.TestCase):
     def test_load_cached_tokens(self, mock_read_file):
         cli = TestCli()
         mock_read_file.return_value = [TestProfile.token_entry1]
-        profile = Profile(cli, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, use_global_creds_cache=False)
         cache = profile._creds_cache.adal_token_cache
         matched = cache.find({
             "_authority": "https://login.microsoftonline.com/common",
@@ -426,7 +426,7 @@ class TestProfile(unittest.TestCase):
         mock_get_token.return_value = (some_token_type, TestProfile.raw_token1)
         # setup
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1,
                                                      [self.subscription1],
                                                      False)
@@ -453,7 +453,7 @@ class TestProfile(unittest.TestCase):
 
         # setup an existing msi subscription
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_tenant_id = '12345678-38d6-4fb2-bad9-b7b93a3e1234'
         test_port = '12345'
@@ -498,7 +498,7 @@ class TestProfile(unittest.TestCase):
 
         # setup an existing msi subscription
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_tenant_id = '12345678-38d6-4fb2-bad9-b7b93a3e1234'
         test_port = '12345'
@@ -545,7 +545,7 @@ class TestProfile(unittest.TestCase):
 
         # setup an existing msi subscription
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         test_object_id = '12345678-38d6-4fb2-bad9-b7b93a3e9999'
         msi_subscription = SubscriptionStub('/subscriptions/12345678-1bf0-4dda-aec3-cb9272f09590',
                                             'MSIObject-{}@12345'.format(test_object_id),
@@ -584,7 +584,7 @@ class TestProfile(unittest.TestCase):
 
         # setup an existing msi subscription
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         test_sub_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_res_id = ('/subscriptions/{}/resourceGroups/r1/providers/Microsoft.ManagedIdentity/'
                        'userAssignedIdentities/id1').format(test_sub_id)
@@ -654,7 +654,7 @@ class TestProfile(unittest.TestCase):
                                        TestProfile.token_entry1)
         # setup
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1,
                                                      [self.subscription1],
                                                      False)
@@ -682,7 +682,7 @@ class TestProfile(unittest.TestCase):
         mock_get_token.return_value = (some_token_type, TestProfile.raw_token1)
         # setup
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1, [self.subscription1],
                                                      False)
         profile._set_subscriptions(consolidated)
@@ -722,7 +722,7 @@ class TestProfile(unittest.TestCase):
         setattr(test_sub, 'tenant_id', '54826b22-38d6-4fb2-bad9-b7b93a3e9c5a')
 
         with mock.patch('azure.cli.core._profile.SubscriptionFinder._find_using_specific_tenant', autospec=True, return_value=[test_sub]):
-            profile = Profile(cli, use_global_creds_cache=False, storage=test_account)
+            profile = Profile(cli_ctx=cli, use_global_creds_cache=False, storage=test_account)
             result_accounts = profile.find_subscriptions_in_cloud_console([arm_token, kv_token])
 
         # verify the local account
@@ -787,7 +787,7 @@ class TestProfile(unittest.TestCase):
         mock_get_token.return_value = (some_token_type, TestProfile.raw_token1)
         # setup
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1, [self.subscription1],
                                                      False)
         profile._set_subscriptions(consolidated)
@@ -808,7 +808,7 @@ class TestProfile(unittest.TestCase):
         mock_read_cred_file.return_value = [TestProfile.token_entry1]
 
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1,
                                                      [self.subscription1],
                                                      False)
@@ -827,7 +827,7 @@ class TestProfile(unittest.TestCase):
         cli = TestCli()
         # setup
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1,
                                                      [self.subscription1],
                                                      False)
@@ -877,7 +877,7 @@ class TestProfile(unittest.TestCase):
         mock_get_client_class.return_value = ClientStub
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         test_token_entry = {
             'token_type': 'Bearer',
@@ -913,7 +913,7 @@ class TestProfile(unittest.TestCase):
         mock_get_client_class.return_value = ClientStub
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         test_token_entry = {
             'token_type': 'Bearer',
@@ -950,7 +950,7 @@ class TestProfile(unittest.TestCase):
         mock_get_client_class.return_value = ClientStub
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         test_token_entry = {
             'token_type': 'Bearer',
@@ -985,7 +985,7 @@ class TestProfile(unittest.TestCase):
         mock_get_client_class.return_value = ClientStub
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         test_token_entry = {
             'token_type': 'Bearer',
@@ -1155,7 +1155,7 @@ class TestProfile(unittest.TestCase):
     def test_refresh_accounts_one_user_account(self, mock_auth_context):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False)
         profile._set_subscriptions(consolidated)
         mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1
@@ -1178,7 +1178,7 @@ class TestProfile(unittest.TestCase):
     def test_refresh_accounts_one_user_account_one_sp_account(self, mock_auth_context):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         sp_subscription1 = SubscriptionStub('sp-sub/3', 'foo-subname', self.state1, 'foo_tenant.onmicrosoft.com')
         consolidated = profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False)
         consolidated += profile._normalize_properties('http://foo', [sp_subscription1], True)
@@ -1207,7 +1207,7 @@ class TestProfile(unittest.TestCase):
     def test_refresh_accounts_with_nothing(self, mock_auth_context):
         cli = TestCli()
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
         consolidated = profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False)
         profile._set_subscriptions(consolidated)
         mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1
@@ -1416,7 +1416,7 @@ class TestProfile(unittest.TestCase):
         adfs_url_1 = 'https://adfs.redmond.ext-u15f2402.masd.stbtest.microsoft.com/adfs/'
         cli.cloud.endpoints.active_directory = adfs_url_1
         storage_mock = {'subscriptions': None}
-        profile = Profile(cli, storage_mock, use_global_creds_cache=False)
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False)
 
         # test w/ trailing slash
         r = profile.auth_ctx_factory(cli, 'common', None)

--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -8,12 +8,7 @@ import sys
 from knack.completion import ARGCOMPLETE_ENV_NAME
 from knack.log import get_logger
 
-from azure.cli.core import MainCommandsLoader, AzCli
-from azure.cli.core.azlogging import AzCliLogging
-from azure.cli.core.commands import AzCliCommandInvoker
-from azure.cli.core.parser import AzCliCommandParser
-from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
-from azure.cli.core._help import AzCliHelp
+from azure.cli.core import get_default_cli
 
 import azure.cli.core.telemetry as telemetry
 
@@ -24,14 +19,7 @@ def cli_main(cli, args):
     return cli.invoke(args)
 
 
-az_cli = AzCli(cli_name='az',
-               config_dir=GLOBAL_CONFIG_DIR,
-               config_env_var_prefix=ENV_VAR_PREFIX,
-               commands_loader_cls=MainCommandsLoader,
-               invocation_cls=AzCliCommandInvoker,
-               parser_cls=AzCliCommandParser,
-               logging_cls=AzCliLogging,
-               help_cls=AzCliHelp)
+az_cli = get_default_cli()
 
 telemetry.set_application(az_cli, ARGCOMPLETE_ENV_NAME)
 

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_docker_utils.py
@@ -53,7 +53,7 @@ def _get_aad_token(cli_ctx, login_server, only_refresh_token, repository=None, p
     authhost = urlunparse((authurl[0], authurl[1], '/oauth2/exchange', '', '', ''))
 
     from azure.cli.core._profile import Profile
-    profile = Profile(cli_ctx)
+    profile = Profile(cli_ctx=cli_ctx)
     sp_id, refresh, access, tenant = profile.get_refresh_token()
 
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
@@ -44,7 +44,7 @@ def get_graph_rbac_management_client(cli_ctx, **_):
     from azure.cli.core._profile import Profile
     from azure.graphrbac import GraphRbacManagementClient
 
-    profile = Profile(cli_ctx)
+    profile = Profile(cli_ctx=cli_ctx)
     cred, _, tenant_id = profile.get_login_credentials(
         resource=cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
     client = GraphRbacManagementClient(

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -343,7 +343,7 @@ def k8s_install_connector(cmd, client, name, resource_group_name, connector_name
     client_secret = principal_obj.get("client_secret")
     service_principal = principal_obj.get("service_principal")
     # Get the TenantID
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
     _, _, tenant_id = profile.get_login_credentials()
     # Check if we want the linux connector
     if os_type.lower() in ['linux', 'both']:
@@ -475,7 +475,7 @@ def _add_role_assignment(cli_ctx, role, service_principal, delay=2):
 
 
 def _get_subscription_id(cli_ctx):
-    _, sub_id, _ = Profile(cli_ctx).get_login_credentials(subscription_id=None)
+    _, sub_id, _ = Profile(cli_ctx=cli_ctx).get_login_credentials(subscription_id=None)
     return sub_id
 
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/vsts_cd_provider.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/vsts_cd_provider.py
@@ -22,7 +22,7 @@ class VstsContinuousDeliveryProvider(object):
         """
 
         # Gather information about the Azure connection
-        profile = Profile(cli_ctx)
+        profile = Profile(cli_ctx=cli_ctx)
         subscription = profile.get_subscription()
         user = profile.get_current_account_user()
         cred, _, _ = profile.get_login_credentials(subscription_id=None)

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_client_factory.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_client_factory.py
@@ -74,7 +74,7 @@ def batch_data_service_factory(cli_ctx, kwargs):
     credentials = None
     if not account_key:
         from azure.cli.core._profile import Profile
-        profile = Profile(cli_ctx)
+        profile = Profile(cli_ctx=cli_ctx)
         credentials, _, _ = profile.get_login_credentials(
             resource=cli_ctx.cloud.endpoints.batch_resource_id)
     else:

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/custom.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/custom.py
@@ -102,7 +102,7 @@ def login_account(cmd, client, resource_group_name, account_name, shared_key_aut
         cmd.cli_ctx.config.set_value('batch', 'auth_mode', 'aad')
         if show:
             resource = cmd.cli_ctx.cloud.endpoints.batch_resource_id
-            profile = Profile(cmd.cli_ctx)
+            profile = Profile(cli_ctx=cmd.cli_ctx)
             creds, subscription, tenant = profile.get_raw_token(resource=resource)
             return {
                 'tokenType': creds[0],

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/custom.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/custom.py
@@ -58,7 +58,7 @@ def _config_env_public_azure(cli_ctx, _):
             method_index = prompt_choice_list(MSG_PROMPT_LOGIN, LOGIN_METHOD_LIST)
             answers['login_index'] = method_index
             answers['login_options'] = str(LOGIN_METHOD_LIST)
-            profile = Profile(cli_ctx)
+            profile = Profile(cli_ctx=cli_ctx)
             interactive = False
             username = None
             password = None

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_client_factory.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_client_factory.py
@@ -26,7 +26,7 @@ def cf_dls_filesystem(cli_ctx, account_name):
     from azure.datalake.store import core
     from azure.cli.core._profile import Profile
 
-    profile = Profile(cli_ctx)
+    profile = Profile(cli_ctx=cli_ctx)
     subscription_id = None
     cred, subscription_id, _ = profile.get_login_credentials(
         subscription_id=subscription_id,

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -263,7 +263,7 @@ class AzInteractiveShell(object):
     def _toolbar_info(self):
         sub_name = ""
         try:
-            profile = Profile(self.cli_ctx)
+            profile = Profile(cli_ctx=self.cli_ctx)
             sub_name = profile.get_subscription()[_SUBSCRIPTION_NAME]
         except CLIError:
             pass

--- a/src/command_modules/azure-cli-interactive/azclishell/telemetry.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/telemetry.py
@@ -39,7 +39,7 @@ class Telemetry(TelemetryClient):
         # adding context
         self.context.application.id = 'Azure CLI Shell'
         self.context.application.ver = __version__
-        self.context.user.id = Profile(cli_ctx).get_installation_id()
+        self.context.user.id = Profile(cli_ctx=cli_ctx).get_installation_id()
         self.context.instrumentation_key = INSTRUMENTATION_KEY
 
     def _track_event(self, name, properties=None, measurements=None):

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_client_factory.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_client_factory.py
@@ -23,7 +23,7 @@ def keyvault_data_plane_factory(cli_ctx, _):
         import adal
         from azure.cli.core._profile import Profile
         try:
-            return Profile(cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
+            return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
         except adal.AdalError as err:
             # pylint: disable=no-member
             if (hasattr(err, 'error_response') and

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_completers.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_completers.py
@@ -8,7 +8,7 @@ from azure.cli.core._profile import Profile
 
 
 def _get_token(cli_ctx, server, resource, scope):  # pylint: disable=unused-argument
-    return Profile(cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
+    return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
 
 
 def get_keyvault_name_completion_list(resource_name):

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -206,7 +206,7 @@ def get_default_policy(client, scaffold=False):  # pylint: disable=unused-argume
 def recover_keyvault(cmd, client, vault_name, resource_group_name, location):
     from azure.mgmt.keyvault.models import VaultCreateOrUpdateParameters, CreateMode
     from azure.cli.core._profile import Profile
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
     _, _, tenant_id = profile.get_login_credentials(
         resource=cmd.cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
 
@@ -231,7 +231,7 @@ def create_keyvault(cmd, client,  # pylint: disable=too-many-locals
     from azure.mgmt.keyvault.models import VaultCreateOrUpdateParameters
     from azure.cli.core._profile import Profile
     from azure.graphrbac.models import GraphErrorException
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
     cred, _, tenant_id = profile.get_login_credentials(
         resource=cmd.cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
 
@@ -341,7 +341,7 @@ def update_keyvault(instance, enabled_for_deployment=None, enabled_for_disk_encr
 def _object_id_args_helper(cli_ctx, object_id, spn, upn):
     if not object_id:
         from azure.cli.core._profile import Profile
-        profile = Profile(cli_ctx)
+        profile = Profile(cli_ctx=cli_ctx)
         cred, _, tenant_id = profile.get_login_credentials(
             resource=cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
         graph_client = GraphRbacManagementClient(cred,

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
@@ -120,7 +120,7 @@ def validate_claim_vm(namespace):
 def _get_owner_object_id(cli_ctx):
     from azure.cli.core._profile import Profile
     from azure.graphrbac.models import GraphErrorException
-    profile = Profile(cli_ctx)
+    profile = Profile(cli_ctx=cli_ctx)
     cred, _, tenant_id = profile.get_login_credentials(
         resource=cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
     graph_client = GraphRbacManagementClient(cred,

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -21,7 +21,7 @@ _CLOUD_CONSOLE_WARNING_TEMPLATE = ("Azure Cloud Shell automatically authenticate
 
 
 def _load_subscriptions(cli_ctx, all_clouds=False, refresh=False):
-    profile = Profile(cli_ctx)
+    profile = Profile(cli_ctx=cli_ctx)
     if refresh:
         subscriptions = profile.refresh_accounts()
     subscriptions = profile.load_cached_subscriptions(all_clouds)
@@ -47,7 +47,7 @@ def list_subscriptions(cmd, all=False, refresh=False):  # pylint: disable=redefi
 # pylint: disable=inconsistent-return-statements
 def show_subscription(cmd, subscription=None, show_auth_for_sdk=None):
     import json
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
     if not show_auth_for_sdk:
         return profile.get_subscription(subscription)
 
@@ -62,7 +62,7 @@ def get_access_token(cmd, subscription=None, resource=None):
     Use 'az cloud show' command for other Azure resources
     '''
     resource = (resource or cmd.cli_ctx.cloud.endpoints.active_directory_resource_id)
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
     creds, subscription, tenant = profile.get_raw_token(subscription=subscription, resource=resource)
     return {
         'tokenType': creds[0],
@@ -75,7 +75,7 @@ def get_access_token(cmd, subscription=None, resource=None):
 
 def set_active_subscription(cmd, subscription):
     """Set the current subscription"""
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
     if not id:
         raise CLIError('Please provide subscription id or unique name.')
     profile.set_active_subscription(subscription)
@@ -83,7 +83,7 @@ def set_active_subscription(cmd, subscription):
 
 def account_clear(cmd):
     """Clear all stored subscriptions. To clear individual, use 'logout'"""
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
     profile.logout_all()
 
 
@@ -103,7 +103,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
 
     interactive = False
 
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
 
     if in_cloud_console():
         console_tokens = os.environ.get('AZURE_CONSOLE_TOKENS', None)
@@ -125,7 +125,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
         interactive = True
 
     try:
-        profile = Profile(cmd.cli_ctx)
+        profile = Profile(cli_ctx=cmd.cli_ctx)
         subscriptions = profile.find_subscriptions_on_login(
             interactive,
             username,
@@ -157,7 +157,7 @@ def logout(cmd, username=None):
         logger.warning(_CLOUD_CONSOLE_WARNING_TEMPLATE, 'logout')
         return
 
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
     if not username:
         username = profile.get_current_account_user()
     profile.logout(username)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_client_factory.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_client_factory.py
@@ -20,7 +20,7 @@ def _graph_client_factory(cli_ctx, **_):
     from azure.cli.core._profile import Profile
     from azure.cli.core.commands.client_factory import configure_common_settings
     from azure.graphrbac import GraphRbacManagementClient
-    profile = Profile(cli_ctx)
+    profile = Profile(cli_ctx=cli_ctx)
     cred, _, tenant_id = profile.get_login_credentials(
         resource=cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
     client = GraphRbacManagementClient(cred, tenant_id,

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
@@ -36,7 +36,7 @@ def validate_member_id(namespace):
     cli_ctx = namespace.cmd.cli_ctx
     try:
         uuid.UUID(namespace.url)
-        profile = Profile(cli_ctx)
+        profile = Profile(cli_ctx=cli_ctx)
         _, _, tenant_id = profile.get_login_credentials()
         graph_url = cli_ctx.cloud.endpoints.active_directory_graph_resource_id
         namespace.url = '{}{}/directoryObjects/{}'.format(graph_url, tenant_id,

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -717,7 +717,7 @@ def create_service_principal_for_rbac(
     if show_auth_for_sdk:
         import json
         from azure.cli.core._profile import Profile
-        profile = Profile(cmd.cli_ctx)
+        profile = Profile(cli_ctx=cmd.cli_ctx)
         result = profile.get_sp_auth_info(scopes[0].split('/')[2] if scopes else None,
                                           app_id, password, cert_file)
         # sdk-auth file should be in json format all the time, hence the print
@@ -744,7 +744,7 @@ def _get_keyvault_client(cli_ctx):
     from azure.keyvault import KeyVaultClient, KeyVaultAuthentication
 
     def _get_token(server, resource, scope):  # pylint: disable=unused-argument
-        return Profile(cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
+        return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
 
     return KeyVaultClient(KeyVaultAuthentication(_get_token))
 

--- a/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
@@ -1566,7 +1566,7 @@ def _get_keyVault_not_arm_client(cli_ctx):
     from azure.cli.core._profile import Profile
 
     def get_token(server, resource, scope):  # pylint: disable=unused-argument
-        return Profile(cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
+        return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
 
     client = KeyVaultClient(KeyVaultAuthentication(get_token))
     return client
@@ -1584,7 +1584,7 @@ def _create_keyvault(cli_ctx,
     from azure.mgmt.keyvault.models import VaultCreateOrUpdateParameters
     from azure.cli.core._profile import Profile
     from azure.graphrbac.models import GraphErrorException
-    profile = Profile(cli_ctx)
+    profile = Profile(cli_ctx=cli_ctx)
     cred, _, tenant_id = profile.get_login_credentials(
         resource=cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
     graph_client = GraphRbacManagementClient(cred,

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
@@ -1044,7 +1044,7 @@ def server_ad_admin_set(
         server_name,
         **kwargs):
 
-    profile = Profile(cmd.cli_ctx)
+    profile = Profile(cli_ctx=cmd.cli_ctx)
     sub = profile.get_subscription()
     kwargs['tenant_id'] = sub['tenantId']
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -86,7 +86,7 @@ def create_keyvault_data_plane_client(cli_ctx):
     from azure.cli.core._profile import Profile
 
     def get_token(server, resource, scope):  # pylint: disable=unused-argument
-        return Profile(cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
+        return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
 
     from azure.keyvault import KeyVaultClient, KeyVaultAuthentication
     return KeyVaultClient(KeyVaultAuthentication(get_token))


### PR DESCRIPTION
Fixes #5199. Allows creation of a default CLI instance if one is not supplied when creating a Profile object or calling `get_active_cloud`. 
  