### PR TITLE
Hide mysql/postgres db create/delete/show

### DIFF
--- a/src/command_modules/azure-cli-rdbms/HISTORY.rst
+++ b/src/command_modules/azure-cli-rdbms/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.11
+++++++
+* Minor fixes.
+
 0.0.10
 ++++++
 * Update for CLI core changes.

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_help.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_help.py
@@ -146,23 +146,23 @@ def add_helps(command_group, server_type):
                 type: group
                 short-summary: Manage {0} databases on a server.
                 """.format(server_type)
-    helps['{} db create'.format(command_group)] = """
-                type: command
-                short-summary: Create a {0} database.
-                examples:
-                    - name: Create database 'testdb' in the server 'testsvr' with the default parameters.
-                      text: az {1} db create -g testgroup -s testsvr -n testdb
-                    - name: Create database 'testdb' in server 'testsvr' with a given character set and collation rules.
-                      text: az {1} db create -g testgroup -s testsvr -n testdb --charset <valid_charset> --collation <valid_collation>
-                """.format(server_type, command_group)
-    helps['{} db delete'.format(command_group)] = """
-                type: command
-                short-summary: Delete a database.
-                """
-    helps['{} db show'.format(command_group)] = """
-                type: command
-                short-summary: Show the details of a database.
-                """
+    # helps['{} db create'.format(command_group)] = """
+    #             type: command
+    #             short-summary: Create a {0} database.
+    #             examples:
+    #                 - name: Create database 'testdb' in the server 'testsvr' with the default parameters.
+    #                   text: az {1} db create -g testgroup -s testsvr -n testdb
+    #                 - name: Create database 'testdb' in server 'testsvr' with a given character set and collation rules.
+    #                   text: az {1} db create -g testgroup -s testsvr -n testdb --charset <valid_charset> --collation <valid_collation>
+    #             """.format(server_type, command_group)
+    # helps['{} db delete'.format(command_group)] = """
+    #             type: command
+    #             short-summary: Delete a database.
+    #             """
+    # helps['{} db show'.format(command_group)] = """
+    #             type: command
+    #             short-summary: Show the details of a database.
+    #             """
     helps['{} db list'.format(command_group)] = """
                 type: command
                 short-summary: List the databases for a server.

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_help.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_help.py
@@ -5,6 +5,8 @@
 
 from knack.help_files import helps
 
+#  pylint: disable=line-too-long
+
 
 def add_helps(command_group, server_type):
     helps['{}'.format(command_group)] = """

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/commands.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/commands.py
@@ -116,13 +116,13 @@ def load_command_table(self, _):
         g.custom_command('download', '_download_log_files')
 
     with self.command_group('mysql db', mysql_db_sdk) as g:
-        g.command('create', 'create_or_update')
-        g.command('delete', 'delete', confirmation=True)
-        g.command('show', 'get')
+        # g.command('create', 'create_or_update')
+        # g.command('delete', 'delete', confirmation=True)
+        # g.command('show', 'get')
         g.command('list', 'list_by_server')
 
     with self.command_group('postgres db', postgres_db_sdk) as g:
-        g.command('create', 'create_or_update')
-        g.command('delete', 'delete', confirmation=True)
-        g.command('show', 'get')
+        # g.command('create', 'create_or_update')
+        # g.command('delete', 'delete', confirmation=True)
+        # g.command('show', 'get')
         g.command('list', 'list_by_server')

--- a/src/command_modules/azure-cli-rdbms/setup.py
+++ b/src/command_modules/azure-cli-rdbms/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.10"
+VERSION = "0.0.11"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
In 2.0.23, the command was commented out.
Post-knack change, it was re-added but it should still be commented out.

https://github.com/Azure/azure-cli/blob/azure-cli-2.0.23/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/commands.py#L95