### PR TITLE
VM: improve supports for using marketplace images

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 2.0.25
 ++++++
+* vm image: support accept market terms to use vm images
 * vm/vmss create: ensure commands can run under proxy with unsigned certificates.
 * vmss:(PREVIEW) support low priority
 * `vm/vmss create` - `--admin-password` updated to type secureString.

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_actions.py
@@ -173,3 +173,15 @@ def _create_image_instance(publisher, offer, sku, version):
         'sku': sku,
         'version': version
     }
+
+
+def _get_latest_image_version(cli_ctx, location, publisher, offer, sku):
+    top_one = _compute_client_factory(cli_ctx).virtual_machine_images.list(location,
+                                                                           publisher,
+                                                                           offer,
+                                                                           sku,
+                                                                           top=1,
+                                                                           orderby='name desc')
+    if not top_one:
+        raise CLIError("Can't resolve the vesion of '{}:{}:{}'".format(publisher, offer, sku))
+    return top_one[0].name

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -807,6 +807,11 @@ helps['vm image show'] = """
             az vm image show -l westus -f CentOS -p OpenLogic --s 7.3 --version {latest}
 """
 
+helps['vm image accept-term'] = """
+    type: command
+    short-summary: Accept Azure Marketplace term so that the image can be used to create VMs
+"""
+
 helps['vm nic'] = """
     type: group
     short-summary: Manage network interfaces. See also `az network nic`.

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -193,8 +193,12 @@ def load_arguments(self, _):
 
     with self.argument_context('vm image') as c:
         c.argument('publisher_name', options_list=['--publisher', '-p'])
-        c.argument('offer', options_list=['--offer', '-f'])
-        c.argument('sku', options_list=['--sku', '-s'])
+        c.argument('publisher', options_list=['--publisher', '-p'], help='image publisher')
+        c.argument('offer', options_list=['--offer', '-f'], help='image offer')
+        c.argument('plan', help='image billing plan')
+        c.argument('sku', options_list=['--sku', '-s'], help='image sku')
+        c.argument('version', help="image sku's version")
+        c.argument('urn', help="URN, in format of 'publisher:offer:sku:versin'. If specified, other argument values can be omitted")
 
     with self.argument_context('vm image list') as c:
         c.argument('image_location', get_location_type(self.cli_ctx))

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -19,7 +19,7 @@ from azure.cli.command_modules.vm._template_builder import StorageProfile
 import azure.cli.core.keys as keys
 
 from ._client_factory import _compute_client_factory
-
+from ._actions import _get_latest_image_version
 logger = get_logger(__name__)
 
 
@@ -227,16 +227,8 @@ def _get_image_plan_info_if_exists(cmd, namespace):
     try:
         compute_client = _compute_client_factory(cmd.cli_ctx)
         if namespace.os_version.lower() == 'latest':
-            top_one = compute_client.virtual_machine_images.list(namespace.location,
-                                                                 namespace.os_publisher,
-                                                                 namespace.os_offer,
-                                                                 namespace.os_sku,
-                                                                 top=1,
-                                                                 orderby='name desc')
-            if not top_one:
-                raise CLIError("Can't resolve the vesion of '{}'".format(namespace.image))
-
-            image_version = top_one[0].name
+            image_version = _get_latest_image_version(cmd.cli_ctx, namespace.location, namespace.os_publisher,
+                                                      namespace.os_offer, namespace.os_sku)
         else:
             image_version = namespace.os_version
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -227,12 +227,12 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_vm_extension_images')
 
     with self.command_group('vm image', compute_vm_image_sdk) as g:
-        g.command('show', 'get', exception_handler=empty_on_404)
         g.command('list-offers', 'list_offers')
         g.command('list-publishers', 'list_publishers')
         g.command('list-skus', 'list_skus')
         g.custom_command('list', 'list_vm_images')
         g.custom_command('accept-term', 'accept_market_ordering_term')
+        g.custom_command('show', 'show_vm_image', exception_handler=empty_on_404)
 
     with self.command_group('vm nic', compute_vm_sdk) as g:
         g.custom_command('add', 'add_vm_nic')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -231,7 +231,7 @@ def load_command_table(self, _):
         g.command('list-publishers', 'list_publishers')
         g.command('list-skus', 'list_skus')
         g.custom_command('list', 'list_vm_images')
-        g.custom_command('accept-term', 'accept_market_ordering_term')
+        g.custom_command('accept-terms', 'accept_market_ordering_terms')
         g.custom_command('show', 'show_vm_image', exception_handler=empty_on_404)
 
     with self.command_group('vm nic', compute_vm_sdk) as g:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -232,6 +232,7 @@ def load_command_table(self, _):
         g.command('list-publishers', 'list_publishers')
         g.command('list-skus', 'list_skus')
         g.custom_command('list', 'list_vm_images')
+        g.custom_command('accept-term', 'accept_market_ordering_term')
 
     with self.command_group('vm nic', compute_vm_sdk) as g:
         g.custom_command('add', 'add_vm_nic')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1238,9 +1238,6 @@ def show_vm_image(cmd, urn=None, publisher=None, offer=None, sku=None, version=N
 
 def accept_market_ordering_term(cmd, urn=None, publisher=None, offer=None, plan=None):
     from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
-    # pylint: disable=protected-access
-    from azure.mgmt.marketplaceordering.models import AgreementTerms
-    AgreementTerms._attribute_map['retrieve_datetime']['type'] = 'str'
 
     usage_err = 'usage error: --plan STRING --offer STRING --publish STRING |--urn STRING'
     if urn:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1221,7 +1221,11 @@ def list_vm_images(cmd, image_location=None, publisher_name=None, offer=None, sk
 
 def accept_market_ordering_term(cmd, publisher_id, offer_id, plan_id):
     from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
+    from azure.mgmt.marketplaceordering.models import AgreementTerms
     market_place_client = get_mgmt_service_client(cmd.cli_ctx, MarketplaceOrderingAgreements)
+
+    AgreementTerms._attribute_map['retrieve_datetime']['type'] = 'str'
+
     term = market_place_client.marketplace_agreements.get(publisher_id, offer_id, plan_id)
     term.accepted=True
     return market_place_client.marketplace_agreements.create(publisher_id, offer_id, plan_id, term)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1217,6 +1217,14 @@ def list_vm_images(cmd, image_location=None, publisher_name=None, offer=None, sk
     for i in all_images:
         i['urn'] = ':'.join([i['publisher'], i['offer'], i['sku'], i['version']])
     return all_images
+
+
+def accept_market_ordering_term(cmd, publisher_id, offer_id, plan_id):
+    from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
+    market_place_client = get_mgmt_service_client(cmd.cli_ctx, MarketplaceOrderingAgreements)
+    term = market_place_client.marketplace_agreements.get(publisher_id, offer_id, plan_id)
+    term.accepted=True
+    return market_place_client.marketplace_agreements.create(publisher_id, offer_id, plan_id, term)
 # endregion
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1236,7 +1236,7 @@ def show_vm_image(cmd, urn=None, publisher=None, offer=None, sku=None, version=N
     return client.virtual_machine_images.get(location, publisher, offer, sku, version)
 
 
-def accept_market_ordering_term(cmd, urn=None, publisher=None, offer=None, plan=None):
+def accept_market_ordering_terms(cmd, urn=None, publisher=None, offer=None, plan=None):
     from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
 
     usage_err = 'usage error: --plan STRING --offer STRING --publish STRING |--urn STRING'
@@ -1246,7 +1246,7 @@ def accept_market_ordering_term(cmd, urn=None, publisher=None, offer=None, plan=
         publisher, offer, _, _ = urn.split(':')
         image = show_vm_image(cmd, urn)
         if not image.plan:
-            logger.warning('No plan information is associated with the image, hence not term to accept')
+            logger.warning("Image '%s' has no terms to accept.", urn)
             return
         plan = image.plan.name
     else:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_with_market_place_image.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_with_market_place_image.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -8,8 +8,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
@@ -20,7 +20,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 21 Jan 2018 03:27:31 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -34,8 +34,8 @@ interactions:
       CommandName: [vm image show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 subscriptionclient/1.2.1 Azure-SDK-For-Python AZURECLI/2.0.26]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 subscriptionclient/1.2.1 Azure-SDK-For-Python AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/locations?api-version=2016-06-01
@@ -71,7 +71,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['4523']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 21 Jan 2018 03:27:34 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -85,8 +85,8 @@ interactions:
       CommandName: [vm image show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -102,7 +102,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['492']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 21 Jan 2018 03:27:34 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -115,23 +115,23 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm image accept-term]
+      CommandName: [vm image accept-terms]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/publishers/kemptech/offers/vlm-azure/plans/basic-byol/agreements/current?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-21T03:27:36.1905375Z","signature":"ASNZIYMDVM4WEIXMFHULZAWRV4QZ3LJCSFQHOQINN3IW3PML5OG6KV4NQKSWL5GSHJX536XKJKOB4KEUUHMT2VYV7EKCR6SDZF7BQ2A","accepted":true}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-24T19:08:54.6459796Z","signature":"E7DNASSSEYB2APWOP362N5JF6SMT6UG4PTRCFB3LHCH6XTBKZJJ6R6E4HW2HWGRBOW62LKKYTBF7EXGIHDXHAH5E4YMPVTALTO7VA5Q","accepted":true}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['815']
       content-type: [application/json; charset=utf-8]
       dataserviceversion: ['5.2.1.374 (AzureUX-Store:dev.91f4fb9a.180111-0335)']
-      date: ['Sun, 21 Jan 2018 03:27:35 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -141,32 +141,31 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"accepted": true, "retrieveDatetime": "2018-01-21T03:27:36.1905375Z",
-      "plan": "basic-byol", "privacyPolicyLink": "http://kemptechnologies.com/privacy-policy",
-      "publisher": "kemptech", "signature": "ASNZIYMDVM4WEIXMFHULZAWRV4QZ3LJCSFQHOQINN3IW3PML5OG6KV4NQKSWL5GSHJX536XKJKOB4KEUUHMT2VYV7EKCR6SDZF7BQ2A",
-      "licenseTextLink": "https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt",
-      "product": "vlm-azure"}}'
+    body: '{"properties": {"licenseTextLink": "https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt",
+      "plan": "basic-byol", "accepted": true, "retrieveDatetime": "2018-01-24T19:08:54.6459796Z",
+      "product": "vlm-azure", "signature": "E7DNASSSEYB2APWOP362N5JF6SMT6UG4PTRCFB3LHCH6XTBKZJJ6R6E4HW2HWGRBOW62LKKYTBF7EXGIHDXHAH5E4YMPVTALTO7VA5Q",
+      "publisher": "kemptech", "privacyPolicyLink": "http://kemptechnologies.com/privacy-policy"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm image accept-term]
+      CommandName: [vm image accept-terms]
       Connection: [keep-alive]
       Content-Length: ['608']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/publishers/kemptech/offers/vlm-azure/plans/basic-byol/agreements/current?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-21T03:27:36.1905375Z","signature":"ASNZIYMDVM4WEIXMFHULZAWRV4QZ3LJCSFQHOQINN3IW3PML5OG6KV4NQKSWL5GSHJX536XKJKOB4KEUUHMT2VYV7EKCR6SDZF7BQ2A","accepted":true}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-24T19:08:54.6459796Z","signature":"E7DNASSSEYB2APWOP362N5JF6SMT6UG4PTRCFB3LHCH6XTBKZJJ6R6E4HW2HWGRBOW62LKKYTBF7EXGIHDXHAH5E4YMPVTALTO7VA5Q","accepted":true}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['815']
       content-type: [application/json; charset=utf-8]
       dataserviceversion: ['5.2.1.374 (AzureUX-Store:dev.91f4fb9a.180111-0335)']
-      date: ['Sun, 21 Jan 2018 03:27:37 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -181,11 +180,11 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm image accept-term]
+      CommandName: [vm image accept-terms]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 subscriptionclient/1.2.1 Azure-SDK-For-Python AZURECLI/2.0.26]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 subscriptionclient/1.2.1 Azure-SDK-For-Python AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/locations?api-version=2016-06-01
@@ -221,7 +220,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['4523']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 21 Jan 2018 03:27:38 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -232,11 +231,11 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm image accept-term]
+      CommandName: [vm image accept-terms]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -252,7 +251,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['492']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 21 Jan 2018 03:27:38 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -265,23 +264,23 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm image accept-term]
+      CommandName: [vm image accept-terms]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/publishers/kemptech/offers/vlm-azure/plans/basic-byol/agreements/current?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-21T03:27:40.2771914Z","signature":"TYOYYFIS7LV4X33TMLJG6Q5WLUZHXAVJXNTQYIZT6PGVEYUIBQ4ZKTLSC7WXGHCDLERVB2OAKMNGL5KCELSDIZ5TO2CQUHID4UKZM3Q","accepted":true}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-24T19:08:57.2132085Z","signature":"2GYYU5J37LYZJD2LHAEC6SPJCFZRPTDW4JJVERJOQQ2I3JV4NEQBSU44LKR3AYLAMMLEHFUYLRSHJMFVSV2EJOH3YYZYFTPOKZJWDVA","accepted":true}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['815']
       content-type: [application/json; charset=utf-8]
       dataserviceversion: ['5.2.1.374 (AzureUX-Store:dev.91f4fb9a.180111-0335)']
-      date: ['Sun, 21 Jan 2018 03:27:39 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -291,32 +290,31 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"accepted": true, "retrieveDatetime": "2018-01-21T03:27:40.2771914Z",
-      "plan": "basic-byol", "privacyPolicyLink": "http://kemptechnologies.com/privacy-policy",
-      "publisher": "kemptech", "signature": "TYOYYFIS7LV4X33TMLJG6Q5WLUZHXAVJXNTQYIZT6PGVEYUIBQ4ZKTLSC7WXGHCDLERVB2OAKMNGL5KCELSDIZ5TO2CQUHID4UKZM3Q",
-      "licenseTextLink": "https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt",
-      "product": "vlm-azure"}}'
+    body: '{"properties": {"licenseTextLink": "https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt",
+      "plan": "basic-byol", "accepted": true, "retrieveDatetime": "2018-01-24T19:08:57.2132085Z",
+      "product": "vlm-azure", "signature": "2GYYU5J37LYZJD2LHAEC6SPJCFZRPTDW4JJVERJOQQ2I3JV4NEQBSU44LKR3AYLAMMLEHFUYLRSHJMFVSV2EJOH3YYZYFTPOKZJWDVA",
+      "publisher": "kemptech", "privacyPolicyLink": "http://kemptechnologies.com/privacy-policy"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm image accept-term]
+      CommandName: [vm image accept-terms]
       Connection: [keep-alive]
       Content-Length: ['608']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/publishers/kemptech/offers/vlm-azure/plans/basic-byol/agreements/current?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-21T03:27:40.2771914Z","signature":"TYOYYFIS7LV4X33TMLJG6Q5WLUZHXAVJXNTQYIZT6PGVEYUIBQ4ZKTLSC7WXGHCDLERVB2OAKMNGL5KCELSDIZ5TO2CQUHID4UKZM3Q","accepted":true}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-24T19:08:57.2132085Z","signature":"2GYYU5J37LYZJD2LHAEC6SPJCFZRPTDW4JJVERJOQQ2I3JV4NEQBSU44LKR3AYLAMMLEHFUYLRSHJMFVSV2EJOH3YYZYFTPOKZJWDVA","accepted":true}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['815']
       content-type: [application/json; charset=utf-8]
       dataserviceversion: ['5.2.1.374 (AzureUX-Store:dev.91f4fb9a.180111-0335)']
-      date: ['Sun, 21 Jan 2018 03:27:40 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -324,7 +322,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: ['Accept-Encoding,Accept-Encoding']
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -334,8 +332,8 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -346,7 +344,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 21 Jan 2018 03:27:41 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -360,8 +358,8 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -377,7 +375,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['492']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 21 Jan 2018 03:27:42 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -393,8 +391,8 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-11-01
@@ -404,7 +402,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 21 Jan 2018 03:27:43 GMT']
+      date: ['Wed, 24 Jan 2018 19:08:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -412,63 +410,62 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: 'b''{"properties": {"mode": "Incremental", "parameters": {}, "template":
-      {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {}, "resources": [{"name": "vm1VNET",
-      "apiVersion": "2015-06-15", "location": "westus", "tags": {}, "type": "Microsoft.Network/virtualNetworks",
-      "dependsOn": [], "properties": {"subnets": [{"name": "vm1Subnet", "properties":
-      {"addressPrefix": "10.0.0.0/24"}}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}},
-      {"name": "vm1NSG", "apiVersion": "2015-06-15", "location": "westus", "tags":
-      {}, "type": "Microsoft.Network/networkSecurityGroups", "dependsOn": [], "properties":
-      {"securityRules": [{"name": "default-allow-ssh", "properties": {"sourcePortRange":
-      "*", "access": "Allow", "sourceAddressPrefix": "*", "direction": "Inbound",
-      "destinationPortRange": "22", "destinationAddressPrefix": "*", "priority": 1000,
-      "protocol": "Tcp"}}]}}, {"name": "vm1PublicIP", "apiVersion": "2017-11-01",
-      "location": "westus", "tags": {}, "type": "Microsoft.Network/publicIPAddresses",
-      "dependsOn": [], "properties": {"publicIPAllocationMethod": "dynamic"}}, {"name":
-      "vm1VMNic", "apiVersion": "2015-06-15", "location": "westus", "tags": {}, "type":
-      "Microsoft.Network/networkInterfaces", "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET",
-      "Microsoft.Network/networkSecurityGroups/vm1NSG", "Microsoft.Network/publicIpAddresses/vm1PublicIP"],
-      "properties": {"ipConfigurations": [{"name": "ipconfigvm1", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"}}}],
-      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"}}},
-      {"name": "vm1", "plan": {"name": "basic-byol", "publisher": "kemptech", "promotionCode":
-      null, "product": "vlm-azure"}, "apiVersion": "2017-12-01", "location": "westus",
-      "tags": {}, "type": "Microsoft.Compute/virtualMachines", "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"],
-      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "storageProfile":
-      {"osDisk": {"name": null, "createOption": "fromImage", "managedDisk": {"storageAccountType":
-      null}, "caching": "ReadWrite"}, "imageReference": {"publisher": "kemptech",
-      "sku": "basic-byol", "offer": "vlm-azure", "version": "7.2.362142710"}}, "networkProfile":
-      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "osProfile": {"adminUsername": "yugangw2", "computerName": "vm1", "linuxConfiguration":
-      {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==
-      yugangw2@YUGANGLP2\\n", "path": "/home/yugangw2/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
-      true}}}}], "outputs": {}, "variables": {}}}}'''
+      {"variables": {}, "contentVersion": "1.0.0.0", "outputs": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "parameters": {}, "resources": [{"properties": {"subnets": [{"name": "vm1Subnet",
+      "properties": {"addressPrefix": "10.0.0.0/24"}}], "addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}}, "name": "vm1VNET", "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2015-06-15", "location": "westus", "tags": {}, "dependsOn": []},
+      {"properties": {"securityRules": [{"name": "default-allow-ssh", "properties":
+      {"sourceAddressPrefix": "*", "access": "Allow", "priority": 1000, "protocol":
+      "Tcp", "sourcePortRange": "*", "direction": "Inbound", "destinationPortRange":
+      "22", "destinationAddressPrefix": "*"}}]}, "name": "vm1NSG", "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2015-06-15", "location": "westus", "tags": {}, "dependsOn": []},
+      {"properties": {"publicIPAllocationMethod": "dynamic"}, "name": "vm1PublicIP",
+      "type": "Microsoft.Network/publicIPAddresses", "apiVersion": "2017-11-01", "location":
+      "westus", "tags": {}, "dependsOn": []}, {"properties": {"networkSecurityGroup":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
+      "ipConfigurations": [{"name": "ipconfigvm1", "properties": {"subnet": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
+      "privateIPAllocationMethod": "Dynamic"}}]}, "name": "vm1VMNic", "type": "Microsoft.Network/networkInterfaces",
+      "apiVersion": "2015-06-15", "location": "westus", "tags": {}, "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET",
+      "Microsoft.Network/networkSecurityGroups/vm1NSG", "Microsoft.Network/publicIpAddresses/vm1PublicIP"]},
+      {"properties": {"osProfile": {"adminUsername": "yugangw", "computerName": "vm1",
+      "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh": {"publicKeys":
+      [{"path": "/home/yugangw/.ssh/authorized_keys", "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n"}]}}}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "storageProfile": {"osDisk":
+      {"managedDisk": {"storageAccountType": null}, "name": null, "createOption":
+      "fromImage", "caching": "ReadWrite"}, "imageReference": {"offer": "vlm-azure",
+      "sku": "basic-byol", "version": "7.2.362142710", "publisher": "kemptech"}}},
+      "plan": {"name": "basic-byol", "product": "vlm-azure", "promotionCode": null,
+      "publisher": "kemptech"}, "name": "vm1", "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2017-12-01", "location": "westus", "tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"]}]}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm create]
       Connection: [keep-alive]
-      Content-Length: ['3791']
+      Content-Length: ['3787']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_xqkU1SY8iW4T4zx3DxcgrW4MH1c7zFOJ","name":"vm_deploy_xqkU1SY8iW4T4zx3DxcgrW4MH1c7zFOJ","properties":{"templateHash":"6276077726063885985","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-01-21T03:27:50.2008168Z","duration":"PT5.1074402S","correlationId":"a4b63b36-b59e-47de-a5aa-4d4633eaed17","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_K2aFtxpTy3i71zMyW2vW4EjklSjR8ri2","name":"vm_deploy_K2aFtxpTy3i71zMyW2vW4EjklSjR8ri2","properties":{"templateHash":"8003772759962487224","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-01-24T19:09:05.8220471Z","duration":"PT4.9965404S","correlationId":"faf04598-b90a-41b6-b36c-831b909e2a2f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_xqkU1SY8iW4T4zx3DxcgrW4MH1c7zFOJ/operationStatuses/08586851016203842616?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_K2aFtxpTy3i71zMyW2vW4EjklSjR8ri2/operationStatuses/08586847859446521284?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['2701']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 21 Jan 2018 03:27:50 GMT']
+      date: ['Wed, 24 Jan 2018 19:09:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1187']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -479,8 +476,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
-          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: DELETE
@@ -490,9 +487,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Sun, 21 Jan 2018 03:27:51 GMT']
+      date: ['Wed, 24 Jan 2018 19:09:06 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdHVjJBUzc0RldRNEhaRkxNV05QNDc1TlNIV09VNzI0QlJBS3xDOTM5RjMwMDhFMEE1RDRELVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdDT0FJSDNBV1M3UU9QWVJONU5KUkIyTUtTUTRCT0VKU1IzSnw1OUQ0NzA3NTU0OEFERkM5LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_with_market_place_image.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_create_with_market_place_image.yaml
@@ -1,0 +1,500 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 21 Jan 2018 03:27:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm image show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 subscriptionclient/1.2.1 Azure-SDK-For-Python AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/locations?api-version=2016-06-01
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasia","name":"eastasia","displayName":"East
+        Asia","longitude":"114.188","latitude":"22.267"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasia","name":"southeastasia","displayName":"Southeast
+        Asia","longitude":"103.833","latitude":"1.283"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralus","name":"centralus","displayName":"Central
+        US","longitude":"-93.6208","latitude":"41.5908"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus","name":"eastus","displayName":"East
+        US","longitude":"-79.8164","latitude":"37.3719"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2","name":"eastus2","displayName":"East
+        US 2","longitude":"-78.3889","latitude":"36.6681"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus","name":"westus","displayName":"West
+        US","longitude":"-122.417","latitude":"37.783"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralus","name":"northcentralus","displayName":"North
+        Central US","longitude":"-87.6278","latitude":"41.8819"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus","name":"southcentralus","displayName":"South
+        Central US","longitude":"-98.5","latitude":"29.4167"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northeurope","name":"northeurope","displayName":"North
+        Europe","longitude":"-6.2597","latitude":"53.3478"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westeurope","name":"westeurope","displayName":"West
+        Europe","longitude":"4.9","latitude":"52.3667"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japanwest","name":"japanwest","displayName":"Japan
+        West","longitude":"135.5022","latitude":"34.6939"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japaneast","name":"japaneast","displayName":"Japan
+        East","longitude":"139.77","latitude":"35.68"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsouth","name":"brazilsouth","displayName":"Brazil
+        South","longitude":"-46.633","latitude":"-23.55"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiaeast","name":"australiaeast","displayName":"Australia
+        East","longitude":"151.2094","latitude":"-33.86"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiasoutheast","name":"australiasoutheast","displayName":"Australia
+        Southeast","longitude":"144.9631","latitude":"-37.8136"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia","name":"southindia","displayName":"South
+        India","longitude":"80.1636","latitude":"12.9822"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralindia","name":"centralindia","displayName":"Central
+        India","longitude":"73.9197","latitude":"18.5822"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westindia","name":"westindia","displayName":"West
+        India","longitude":"72.868","latitude":"19.088"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadacentral","name":"canadacentral","displayName":"Canada
+        Central","longitude":"-79.383","latitude":"43.653"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadaeast","name":"canadaeast","displayName":"Canada
+        East","longitude":"-71.217","latitude":"46.817"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uksouth","name":"uksouth","displayName":"UK
+        South","longitude":"-0.799","latitude":"50.941"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/ukwest","name":"ukwest","displayName":"UK
+        West","longitude":"-3.084","latitude":"53.427"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westcentralus","name":"westcentralus","displayName":"West
+        Central US","longitude":"-110.234","latitude":"40.890"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2","name":"westus2","displayName":"West
+        US 2","longitude":"-119.852","latitude":"47.233"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreacentral","name":"koreacentral","displayName":"Korea
+        Central","longitude":"126.9780","latitude":"37.5665"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreasouth","name":"koreasouth","displayName":"Korea
+        South","longitude":"129.0756","latitude":"35.1796"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['4523']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 21 Jan 2018 03:27:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm image show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/publishers/kemptech/artifacttypes/vmimage/offers/vlm-azure/skus/basic-byol/versions/7.2.362142710?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"plan\": {\r\n      \"publisher\"\
+        : \"kemptech\",\r\n      \"name\": \"basic-byol\",\r\n      \"product\": \"\
+        vlm-azure\"\r\n    },\r\n    \"osDiskImage\": {\r\n      \"operatingSystem\"\
+        : \"Linux\"\r\n    },\r\n    \"dataDiskImages\": []\r\n  },\r\n  \"location\"\
+        : \"westus\",\r\n  \"name\": \"7.2.362142710\",\r\n  \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus/Publishers/kemptech/ArtifactTypes/VMImage/Offers/vlm-azure/Skus/basic-byol/Versions/7.2.362142710\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['492']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 21 Jan 2018 03:27:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm image accept-term]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/publishers/kemptech/offers/vlm-azure/plans/basic-byol/agreements/current?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-21T03:27:36.1905375Z","signature":"ASNZIYMDVM4WEIXMFHULZAWRV4QZ3LJCSFQHOQINN3IW3PML5OG6KV4NQKSWL5GSHJX536XKJKOB4KEUUHMT2VYV7EKCR6SDZF7BQ2A","accepted":true}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['815']
+      content-type: [application/json; charset=utf-8]
+      dataserviceversion: ['5.2.1.374 (AzureUX-Store:dev.91f4fb9a.180111-0335)']
+      date: ['Sun, 21 Jan 2018 03:27:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"accepted": true, "retrieveDatetime": "2018-01-21T03:27:36.1905375Z",
+      "plan": "basic-byol", "privacyPolicyLink": "http://kemptechnologies.com/privacy-policy",
+      "publisher": "kemptech", "signature": "ASNZIYMDVM4WEIXMFHULZAWRV4QZ3LJCSFQHOQINN3IW3PML5OG6KV4NQKSWL5GSHJX536XKJKOB4KEUUHMT2VYV7EKCR6SDZF7BQ2A",
+      "licenseTextLink": "https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt",
+      "product": "vlm-azure"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm image accept-term]
+      Connection: [keep-alive]
+      Content-Length: ['608']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/publishers/kemptech/offers/vlm-azure/plans/basic-byol/agreements/current?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-21T03:27:36.1905375Z","signature":"ASNZIYMDVM4WEIXMFHULZAWRV4QZ3LJCSFQHOQINN3IW3PML5OG6KV4NQKSWL5GSHJX536XKJKOB4KEUUHMT2VYV7EKCR6SDZF7BQ2A","accepted":true}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['815']
+      content-type: [application/json; charset=utf-8]
+      dataserviceversion: ['5.2.1.374 (AzureUX-Store:dev.91f4fb9a.180111-0335)']
+      date: ['Sun, 21 Jan 2018 03:27:37 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm image accept-term]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 subscriptionclient/1.2.1 Azure-SDK-For-Python AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/locations?api-version=2016-06-01
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasia","name":"eastasia","displayName":"East
+        Asia","longitude":"114.188","latitude":"22.267"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasia","name":"southeastasia","displayName":"Southeast
+        Asia","longitude":"103.833","latitude":"1.283"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralus","name":"centralus","displayName":"Central
+        US","longitude":"-93.6208","latitude":"41.5908"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus","name":"eastus","displayName":"East
+        US","longitude":"-79.8164","latitude":"37.3719"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2","name":"eastus2","displayName":"East
+        US 2","longitude":"-78.3889","latitude":"36.6681"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus","name":"westus","displayName":"West
+        US","longitude":"-122.417","latitude":"37.783"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralus","name":"northcentralus","displayName":"North
+        Central US","longitude":"-87.6278","latitude":"41.8819"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus","name":"southcentralus","displayName":"South
+        Central US","longitude":"-98.5","latitude":"29.4167"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/northeurope","name":"northeurope","displayName":"North
+        Europe","longitude":"-6.2597","latitude":"53.3478"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westeurope","name":"westeurope","displayName":"West
+        Europe","longitude":"4.9","latitude":"52.3667"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japanwest","name":"japanwest","displayName":"Japan
+        West","longitude":"135.5022","latitude":"34.6939"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/japaneast","name":"japaneast","displayName":"Japan
+        East","longitude":"139.77","latitude":"35.68"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsouth","name":"brazilsouth","displayName":"Brazil
+        South","longitude":"-46.633","latitude":"-23.55"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiaeast","name":"australiaeast","displayName":"Australia
+        East","longitude":"151.2094","latitude":"-33.86"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiasoutheast","name":"australiasoutheast","displayName":"Australia
+        Southeast","longitude":"144.9631","latitude":"-37.8136"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia","name":"southindia","displayName":"South
+        India","longitude":"80.1636","latitude":"12.9822"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralindia","name":"centralindia","displayName":"Central
+        India","longitude":"73.9197","latitude":"18.5822"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westindia","name":"westindia","displayName":"West
+        India","longitude":"72.868","latitude":"19.088"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadacentral","name":"canadacentral","displayName":"Canada
+        Central","longitude":"-79.383","latitude":"43.653"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadaeast","name":"canadaeast","displayName":"Canada
+        East","longitude":"-71.217","latitude":"46.817"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/uksouth","name":"uksouth","displayName":"UK
+        South","longitude":"-0.799","latitude":"50.941"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/ukwest","name":"ukwest","displayName":"UK
+        West","longitude":"-3.084","latitude":"53.427"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westcentralus","name":"westcentralus","displayName":"West
+        Central US","longitude":"-110.234","latitude":"40.890"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2","name":"westus2","displayName":"West
+        US 2","longitude":"-119.852","latitude":"47.233"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreacentral","name":"koreacentral","displayName":"Korea
+        Central","longitude":"126.9780","latitude":"37.5665"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreasouth","name":"koreasouth","displayName":"Korea
+        South","longitude":"129.0756","latitude":"35.1796"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['4523']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 21 Jan 2018 03:27:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm image accept-term]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/publishers/kemptech/artifacttypes/vmimage/offers/vlm-azure/skus/basic-byol/versions/7.2.362142710?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"plan\": {\r\n      \"publisher\"\
+        : \"kemptech\",\r\n      \"name\": \"basic-byol\",\r\n      \"product\": \"\
+        vlm-azure\"\r\n    },\r\n    \"osDiskImage\": {\r\n      \"operatingSystem\"\
+        : \"Linux\"\r\n    },\r\n    \"dataDiskImages\": []\r\n  },\r\n  \"location\"\
+        : \"westus\",\r\n  \"name\": \"7.2.362142710\",\r\n  \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus/Publishers/kemptech/ArtifactTypes/VMImage/Offers/vlm-azure/Skus/basic-byol/Versions/7.2.362142710\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['492']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 21 Jan 2018 03:27:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm image accept-term]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/publishers/kemptech/offers/vlm-azure/plans/basic-byol/agreements/current?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-21T03:27:40.2771914Z","signature":"TYOYYFIS7LV4X33TMLJG6Q5WLUZHXAVJXNTQYIZT6PGVEYUIBQ4ZKTLSC7WXGHCDLERVB2OAKMNGL5KCELSDIZ5TO2CQUHID4UKZM3Q","accepted":true}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['815']
+      content-type: [application/json; charset=utf-8]
+      dataserviceversion: ['5.2.1.374 (AzureUX-Store:dev.91f4fb9a.180111-0335)']
+      date: ['Sun, 21 Jan 2018 03:27:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"accepted": true, "retrieveDatetime": "2018-01-21T03:27:40.2771914Z",
+      "plan": "basic-byol", "privacyPolicyLink": "http://kemptechnologies.com/privacy-policy",
+      "publisher": "kemptech", "signature": "TYOYYFIS7LV4X33TMLJG6Q5WLUZHXAVJXNTQYIZT6PGVEYUIBQ4ZKTLSC7WXGHCDLERVB2OAKMNGL5KCELSDIZ5TO2CQUHID4UKZM3Q",
+      "licenseTextLink": "https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt",
+      "product": "vlm-azure"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm image accept-term]
+      Connection: [keep-alive]
+      Content-Length: ['608']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 azure-mgmt-marketplaceordering/0.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/publishers/kemptech/offers/vlm-azure/plans/basic-byol/agreements/current?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offertypes/kemptech/offers/vlm-azure/plans/basic-byol","name":"basic-byol","type":"Microsoft.MarketplaceOrdering/offertypes","properties":{"publisher":"kemptech","product":"vlm-azure","plan":"basic-byol","licenseTextLink":"https://storelegalterms.blob.core.windows.net/legalterms/3E5ED_legalterms_KEMPTECH%253a24VLM%253a2DAZURE%253a24BASIC%253a2DBYOL%253a24BKPMLUT3VJJUTANJBMAT7OS2JRWDEOOBP2WHHP6GZME6OS6HOWKH2WICHWCAFFDDTEERBGXUIN3SK3FU7M5DWFYJXVQFN5YC6ZTQH4I.txt","privacyPolicyLink":"http://kemptechnologies.com/privacy-policy","retrieveDatetime":"2018-01-21T03:27:40.2771914Z","signature":"TYOYYFIS7LV4X33TMLJG6Q5WLUZHXAVJXNTQYIZT6PGVEYUIBQ4ZKTLSC7WXGHCDLERVB2OAKMNGL5KCELSDIZ5TO2CQUHID4UKZM3Q","accepted":true}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['815']
+      content-type: [application/json; charset=utf-8]
+      dataserviceversion: ['5.2.1.374 (AzureUX-Store:dev.91f4fb9a.180111-0335)']
+      date: ['Sun, 21 Jan 2018 03:27:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 21 Jan 2018 03:27:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/publishers/kemptech/artifacttypes/vmimage/offers/vlm-azure/skus/basic-byol/versions/7.2.362142710?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"plan\": {\r\n      \"publisher\"\
+        : \"kemptech\",\r\n      \"name\": \"basic-byol\",\r\n      \"product\": \"\
+        vlm-azure\"\r\n    },\r\n    \"osDiskImage\": {\r\n      \"operatingSystem\"\
+        : \"Linux\"\r\n    },\r\n    \"dataDiskImages\": []\r\n  },\r\n  \"location\"\
+        : \"westus\",\r\n  \"name\": \"7.2.362142710\",\r\n  \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus/Publishers/kemptech/ArtifactTypes/VMImage/Offers/vlm-azure/Skus/basic-byol/Versions/7.2.362142710\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['492']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 21 Jan 2018 03:27:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-11-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 21 Jan 2018 03:27:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"properties": {"mode": "Incremental", "parameters": {}, "template":
+      {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {}, "resources": [{"name": "vm1VNET",
+      "apiVersion": "2015-06-15", "location": "westus", "tags": {}, "type": "Microsoft.Network/virtualNetworks",
+      "dependsOn": [], "properties": {"subnets": [{"name": "vm1Subnet", "properties":
+      {"addressPrefix": "10.0.0.0/24"}}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}},
+      {"name": "vm1NSG", "apiVersion": "2015-06-15", "location": "westus", "tags":
+      {}, "type": "Microsoft.Network/networkSecurityGroups", "dependsOn": [], "properties":
+      {"securityRules": [{"name": "default-allow-ssh", "properties": {"sourcePortRange":
+      "*", "access": "Allow", "sourceAddressPrefix": "*", "direction": "Inbound",
+      "destinationPortRange": "22", "destinationAddressPrefix": "*", "priority": 1000,
+      "protocol": "Tcp"}}]}}, {"name": "vm1PublicIP", "apiVersion": "2017-11-01",
+      "location": "westus", "tags": {}, "type": "Microsoft.Network/publicIPAddresses",
+      "dependsOn": [], "properties": {"publicIPAllocationMethod": "dynamic"}}, {"name":
+      "vm1VMNic", "apiVersion": "2015-06-15", "location": "westus", "tags": {}, "type":
+      "Microsoft.Network/networkInterfaces", "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET",
+      "Microsoft.Network/networkSecurityGroups/vm1NSG", "Microsoft.Network/publicIpAddresses/vm1PublicIP"],
+      "properties": {"ipConfigurations": [{"name": "ipconfigvm1", "properties": {"privateIPAllocationMethod":
+      "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"}}},
+      {"name": "vm1", "plan": {"name": "basic-byol", "publisher": "kemptech", "promotionCode":
+      null, "product": "vlm-azure"}, "apiVersion": "2017-12-01", "location": "westus",
+      "tags": {}, "type": "Microsoft.Compute/virtualMachines", "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"],
+      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "storageProfile":
+      {"osDisk": {"name": null, "createOption": "fromImage", "managedDisk": {"storageAccountType":
+      null}, "caching": "ReadWrite"}, "imageReference": {"publisher": "kemptech",
+      "sku": "basic-byol", "offer": "vlm-azure", "version": "7.2.362142710"}}, "networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "osProfile": {"adminUsername": "yugangw2", "computerName": "vm1", "linuxConfiguration":
+      {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==
+      yugangw2@YUGANGLP2\\n", "path": "/home/yugangw2/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
+      true}}}}], "outputs": {}, "variables": {}}}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Length: ['3791']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_xqkU1SY8iW4T4zx3DxcgrW4MH1c7zFOJ","name":"vm_deploy_xqkU1SY8iW4T4zx3DxcgrW4MH1c7zFOJ","properties":{"templateHash":"6276077726063885985","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-01-21T03:27:50.2008168Z","duration":"PT5.1074402S","correlationId":"a4b63b36-b59e-47de-a5aa-4d4633eaed17","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_xqkU1SY8iW4T4zx3DxcgrW4MH1c7zFOJ/operationStatuses/08586851016203842616?api-version=2017-05-10']
+      cache-control: [no-cache]
+      content-length: ['2701']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 21 Jan 2018 03:27:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1187']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.17.0 msrest/0.4.23
+          msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Sun, 21 Jan 2018 03:27:51 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdHVjJBUzc0RldRNEhaRkxNV05QNDc1TlNIV09VNzI0QlJBS3xDOTM5RjMwMDhFMEE1RDRELVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -353,12 +353,12 @@ class VMImageWithPlanTest(ScenarioTest):
             'sku': 'basic-byol',
             'plan': 'basic-byol'
         })
-        urn = '{}:{}:{}:7.2.362142710'.format(self.kwargs['publisher'], self.kwargs['offer'], self.kwargs['sku'])
-        self.cmd('vm image show --urn ' + urn, checks=self.check('plan.name', self.kwargs['plan']))
-        self.cmd('vm image accept-term -p {publisher} --offer {offer} --plan {plan}', checks=self.check('accepted', True))
+        self.kwargs['urn'] = '{publisher}:{offer}:{sku}:7.2.362142710'.format(**self.kwargs)
+        self.cmd('vm image show --urn {urn}', checks=self.check('plan.name', '{plan}'))
+        self.cmd('vm image accept-terms -p {publisher} --offer {offer} --plan {plan}', checks=self.check('accepted', True))
         # repeat the same command using --urn
-        self.cmd('vm image accept-term --urn ' + urn, checks=self.check('accepted', True))
-        self.cmd('vm create -g {rg} -n vm1 --no-wait --image ' + urn)
+        self.cmd('vm image accept-terms --urn {urn}', checks=self.check('accepted', True))
+        self.cmd('vm create -g {rg} -n vm1 --no-wait --image {urn}')
 
 
 class VMCreateFromUnmanagedDiskTest(ScenarioTest):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -329,7 +329,7 @@ class VMCustomImageTest(ScenarioTest):
         ])
 
 
-class VMCustomImageWithPlanTest(ScenarioTest):
+class VMImageWithPlanTest(ScenarioTest):
 
     @ResourceGroupPreparer()
     def test_custom_image_with_plan(self, resource_group):
@@ -343,6 +343,22 @@ class VMCustomImageWithPlanTest(ScenarioTest):
         self.cmd('vm create -g {rg} -n vm1 --admin-username cliuser --image {prepared_image_with_plan_info} --generate-ssh-keys --plan-publisher microsoft-ads --plan-name {plan} --plan-product linux-data-science-vm-ubuntu')
         self.cmd('vm show -g {rg} -n vm1',
                  checks=self.check('plan.name', '{plan}'))
+
+    @ResourceGroupPreparer()
+    def test_vm_create_with_market_place_image(self, resource_group, resource_group_location):
+        self.kwargs.update({
+            'location': resource_group_location,
+            'publisher': 'kemptech',
+            'offer': 'vlm-azure',
+            'sku': 'basic-byol',
+            'plan': 'basic-byol'
+        })
+        urn = '{}:{}:{}:7.2.362142710'.format(self.kwargs['publisher'], self.kwargs['offer'], self.kwargs['sku'])
+        self.cmd('vm image show --urn ' + urn, checks=self.check('plan.name', self.kwargs['plan']))
+        self.cmd('vm image accept-term -p {publisher} --offer {offer} --plan {plan}', checks=self.check('accepted', True))
+        # repeat the same command using --urn
+        self.cmd('vm image accept-term --urn ' + urn, checks=self.check('accepted', True))
+        self.cmd('vm create -g {rg} -n vm1 --no-wait --image ' + urn)
 
 
 class VMCreateFromUnmanagedDiskTest(ScenarioTest):

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -39,6 +39,7 @@ DEPENDENCIES = [
     'azure-mgmt-network==1.7.0',
     'azure-mgmt-resource==1.2.1',
     'azure-multiapi-storage==0.1.7',
+    'azure-mmgmt-marketplaceordering==0.1.0',
     'azure-cli-core'
 ]
 

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -39,7 +39,7 @@ DEPENDENCIES = [
     'azure-mgmt-network==1.7.0',
     'azure-mgmt-resource==1.2.1',
     'azure-multiapi-storage==0.1.7',
-    'azure-mmgmt-marketplaceordering==0.1.0',
+    'azure-mgmt-marketplaceordering==0.1.0',
     'azure-cli-core'
 ]
 


### PR DESCRIPTION
2 things:
1. Through the new command of `az vm image accept-term`, users can accept the term to use some market-place images with its own billing. Before, they have to do it through portal. This fixes #3411.
2. Update `az vm image show` to support `--urn`, so users can supply the urn returned from `az vm image list` and get the billing plan information easily

The flow looks like
```
urn = $(az vm image list --all --publisher kemptech --offer vlm-azure --sku basic-byol --query '[0].urn')
az vm image accept-term --urn $urn
az vm create -g rg -n vm1 --image $urn
```
### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
