### PR TITLE
Fixed cli_ctx in Profile

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -112,11 +112,11 @@ class Profile(object):
         self._storage = storage or ACCOUNT
         self.auth_ctx_factory = auth_ctx_factory or _AUTH_CTX_FACTORY
         if use_global_creds_cache:
-            self._creds_cache = CredsCache(cli_ctx, _AUTH_CTX_FACTORY, async_persist=True)
+            self._creds_cache = CredsCache(self.cli_ctx, _AUTH_CTX_FACTORY, async_persist=True)
         else:
             self._creds_cache = CredsCache(self.auth_ctx_factory, async_persist=False)
-        self._management_resource_uri = cli_ctx.cloud.endpoints.management
-        self._ad_resource_uri = cli_ctx.cloud.endpoints.active_directory_resource_id
+        self._management_resource_uri = self.cli_ctx.cloud.endpoints.management
+        self._ad_resource_uri = self.cli_ctx.cloud.endpoints.active_directory_resource_id
         self._msi_creds = None
 
     def find_subscriptions_on_login(self,


### PR DESCRIPTION
@tjprescott, @lmazuel 
Currently the profile still tries to use the cli_ctx that was passed as a parameter even though it might be None.