### PR TITLE
Use pkg_resources instead of pip internal methods

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -47,13 +47,17 @@ def truncate_text(str_to_shorten, width=70, placeholder=' [...]'):
     return str_to_shorten[:s_len] + (str_to_shorten[s_len:] and placeholder)
 
 
+def get_installed_cli_distributions():
+    from pkg_resources import working_set
+    return [d for d in list(working_set) if d.key == CLI_PACKAGE_NAME or d.key.startswith(COMPONENT_PREFIX)]
+
+
 def get_az_version_string():
     import platform
-    from pip import get_installed_distributions
     from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR
 
     output = six.StringIO()
-    installed_dists = get_installed_distributions(local_only=True)
+    installed_dists = get_installed_cli_distributions()
 
     cli_info = None
     for dist in installed_dists:

--- a/src/command_modules/azure-cli-feedback/HISTORY.rst
+++ b/src/command_modules/azure-cli-feedback/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.8
++++++
+* Minor fixes.
+
 2.0.7
 ++++++
 * Update for CLI core changes.

--- a/src/command_modules/azure-cli-feedback/azure/cli/command_modules/feedback/custom.py
+++ b/src/command_modules/azure-cli-feedback/azure/cli/command_modules/feedback/custom.py
@@ -11,7 +11,7 @@ from knack.prompting import prompt, NoTTYException
 from knack.util import CLIError
 
 from azure.cli.core import __version__ as core_version
-from azure.cli.core.util import COMPONENT_PREFIX
+from azure.cli.core.util import COMPONENT_PREFIX, get_installed_cli_distributions
 
 logger = get_logger(__name__)
 
@@ -47,8 +47,7 @@ def _prompt_net_promoter_score():
 
 
 def _get_version_info():
-    from pip import get_installed_distributions
-    installed_dists = get_installed_distributions(local_only=True)
+    installed_dists = get_installed_cli_distributions()
 
     component_version_info = sorted([{'name': dist.key.replace(COMPONENT_PREFIX, ''),
                                       'version': dist.version}

--- a/src/command_modules/azure-cli-feedback/setup.py
+++ b/src/command_modules/azure-cli-feedback/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.7"
+VERSION = "2.0.8"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/tools/automation/verify/verify_packages.py
+++ b/tools/automation/verify/verify_packages.py
@@ -7,12 +7,12 @@
 
 import os.path
 import subprocess
-import pip
 import imp
 import glob
 import zipfile
 import logging
 import unittest
+from pkg_resources import working_set
 
 import automation.utilities.path as automation_path
 from automation.utilities.const import COMMAND_MODULE_PREFIX
@@ -43,10 +43,7 @@ class PackageVerifyTests(unittest.TestCase):
     def test_azure_cli_module_installation(self):
         expected_modules = set([n for n, _ in automation_path.get_command_modules_paths(include_prefix=True)])
 
-        pip.utils.pkg_resources = imp.reload(pip.utils.pkg_resources)
-        installed_command_modules = [dist.key for dist in
-                                     pip.get_installed_distributions(local_only=True)
-                                     if dist.key.startswith(COMMAND_MODULE_PREFIX)]
+        installed_command_modules = [dist.key for dist in list(working_set) if dist.key.startswith(COMMAND_MODULE_PREFIX)]
 
         logger.info('Installed command modules %s', installed_command_modules)
 


### PR DESCRIPTION
`pip` is moving it's internal methods to be private in the future so we should no longer rely on them.
https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [n/a] Each command and parameter has a meaningful description.
- [n/a] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
