### PR TITLE
 vm: support image sharing across subscriptions

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.24
+++++++
+* vm: support use image from other subscriptions
 
 2.0.23
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_client_factory.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_client_factory.py
@@ -4,10 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 
-def _compute_client_factory(cli_ctx, **_):
+def _compute_client_factory(cli_ctx, **kwargs):
     from azure.cli.core.profiles import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_COMPUTE)
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_COMPUTE, subscription_id=kwargs.get('subscription_id'))
 
 
 def cf_ni(cli_ctx, _):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -372,7 +372,7 @@ def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):
     if namespace.storage_profile == StorageProfile.ManagedCustomImage:
         # extract additional information from a managed custom image
         res = parse_resource_id(namespace.image)
-        compute_client = _compute_client_factory(cmd.cli_ctx)
+        compute_client = _compute_client_factory(cmd.cli_ctx, subscription_id=res['subscription'])
         image_info = compute_client.images.get(res['resource_group'], res['name'])
         # pylint: disable=no-member
         namespace.os_type = image_info.storage_profile.os_disk.os_type.value

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -277,9 +277,10 @@ class VMCustomImageTest(ScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_test_vm_custom_image')
     def test_custom_image(self, resource_group):
         # this test should be recorded using accounts "@azuresdkteam.onmicrosoft.com", as it uses pre-made generalized vms
+        subscription_id = self.get_subscription_id()
         self.kwargs.update({
-            'prepared_vm_unmanaged': '/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/sdk-test/providers/Microsoft.Compute/virtualMachines/sdk-test-um',
-            'prepared_vm': '/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/sdk-test/providers/Microsoft.Compute/virtualMachines/sdk-test-m',
+            'prepared_vm_unmanaged': '/subscriptions/{}/resourceGroups/sdk-test/providers/Microsoft.Compute/virtualMachines/sdk-test-um'.format(subscription_id),
+            'prepared_vm': '/subscriptions/{}/resourceGroups/sdk-test/providers/Microsoft.Compute/virtualMachines/sdk-test-m'.format(subscription_id),
             'image': 'image1'  # for image captured from vm with unmanaged disk
         })
 
@@ -333,8 +334,9 @@ class VMCustomImageWithPlanTest(ScenarioTest):
     @ResourceGroupPreparer()
     def test_custom_image_with_plan(self, resource_group):
         # this test should be recorded using accounts "@azuresdkteam.onmicrosoft.com", as it uses pre-made custom image
+        subscription_id = self.get_subscription_id()
         self.kwargs.update({
-            'prepared_image_with_plan_info': '/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/sdk-test/providers/Microsoft.Compute/images/custom-image-with-plan',
+            'prepared_image_with_plan_info': '/subscriptions/{}/resourceGroups/sdk-test/providers/Microsoft.Compute/images/custom-image-with-plan'.format(subscription_id),
             'plan': 'linuxdsvmubuntu'
         })
 

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.23"
+VERSION = "2.0.24"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fix #5135
No command signature change. CLI just starts to respect every piece of information in the resource id, including the subscription id.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))

  