### PR TITLE
core: bring progress info back

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -438,7 +438,8 @@ class LongRunningOperation(object):  # pylint: disable=too-few-public-methods
         self.cli_ctx.get_progress_controller().begin()
         correlation_id = None
 
-        is_verbose = any(handler.level <= logs.INFO for handler in logger.handlers)
+        cli_logger = get_logger()  # get CLI logger which has the level set through command lines
+        is_verbose = any(handler.level <= logs.INFO for handler in cli_logger.handlers)
 
         while not poller.done():
             self.cli_ctx.get_progress_controller().add(message='Running')

--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -31,6 +31,7 @@ def get_active_api_profile(cli_ctx):
 def force_progress_logging():
     from six import StringIO
     import logging
+    from knack.log import get_logger
     from azure.cli.core.commands import logger as cmd_logger
 
     # register a progress logger handler to get the content to verify
@@ -41,7 +42,7 @@ def force_progress_logging():
     cmd_logger.setLevel(logging.INFO)
 
     # this tells progress logger we are under verbose, so should log
-    az_logger = logging.getLogger('az')
+    az_logger = get_logger()
     old_az_level = az_logger.handlers[0].level
     az_logger.handlers[0].level = logging.INFO
 


### PR DESCRIPTION
This should get `test_vm_create_progress` pass

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
