### PR TITLE
[AKS] fix SP role assignment and reenable last scenario test

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1143,7 +1143,7 @@ def create_role_assignment(cli_ctx, role, assignee, resource_group_name=None, sc
 
 
 def _create_role_assignment(cli_ctx, role, assignee, resource_group_name=None, scope=None, resolve_assignee=True):
-    factory = get_auth_management_client(scope)
+    factory = get_auth_management_client(cli_ctx, scope)
     assignments_client = factory.role_assignments
     definitions_client = factory.role_definitions
 

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/recordings/latest/test_acs_create_kubernetes.yaml
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/recordings/latest/test_acs_create_kubernetes.yaml
@@ -8,9 +8,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001?api-version=2017-05-10
@@ -20,11 +20,11 @@ interactions:
       cache-control: [no-cache]
       content-length: ['212']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 20 Dec 2017 06:09:53 GMT']
+      date: ['Wed, 10 Jan 2018 19:12:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -34,12 +34,12 @@ interactions:
       CommandName: [ad sp create-for-rbac]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6&$filter=servicePrincipalNames%2Fany%28x%3Ax%20eq%20%27http%3A%2F%2Fclitest000002%27%29
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28x%3Ax%20eq%20%27http%3A%2F%2Fclitest000002%27%29&api-version=1.6
   response:
     body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[]}'}
     headers:
@@ -48,13 +48,13 @@ interactions:
       content-length: ['166']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 20 Dec 2017 06:09:54 GMT']
-      duration: ['521198']
+      date: ['Wed, 10 Jan 2018 19:12:42 GMT']
+      duration: ['654276']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [3fY/YTKtktC55i2uj7nRnEH4MiQwtS8nnnh325mrC/0=]
-      ocp-aad-session-key: [Z29ef_Fh_Rlv7vFLOhvRryqqX1vTEWnobc_NDhf7BISKcXLu0F_BbFfOUOpon-JIIJT7oImxm2rG0BWbGfuRWwZhSC5BV-R6vFDyzoHdvsEsZqVk3ppn_CSQNZmPp78REL5giMlRuNBqdZEc0A6BNxod6Ots0toXR0isIYAExty0WL-NkcV6GP03fl9N55Wzgfk36l7nfVRY0BCeIK2veg.o7doZMBfC12kL8q0UZ0l76OcrOEVSSmaLcPtHg2D7sQ]
+      ocp-aad-diagnostics-server-name: [/qlcEIqkKGQ9rgmLHd1kED9DOA/6rNJzUGuBELRCU6g=]
+      ocp-aad-session-key: [R4oF8GutIP5WMJOqaofGDO1GDBqJxHWwjDLUqL54loFlVcTOe0aLrOKeMcEzJa0pQJF_5zjNwo0rMQmvnJnpdIyyqiEuWL6mcPwFmF75S1lQd9biZZWHJUvsiTL41W53ys7OVa5FAchzh7Rgpw7OiXxO9_J5VITRpnouKzj0eSf8JLeckFVrCQyrBF55oui2yCzGi1HDDJl1ns164UrlMQ.KNAWxPdVtFA0-9lQQoIjakm-D2uQsU2uDLhsGS1o5V0]
       pragma: [no-cache]
-      request-id: [409c30f5-78f9-4cd3-8942-276c5c684f40]
+      request-id: [94579ecd-d027-44eb-993a-0e90d714f295]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -63,11 +63,11 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"availableToOtherTenants": false, "displayName": "azure-cli-2017-12-20-06-09-55",
-      "homepage": "http://azure-cli-2017-12-20-06-09-55", "passwordCredentials": [{"endDate":
-      "2018-12-20T06:09:55.19139099999999998Z", "value": "4d13f131-b7ff-439f-bddf-8bab1676e81d",
-      "keyId": "49750f7e-fa24-49b5-9685-ed1dcc689ac0", "startDate": "2017-12-20T06:09:55.19139099999999998Z"}],
-      "identifierUris": ["http://clitest000002"]}'''
+    body: 'b''{"availableToOtherTenants": false, "displayName": "azure-cli-2018-01-10-19-12-42",
+      "homepage": "http://azure-cli-2018-01-10-19-12-42", "identifierUris": ["http://clitest000002"],
+      "passwordCredentials": [{"startDate": "2018-01-10T19:12:42.33563299999999996Z",
+      "endDate": "2019-01-10T19:12:42.33563299999999996Z", "keyId": "b72bf0b8-9586-4d40-93e4-4afa2921430e",
+      "value": "aeee4d58-47d1-4fc3-ac1a-f1ba3bd53c2a"}]}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -75,32 +75,32 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['415']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"29846b0f-d7e9-42ba-9756-0b8f9073cb5c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"554e7908-6259-4516-bbaa-4f6a768bb2fb","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2017-12-20-06-09-55","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2017-12-20-06-09-55","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2017-12-20-06-09-55","id":"12ad8152-06ea-4806-8509-131d8d0a4581","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2017-12-20-06-09-55","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2018-12-20T06:09:55.191391Z","keyId":"49750f7e-fa24-49b5-9685-ed1dcc689ac0","startDate":"2017-12-20T06:09:55.191391Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"ab571e1d-35b7-44c4-beb0-949122478a7f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"9109f07c-4ed8-4b4e-bd53-5fd9e547a802","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-10-19-12-42","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-10-19-12-42","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-10-19-12-42","id":"d20be26d-c59f-4f1c-b4bf-8350c7b5c0e6","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-10-19-12-42","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-10T19:12:42.335633Z","keyId":"b72bf0b8-9586-4d40-93e4-4afa2921430e","startDate":"2018-01-10T19:12:42.335633Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1772']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 20 Dec 2017 06:09:54 GMT']
-      duration: ['5418120']
+      date: ['Wed, 10 Jan 2018 19:12:42 GMT']
+      duration: ['3964588']
       expires: ['-1']
-      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/29846b0f-d7e9-42ba-9756-0b8f9073cb5c/Microsoft.DirectoryServices.Application']
-      ocp-aad-diagnostics-server-name: [gzTHd9xPT6UpzqL1VdRsA3bqkd3Ju1OXrLwpKneHrpg=]
-      ocp-aad-session-key: [kqCPoQCELZN9nWF6RhVGLMsTw--610M8-8vA1K0OVmZ9233LvNH96SxSUcnVsP09OuCTM5y2u9x0oFsMSXQ-e0rqRUX0tw7rKD78LHx5ZGymhlkmuVrg_9mOowTaPY5xzlDqvonwnhXKcoXVl177uosd-rIQ-Tat7TC0wdYaaLwmDvvdl0AkrmjxB6O6cJvjoQOUNL0gxFmufaGSzvh94w.yTj6EDbwwg1oaC1trK4TjSiXGr0NlCAHmr0maCjNLlg]
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/ab571e1d-35b7-44c4-beb0-949122478a7f/Microsoft.DirectoryServices.Application']
+      ocp-aad-diagnostics-server-name: [jdVXMi9H0iTylUQ5wYOVQedHu7bfyEE6Gey2E2034Y0=]
+      ocp-aad-session-key: [42E0lDDcZ_nO4RoiKrm87GM5xT8o5cTl7XYbmo-0vBMHrDwGZFVmr1ci6-87WCvGjbqBMR_JLJqbyJypgi_J06PZ9xC-fRfkZl3wEf2M_TFHAR06pt7Xvf9MQ1H3s4W1ZoAp_WL9sZqdw17dtmvPpHpKoTX82AY3NqOyYZLbKiAScqm06jQqlvQ2atGggx9J4MxWv9MUFg-Dn0pwPaeeGw.yWHtyX55Acvs35rvQldD5eLn6awykOwWw82hUjKimeA]
       pragma: [no-cache]
-      request-id: [8b9eb709-3eff-405e-9771-325c5ada1bc1]
+      request-id: [c7f0debf-8e27-4d35-86ea-ad56af053f0b]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -109,7 +109,7 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"accountEnabled": true, "appId": "554e7908-6259-4516-bbaa-4f6a768bb2fb"}'
+    body: '{"appId": "9109f07c-4ed8-4b4e-bd53-5fd9e547a802", "accountEnabled": true}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -117,32 +117,32 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"aeeb5763-98d0-4ae5-bd07-37ee8e2400c1","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2017-12-20-06-09-55","appId":"554e7908-6259-4516-bbaa-4f6a768bb2fb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2017-12-20-06-09-55","errorUrl":null,"homepage":"http://azure-cli-2017-12-20-06-09-55","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2017-12-20-06-09-55","id":"12ad8152-06ea-4806-8509-131d8d0a4581","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2017-12-20-06-09-55","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["554e7908-6259-4516-bbaa-4f6a768bb2fb","http://clitest000002"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"3402c532-a8e6-4e09-bb09-b99447a11bb0","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-10-19-12-42","appId":"9109f07c-4ed8-4b4e-bd53-5fd9e547a802","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-10-19-12-42","errorUrl":null,"homepage":"http://azure-cli-2018-01-10-19-12-42","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-10-19-12-42","id":"d20be26d-c59f-4f1c-b4bf-8350c7b5c0e6","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-10-19-12-42","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["9109f07c-4ed8-4b4e-bd53-5fd9e547a802","http://clitest000002"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1526']
+      content-length: ['1523']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 20 Dec 2017 06:09:54 GMT']
-      duration: ['2695333']
+      date: ['Wed, 10 Jan 2018 19:12:43 GMT']
+      duration: ['2560744']
       expires: ['-1']
-      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/aeeb5763-98d0-4ae5-bd07-37ee8e2400c1/Microsoft.DirectoryServices.ServicePrincipal']
-      ocp-aad-diagnostics-server-name: [j4TfrIcuXv6cz1XEFyVQir6Ee64fZtWPXl/gd62UzeM=]
-      ocp-aad-session-key: [nF3yRngqRLVecTMu5QmY5zFZoP4_4NPdrRKdf_KqiD60awrCtoeIqHLa3oRYnwYPTwEUGHaJ1Zs8MWUpZzRthQTQRSOCkC_1h6Ioz75l9Xm_k1i1xJNuwQeT15ss-puo7waVOXu44TbPB9AeyY12quvsUHFGP07yuwqFCAUcxlMoj6IVso3oJfMnXMzdfNsV7zdqX1nKDEf7NxmIQAU1Ow.ODYJJriQg41YWjMIfc64N50DKJa7FNH3Zu624ghTLBI]
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/3402c532-a8e6-4e09-bb09-b99447a11bb0/Microsoft.DirectoryServices.ServicePrincipal']
+      ocp-aad-diagnostics-server-name: [q4xdW5Eam+nA8Gmr8wXBfFiMX1F+vK+gBordZAyoY70=]
+      ocp-aad-session-key: [egw6ceGHzfLApfIqRYtILwA-OwxQ9_roSF9WHmmXPFXKQvqqo5HYR3_VOSCLkhJNjitHXa_mu76vsW_SIY2fWLBEZ-dN8yZ4tpvpKgBuNhgnLR7JQ0IcnFGtmk-gepF6wn2osgPiWGnMi1qSS03HAacpgJRQnIq2bAQY2ZmCr-OEmsatmIH_r_5fJId06ZDx8O5pC6v9-CHasbCgeFtGIw.G_ykIUcrHrjNAwZiIvgTbaEHGGxpSNXpXxI4ywVgt1c]
       pragma: [no-cache]
-      request-id: [a5e87249-f1aa-440a-afef-e1de63103693]
+      request-id: [b87262ed-c090-44dd-b5de-73feef94d447]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -155,12 +155,606 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['696']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:12:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "3402c532-a8e6-4e09-bb09-b99447a11bb0"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5477b2f0-fece-4677-9bd6-2d26827fd26e?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 3402c532a8e64e09bb09b99447a11bb0
+        does not exist in the directory 72f988bf-86f1-41af-91ab-2d7cd011db47."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:12:45 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['696']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:12:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "3402c532-a8e6-4e09-bb09-b99447a11bb0"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/82c01e73-4de9-4212-98f2-187cd780ec7e?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 3402c532a8e64e09bb09b99447a11bb0
+        does not exist in the directory 72f988bf-86f1-41af-91ab-2d7cd011db47."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:12:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['696']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:12:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "3402c532-a8e6-4e09-bb09-b99447a11bb0"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e46ab8d6-6715-4426-bd4e-fbf398c34046?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 3402c532a8e64e09bb09b99447a11bb0
+        does not exist in the directory 72f988bf-86f1-41af-91ab-2d7cd011db47."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:12:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['696']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "3402c532-a8e6-4e09-bb09-b99447a11bb0"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/89755393-c216-4963-ab10-c2ecec094c88?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 3402c532a8e64e09bb09b99447a11bb0
+        does not exist in the directory 72f988bf-86f1-41af-91ab-2d7cd011db47."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['696']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "3402c532-a8e6-4e09-bb09-b99447a11bb0"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/212480df-4afc-4796-91e0-6afbcc91197a?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 3402c532a8e64e09bb09b99447a11bb0
+        does not exist in the directory 72f988bf-86f1-41af-91ab-2d7cd011db47."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['696']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "3402c532-a8e6-4e09-bb09-b99447a11bb0"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/54d1c9ba-d6d6-4d94-9d9c-10a9152f0ac7?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 3402c532a8e64e09bb09b99447a11bb0
+        does not exist in the directory 72f988bf-86f1-41af-91ab-2d7cd011db47."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1186']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['696']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "3402c532-a8e6-4e09-bb09-b99447a11bb0"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b2e449f7-cc1c-4fa5-a012-7ed38c84926b?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 3402c532a8e64e09bb09b99447a11bb0
+        does not exist in the directory 72f988bf-86f1-41af-91ab-2d7cd011db47."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['696']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "3402c532-a8e6-4e09-bb09-b99447a11bb0"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/68258176-4007-4fbb-ba65-f9bc8433ebf5?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 3402c532a8e64e09bb09b99447a11bb0
+        does not exist in the directory 72f988bf-86f1-41af-91ab-2d7cd011db47."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1185']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['696']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "3402c532-a8e6-4e09-bb09-b99447a11bb0"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp create-for-rbac]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e7cf9ca1-acf9-40de-997a-a3633ad46eb3?api-version=2015-07-01
+  response:
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3402c532-a8e6-4e09-bb09-b99447a11bb0","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","createdOn":"2018-01-10T19:13:41.7917226Z","updatedOn":"2018-01-10T19:13:41.7917226Z","createdBy":null,"updatedBy":"856c5a9a-1657-4536-a0a2-cfab2084cf26"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e7cf9ca1-acf9-40de-997a-a3633ad46eb3","type":"Microsoft.Authorization/roleAssignments","name":"e7cf9ca1-acf9-40de-997a-a3633ad46eb3"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['686']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:13:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-request-charge: ['2']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
       CommandName: [acs create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001?api-version=2017-05-10
@@ -170,31 +764,30 @@ interactions:
       cache-control: [no-cache]
       content-length: ['212']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 20 Dec 2017 06:09:56 GMT']
+      date: ['Wed, 10 Jan 2018 19:14:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''b\''{"properties": {"parameters": {"clientSecret": {"value": "4d13f131-b7ff-439f-bddf-8bab1676e81d"}},
-      "template": {"parameters": {"clientSecret": {"type": "secureString", "metadata":
-      {"description": "The client secret for the service principal"}}}, "resources":
-      [{"properties": {"servicePrincipalProfile": {"clientId": "http://clitest000002",
-      "secret": "[parameters(\\\''clientSecret\\\'')]"}, "orchestratorProfile": {"orchestratorType":
-      "Kubernetes"}, "agentPoolProfiles": [{"count": 3, "dnsPrefix": "acsnwrysra-clitest2mqoxwfk6-0b1f64agent",
-      "vmSize": "Standard_D2_v2", "osType": "Linux", "name": "agentpool0"}], "masterProfile":
-      {"count": 1, "dnsPrefix": "acsnwrysra-clitest2mqoxwfk6-0b1f64mgmt"}, "linuxProfile":
-      {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-      test@example.com\\\\n"}]}, "adminUsername": "azureuser"}}, "location": "eastus",
-      "type": "Microsoft.ContainerService/containerServices", "tags": null, "apiVersion":
-      "2017-01-31", "name": "acs000003"}], "outputs": {"sshMaster0": {"type": "string",
+    body: 'b''b\''{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "resources": [{"apiVersion": "2017-01-31", "location":
+      "eastus", "type": "Microsoft.ContainerService/containerServices", "name": "acs000003",
+      "tags": null, "properties": {"orchestratorProfile": {"orchestratorType": "Kubernetes"},
+      "masterProfile": {"count": 1, "dnsPrefix": "acs3tl422o-clitest6y53tuiyn-e240e5mgmt"},
+      "agentPoolProfiles": [{"count": 3, "vmSize": "Standard_D2_v2", "osType": "Linux",
+      "dnsPrefix": "acs3tl422o-clitest6y53tuiyn-e240e5agent", "name": "agentpool0"}],
+      "linuxProfile": {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}, "adminUsername": "azureuser"}, "servicePrincipalProfile":
+      {"clientId": "http://clitest000002", "secret": "[parameters(\\\''clientSecret\\\'')]"}}}],
+      "outputs": {"masterFQDN": {"type": "string", "value": "[reference(concat(\\\''Microsoft.ContainerService/containerServices/\\\'',
+      \\\''acs000003\\\'')).masterProfile.fqdn]"}, "sshMaster0": {"type": "string",
       "value": "[concat(\\\''ssh \\\'', \\\''azureuser\\\'', \\\''@\\\'', reference(concat(\\\''Microsoft.ContainerService/containerServices/\\\'',
-      \\\''acs000003\\\'')).masterProfile.fqdn, \\\'' -A -p 22\\\'')]"}, "masterFQDN":
-      {"type": "string", "value": "[reference(concat(\\\''Microsoft.ContainerService/containerServices/\\\'',
-      \\\''acs000003\\\'')).masterProfile.fqdn]"}}, "contentVersion": "1.0.0.0", "$schema":
-      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
-      "mode": "Incremental"}}\'''''
+      \\\''acs000003\\\'')).masterProfile.fqdn, \\\'' -A -p 22\\\'')]"}}, "parameters":
+      {"clientSecret": {"type": "secureString", "metadata": {"description": "The client
+      secret for the service principal"}}}}, "parameters": {"clientSecret": {"value":
+      "aeee4d58-47d1-4fc3-ac1a-f1ba3bd53c2a"}}, "mode": "Incremental"}}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -202,24 +795,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['2187']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Resources/deployments/azurecli1513750196.86754610215","name":"azurecli1513750196.86754610215","properties":{"templateHash":"8845198900047243484","parameters":{"clientSecret":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-12-20T06:10:00.5435335Z","duration":"PT1.4545526S","correlationId":"8e9a8853-18dc-4537-8342-8b4220284af8","providers":[{"namespace":"Microsoft.ContainerService","resourceTypes":[{"resourceType":"containerServices","locations":["eastus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Resources/deployments/azurecli1515611684.0060923034","name":"azurecli1515611684.0060923034","properties":{"templateHash":"15762691977927112671","parameters":{"clientSecret":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-01-10T19:14:47.307302Z","duration":"PT1.1306563S","correlationId":"cec0819a-07ea-4b1f-b444-e25e558d28fd","providers":[{"namespace":"Microsoft.ContainerService","resourceTypes":[{"resourceType":"containerServices","locations":["eastus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/azurecli1513750196.86754610215/operationStatuses/08586878566863886286?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/azurecli1515611684.0060923034/operationStatuses/08586859951993009655?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['641']
+      content-length: ['639']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 20 Dec 2017 06:10:00 GMT']
+      date: ['Wed, 10 Jan 2018 19:14:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1189']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -229,27 +822,463 @@ interactions:
       CommandName: [acs create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586878566863886286?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
   response:
-    body: {string: '{"status":"Failed","error":{"code":"DeploymentFailed","message":"At
-        least one resource deployment operation failed. Please list deployment operations
-        for details. Please see https://aka.ms/arm-debug for usage details.","details":[{"code":"BadRequest","message":"{\r\n  \"error\":
-        {\r\n    \"code\": \"BadRequest\",\r\n    \"message\": \"The credentials in
-        ServicePrincipalProfile were invalid. Please see https://aka.ms/acs-sp-help
-        for more details. (Details: AADSTS70001: Application with identifier ''http://clitest000002''
-        was not found in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\\r\\nTrace
-        ID: 20c5994f-e552-4f48-9bd4-088184fb1f00\\r\\nCorrelation ID: 71351225-dabd-4997-996f-90908c30a1c1\\r\\nTimestamp:
-        2017-12-20 06:10:06Z)\"\r\n  }\r\n}"}]}}'}
+    body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['762']
+      content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 20 Dec 2017 06:10:31 GMT']
+      date: ['Wed, 10 Jan 2018 19:15:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:15:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:16:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:16:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:17:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:17:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:18:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:18:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:19:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:19:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:20:24 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:20:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:21:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:21:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:22:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:22:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586859951993009655?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:23:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [acs create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Resources/deployments/azurecli1515611684.0060923034","name":"azurecli1515611684.0060923034","properties":{"templateHash":"15762691977927112671","parameters":{"clientSecret":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-01-10T19:23:08.2680535Z","duration":"PT8M22.0914078S","correlationId":"cec0819a-07ea-4b1f-b444-e25e558d28fd","providers":[{"namespace":"Microsoft.ContainerService","resourceTypes":[{"resourceType":"containerServices","locations":["eastus"]}]}],"dependencies":[],"outputs":{"masterFQDN":{"type":"String","value":"acs3tl422o-clitest6y53tuiyn-e240e5mgmt.eastus.cloudapp.azure.com"},"sshMaster0":{"type":"String","value":"ssh
+        azureuser@acs3tl422o-clitest6y53tuiyn-e240e5mgmt.eastus.cloudapp.azure.com
+        -A -p 22"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/containerServices/acs000003"}]}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1075']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:23:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -263,71 +1292,31 @@ interactions:
       CommandName: [ad sp delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6&$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27554e7908-6259-4516-bbaa-4f6a768bb2fb%27%29
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%279109f07c-4ed8-4b4e-bd53-5fd9e547a802%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"aeeb5763-98d0-4ae5-bd07-37ee8e2400c1","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2017-12-20-06-09-55","appId":"554e7908-6259-4516-bbaa-4f6a768bb2fb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2017-12-20-06-09-55","errorUrl":null,"homepage":"http://azure-cli-2017-12-20-06-09-55","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2017-12-20-06-09-55","id":"12ad8152-06ea-4806-8509-131d8d0a4581","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2017-12-20-06-09-55","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","554e7908-6259-4516-bbaa-4f6a768bb2fb"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
-    headers:
-      access-control-allow-origin: ['*']
-      cache-control: [no-cache]
-      content-length: ['1529']
-      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
-      dataserviceversion: [3.0;]
-      date: ['Wed, 20 Dec 2017 06:10:31 GMT']
-      duration: ['535261']
-      expires: ['-1']
-      ocp-aad-diagnostics-server-name: [2DD9Uu67ybR8Pd6jBxWLoYGX++26Si/Rh4KiODEAByo=]
-      ocp-aad-session-key: [B1XTVv2Pr5VFVua2aYCQOk_VeV7w0CQWO2QYgV6WXFt04ASSX2B1hxYJaq_3O0Kon7h57i-E01uwpRip21JkqE2KemfredXlzq5qkvwm9EZXfPRD7urw-BWwUAjZCQLEf_QPTZNnaaNm-5bJyE03h5mnX8zzAXlfzV5iV8Id0y1ow7MfHiXXmWd8dww0knOIUE7aTC-rlRzZhhTQ648fAg.zylPV0t1HCaKWE88m2xoSWvGUXmn-5l84x7AoFZn1yw]
-      pragma: [no-cache]
-      request-id: [770b67d4-dd53-4d0d-9f81-fb7765d1dccd]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET, ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [ad sp delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
-      accept-language: [en-US]
-    method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/aeeb5763-98d0-4ae5-bd07-37ee8e2400c1?api-version=1.6
-  response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"aeeb5763-98d0-4ae5-bd07-37ee8e2400c1","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2017-12-20-06-09-55","appId":"554e7908-6259-4516-bbaa-4f6a768bb2fb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2017-12-20-06-09-55","errorUrl":null,"homepage":"http://azure-cli-2017-12-20-06-09-55","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2017-12-20-06-09-55","id":"12ad8152-06ea-4806-8509-131d8d0a4581","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2017-12-20-06-09-55","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","554e7908-6259-4516-bbaa-4f6a768bb2fb"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"3402c532-a8e6-4e09-bb09-b99447a11bb0","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-10-19-12-42","appId":"9109f07c-4ed8-4b4e-bd53-5fd9e547a802","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-10-19-12-42","errorUrl":null,"homepage":"http://azure-cli-2018-01-10-19-12-42","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-10-19-12-42","id":"d20be26d-c59f-4f1c-b4bf-8350c7b5c0e6","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-10-19-12-42","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","9109f07c-4ed8-4b4e-bd53-5fd9e547a802"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1526']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 20 Dec 2017 06:10:31 GMT']
-      duration: ['635798']
+      date: ['Wed, 10 Jan 2018 19:23:32 GMT']
+      duration: ['2702140']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [Di2Mb1FQpAkptjcd3t0sJrUHBU1H5BG1v34ttQWjQvo=]
-      ocp-aad-session-key: [fXDWjWLZYZR6rtCqDunEcPq4sHBTUZdpgYzvcsWstskZG8GkdKWMPp4JMZOASEJ8hV5REmKuvjpH0u-kWpwF0d0VeuR9yUZB96xL9vAV6R6aMkLshqDNd9zOelUPHzJgrZruYg9gya4aWxm2wOd9wwSrzQn4cz6Ks2dDwHxBgD_2oyXyGt34MYISxcH82QlG54Gn-a6LfjTQvOAV5ZbqAQ.JNp936DRNZym530PTT9ytcKdpOb0N-zofrKpWhp3mcE]
+      ocp-aad-diagnostics-server-name: [0WLtM69GQf2x2bLvgYW0rMNR73R6k54TrHsVGVQ/LGA=]
+      ocp-aad-session-key: [0FQQ5sfAiU36T8f9h7_MbMHPBNS9Bds_Nj5EqammSUgC7l1oI2W8bQsTtxH92HF0kw77_qMvllUFs3eZQmP4sBPRWQXS5vKPA2B0nD3OhMuHs9L1Uvtan6UKx8L7hgafd8VJqi4z8xUZK2vV_tMJunzQ5o1JABnWZIUFiFqQZNaZVT2IrnMxHppEsY-Tbjy-dPEVxiO3OaBhio1iQ3GjRg.bD3W4KBLp1hAO1tA4Fx_pQwUetLaZtL2xd9V3hlqa3E]
       pragma: [no-cache]
-      request-id: [8bf1d211-f4d9-4d51-bd91-2a1450a68422]
+      request-id: [9e4d6291-1831-410e-93af-40c7165673d5]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -343,31 +1332,71 @@ interactions:
       CommandName: [ad sp delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fclitest000002%27%29
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/3402c532-a8e6-4e09-bb09-b99447a11bb0?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"29846b0f-d7e9-42ba-9756-0b8f9073cb5c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"554e7908-6259-4516-bbaa-4f6a768bb2fb","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2017-12-20-06-09-55","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2017-12-20-06-09-55","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2017-12-20-06-09-55","id":"12ad8152-06ea-4806-8509-131d8d0a4581","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2017-12-20-06-09-55","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2018-12-20T06:09:55.191391Z","keyId":"49750f7e-fa24-49b5-9685-ed1dcc689ac0","startDate":"2017-12-20T06:09:55.191391Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"3402c532-a8e6-4e09-bb09-b99447a11bb0","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-10-19-12-42","appId":"9109f07c-4ed8-4b4e-bd53-5fd9e547a802","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-10-19-12-42","errorUrl":null,"homepage":"http://azure-cli-2018-01-10-19-12-42","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-10-19-12-42","id":"d20be26d-c59f-4f1c-b4bf-8350c7b5c0e6","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-10-19-12-42","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","9109f07c-4ed8-4b4e-bd53-5fd9e547a802"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1523']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Wed, 10 Jan 2018 19:23:32 GMT']
+      duration: ['688756']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [2YNZyWY4LM/0gxa9nMCJa9oe6ttnYrs+gIRavg2zwms=]
+      ocp-aad-session-key: [7P6MAptImPVAG2IC0-Yt5F-jUFMlVOykSTjXiDuLGZTGMGWwkU9U8YmHgXVAbOO3cRLlVVm1Cx6IJNNFySwdFb8lofQQhjmgOV09fRX_08uTzxM38dfjgEYWMDpZkeABb2HUpK3L92q9-uWZ8mzmKGsXyyGceJC0or_9HR7aZmdrmhRUtjgFeX43Ufu6YjY8GF1lw2d7UVR5m1b3YwJBbw.-DlKu-mfb3qNA-qID4MgFHCF-8mGcXIDYgg_Qe5CDCQ]
+      pragma: [no-cache]
+      request-id: [c30f4fc7-9853-4d9f-8945-9167ae175656]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp delete]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fclitest000002%27%29&api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"ab571e1d-35b7-44c4-beb0-949122478a7f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"9109f07c-4ed8-4b4e-bd53-5fd9e547a802","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-10-19-12-42","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-10-19-12-42","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-10-19-12-42","id":"d20be26d-c59f-4f1c-b4bf-8350c7b5c0e6","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-10-19-12-42","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-10T19:12:42.335633Z","keyId":"b72bf0b8-9586-4d40-93e4-4afa2921430e","startDate":"2018-01-10T19:12:42.335633Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1775']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 20 Dec 2017 06:10:32 GMT']
-      duration: ['730169']
+      date: ['Wed, 10 Jan 2018 19:23:32 GMT']
+      duration: ['709185']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [1mZWOAvwnETziiyOUezZwk4btUj3M9yZQUGwmKHQ+/8=]
-      ocp-aad-session-key: [p386nYe9JhSu_c5Fh8rZJes2UVjQbJxelWlePSepIofI32JeAf1cGy-pnM9KsMWSAD1SwpjhXukwXC7Cwb4aW3tCU09FTmxa7HYQr6j2lVk1Rw4NFMGYLFo7ro9ejN_j3tskyzzNiSNIVeUy3iRpvEsvFzZv-MFgh4CX6BF7oKyGr3qNvDQrmumNPP-mTdtqJ8N5O5G-iXQNoK1RZr4baw.jm-hGXcbgtY8fBOARAsXIpNDrXmZLG_LBgLo5K_pHKI]
+      ocp-aad-diagnostics-server-name: [KslFvWWZrwibsXDcyqbxKKwRFbYUBYT2pMGGsSqjmZ0=]
+      ocp-aad-session-key: [flEb9nB2K4MkMIM1kb0o4yvOFnF1Ddxq7bGdX5LJGNrQkPo5UlBqdSLdGk9Xfn-FqI1OPOr-0OWJBmIisvqPgl-jXZKujNUrW5PCo2X3xv82qJaDFIMRUfYAYAbGns3dbYQG7qSuPSqXy-alVhC-YE6pjbY_gHq2t_-RqGYI8cydO6WKRgd1ed3mFF4KDGVg5rkj8waHxKOt6x0Oso0hDw.Y8xhSg1Daw5JGNJPrwSR1zht_HZ6b8UkfhwgE20lDG0]
       pragma: [no-cache]
-      request-id: [02b94bfb-725f-4bfc-b083-7d0af0f87dc8]
+      request-id: [ec273c3f-6040-49cb-8139-52895385b3ce]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -383,31 +1412,31 @@ interactions:
       CommandName: [ad sp delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6&$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27554e7908-6259-4516-bbaa-4f6a768bb2fb%27%29
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%279109f07c-4ed8-4b4e-bd53-5fd9e547a802%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"aeeb5763-98d0-4ae5-bd07-37ee8e2400c1","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2017-12-20-06-09-55","appId":"554e7908-6259-4516-bbaa-4f6a768bb2fb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2017-12-20-06-09-55","errorUrl":null,"homepage":"http://azure-cli-2017-12-20-06-09-55","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2017-12-20-06-09-55","id":"12ad8152-06ea-4806-8509-131d8d0a4581","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2017-12-20-06-09-55 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2017-12-20-06-09-55","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","554e7908-6259-4516-bbaa-4f6a768bb2fb"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"3402c532-a8e6-4e09-bb09-b99447a11bb0","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-10-19-12-42","appId":"9109f07c-4ed8-4b4e-bd53-5fd9e547a802","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-10-19-12-42","errorUrl":null,"homepage":"http://azure-cli-2018-01-10-19-12-42","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-10-19-12-42","id":"d20be26d-c59f-4f1c-b4bf-8350c7b5c0e6","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-10-19-12-42","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","9109f07c-4ed8-4b4e-bd53-5fd9e547a802"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1529']
+      content-length: ['1526']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 20 Dec 2017 06:10:32 GMT']
-      duration: ['728419']
+      date: ['Wed, 10 Jan 2018 19:23:33 GMT']
+      duration: ['1579309']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [FOJvei39+0RRAEZx+MJDWbFlWIOKl/laHJPN6//+pmE=]
-      ocp-aad-session-key: [ou4qhqArYZSVY73NxkdZ9I4p24fj8BuSs3aOOtQamALuELaSkM1TjCeotDWKIoCs-1ryqlMd7er3H-Sz4lyef0SZWGBJGxW07H7cQSis85eS_MwGZbMpJJFK7zYV7BKaMc4V0NuDXRKOYO2D4jryOjonbMRyGlXCGd102dxTCsmBG0YJiGXP_w98UBRo7iiPMslyCD2Zttvphb7zBiGC-A.dOFubY57GaWnbjfGE4M7ST8Nw69ir1zxHcmthzKVHq0]
+      ocp-aad-diagnostics-server-name: [PHA+MZLp3HM+MiVXTghBS0Om6GJiS3JCb0/eer+s+cI=]
+      ocp-aad-session-key: [K98CcALA42PA_4RzYXtyPvHqK6PGCjUkod6MqXIZ9vVcWsp56MZLi4TBJyGkz-K4ZcUBixKumwIDNFHJeTej4G9RH79HYtGpMjtI3y180L_3rcEMpxB76Ywz_ksdGLQyc26fp4wYlkKXaHmPoF412B-Y9mP2mQGNyMUHozt9y8XkVe2bR4iJPVrCKndO9v88xD_W0io00Qs1uWTt5YqVwg.cPnXVu7rkxoj5bkwf7_55neMY2iB7E0Q_DZk7c0XoHk]
       pragma: [no-cache]
-      request-id: [d7a7013d-d979-4984-a109-97a81b5c63c3]
+      request-id: [2f5240c4-2b6e-4d65-9786-bcb1a41274b4]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -423,19 +1452,19 @@ interactions:
       CommandName: [ad sp delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01&$filter=principalId%20eq%20%27aeeb5763-98d0-4ae5-bd07-37ee8e2400c1%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%273402c532-a8e6-4e09-bb09-b99447a11bb0%27&api-version=2015-07-01
   response:
-    body: {string: '{"value":[]}'}
+    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3402c532-a8e6-4e09-bb09-b99447a11bb0","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","createdOn":"2018-01-10T19:13:43.1354505Z","updatedOn":"2018-01-10T19:13:43.1354505Z","createdBy":"856c5a9a-1657-4536-a0a2-cfab2084cf26","updatedBy":"856c5a9a-1657-4536-a0a2-cfab2084cf26"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e7cf9ca1-acf9-40de-997a-a3633ad46eb3","type":"Microsoft.Authorization/roleAssignments","name":"e7cf9ca1-acf9-40de-997a-a3633ad46eb3"}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['12']
+      content-length: ['732']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 20 Dec 2017 06:10:33 GMT']
+      date: ['Wed, 10 Jan 2018 19:23:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -454,27 +1483,1071 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [ad sp delete]
       Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01
+  response:
+    body: {string: "{\"value\":[{\"properties\":{\"roleName\":\"Azure Service Deploy\
+        \ Release Management Contributor\",\"type\":\"CustomRole\",\"description\"\
+        :\"Contributor role for services deploying through Azure Service Deploy.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*\"],\"notActions\"\
+        :[\"Microsoft.Authorization/*/Delete\",\"Microsoft.Authorization/*/Write\"\
+        ]}],\"createdOn\":\"2016-02-04T02:26:31.5413362Z\",\"updatedOn\":\"2018-01-08T20:20:16.3660174Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/21d96096-b162-414a-8302-d8354f9d91b2\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"21d96096-b162-414a-8302-d8354f9d91b2\"\
+        },{\"properties\":{\"roleName\":\"GenevaWarmPathResourceContributor\",\"type\"\
+        :\"CustomRole\",\"description\":\"Can manage service bus and storage accounts.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.EventHub/namespaces/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/*\",\"Microsoft.ServiceBus/namespaces/*\"\
+        ,\"Microsoft.Storage/storageAccounts/*\"],\"notActions\":[]}],\"createdOn\"\
+        :\"2017-03-14T22:30:10.1999436Z\",\"updatedOn\":\"2017-03-14T22:30:10.1999436Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9f15f5f5-77bd-413a-aa88-4b9c68b1e7bc\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9f15f5f5-77bd-413a-aa88-4b9c68b1e7bc\"\
+        },{\"properties\":{\"roleName\":\"masterreader\",\"type\":\"CustomRole\",\"\
+        description\":\"Lets you view everything, but not make any changes.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"*/read\"],\"notActions\":[]}],\"\
+        createdOn\":\"2017-11-14T23:38:05.3353858Z\",\"updatedOn\":\"2017-11-14T23:38:05.3353858Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/a48d7796-14b4-4889-afef-fbb65a93e5a2\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"a48d7796-14b4-4889-afef-fbb65a93e5a2\"\
+        },{\"properties\":{\"roleName\":\"Monitor permissions\",\"type\":\"CustomRole\"\
+        ,\"description\":\"Enables read permissions for monitoring.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/classicAdministrators/read\"\
+        ,\"Microsoft.Authorization/roleAssignments/read\"],\"notActions\":[]}],\"\
+        createdOn\":\"2017-08-22T00:43:09.3217392Z\",\"updatedOn\":\"2017-08-22T00:43:09.3217392Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/a042fe8d-14b3-4850-9120-e2f357577b2d\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"a042fe8d-14b3-4850-9120-e2f357577b2d\"\
+        },{\"properties\":{\"roleName\":\"Office DevOps\",\"type\":\"CustomRole\"\
+        ,\"description\":\"Custom access for developers to operations but not secrets.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Compute/virtualMachineScaleSets/restart/action\"\
+        ,\"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/restart/action\"\
+        ,\"Microsoft.Sql/servers/databases/replicationLinks/delete\",\"Microsoft.Sql/servers/databases/replicationLinks/failover/action\"\
+        ,\"Microsoft.Sql/servers/databases/replicationLinks/forceFailoverAllowDataLoss/action\"\
+        ,\"Microsoft.Sql/servers/databases/replicationLinks/operationResults/read\"\
+        ,\"Microsoft.Sql/servers/databases/replicationLinks/read\",\"Microsoft.Sql/servers/databases/replicationLinks/unlink/action\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2016-10-07T08:11:46.1639398Z\",\"updatedOn\"\
+        :\"2017-03-16T18:43:08.3234306Z\",\"createdBy\":\"25aea6be-b605-4347-a92d-33e178e412ec\"\
+        ,\"updatedBy\":\"25aea6be-b605-4347-a92d-33e178e412ec\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7fd64851-3279-459b-b614-e2b2ba760f5b\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"7fd64851-3279-459b-b614-e2b2ba760f5b\"\
+        },{\"properties\":{\"roleName\":\"API Management Service Contributor\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Can manage service and the APIs\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ApiManagement/service/*\"\
+        ,\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\"\
+        :\"2017-01-23T23:12:00.5823195Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/312a565d-c81f-4fd8-895a-4e21e48d571c\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"312a565d-c81f-4fd8-895a-4e21e48d571c\"\
+        },{\"properties\":{\"roleName\":\"API Management Service Operator Role\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Can manage service but not the APIs\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ApiManagement/service/*/read\"\
+        ,\"Microsoft.ApiManagement/service/backup/action\",\"Microsoft.ApiManagement/service/delete\"\
+        ,\"Microsoft.ApiManagement/service/managedeployments/action\",\"Microsoft.ApiManagement/service/read\"\
+        ,\"Microsoft.ApiManagement/service/restore/action\",\"Microsoft.ApiManagement/service/updatecertificate/action\"\
+        ,\"Microsoft.ApiManagement/service/updatehostname/action\",\"Microsoft.ApiManagement/service/write\"\
+        ,\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[\"Microsoft.ApiManagement/service/users/keys/read\"]}],\"\
+        createdOn\":\"2016-11-09T00:03:42.1194019Z\",\"updatedOn\":\"2016-11-18T23:56:25.4682649Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e022efe7-f5ba-4159-bbe4-b44f577e9b61\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e022efe7-f5ba-4159-bbe4-b44f577e9b61\"\
+        },{\"properties\":{\"roleName\":\"API Management Service Reader Role\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Read-only access to service and APIs\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ApiManagement/service/*/read\"\
+        ,\"Microsoft.ApiManagement/service/read\",\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.ApiManagement/service/users/keys/read\"\
+        ]}],\"createdOn\":\"2016-11-09T00:26:45.1540473Z\",\"updatedOn\":\"2017-01-23T23:10:34.8876776Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/71522526-b88f-4d52-b57f-d31fc3546d0d\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"71522526-b88f-4d52-b57f-d31fc3546d0d\"\
+        },{\"properties\":{\"roleName\":\"Application Insights Component Contributor\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Can manage Application Insights\
+        \ components\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.Insights/components/*\",\"Microsoft.Insights/webtests/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-11-29T20:30:34.2313394Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ae349356-3a1b-4a5e-921d-050484c6347e\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ae349356-3a1b-4a5e-921d-050484c6347e\"\
+        },{\"properties\":{\"roleName\":\"Application Insights Snapshot Debugger\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Gives user permission to use Application\
+        \ Insights Snapshot Debugger features\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Insights/components/*/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-19T21:25:12.3728747Z\",\"updatedOn\"\
+        :\"2017-04-19T23:34:59.9511581Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/08954f03-6346-4c2e-81c0-ec3a5cfae23b\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"08954f03-6346-4c2e-81c0-ec3a5cfae23b\"\
+        },{\"properties\":{\"roleName\":\"Automation Job Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Create and Manage Jobs using Automation Runbooks.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/read\",\"Microsoft.Automation/automationAccounts/jobs/resume/action\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/stop/action\",\"Microsoft.Automation/automationAccounts/jobs/streams/read\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/suspend/action\",\"Microsoft.Automation/automationAccounts/jobs/write\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-19T20:52:41.0020018Z\",\"updatedOn\"\
+        :\"2017-04-25T01:02:08.3049604Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4fe576fe-1146-4730-92eb-48519fa6bf9f\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4fe576fe-1146-4730-92eb-48519fa6bf9f\"\
+        },{\"properties\":{\"roleName\":\"Automation Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Automation Operators are able to start, stop, suspend,\
+        \ and resume jobs\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Automation/automationAccounts/jobs/read\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/resume/action\",\"Microsoft.Automation/automationAccounts/jobs/stop/action\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/streams/read\",\"Microsoft.Automation/automationAccounts/jobs/suspend/action\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/write\",\"Microsoft.Automation/automationAccounts/jobSchedules/read\"\
+        ,\"Microsoft.Automation/automationAccounts/jobSchedules/write\",\"Microsoft.Automation/automationAccounts/read\"\
+        ,\"Microsoft.Automation/automationAccounts/runbooks/read\",\"Microsoft.Automation/automationAccounts/schedules/read\"\
+        ,\"Microsoft.Automation/automationAccounts/schedules/write\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2015-08-18T01:05:03.3916130Z\",\"updatedOn\"\
+        :\"2016-05-31T23:13:38.5728496Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/d3881f73-407a-4167-8283-e981cbba0404\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"d3881f73-407a-4167-8283-e981cbba0404\"\
+        },{\"properties\":{\"roleName\":\"Automation Runbook Operator\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Read Runbook properties - to be able to create\
+        \ Jobs of the runbook.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Automation/automationAccounts/runbooks/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-19T20:47:49.5640674Z\",\"updatedOn\"\
+        :\"2017-04-25T01:00:45.6444999Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5fb5aef8-1081-4b8e-bb16-9d5d0385bab5\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5fb5aef8-1081-4b8e-bb16-9d5d0385bab5\"\
+        },{\"properties\":{\"roleName\":\"Azure Stack Registration Owner\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Lets you manage Azure Stack registrations.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.AzureStack/registrations/products/listDetails/action\"\
+        ,\"Microsoft.AzureStack/registrations/products/read\",\"Microsoft.AzureStack/registrations/read\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-11-13T23:42:06.2161827Z\",\"updatedOn\"\
+        :\"2017-11-13T23:54:02.4007080Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6f12a6df-dd06-4f3e-bcb1-ce8be600526a\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6f12a6df-dd06-4f3e-bcb1-ce8be600526a\"\
+        },{\"properties\":{\"roleName\":\"Backup Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage backup service,but can't create vaults\
+        \ and give access to others\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Network/virtualNetworks/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/operationResults/*\",\"\
+        Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/*\",\"\
+        Microsoft.RecoveryServices/Vaults/backupJobs/*\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupManagementMetaData/*\",\"Microsoft.RecoveryServices/Vaults/backupOperationResults/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/*\",\"Microsoft.RecoveryServices/Vaults/backupProtectableItems/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupProtectedItems/*\",\"Microsoft.RecoveryServices/Vaults/backupProtectionContainers/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/certificates/*\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/*\",\"Microsoft.RecoveryServices/Vaults/usages/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupUsageSummaries/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.RecoveryServices/locations/allocatedStamp/read\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupconfig/vaultconfig/*\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupSecurityPIN/*\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-01-03T13:12:15.7321344Z\",\"updatedOn\"\
+        :\"2017-07-07T06:22:36.4530284Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5e467623-bb1f-42f4-a55d-6e525e11384b\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5e467623-bb1f-42f4-a55d-6e525e11384b\"\
+        },{\"properties\":{\"roleName\":\"Backup Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage backup services, except removal of backup,\
+        \ vault creation and giving access to others\",\"assignableScopes\":[\"/\"\
+        ],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Network/virtualNetworks/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/backup/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationsStatus/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/restore/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupJobs/*\",\"Microsoft.RecoveryServices/Vaults/backupJobs/cancel/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupJobs/operationResults/read\",\"\
+        Microsoft.RecoveryServices/Vaults/backupJobs/read\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupManagementMetaData/read\",\"Microsoft.RecoveryServices/Vaults/backupOperationResults/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectableItems/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupProtectableItems/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupProtectionContainers/read\",\"\
+        Microsoft.RecoveryServices/Vaults/backupUsageSummaries/read\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/extendedInformation/write\",\"Microsoft.RecoveryServices/Vaults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/refreshContainers/*\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/provisionInstantItemRecovery/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/revokeInstantItemRecovery/action\"\
+        ,\"Microsoft.RecoveryServices/locations/allocatedStamp/read\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupconfig/vaultconfig/*\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/operationStatus/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/certificates/write\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-01-03T13:21:11.8947640Z\",\"updatedOn\"\
+        :\"2017-09-13T10:34:41.5049784Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00c29273-979b-4161-815c-10b084fb9324\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"00c29273-979b-4161-815c-10b084fb9324\"\
+        },{\"properties\":{\"roleName\":\"Backup Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can view backup services, but can't make changes\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationsStatus/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupJobs/operationResults/read\",\"\
+        Microsoft.RecoveryServices/Vaults/backupJobs/read\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupManagementMetaData/read\",\"Microsoft.RecoveryServices/Vaults/backupOperationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupProtectionContainers/read\",\"\
+        Microsoft.RecoveryServices/Vaults/backupUsageSummaries/read\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupconfig/vaultconfig/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupJobsExport/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/usages/read\"],\"notActions\":[]}],\"\
+        createdOn\":\"2017-01-03T13:18:41.3893065Z\",\"updatedOn\":\"2017-09-13T10:33:25.5814653Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/a795c7a0-d4a2-40c1-ae25-d81f01202912\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"a795c7a0-d4a2-40c1-ae25-d81f01202912\"\
+        },{\"properties\":{\"roleName\":\"Billing Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Allows read access to billing data\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Billing/*/read\",\"Microsoft.Consumption/*/read\",\"Microsoft.Commerce/*/read\"\
+        ,\"Microsoft.Management/managementGroups/read\",\"Microsoft.Support/*\"],\"\
+        notActions\":[]}],\"createdOn\":\"2017-04-25T02:13:38.9054151Z\",\"updatedOn\"\
+        :\"2017-09-19T17:36:32.7624564Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64\"\
+        },{\"properties\":{\"roleName\":\"BizTalk Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage BizTalk services, but not access to them.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.BizTalkServices/BizTalk/*\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\"\
+        :\"2016-05-31T23:13:55.8430061Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5e3c6656-6cfa-4708-81fe-0de47ac73342\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5e3c6656-6cfa-4708-81fe-0de47ac73342\"\
+        },{\"properties\":{\"roleName\":\"CDN Endpoint Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can manage CDN endpoints, but can\u2019t grant access to\
+        \ other users.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\"\
+        ,\"Microsoft.Cdn/profiles/endpoints/*\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:52.6231539Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/426e0c7f-0c7e-4658-b36f-ff54d6c29b45\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"426e0c7f-0c7e-4658-b36f-ff54d6c29b45\"\
+        },{\"properties\":{\"roleName\":\"CDN Endpoint Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can view CDN endpoints, but can\u2019t make changes.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\",\"\
+        Microsoft.Cdn/profiles/endpoints/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:53.1585846Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/871e35f6-b5c1-49cc-a043-bde969a0f2cd\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"871e35f6-b5c1-49cc-a043-bde969a0f2cd\"\
+        },{\"properties\":{\"roleName\":\"CDN Profile Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can manage CDN profiles and their endpoints, but can\u2019\
+        t grant access to other users.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\"\
+        ,\"Microsoft.Cdn/operationresults/*\",\"Microsoft.Cdn/profiles/*\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:53.7051278Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ec156ff8-a8d1-4d15-830c-5b80698ca432\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ec156ff8-a8d1-4d15-830c-5b80698ca432\"\
+        },{\"properties\":{\"roleName\":\"CDN Profile Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can view CDN profiles and their endpoints, but can\u2019\
+        t make changes.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\"\
+        ,\"Microsoft.Cdn/profiles/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:54.2283001Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8f96442b-4075-438f-813d-ad51ab4019af\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8f96442b-4075-438f-813d-ad51ab4019af\"\
+        },{\"properties\":{\"roleName\":\"Classic Network Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage classic networks, but not\
+        \ access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicNetwork/*\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\"\
+        :\"2016-05-31T23:13:56.3934954Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b34d265f-36f7-4a0d-a4d4-e158ca92e90f\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b34d265f-36f7-4a0d-a4d4-e158ca92e90f\"\
+        },{\"properties\":{\"roleName\":\"Classic Storage Account Contributor\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Lets you manage classic storage accounts,\
+        \ but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicStorage/storageAccounts/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:56.9379206Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/86e8f5dc-a6e9-4c67-9d15-de283e8eac25\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"86e8f5dc-a6e9-4c67-9d15-de283e8eac25\"\
+        },{\"properties\":{\"roleName\":\"Classic Storage Account Key Operator Service\
+        \ Role\",\"type\":\"BuiltInRole\",\"description\":\"Classic Storage Account\
+        \ Key Operators are allowed to list and regenerate keys on Classic Storage\
+        \ Accounts\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.ClassicStorage/storageAccounts/listkeys/action\",\"Microsoft.ClassicStorage/storageAccounts/regeneratekey/action\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-13T18:22:52.1461100Z\",\"updatedOn\"\
+        :\"2017-04-13T20:54:03.0505986Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/985d6b00-f706-48f5-a6fe-d0ca12fb668d\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"985d6b00-f706-48f5-a6fe-d0ca12fb668d\"\
+        },{\"properties\":{\"roleName\":\"Classic Virtual Machine Contributor\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Lets you manage classic virtual machines,\
+        \ but not access to them, and not the virtual network or storage account they\u2019\
+        re connected to.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicCompute/domainNames/*\"\
+        ,\"Microsoft.ClassicCompute/virtualMachines/*\",\"Microsoft.ClassicNetwork/networkSecurityGroups/join/action\"\
+        ,\"Microsoft.ClassicNetwork/reservedIps/link/action\",\"Microsoft.ClassicNetwork/reservedIps/read\"\
+        ,\"Microsoft.ClassicNetwork/virtualNetworks/join/action\",\"Microsoft.ClassicNetwork/virtualNetworks/read\"\
+        ,\"Microsoft.ClassicStorage/storageAccounts/disks/read\",\"Microsoft.ClassicStorage/storageAccounts/images/read\"\
+        ,\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.ClassicStorage/storageAccounts/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:57.4788684Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/d73bb868-a0df-4d4d-bd69-98a00b01fccb\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"d73bb868-a0df-4d4d-bd69-98a00b01fccb\"\
+        },{\"properties\":{\"roleName\":\"ClearDB MySQL DB Contributor\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Lets you manage ClearDB MySQL databases,\
+        \ but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ,\"successbricks.cleardb/databases/*\"],\"notActions\":[]}],\"createdOn\"\
+        :\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:13:58.1393839Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9106cda0-8a86-4e81-b686-29a22c54effe\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9106cda0-8a86-4e81-b686-29a22c54effe\"\
+        },{\"properties\":{\"roleName\":\"Contributor\",\"type\":\"BuiltInRole\",\"\
+        description\":\"Lets you manage everything except access to resources.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*\"],\"notActions\"\
+        :[\"Microsoft.Authorization/*/Delete\",\"Microsoft.Authorization/*/Write\"\
+        ,\"Microsoft.Authorization/elevateAccess/Action\"]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-12-14T02:04:45.1393855Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b24988ac-6180-42a0-ab88-20f7382dd24c\"\
+        },{\"properties\":{\"roleName\":\"Cosmos DB Account Reader Role\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Can read Azure Cosmos DB Accounts data\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.DocumentDB/*/read\",\"Microsoft.DocumentDB/databaseAccounts/readonlykeys/action\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2017-10-30T17:53:54.6005577Z\"\
+        ,\"updatedOn\":\"2018-01-08T19:57:53.2779811Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fbdf93bf-df7d-467e-a4d2-9458aa1360c8\"\
+        },{\"properties\":{\"roleName\":\"Data Factory Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Create and manage data factories, as well as child resources\
+        \ within them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.DataFactory/dataFactories/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-09-12T19:16:42.3441035Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/673868aa-7521-48a0-acc6-0f60742d39f5\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"673868aa-7521-48a0-acc6-0f60742d39f5\"\
+        },{\"properties\":{\"roleName\":\"Data Lake Analytics Developer\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Lets you submit, monitor, and manage your\
+        \ own jobs but not create or delete Data Lake Analytics accounts.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.BigAnalytics/accounts/*\",\"Microsoft.DataLakeAnalytics/accounts/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.BigAnalytics/accounts/Delete\"\
+        ,\"Microsoft.BigAnalytics/accounts/TakeOwnership/action\",\"Microsoft.BigAnalytics/accounts/Write\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/Delete\",\"Microsoft.DataLakeAnalytics/accounts/TakeOwnership/action\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/Write\",\"Microsoft.DataLakeAnalytics/accounts/dataLakeStoreAccounts/Write\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/dataLakeStoreAccounts/Delete\",\"\
+        Microsoft.DataLakeAnalytics/accounts/storageAccounts/Write\",\"Microsoft.DataLakeAnalytics/accounts/storageAccounts/Delete\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/firewallRules/Write\",\"Microsoft.DataLakeAnalytics/accounts/firewallRules/Delete\"\
+        ,\"Microsoft.DataLakeAnalytics/accounts/computePolicies/Write\",\"Microsoft.DataLakeAnalytics/accounts/computePolicies/Delete\"\
+        ]}],\"createdOn\":\"2015-10-20T00:33:29.3115234Z\",\"updatedOn\":\"2017-08-18T00:00:17.0411642Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/47b7735b-770e-4598-a7da-8b91488b4c88\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"47b7735b-770e-4598-a7da-8b91488b4c88\"\
+        },{\"properties\":{\"roleName\":\"DevTest Labs User\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you connect, start, restart, and shutdown your virtual\
+        \ machines in your Azure DevTest Labs.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Compute/availabilitySets/read\"\
+        ,\"Microsoft.Compute/virtualMachines/*/read\",\"Microsoft.Compute/virtualMachines/deallocate/action\"\
+        ,\"Microsoft.Compute/virtualMachines/read\",\"Microsoft.Compute/virtualMachines/restart/action\"\
+        ,\"Microsoft.Compute/virtualMachines/start/action\",\"Microsoft.DevTestLab/*/read\"\
+        ,\"Microsoft.DevTestLab/labs/createEnvironment/action\",\"Microsoft.DevTestLab/labs/claimAnyVm/action\"\
+        ,\"Microsoft.DevTestLab/labs/formulas/delete\",\"Microsoft.DevTestLab/labs/formulas/read\"\
+        ,\"Microsoft.DevTestLab/labs/formulas/write\",\"Microsoft.DevTestLab/labs/policySets/evaluatePolicies/action\"\
+        ,\"Microsoft.DevTestLab/labs/virtualMachines/claim/action\",\"Microsoft.Network/loadBalancers/backendAddressPools/join/action\"\
+        ,\"Microsoft.Network/loadBalancers/inboundNatRules/join/action\",\"Microsoft.Network/networkInterfaces/*/read\"\
+        ,\"Microsoft.Network/networkInterfaces/join/action\",\"Microsoft.Network/networkInterfaces/read\"\
+        ,\"Microsoft.Network/networkInterfaces/write\",\"Microsoft.Network/publicIPAddresses/*/read\"\
+        ,\"Microsoft.Network/publicIPAddresses/join/action\",\"Microsoft.Network/publicIPAddresses/read\"\
+        ,\"Microsoft.Network/virtualNetworks/subnets/join/action\",\"Microsoft.Resources/deployments/operations/read\"\
+        ,\"Microsoft.Resources/deployments/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Storage/storageAccounts/listKeys/action\"],\"notActions\":[\"\
+        Microsoft.Compute/virtualMachines/vmSizes/read\"]}],\"createdOn\":\"2015-06-08T21:52:45.0657582Z\"\
+        ,\"updatedOn\":\"2017-02-02T02:38:38.2961026Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/76283e04-6283-4c54-8f91-bcf1374a3c64\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"76283e04-6283-4c54-8f91-bcf1374a3c64\"\
+        },{\"properties\":{\"roleName\":\"DNS Zone Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage DNS zones and record sets in Azure DNS,\
+        \ but does not let you control who has access to them.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/dnsZones/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2015-10-15T23:33:25.9730842Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:40.3710365Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/befefa01-2a29-4197-83a8-272ff33ce314\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"befefa01-2a29-4197-83a8-272ff33ce314\"\
+        },{\"properties\":{\"roleName\":\"DocumentDB Account Contributor\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Lets you manage DocumentDB accounts, but\
+        \ not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.DocumentDb/databaseAccounts/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:07.2132374Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5bd9cd88-fe45-4216-938b-f97437e15450\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5bd9cd88-fe45-4216-938b-f97437e15450\"\
+        },{\"properties\":{\"roleName\":\"Intelligent Systems Account Contributor\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Lets you manage Intelligent Systems\
+        \ accounts, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.IntelligentSystems/accounts/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:13:59.7946586Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/03a6d094-3444-4b3d-88af-7477090a9e5e\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"03a6d094-3444-4b3d-88af-7477090a9e5e\"\
+        },{\"properties\":{\"roleName\":\"Key Vault Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage key vaults, but not access to them.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.KeyVault/*\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[\"Microsoft.KeyVault/locations/deletedVaults/purge/action\"\
+        ,\"Microsoft.KeyVault/hsmPools/*\"]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2017-12-14T02:01:18.4641200Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/f25e0fa2-a7c8-4377-a976-54943a77a395\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"f25e0fa2-a7c8-4377-a976-54943a77a395\"\
+        },{\"properties\":{\"roleName\":\"Log Analytics Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Log Analytics Contributor can read all monitoring\
+        \ data and edit monitoring settings. Editing monitoring settings includes\
+        \ adding the VM extension to VMs; reading storage account keys to be able\
+        \ to configure collection of logs from Azure Storage; creating and configuring\
+        \ Automation accounts; adding solutions; and configuring Azure diagnostics\
+        \ on all Azure resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Automation/automationAccounts/*\",\"*/read\",\"Microsoft.ClassicCompute/virtualMachines/extensions/*\"\
+        ,\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.Compute/virtualMachines/extensions/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/diagnosticSettings/*\"\
+        ,\"Microsoft.OperationalInsights/*\",\"Microsoft.OperationsManagement/*\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourcegroups/deployments/*\"\
+        ,\"Microsoft.Storage/storageAccounts/listKeys/action\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-04-25T21:51:45.3174711Z\",\"updatedOn\"\
+        :\"2017-05-19T04:00:50.7280454Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\
+        },{\"properties\":{\"roleName\":\"Log Analytics Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Log Analytics Reader can view and search all monitoring\
+        \ data as well as and view monitoring settings, including viewing the configuration\
+        \ of Azure diagnostics on all Azure resources.\",\"assignableScopes\":[\"\
+        /\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.OperationalInsights/workspaces/analytics/query/action\"\
+        ,\"Microsoft.OperationalInsights/workspaces/search/action\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[\"Microsoft.OperationalInsights/workspaces/sharedKeys/read\"\
+        ]}],\"createdOn\":\"2017-05-02T00:20:28.1449012Z\",\"updatedOn\":\"2017-05-02T22:36:45.2104697Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/73c42c96-874c-492b-b04d-ab87d138a893\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"73c42c96-874c-492b-b04d-ab87d138a893\"\
+        },{\"properties\":{\"roleName\":\"Logic App Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage logic app, but not access to them.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.ClassicStorage/storageAccounts/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/diagnosticSettings/*\"\
+        ,\"Microsoft.Insights/logdefinitions/*\",\"Microsoft.Insights/metricDefinitions/*\"\
+        ,\"Microsoft.Logic/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/operationresults/read\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/listkeys/action\"\
+        ,\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.Support/*\",\"Microsoft.Web/connections/*\"\
+        ,\"Microsoft.Web/connectionGateways/*\",\"Microsoft.Web/serverFarms/join/action\"\
+        ,\"Microsoft.Web/serverFarms/read\",\"Microsoft.Web/sites/functions/listSecrets/action\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2016-04-28T21:33:30.4656007Z\",\"updatedOn\"\
+        :\"2016-11-09T20:20:11.3665904Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/87a39d53-fc1b-424a-814c-f7e04687dc9e\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"87a39d53-fc1b-424a-814c-f7e04687dc9e\"\
+        },{\"properties\":{\"roleName\":\"Logic App Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you read, enable and disable logic app.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*/read\",\"Microsoft.Insights/diagnosticSettings/*/read\"\
+        ,\"Microsoft.Insights/metricDefinitions/*/read\",\"Microsoft.Logic/*/read\"\
+        ,\"Microsoft.Logic/workflows/disable/action\",\"Microsoft.Logic/workflows/enable/action\"\
+        ,\"Microsoft.Logic/workflows/validate/action\",\"Microsoft.Resources/deployments/operations/read\"\
+        ,\"Microsoft.Resources/subscriptions/operationresults/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.Web/connections/*/read\",\"Microsoft.Web/connectionGateways/*/read\"\
+        ,\"Microsoft.Web/serverFarms/read\"],\"notActions\":[]}],\"createdOn\":\"\
+        2016-04-28T21:33:30.4656007Z\",\"updatedOn\":\"2016-11-09T20:26:07.8911630Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/515c2055-d9d4-4321-b1b9-bd0c9a0f79fe\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"515c2055-d9d4-4321-b1b9-bd0c9a0f79fe\"\
+        },{\"properties\":{\"roleName\":\"Managed Identity Contributor\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Create, Read, Update, and Delete User Assigned\
+        \ Identity\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.ManagedIdentity/userAssignedIdentities/*/read\",\"Microsoft.ManagedIdentity/userAssignedIdentities/*/write\"\
+        ,\"Microsoft.ManagedIdentity/userAssignedIdentities/*/delete\",\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Support/*\"],\"notActions\"\
+        :[]}],\"createdOn\":\"2017-12-14T19:53:42.8804692Z\",\"updatedOn\":\"2017-12-14T22:17:02.2740594Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e40ec5ca-96e0-45a2-b4ff-59039f2c2b59\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e40ec5ca-96e0-45a2-b4ff-59039f2c2b59\"\
+        },{\"properties\":{\"roleName\":\"Managed Identity Operator\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Read and Assign User Assigned Identity\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ManagedIdentity/userAssignedIdentities/*/read\"\
+        ,\"Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action\",\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Support/*\"],\"notActions\"\
+        :[]}],\"createdOn\":\"2017-12-14T19:52:04.3924594Z\",\"updatedOn\":\"2017-12-14T22:16:00.1483256Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"f1a07417-d97a-45cb-824c-7a7467783830\"\
+        },{\"properties\":{\"roleName\":\"Monitoring Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can read all monitoring data and update monitoring settings.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"\
+        Microsoft.AlertsManagement/alerts/*\",\"Microsoft.AlertsManagement/alertsSummary/*\"\
+        ,\"Microsoft.Insights/AlertRules/*\",\"Microsoft.Insights/components/*\",\"\
+        Microsoft.Insights/DiagnosticSettings/*\",\"Microsoft.Insights/eventtypes/*\"\
+        ,\"Microsoft.Insights/LogDefinitions/*\",\"Microsoft.Insights/MetricDefinitions/*\"\
+        ,\"Microsoft.Insights/Metrics/*\",\"Microsoft.Insights/Register/Action\",\"\
+        Microsoft.Insights/webtests/*\",\"Microsoft.OperationalInsights/workspaces/intelligencepacks/*\"\
+        ,\"Microsoft.OperationalInsights/workspaces/savedSearches/*\",\"Microsoft.OperationalInsights/workspaces/search/action\"\
+        ,\"Microsoft.OperationalInsights/workspaces/sharedKeys/action\",\"Microsoft.OperationalInsights/workspaces/storageinsightconfigs/*\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-09-21T19:21:08.4345976Z\"\
+        ,\"updatedOn\":\"2017-12-20T18:41:58.1319162Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"749f88d5-cbae-40b8-bcfc-e573ddc772fa\"\
+        },{\"properties\":{\"roleName\":\"Monitoring Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Can read all monitoring data.\",\"assignableScopes\":[\"\
+        /\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.OperationalInsights/workspaces/search/action\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-09-21T19:19:52.4939376Z\"\
+        ,\"updatedOn\":\"2017-07-07T20:00:57.2225683Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/43d0d8ad-25c7-4714-9337-8ba259a9fe05\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"43d0d8ad-25c7-4714-9337-8ba259a9fe05\"\
+        },{\"properties\":{\"roleName\":\"Network Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage networks, but not access to them.\",\"\
+        assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2015-06-02T00:18:27.3542698Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:00.3326359Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4d97b98b-1d4f-4787-a291-c67834d212e7\"\
+        },{\"properties\":{\"roleName\":\"New Relic APM Account Contributor\",\"type\"\
+        :\"BuiltInRole\",\"description\":\"Lets you manage New Relic Application Performance\
+        \ Management accounts and applications, but not access to them.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\",\"NewRelic.APM/accounts/*\"],\"notActions\":[]}],\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:07.7538043Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5d28c62d-5b37-4476-8438-e587778df237\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5d28c62d-5b37-4476-8438-e587778df237\"\
+        },{\"properties\":{\"roleName\":\"Owner\",\"type\":\"BuiltInRole\",\"description\"\
+        :\"Lets you manage everything, including access to resources.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"*\"],\"notActions\":[]}],\"createdOn\"\
+        :\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:00.9179619Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8e3af657-a8ff-443c-a75c-2fe8c4bcb635\"\
+        },{\"properties\":{\"roleName\":\"Reader\",\"type\":\"BuiltInRole\",\"description\"\
+        :\"Lets you view everything, but not make any changes.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"*/read\"],\"notActions\":[]}],\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-08-19T00:03:56.0652623Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"acdd72a7-3385-48ef-bd42-f606fba81ae7\"\
+        },{\"properties\":{\"roleName\":\"Redis Cache Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage Redis caches, but not access to them.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Cache/redis/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:01.9877071Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e0f68234-74aa-48ed-b826-c38b57376e17\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e0f68234-74aa-48ed-b826-c38b57376e17\"\
+        },{\"properties\":{\"roleName\":\"Resource Policy Contributor (Preview)\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"(Preview) Backfilled users from\
+        \ EA, with rights to create/modify resource policy, create support ticket\
+        \ and read resources/hierarchy.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"*/read\",\"Microsoft.Authorization/policyassignments/*\"\
+        ,\"Microsoft.Authorization/policydefinitions/*\",\"Microsoft.PolicyInsights/*\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.Authorization/policysetdefinitions/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-08-25T19:08:01.3861639Z\",\"updatedOn\"\
+        :\"2017-12-11T19:50:28.9095808Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/36243c78-bf99-498c-9df9-86d9f8d28608\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"36243c78-bf99-498c-9df9-86d9f8d28608\"\
+        },{\"properties\":{\"roleName\":\"Scheduler Job Collections Contributor\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Lets you manage Scheduler job\
+        \ collections, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Scheduler/jobcollections/*\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:02.5343995Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/188a0f2f-5c9e-469b-ae67-2aa5ce574b94\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"188a0f2f-5c9e-469b-ae67-2aa5ce574b94\"\
+        },{\"properties\":{\"roleName\":\"Search Service Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage Search services, but not access\
+        \ to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Search/searchServices/*\",\"Microsoft.Support/*\"],\"notActions\"\
+        :[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:03.0463472Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7ca78c08-252a-4471-8644-bb5ff32d4ba0\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"7ca78c08-252a-4471-8644-bb5ff32d4ba0\"\
+        },{\"properties\":{\"roleName\":\"Security Admin\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Security Admin Role\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.operationalInsights/workspaces/*/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Security/*/read\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.Authorization/policyAssignments/*\",\"\
+        Microsoft.Authorization/policySetDefinitions/*\",\"Microsoft.Authorization/policyDefinitions/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-05-03T07:51:23.0917487Z\",\"updatedOn\"\
+        :\"2017-11-09T01:46:17.1597247Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fb1c8493-542b-48eb-b624-b4c8fea62acd\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fb1c8493-542b-48eb-b624-b4c8fea62acd\"\
+        },{\"properties\":{\"roleName\":\"Security Manager\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage security components, security policies\
+        \ and virtual machines\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicCompute/*/read\"\
+        ,\"Microsoft.ClassicCompute/virtualMachines/*/write\",\"Microsoft.ClassicNetwork/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Security/*\",\"Microsoft.Support/*\"],\"notActions\":[]}],\"\
+        createdOn\":\"2015-06-22T17:45:15.8986455Z\",\"updatedOn\":\"2016-05-31T23:14:03.5656122Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e3d13bf0-dd5a-482e-ba6b-9b8433878d10\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e3d13bf0-dd5a-482e-ba6b-9b8433878d10\"\
+        },{\"properties\":{\"roleName\":\"Security Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Security Reader Role\",\"assignableScopes\":[\"/\"],\"\
+        permissions\":[{\"actions\":[\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.operationalInsights/workspaces/*/read\",\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Security/*/read\"],\"notActions\":[]}],\"createdOn\":\"2017-05-03T07:48:49.0516559Z\"\
+        ,\"updatedOn\":\"2017-05-03T18:42:54.9787380Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"39bc4728-0917-49c7-9d2c-d95423bc2eb4\"\
+        },{\"properties\":{\"roleName\":\"Site Recovery Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage Site Recovery sservice except\
+        \ vault creation and role assignment\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\"\
+        ,\"Microsoft.RecoveryServices/locations/allocateStamp/action\",\"Microsoft.RecoveryServices/Vaults/certificates/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/extendedInformation/*\",\"Microsoft.RecoveryServices/Vaults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/*\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationAlertSettings/*\",\"Microsoft.RecoveryServices/vaults/replicationEvents/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/*\",\"Microsoft.RecoveryServices/vaults/replicationJobs/*\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationPolicies/*\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/storageConfig/*\",\"Microsoft.RecoveryServices/Vaults/tokenInfo/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.RecoveryServices/Vaults/vaultTokens/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/*\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2017-05-19T13:46:17.4592776Z\"\
+        ,\"updatedOn\":\"2017-06-29T05:31:19.7240473Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6670b86e-a3f7-4917-ac9b-5d6ab1be4567\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6670b86e-a3f7-4917-ac9b-5d6ab1be4567\"\
+        },{\"properties\":{\"roleName\":\"Site Recovery Operator\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you failover and failback but not perform other Site\
+        \ Recovery management operations\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\"\
+        ,\"Microsoft.RecoveryServices/locations/allocateStamp/action\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/vaults/replicationAlertSettings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationEvents/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/checkConsistency/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/reassociateGateway/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/renewcertificate/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/replicationNetworkMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectableItems/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/applyRecoveryPoint/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/failoverCommit/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/plannedFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/recoveryPoints/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/repairReplication/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/reProtect/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/testFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/testFailoverCleanup/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/unplannedFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/updateMobilityService/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionContainerMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders/refreshProvider/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/replicationStorageClassificationMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationvCenters/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationJobs/*\",\"Microsoft.RecoveryServices/vaults/replicationPolicies/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/failoverCommit/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/plannedFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/read\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/reProtect/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/testFailover/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/testFailoverCleanup/action\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/unplannedFailover/action\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/*\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/storageConfig/read\",\"Microsoft.RecoveryServices/Vaults/tokenInfo/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.RecoveryServices/Vaults/vaultTokens/read\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2017-05-19T13:47:50.1341148Z\"\
+        ,\"updatedOn\":\"2017-06-29T05:42:27.1715639Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/494ae006-db33-4328-bf46-533a6560a3ca\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"494ae006-db33-4328-bf46-533a6560a3ca\"\
+        },{\"properties\":{\"roleName\":\"Site Recovery Reader\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you view Site Recovery status but not perform other\
+        \ management operations\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/vaults/replicationAlertSettings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationEvents/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/replicationNetworkMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectableItems/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/recoveryPoints/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionContainerMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/replicationStorageClassificationMappings/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationvCenters/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationJobs/read\",\"Microsoft.RecoveryServices/vaults/replicationPolicies/read\"\
+        ,\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/tokenInfo/read\",\"Microsoft.RecoveryServices/Vaults/usages/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/vaultTokens/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-05-19T13:35:40.0093634Z\",\"updatedOn\"\
+        :\"2017-05-26T19:54:51.3933250Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/dbaa88c4-0c30-4179-9fb3-46319faa6149\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"dbaa88c4-0c30-4179-9fb3-46319faa6149\"\
+        },{\"properties\":{\"roleName\":\"SQL DB Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage SQL databases, but not access to them.\
+        \ Also, you can't manage their security-related policies or their parent SQL\
+        \ servers.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Sql/locations/*/read\",\"Microsoft.Sql/servers/databases/*\"\
+        ,\"Microsoft.Sql/servers/read\",\"Microsoft.Support/*\"],\"notActions\":[\"\
+        Microsoft.Sql/servers/databases/auditingPolicies/*\",\"Microsoft.Sql/servers/databases/auditingSettings/*\"\
+        ,\"Microsoft.Sql/servers/databases/auditRecords/read\",\"Microsoft.Sql/servers/databases/connectionPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/securityMetrics/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessment/*\"\
+        ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\"\
+        ]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2017-11-13T18:45:48.4626427Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9b7fa17d-e63e-47b0-bb0a-15c516ac86ec\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9b7fa17d-e63e-47b0-bb0a-15c516ac86ec\"\
+        },{\"properties\":{\"roleName\":\"SQL Security Manager\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage the security-related policies of SQL servers\
+        \ and databases, but not access to them.\",\"assignableScopes\":[\"/\"],\"\
+        permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Network/virtualNetworks/subnets/joinViaServiceEndpoint/action\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Sql/servers/auditingPolicies/*\"\
+        ,\"Microsoft.Sql/servers/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditingPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditRecords/read\"\
+        ,\"Microsoft.Sql/servers/databases/connectionPolicies/*\",\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/read\",\"Microsoft.Sql/servers/databases/schemas/read\"\
+        ,\"Microsoft.Sql/servers/databases/schemas/tables/columns/read\",\"Microsoft.Sql/servers/databases/schemas/tables/read\"\
+        ,\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/securityMetrics/*\"\
+        ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessment/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\"\
+        ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\",\"\
+        Microsoft.Sql/servers/firewallRules/*\",\"Microsoft.Sql/servers/read\",\"\
+        Microsoft.Sql/servers/securityAlertPolicies/*\",\"Microsoft.Support/*\"],\"\
+        notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\"\
+        :\"2017-11-13T18:42:25.1400282Z\",\"createdBy\":null,\"updatedBy\":\"yaiyun\"\
+        },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"056cd41c-7e88-42e1-933e-88ba6a50c9c3\"\
+        },{\"properties\":{\"roleName\":\"SQL Server Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage SQL servers and databases, but not access\
+        \ to them, and not their security -related policies.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Sql/locations/*/read\",\"Microsoft.Sql/servers/*\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[\"Microsoft.Sql/servers/auditingPolicies/*\",\"Microsoft.Sql/servers/auditingSettings/*\"\
+        ,\"Microsoft.Sql/servers/databases/auditingPolicies/*\",\"Microsoft.Sql/servers/databases/auditingSettings/*\"\
+        ,\"Microsoft.Sql/servers/databases/auditRecords/read\",\"Microsoft.Sql/servers/databases/connectionPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/securityMetrics/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessment/*\"\
+        ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\"\
+        ,\"Microsoft.Sql/servers/securityAlertPolicies/*\"]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2017-11-13T18:48:48.9023666Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437\"\
+        },{\"properties\":{\"roleName\":\"Storage Account Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage storage accounts, but not\
+        \ access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.Insights/diagnosticSettings/*\",\"Microsoft.Network/virtualNetworks/subnets/joinViaServiceEndpoint/action\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/*\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2015-06-02T00:18:27.3542698Z\"\
+        ,\"updatedOn\":\"2017-08-21T07:43:20.3060994Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"17d1049b-9a84-46fb-8f53-869881c3d3ab\"\
+        },{\"properties\":{\"roleName\":\"Storage Account Key Operator Service Role\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Storage Account Key Operators\
+        \ are allowed to list and regenerate keys on Storage Accounts\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/listkeys/action\"\
+        ,\"Microsoft.Storage/storageAccounts/regeneratekey/action\"],\"notActions\"\
+        :[]}],\"createdOn\":\"2017-04-13T18:26:11.5770570Z\",\"updatedOn\":\"2017-04-13T20:57:14.5990198Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/81a9662b-bebf-436f-a333-f67b29880f12\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"81a9662b-bebf-436f-a333-f67b29880f12\"\
+        },{\"properties\":{\"roleName\":\"Storage Blob Data Contributor (Preview)\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Allows for read, write and delete\
+        \ access to Azure Storage blob containers and data\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/read\"\
+        ,\"Microsoft.Storage/storageAccounts/blobServices/containers/write\",\"Microsoft.Storage/storageAccounts/blobServices/containers/delete\"\
+        ,\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\"\
+        ,\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write\"\
+        ,\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\"\
+        :\"2017-12-21T00:01:24.7972312Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ba92f5b4-2d11-453d-a403-e96b0029c9fe\"\
+        },{\"properties\":{\"roleName\":\"Storage Blob Data Reader (Preview)\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Allows for read access to Azure Storage\
+        \ blob containers and data\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/read\"\
+        ,\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\"\
+        :\"2017-12-21T00:01:24.7972312Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/2a2b9908-6ea1-4ae2-8e65-a410df84e7d1\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"2a2b9908-6ea1-4ae2-8e65-a410df84e7d1\"\
+        },{\"properties\":{\"roleName\":\"Storage Queue Data Contributor (Preview)\"\
+        ,\"type\":\"BuiltInRole\",\"description\":\"Allows for read, write, and delete\
+        \ access to Azure Storage queues and queue messages\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/read\"\
+        ,\"Microsoft.Storage/storageAccounts/queueServices/queues/write\",\"Microsoft.Storage/storageAccounts/queueServices/queues/delete\"\
+        ,\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/read\"\
+        ,\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/write\"\
+        ,\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/delete\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\"\
+        :\"2017-12-21T00:01:24.7972312Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"974c5e8b-45b9-4653-ba55-5f855dd0fb88\"\
+        },{\"properties\":{\"roleName\":\"Storage Queue Data Reader (Preview)\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Allows for read access to Azure Storage\
+        \ queues and queue messages\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        :[{\"actions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/read\"\
+        ,\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/read\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\"\
+        :\"2017-12-21T00:01:24.7972312Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/19e7f393-937e-4f77-808e-94535e297925\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"19e7f393-937e-4f77-808e-94535e297925\"\
+        },{\"properties\":{\"roleName\":\"Support Request Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you create and manage Support requests\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-06-22T22:25:37.8053068Z\",\"updatedOn\"\
+        :\"2017-06-23T01:06:24.2399631Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e\"\
+        },{\"properties\":{\"roleName\":\"Traffic Manager Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage Traffic Manager profiles,\
+        \ but does not let you control who has access to them.\",\"assignableScopes\"\
+        :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/trafficManagerProfiles/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2015-10-15T23:33:25.9730842Z\",\"updatedOn\"\
+        :\"2016-05-31T23:13:44.1458854Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/a4b10055-b0c7-44c2-b00f-c7b5b3550cf7\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"a4b10055-b0c7-44c2-b00f-c7b5b3550cf7\"\
+        },{\"properties\":{\"roleName\":\"User Access Administrator\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage user access to Azure resources.\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"\
+        Microsoft.Authorization/*\",\"Microsoft.Support/*\"],\"notActions\":[]}],\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:04.6964687Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"18d7d88d-d35e-4fb5-a5c3-7773c20a72d9\"\
+        },{\"properties\":{\"roleName\":\"Virtual Machine Contributor\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Lets you manage virtual machines, but not\
+        \ access to them, and not the virtual network or storage account they\uFFFD\
+        re connected to.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
+        :[\"Microsoft.Authorization/*/read\",\"Microsoft.Compute/availabilitySets/*\"\
+        ,\"Microsoft.Compute/locations/*\",\"Microsoft.Compute/virtualMachines/*\"\
+        ,\"Microsoft.Compute/virtualMachineScaleSets/*\",\"Microsoft.DevTestLab/schedules/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/applicationGateways/backendAddressPools/join/action\"\
+        ,\"Microsoft.Network/loadBalancers/backendAddressPools/join/action\",\"Microsoft.Network/loadBalancers/inboundNatPools/join/action\"\
+        ,\"Microsoft.Network/loadBalancers/inboundNatRules/join/action\",\"Microsoft.Network/loadBalancers/probes/join/action\"\
+        ,\"Microsoft.Network/loadBalancers/read\",\"Microsoft.Network/locations/*\"\
+        ,\"Microsoft.Network/networkInterfaces/*\",\"Microsoft.Network/networkSecurityGroups/join/action\"\
+        ,\"Microsoft.Network/networkSecurityGroups/read\",\"Microsoft.Network/publicIPAddresses/join/action\"\
+        ,\"Microsoft.Network/publicIPAddresses/read\",\"Microsoft.Network/virtualNetworks/read\"\
+        ,\"Microsoft.Network/virtualNetworks/subnets/join/action\",\"Microsoft.RecoveryServices/locations/*\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/*/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupFabrics/backupProtectionIntent/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/backupPolicies/read\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/write\"\
+        ,\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/usages/read\"\
+        ,\"Microsoft.RecoveryServices/Vaults/write\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Storage/storageAccounts/listKeys/action\",\"Microsoft.Storage/storageAccounts/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2015-06-02T00:18:27.3542698Z\"\
+        ,\"updatedOn\":\"2017-11-14T03:00:30.1736393Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9980e02c-c2be-4d73-94e8-173b1dc7cf3c\"\
+        },{\"properties\":{\"roleName\":\"Web Plan Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage the web plans for websites, but not access\
+        \ to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.Web/serverFarms/*\"],\"notActions\":[]}],\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:05.9401651Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b\"\
+        },{\"properties\":{\"roleName\":\"Website Contributor\",\"type\":\"BuiltInRole\"\
+        ,\"description\":\"Lets you manage websites (not web plans), but not access\
+        \ to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
+        Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/components/*\"\
+        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ,\"Microsoft.Web/certificates/*\",\"Microsoft.Web/listSitesAssignedToHostName/read\"\
+        ,\"Microsoft.Web/serverFarms/join/action\",\"Microsoft.Web/serverFarms/read\"\
+        ,\"Microsoft.Web/sites/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
+        ,\"updatedOn\":\"2016-05-31T23:14:06.5272742Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"de139f84-1756-47ae-9be6-808fbbe84772\"\
+        }]}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['86050']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:23:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-request-charge: ['1']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"objectIds": ["3402c532-a8e6-4e09-bb09-b99447a11bb0"], "includeDirectoryObjectReferences":
+      true}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp delete]
+      Connection: [keep-alive]
+      Content-Length: ['97']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"3402c532-a8e6-4e09-bb09-b99447a11bb0","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-10-19-12-42","appId":"9109f07c-4ed8-4b4e-bd53-5fd9e547a802","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-10-19-12-42","errorUrl":null,"homepage":"http://azure-cli-2018-01-10-19-12-42","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-10-19-12-42","id":"d20be26d-c59f-4f1c-b4bf-8350c7b5c0e6","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-10-19-12-42 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-10-19-12-42","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","9109f07c-4ed8-4b4e-bd53-5fd9e547a802"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1481']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Wed, 10 Jan 2018 19:23:35 GMT']
+      duration: ['947126']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [zQeduCGWMMrNq1oCm52i7oSfjI5x6HwndIRXPe0iL68=]
+      ocp-aad-session-key: [412m5LzyMHkjwp4L8wQNPDuNmXX14cZaGKMnSdTV3kk5IuRbNqU_E69ZHW5ZFlT8_PQT92YOfL9ROeqzTiRCWCtNn90_LTsG7Jiyuc-sXPunB-P_CiabDDuC2in933ZhM5bYByzghDOV-539Ta8_nijIp8H3E_OvnE5qmgIA0hbyCBXBLtGCHg4Z8q3dFc_i4buC16YARaKsZmP17-EwoA.2DPCu2UGMb6T71fFvNDlkWFqwLhuw7wykQEZt34BIeY]
+      pragma: [no-cache]
+      request-id: [607232da-f9bf-4066-a1e0-ff2eb5ef62ad]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp delete]
+      Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/29846b0f-d7e9-42ba-9756-0b8f9073cb5c?api-version=1.6
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e7cf9ca1-acf9-40de-997a-a3633ad46eb3?api-version=2015-07-01
+  response:
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3402c532-a8e6-4e09-bb09-b99447a11bb0","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","createdOn":"2018-01-10T19:13:43.1354505Z","updatedOn":"2018-01-10T19:13:43.1354505Z","createdBy":"856c5a9a-1657-4536-a0a2-cfab2084cf26","updatedBy":"856c5a9a-1657-4536-a0a2-cfab2084cf26"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e7cf9ca1-acf9-40de-997a-a3633ad46eb3","type":"Microsoft.Authorization/roleAssignments","name":"e7cf9ca1-acf9-40de-997a-a3633ad46eb3"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['720']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 10 Jan 2018 19:23:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-request-charge: ['2']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad sp delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/ab571e1d-35b7-44c4-beb0-949122478a7f?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       dataserviceversion: [1.0;]
-      date: ['Wed, 20 Dec 2017 06:10:36 GMT']
-      duration: ['34742798']
+      date: ['Wed, 10 Jan 2018 19:23:37 GMT']
+      duration: ['2777999']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [hV2ZqDb3QW3c/nJDZIUxQbdsgGQVmX4f43r2oZefMhw=]
-      ocp-aad-session-key: [ZghiVaXvm_6Qkkxo2mkbG2EJcioDe6Jwdcyicmnxa63fM5qmVaqoXoMyKyss80K6ZcQup1KuvQnMEY6sHxODUkqF_apYugCP_6fzPGuaPhK-xIzau1SsD6Th66kSrmXM0UBdj1LTOwSdBAGR_rZFbvStusKsjtTLTCwgVpnHhxWdu-LyC-QB5f1IAdUEhm88p300V_ikosT_TpZVZ1Iobw.jvZ9q-P_yMur_2oUvK2-oGyOGdt81qLNrECKO5RVGfk]
+      ocp-aad-diagnostics-server-name: [fAzcDZyFSvI7esIUZ/nG6AP2lSBjzL8Jnvv5hxgG43k=]
+      ocp-aad-session-key: [dSuCkF1AE4bcxoFLiD_T90vAPHfFBMeNX6RZ1FnIYE2guHxJe3MC9Z9gHEZu5ek3VX5yGSOY3orXoKEHrmNIgNDq57d6-pFdctO10Lzta9xDcNWmi47Nxf3zR-GR9c3yMHuxS83JAe-xw7embHxiZcdYp335dOxr2ZeImt4usxuXhQTkr0K9Nj489M7eDH00LvMC6xg4PJetB7sCOO7XYw.gxz5RKZBX4Bh_goSL_t05BhL-_ZdkMYeLVH_B2wRP7c]
       pragma: [no-cache]
-      request-id: [6be81ecb-01ac-4516-8f64-93aaf814a841]
+      request-id: [22faba40-5cd0-464b-9c09-efb4c33dc5b3]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -491,9 +2564,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.22
-          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001?api-version=2017-05-10
@@ -502,11 +2575,11 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 20 Dec 2017 06:10:39 GMT']
+      date: ['Wed, 10 Jan 2018 19:23:38 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUMk1RT1hXRks2Qi1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUNlk1M1RVSVlOWS1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1191']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_acs_commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_acs_commands.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer,
-                               RoleBasedServicePrincipalPreparer, LiveScenarioTest)
+                               RoleBasedServicePrincipalPreparer)
 
 # flake8: noqa
 
@@ -53,9 +53,7 @@ class AzureContainerServiceScenarioTest(ScenarioTest):
 
         return pathname
 
-
-# TODO: Convert back to ScenarioTest and re-record when issue #5141 is resolved
-class AzureContainerServiceKubernetesScenarioTest(LiveScenarioTest):
+class AzureContainerServiceKubernetesScenarioTest(ScenarioTest):
 
     # the length is set to avoid following error:
     # Resource name k8s-master-ip-cliacstestgae47e-clitestdqdcoaas25vlhygb2aktyv4-c10894mgmt-D811C917
@@ -68,7 +66,7 @@ class AzureContainerServiceKubernetesScenarioTest(LiveScenarioTest):
         cmd = 'acs create -g {} -n {} --orchestrator-type Kubernetes --service-principal {} ' \
               '--client-secret {} --ssh-key-value {}'
         self.cmd(cmd.format(resource_group, acs_name, sp_name, sp_password, ssh_pubkey_file),
-                 checks=[self.check('provisioningState', 'Succeeded')])
+                 checks=[self.check('properties.provisioningState', 'Succeeded')])
 
 
     @classmethod


### PR DESCRIPTION
The issue was a missing `cli_ctx` parameter when creating the SP role assignment. This is a regression that breaks `az acs create --orchestrator-type Kubernetes`, so I hope this can be merged today.

Closes #5141.