### PR TITLE
Ensure run_tests works on bash/Windows

### DIFF
--- a/tools/automation/tests/__init__.py
+++ b/tools/automation/tests/__init__.py
@@ -17,7 +17,9 @@ from ..utilities.path import filter_user_selected_modules_with_tests
 def execute(args):
     from .main import run_tests, collect_test
     try:
-        current_profile = check_output(shlex.split('az cloud show --query profile -otsv'), shell=True).decode('utf-8').strip()
+        use_shell = sys.platform.lower() in ['windows', 'win32']
+        current_profile = check_output(shlex.split('az cloud show --query profile -otsv'),
+                                       shell=use_shell).decode('utf-8').strip()
         if not args.profile:
             args.profile = current_profile
             print('The tests are set to run against current profile {}.'


### PR DESCRIPTION
Fixes #5366.  Tested on Win10 CMD.exe, OSX bash. cc/ @mboersma 

Note: This fix does *not* work on bash on Windows.  While it will avoid the error (it is seen as sys.platform = linux2), it will "successfully" run 0 tests in 0.000 sec.  Since there isn't a lot of demand to run tests on bash on Windows, I suggest merging this fix.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
