### PR TITLE
vmss:(PREVIEW) support low priority

### DIFF
--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-mgmt-authorization==0.30.0',
-    'azure-mgmt-compute==3.1.0rc2',
+    'azure-mgmt-compute==3.1.0rc3',
     'azure-mgmt-containerservice==3.0.0',
     'azure-graphrbac==0.31.0',
     'azure-cli-core',

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.25
+++++++
+* vmss:(PREVIEW) support low priority
 
 2.0.24
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -257,6 +257,7 @@ def load_arguments(self, _):
                 c.argument(dest, vmss_name_type, id_part=None)  # due to instance-ids parameter
 
     with self.argument_context('vmss create') as c:
+        VMPriorityTypes = self.get_models('VirtualMachinePriorityTypes', resource_type=ResourceType.MGMT_COMPUTE)
         c.argument('name', name_arg_type)
         c.argument('nat_backend_port', default=None, help='Backend port to open with NAT rules.  Defaults to 22 on Linux and 3389 on Windows.')
         c.argument('single_placement_group', default=None, help="Enable single placement group. This flag will default to True if instance count <=100, and default to False for instance count >100.", arg_type=get_enum_type(['true', 'false']))
@@ -267,6 +268,8 @@ def load_arguments(self, _):
         c.argument('health_probe', help='(Preview) probe name from the existing load balancer, mainly used for rolling upgrade')
         c.argument('vm_sku', help='Size of VMs in the scale set.  See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.')
         c.argument('nsg', help='Name or ID of an existing Network Security Group.', arg_group='Network')
+        c.argument('priority', resource_type=ResourceType.MGMT_COMPUTE, min_api='2017-12-01', arg_type=get_enum_type(VMPriorityTypes, default='Regular'),
+                   help="(PREVIEW)Priority. Use 'Low' to run short-lived workloads in a cost-effective way")
 
     with self.argument_context('vmss create', arg_group='Network Balancer') as c:
         LoadBalancerSkuName = self.get_models('LoadBalancerSkuName', resource_type=ResourceType.MGMT_NETWORK)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -714,7 +714,8 @@ def build_vmss_resource(cmd, name, naming_prefix, location, tags, overprovision,
                         image=None, admin_password=None, ssh_key_value=None, ssh_key_path=None,
                         os_publisher=None, os_offer=None, os_sku=None, os_version=None,
                         backend_address_pool_id=None, inbound_nat_pool_id=None, health_probe=None,
-                        single_placement_group=None, custom_data=None, secrets=None, license_type=None, zones=None):
+                        single_placement_group=None, custom_data=None, secrets=None, license_type=None,
+                        zones=None, priority=None):
 
     # Build IP configuration
     ip_configuration = {
@@ -858,6 +859,9 @@ def build_vmss_resource(cmd, name, naming_prefix, location, tags, overprovision,
 
     if cmd.supported_api_version(min_api='2016-04-30-preview').virtual_machine_scale_sets:  # pylint: disable=no-member
         vmss_properties['singlePlacementGroup'] = single_placement_group
+
+    if priority and cmd.supported_api_version(min_api='2017-12-01').virtual_machine_scale_sets:  # pylint: disable=no-member
+        vmss_properties['virtualMachineProfile']['priority'] = priority
 
     vmss = {
         'type': 'Microsoft.Compute/virtualMachineScaleSets',

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1674,7 +1674,7 @@ def create_vmss(cmd, vmss_name, resource_group_name, image,
                 single_placement_group=None, custom_data=None, secrets=None,
                 plan_name=None, plan_product=None, plan_publisher=None, plan_promotion_code=None, license_type=None,
                 assign_identity=None, identity_scope=None, identity_role='Contributor',
-                identity_role_id=None, zones=None):
+                identity_role_id=None, zones=None, priority=None):
     from azure.cli.core.commands.client_factory import get_subscription_id
     from azure.cli.core.util import random_string, hash_string
     from azure.cli.command_modules.vm._template_builder import (ArmTemplateBuilder, StorageProfile, build_vmss_resource,
@@ -1876,7 +1876,7 @@ def create_vmss(cmd, vmss_name, resource_group_name, image,
                                         backend_address_pool_id, inbound_nat_pool_id, health_probe=health_probe,
                                         single_placement_group=single_placement_group,
                                         custom_data=custom_data, secrets=secrets,
-                                        license_type=license_type, zones=zones)
+                                        license_type=license_type, zones=zones, priority=priority)
     vmss_resource['dependsOn'] = vmss_dependencies
 
     if plan_name:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vmss_create_with_low_priority.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vmss_create_with_low_priority.yaml
@@ -1,0 +1,476 @@
+interactions:
+- request:
+    body: '{"location": "CentralUSEUAP", "tags": {"use": "az-test"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['57']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001","name":"vmss_low_pri000001","location":"centraluseuap","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['335']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:18:01 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001","name":"vmss_low_pri000001","location":"centraluseuap","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['335']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:18:02 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [raw.githubusercontent.com]
+      User-Agent: [Python-urllib/3.5]
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
+        ,\n  \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\"\
+        :{},\n  \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"\
+        type\":\"object\",\n      \"value\":{\n\n        \"Linux\":{\n          \"\
+        CentOS\":{\n            \"publisher\":\"OpenLogic\",\n            \"offer\"\
+        :\"CentOS\",\n            \"sku\":\"7.3\",\n            \"version\":\"latest\"\
+        \n          },\n          \"CoreOS\":{\n            \"publisher\":\"CoreOS\"\
+        ,\n            \"offer\":\"CoreOS\",\n            \"sku\":\"Stable\",\n  \
+        \          \"version\":\"latest\"\n          },\n          \"Debian\":{\n\
+        \            \"publisher\":\"credativ\",\n            \"offer\":\"Debian\"\
+        ,\n            \"sku\":\"8\",\n            \"version\":\"latest\"\n      \
+        \    },\n          \"openSUSE-Leap\": {\n            \"publisher\":\"SUSE\"\
+        ,\n            \"offer\":\"openSUSE-Leap\",\n            \"sku\":\"42.2\"\
+        ,\n            \"version\": \"latest\"\n          },\n          \"RHEL\":{\n\
+        \            \"publisher\":\"RedHat\",\n            \"offer\":\"RHEL\",\n\
+        \            \"sku\":\"7.3\",\n            \"version\":\"latest\"\n      \
+        \    },\n          \"SLES\":{\n            \"publisher\":\"SUSE\",\n     \
+        \       \"offer\":\"SLES\",\n            \"sku\":\"12-SP2\",\n           \
+        \ \"version\":\"latest\"\n          },\n          \"UbuntuLTS\":{\n      \
+        \      \"publisher\":\"Canonical\",\n            \"offer\":\"UbuntuServer\"\
+        ,\n            \"sku\":\"16.04-LTS\",\n            \"version\":\"latest\"\n\
+        \          }\n        },\n\n        \"Windows\":{\n          \"Win2016Datacenter\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2016-Datacenter\",\n   \
+        \         \"version\":\"latest\"\n          },\n          \"Win2012R2Datacenter\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2012-R2-Datacenter\",\n\
+        \            \"version\":\"latest\"\n          },\n          \"Win2012Datacenter\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2012-Datacenter\",\n   \
+        \         \"version\":\"latest\"\n          },\n          \"Win2008R2SP1\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2008-R2-SP1\",\n       \
+        \     \"version\":\"latest\"\n          }\n        }\n      }\n    }\n  }\n\
+        }\n"}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['*']
+      cache-control: [max-age=300]
+      connection: [close]
+      content-length: ['2235']
+      content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
+      content-type: [text/plain; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:18:04 GMT']
+      etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
+      expires: ['Fri, 12 Jan 2018 21:23:04 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-fastly-request-id: [05bad622b44a4041810e95c0340a38249b4e0bc7]
+      x-frame-options: [deny]
+      x-geo-block-list: ['']
+      x-github-request-id: ['6F7E:1E398:7833:8292:5A59260A']
+      x-served-by: [cache-sea1039-SEA]
+      x-timer: ['S1515791884.126501,VS0,VE27']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-11-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:18:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"properties": {"parameters": {}, "template": {"parameters": {}, "variables":
+      {}, "resources": [{"type": "Microsoft.Network/virtualNetworks", "name": "vmss123VNET",
+      "apiVersion": "2015-06-15", "properties": {"subnets": [{"properties": {"addressPrefix":
+      "10.0.0.0/24"}, "name": "vmss123Subnet"}], "addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}}, "dependsOn": [], "tags": {}, "location": "centraluseuap"},
+      {"type": "Microsoft.Network/publicIPAddresses", "sku": {"name": "Basic"}, "name":
+      "vmss123LBPublicIP", "apiVersion": "2017-11-01", "properties": {"publicIPAllocationMethod":
+      "Dynamic"}, "dependsOn": [], "tags": {}, "location": "centraluseuap"}, {"type":
+      "Microsoft.Network/loadBalancers", "sku": {"name": "Basic"}, "name": "vmss123LB",
+      "apiVersion": "2017-11-01", "properties": {"frontendIPConfigurations": [{"properties":
+      {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/publicIPAddresses/vmss123LBPublicIP"}},
+      "name": "loadBalancerFrontEnd"}], "inboundNatPools": [{"properties": {"backendPort":
+      22, "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
+      \''vmss123LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"},
+      "protocol": "tcp", "frontendPortRangeEnd": "50119", "frontendPortRangeStart":
+      "50000"}, "name": "vmss123LBNatPool"}], "backendAddressPools": [{"name": "vmss123LBBEPool"}]},
+      "dependsOn": ["Microsoft.Network/virtualNetworks/vmss123VNET", "Microsoft.Network/publicIpAddresses/vmss123LBPublicIP"],
+      "tags": {}, "location": "centraluseuap"}, {"type": "Microsoft.Compute/virtualMachineScaleSets",
+      "sku": {"capacity": 2, "name": "Standard_D1_v2"}, "name": "vmss123", "apiVersion":
+      "2017-12-01", "properties": {"overprovision": true, "upgradePolicy": {"mode":
+      "manual"}, "singlePlacementGroup": true, "virtualMachineProfile": {"osProfile":
+      {"adminUsername": "clitester", "computerNamePrefix": "vmss17af3", "adminPassword":
+      "PasswordPassword1!"}, "storageProfile": {"osDisk": {"createOption": "FromImage",
+      "managedDisk": {"storageAccountType": null}, "caching": "ReadWrite"}, "imageReference":
+      {"publisher": "credativ", "version": "latest", "offer": "Debian", "sku": "8"}},
+      "priority": "Low", "networkProfile": {"networkInterfaceConfigurations": [{"properties":
+      {"primary": "true", "ipConfigurations": [{"properties": {"loadBalancerInboundNatPools":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB/inboundNatPools/vmss123LBNatPool"}],
+      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB/backendAddressPools/vmss123LBBEPool"}],
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/virtualNetworks/vmss123VNET/subnets/vmss123Subnet"}},
+      "name": "vmss17af3IPConfig"}]}, "name": "vmss17af3Nic"}]}}}, "dependsOn": ["Microsoft.Network/virtualNetworks/vmss123VNET",
+      "Microsoft.Network/loadBalancers/vmss123LB"], "tags": {}, "location": "centraluseuap"}],
+      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "outputs": {"VMSS": {"type": "object", "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''vmss123\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]"}},
+      "contentVersion": "1.0.0.0"}, "mode": "Incremental"}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Length: ['3791']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/vmss_deploy_Ykt0XSKOVJPonFdNVK5XUQOY1BO0iIbO","name":"vmss_deploy_Ykt0XSKOVJPonFdNVK5XUQOY1BO0iIbO","properties":{"templateHash":"4455374551516717060","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-01-12T21:18:06.7596655Z","duration":"PT0.8234387S","correlationId":"4cca02c4-270a-4fd4-b032-bbbaad77cb27","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["centraluseuap"]},{"resourceType":"publicIPAddresses","locations":["centraluseuap"]},{"resourceType":"loadBalancers","locations":["centraluseuap"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["centraluseuap"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/virtualNetworks/vmss123VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss123VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/publicIPAddresses/vmss123LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss123LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss123LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/virtualNetworks/vmss123VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss123VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss123LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss123","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss123"}]}}'}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/vmss_deploy_Ykt0XSKOVJPonFdNVK5XUQOY1BO0iIbO/operationStatuses/08586858149995414455?api-version=2017-05-10']
+      cache-control: [no-cache]
+      content-length: ['2703']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:18:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586858149995414455?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:18:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586858149995414455?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:19:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586858149995414455?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:19:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586858149995414455?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:20:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586858149995414455?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:20:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586858149995414455?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:21:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Resources/deployments/vmss_deploy_Ykt0XSKOVJPonFdNVK5XUQOY1BO0iIbO","name":"vmss_deploy_Ykt0XSKOVJPonFdNVK5XUQOY1BO0iIbO","properties":{"templateHash":"4455374551516717060","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-01-12T21:20:57.0609126Z","duration":"PT2M51.1246858S","correlationId":"4cca02c4-270a-4fd4-b032-bbbaad77cb27","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["centraluseuap"]},{"resourceType":"publicIPAddresses","locations":["centraluseuap"]},{"resourceType":"loadBalancers","locations":["centraluseuap"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["centraluseuap"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/virtualNetworks/vmss123VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss123VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/publicIPAddresses/vmss123LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss123LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss123LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/virtualNetworks/vmss123VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss123VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss123LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss123","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss123"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss17af3","adminUsername":"clitester","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss17af3Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss17af3IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/virtualNetworks/vmss123VNET/subnets/vmss123Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB/backendAddressPools/vmss123LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB/inboundNatPools/vmss123LBNatPool"}]}}]}}]},"priority":"Low"},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"ae9c2aa3-2bae-458e-b2d8-46fbdb94a863"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss123"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/publicIPAddresses/vmss123LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/virtualNetworks/vmss123VNET"}]}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['5302']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:21:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss123?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
+        \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
+        : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
+        \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
+        \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
+        \      \"computerNamePrefix\": \"vmss17af3\",\r\n        \"adminUsername\"\
+        : \"clitester\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
+        : false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
+        ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
+        \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
+        \        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"\
+        credativ\",\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\"\
+        ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss17af3Nic\"\
+        ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
+        dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
+        :[{\"name\":\"vmss17af3IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/virtualNetworks/vmss123VNET/subnets/vmss123Subnet\"\
+        },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
+        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB/backendAddressPools/vmss123LBBEPool\"\
+        }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Network/loadBalancers/vmss123LB/inboundNatPools/vmss123LBNatPool\"\
+        }]}}]}}]},\r\n      \"priority\": \"Low\"\r\n    },\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"ae9c2aa3-2bae-458e-b2d8-46fbdb94a863\"\
+        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
+        \  \"location\": \"CentralUSEUAP\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmss_low_pri000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss123\"\
+        ,\r\n  \"name\": \"vmss123\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['2499']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Jan 2018 21:21:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;192,Microsoft.Compute/GetVMScaleSet30Min;975']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.25]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vmss_low_pri000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 12 Jan 2018 21:21:14 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1WTVNTOjVGTE9XOjVGUFJJV1JOUVdNVTRGS1BEQ1pMN1ozRjM3NFdOWklXUjRUMnwzMDYyMDM5Rjc0MThFMzAwLUNFTlRSQUxVU0VVQVAiLCJqb2JMb2NhdGlvbiI6ImNlbnRyYWx1c2V1YXAifQ?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -2273,6 +2273,17 @@ class VMSSRollingUpgrade(ScenarioTest):
         self.cmd('vmss rolling-upgrade cancel -g {rg} -n {vmss}', expect_failure=True)
 
 
+class VMSSPriorityTesting(ScenarioTest):
+    @ResourceGroupPreparer(name_prefix='vmss_low_pri', location='CentralUSEUAP')
+    def test_vmss_create_with_low_priority(self, resource_group, resource_group_location):
+        self.kwargs.update({
+            'priority': 'Low',
+            'vmss': 'vmss123'
+        })
+        self.cmd('vmss create -g {rg} -n {vmss} --admin-username clitester --admin-password PasswordPassword1! --image debian --priority {priority}')
+        self.cmd('vmss show -g {rg} -n {vmss}', checks=self.check('virtualMachineProfile.priority', self.kwargs['priority']))
+
+
 class VMLBIntegrationTesting(ScenarioTest):
 
     @ResourceGroupPreparer(name_prefix='cli_test_vm_lb_integration')

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.24"
+VERSION = "2.0.25"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
@@ -33,7 +33,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-mgmt-msi==0.1.0',
     'azure-mgmt-authorization==0.30.0',
-    'azure-mgmt-compute==3.1.0rc2',
+    'azure-mgmt-compute==3.1.0rc3',
     'azure-mgmt-keyvault==0.40.0',
     'azure-keyvault==0.3.7',
     'azure-mgmt-network==1.7.0',


### PR DESCRIPTION
Counterpart of `spot instances` from EC2
```bash
    --priority                         : (PREVIEW)Priority. Use 'Low' to run short-lived workloads
                                         in a cost-effective way.  Allowed values: Low, Regular.
                                         Default: Regular.
```

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
