### PR TITLE
[Interactive]  Fix `az interactive` broken options

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -218,6 +218,8 @@ class AzCommandsLoader(CLICommandsLoader):
         self.min_profile = min_profile
         self.max_profile = max_profile
         self.module_kwargs = kwargs
+        self.command_name = None
+        self.skip_applicability = False
         self._command_group_cls = command_group_cls or AzCommandGroup
         self._argument_context_cls = argument_context_cls or AzArgumentContext
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -508,6 +508,7 @@ def _load_command_loader(loader, args, name, prefix):
 
     if loader_cls:
         command_loader = loader_cls(cli_ctx=loader.cli_ctx)
+        loader.loaders.append(command_loader)  # This will be used by interactive
         if command_loader.supported_api_version():
             command_table = command_loader.load_command_table(args)
             if command_table:
@@ -817,6 +818,8 @@ class AzArgumentContext(ArgumentsContext):
         self.is_stale = True
 
     def _applicable(self):
+        if self.command_loader.skip_applicability:
+            return True
         command_name = self.command_loader.command_name
         scope = self.scope
         return command_name.startswith(scope)

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -71,9 +71,14 @@ helps['acs dcos'] = """
     short-summary: Commands to manage a DC/OS-orchestrated Azure Container Service.
 """
 
-helps['acs install-cli'] = """
+helps['acs dcos install-cli'] = """
     type: command
-    short-summary: Download and install the DC/OS or Kubernetes command-line tool for a cluster.
+    short-summary: Download and install the DC/OS command-line tool for a cluster.
+"""
+
+helps['acs kubernetes install-cli'] = """
+    type: command
+    short-summary: Download and install the Kubernetes command-line tool for a cluster.
 """
 
 helps['acs kubernetes'] = """

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -102,7 +102,7 @@ type: group
 short-summary: Manage a web app's connection strings.
 """
 
-helps['webapp config connection-string show'] = """
+helps['webapp config connection-string list'] = """
 type: command
 short-summary: Get a web app's connection strings.
 """
@@ -599,7 +599,7 @@ helps['functionapp config appsettings'] = """
     short-summary: Configure function app settings.
 """
 
-helps['functionapp config appsettings show'] = """
+helps['functionapp config appsettings list'] = """
     type: command
     short-summary: Show settings for a function app.
 """
@@ -607,6 +607,11 @@ helps['functionapp config appsettings show'] = """
 helps['functionapp config appsettings set'] = """
     type: command
     short-summary: Update a function app's settings.
+"""
+
+helps['functionapp config appsettings delete'] = """
+    type: command
+    short-summary: Delete a function app's settings.
 """
 
 helps['functionapp config hostname'] = """

--- a/src/command_modules/azure-cli-interactive/HISTORY.rst
+++ b/src/command_modules/azure-cli-interactive/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.3.15
+++++++
+* Fixed issue where command option completions no longer appeared.
+
 0.3.14
 ++++++
 * Clean up unused test files

--- a/src/command_modules/azure-cli-interactive/azclishell/_dump_commands.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/_dump_commands.py
@@ -87,7 +87,7 @@ class LoadFreshTable(object):
 
             # if there is extra help for this command but it's not reflected in the command table
             if command_name not in data and help_type == 'command':
-                logger.info('Command: %s not found in command table', command_name)
+                logger.debug('Command: %s not found in command table', command_name)
                 continue
 
             short_summary = help_entry.get('short-summary')
@@ -105,7 +105,7 @@ class LoadFreshTable(object):
                     param_name = param['name'].split()[0]
 
                     if param_name not in data[command_name]['parameters']:
-                        logger.info('Command %s does not have parameter: %s', command_name, param_name)
+                        logger.debug('Command %s does not have parameter: %s', command_name, param_name)
                         continue
 
                     if 'short-summary' in param:
@@ -155,7 +155,7 @@ class LoadFreshTable(object):
 
         self.load_help_files(cmd_table_data)
         elapsed = timeit.default_timer() - start_time
-        logger.info('Command table dumped: {} sec'.format(elapsed))
+        logger.debug('Command table dumped: {} sec'.format(elapsed))
         self.command_table = main_loader.command_table
 
         # dump into the cache file

--- a/src/command_modules/azure-cli-interactive/azclishell/_dump_commands.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/_dump_commands.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 from importlib import import_module
 
 import json
@@ -11,10 +10,60 @@ import os
 import pkgutil
 import yaml
 
+from azure.cli.core import MainCommandsLoader
 from azure.cli.core.commands import BLACKLISTED_MODS
 from azure.cli.core.commands.arm import add_id_parameters
 
 from knack.help_files import helps
+from knack.log import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class AzInteractiveCommandsLoader(MainCommandsLoader):
+
+    def __init__(self, cli_ctx=None):
+        super(AzInteractiveCommandsLoader, self).__init__(cli_ctx)
+        self.loaders = []
+
+    def _update_command_definitions(self):
+
+        for loader in self.loaders:
+            loader.command_table = self.command_table
+            loader._update_command_definitions()  # pylint: disable=protected-access
+
+    def load_command_table(self, args):
+        return super(AzInteractiveCommandsLoader, self).load_command_table(args)
+
+    def load_arguments(self):
+        from azure.cli.core.commands.parameters import resource_group_name_type, get_location_type, deployment_name_type
+        from azure.cli.core import ArgumentsContext
+
+        from knack.arguments import ignore_type
+
+        command_loaders = self.loaders
+
+        if command_loaders:
+            with ArgumentsContext(self, '') as c:
+                c.argument('resource_group_name', resource_group_name_type)
+                c.argument('location', get_location_type(self.cli_ctx))
+                c.argument('deployment_name', deployment_name_type)
+                c.argument('cmd', ignore_type)
+
+            # load each command's arguments via reflection
+            for command_name, command in self.command_table.items():
+                command.load_arguments()
+
+            for loader in command_loaders:
+                loader.skip_applicability = True
+                loader.load_arguments(command)  # load each module's params file to the argument registry
+                self.argument_registry.arguments.update(loader.argument_registry.arguments)
+                self.extra_argument_registry.update(loader.extra_argument_registry)
+                # _update_command_definitions needs these set
+                self.cli_ctx.invocation.commands_loader.argument_registry = self.argument_registry
+                self.cli_ctx.invocation.commands_loader.extra_argument_registry = self.extra_argument_registry
+                loader._update_command_definitions()  # pylint: disable=protected-access
 
 
 class LoadFreshTable(object):
@@ -28,104 +77,91 @@ class LoadFreshTable(object):
 
     def load_help_files(self, data):
         """ loads all the extra information from help files """
-        for cmd in helps:
-            diction_help = yaml.load(helps[cmd])
-            # extra descriptions
-            if "short-summary" in diction_help:
-                if cmd in data:
-                    data[cmd]['help'] = diction_help["short-summary"]
-                else:
-                    data[cmd] = {
-                        'help': diction_help["short-summary"],
-                        'parameters': {}
-                    }
-                if callable(data[cmd]['help']):
-                    data[cmd]['help'] = data[cmd]['help']()
+        for command_name, help_yaml in helps.items():
 
-            # if there is extra help for this command but it's not reflected in the command table
-            if cmd not in data:
-                print("Command: {} not in Command Table".format(cmd))
+            help_entry = yaml.load(help_yaml)
+            try:
+                help_type = help_entry['type']
+            except KeyError:
                 continue
 
-            # extra parameters
-            if "parameters" in diction_help:
-                for param in diction_help["parameters"]:
-                    if param["name"].split()[0] not in data[cmd]['parameters']:
-                        options = {
-                            'name': [],
-                            'required': '',
-                            'help': ''
-                        }
-                        data[cmd]['parameters'] = {
-                            param["name"].split()[0]: options
-                        }
-                    if "short-summary" in param:
-                        data[cmd]['parameters'][param["name"].split()[0]]['help']\
-                            = param["short-summary"]
-            # extra examples
-            if "examples" in diction_help:
-                examples = []
-                for example in diction_help["examples"]:
-                    examples.append([example['name'], example['text']])
-                data[cmd]['examples'] = examples
+            # if there is extra help for this command but it's not reflected in the command table
+            if command_name not in data and help_type == 'command':
+                logger.info('Command: %s not found in command table', command_name)
+                continue
+
+            short_summary = help_entry.get('short-summary')
+            short_summary = short_summary() if callable(short_summary) else short_summary
+            if short_summary and help_type == 'command':
+                data[command_name]['help'] = short_summary
+            else:
+                # must be a command group or sub-group
+                data[command_name] = {'help': short_summary}
+                continue
+
+            if 'parameters' in help_entry:
+                for param in help_entry['parameters']:
+                    # this could fail if the help file and options list are not in the same order
+                    param_name = param['name'].split()[0]
+
+                    if param_name not in data[command_name]['parameters']:
+                        logger.info('Command %s does not have parameter: %s', command_name, param_name)
+                        continue
+
+                    if 'short-summary' in param:
+                        data[command_name]['parameters'][param_name]['help'] = param["short-summary"]
+
+            if 'examples' in help_entry:
+                data[command_name]['examples'] = [[example['name'], example['text']] for example in help_entry['examples']]
 
     def dump_command_table(self, shell_ctx):
         """ dumps the command table """
+        import timeit
 
-        loader = shell_ctx.cli_ctx.invocation.commands_loader
-        cmd_table = loader.load_command_table(None)
-        loader.load_arguments('')
+        start_time = timeit.default_timer()
+        main_loader = AzInteractiveCommandsLoader(shell_ctx.cli_ctx)
 
-        data = {}
-        for cmd in cmd_table:
-            com_descrip = {}  # commands to their descriptions, examples, and parameter info
-            param_descrip = {}  # parameters to their aliases, required, and descriptions
+        main_loader.load_command_table(None)
+        main_loader.load_arguments()
+        add_id_parameters(main_loader.command_table)
+        cmd_table = main_loader.command_table
+
+        cmd_table_data = {}
+        for command_name, cmd in cmd_table.items():
 
             try:
-                command_description = cmd_table[cmd].description
+                command_description = cmd.description
                 if callable(command_description):
                     command_description = command_description()
 
-                com_descrip['help'] = command_description
-                com_descrip['examples'] = ""
-
                 # checking all the parameters for a single command
-                for key in cmd_table[cmd].arguments:
-                    required = ""
-                    help_desc = ""
-
-                    if cmd_table[cmd].arguments[key].type.settings.get('required'):
-                        required = "[REQUIRED]"
-                    if cmd_table[cmd].arguments[key].type.settings.get('help'):
-                        help_desc = cmd_table[cmd].arguments[key].type.settings.get('help')
-
-                    # checking aliasing
-                    name_options = []
-                    for name in cmd_table[cmd].arguments[key].options_list:
-                        name_options.append(name)
-
+                parameter_metadata = {}
+                for key in cmd.arguments:
                     options = {
-                        'name': name_options,
-                        'required': required,
-                        'help': help_desc
+                        'name': [name for name in cmd.arguments[key].options_list],
+                        'required': '[REQUIRED]' if cmd.arguments[key].type.settings.get('required') else '',
+                        'help': cmd.arguments[key].type.settings.get('help') or ''
                     }
                     # the key is the first alias option
-                    param_descrip[cmd_table[cmd].arguments[key].options_list[0]] = options
+                    parameter_metadata[cmd.arguments[key].options_list[0]] = options
 
-                com_descrip['parameters'] = param_descrip
-                data[cmd] = com_descrip
+                cmd_table_data[command_name] = {
+                    'parameters': parameter_metadata,
+                    'help': command_description,
+                    'examples': ''
+                }
             except (ImportError, ValueError):
                 pass
 
-        add_id_parameters(cmd_table)
-        self.load_help_files(data)
-
-        self.command_table = cmd_table
+        self.load_help_files(cmd_table_data)
+        elapsed = timeit.default_timer() - start_time
+        logger.info('Command table dumped: {} sec'.format(elapsed))
+        self.command_table = main_loader.command_table
 
         # dump into the cache file
         command_file = shell_ctx.config.get_help_files()
         with open(os.path.join(get_cache_dir(shell_ctx), command_file), 'w') as help_file:
-            json.dump(data, help_file)
+            json.dump(cmd_table_data, help_file)
 
 
 def get_cache_dir(shell_ctx):

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -96,7 +96,7 @@ class AzInteractiveShell(object):
         from azclishell.color_styles import style_factory
 
         self.cli_ctx = cli_ctx
-        self.config = Configuration(cli_ctx.config)
+        self.config = Configuration(cli_ctx.config, style=style)
         self.config.set_style(style)
         self.styles = style or style_factory(self.config.get_style())
         self.lexer = lexer or get_az_lexer(self.config) if self.styles else None

--- a/src/command_modules/azure-cli-interactive/azclishell/configuration.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/configuration.py
@@ -55,7 +55,7 @@ class Configuration(object):
                       'y': True, 'Y': True, 'n': False, 'N': False}
 
     """ Configuration information """
-    def __init__(self, cli_config):
+    def __init__(self, cli_config, style=None):
         self.config = configparser.ConfigParser({
             'firsttime': 'yes',
             'style': 'default'

--- a/src/command_modules/azure-cli-interactive/azclishell/gather_commands.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/gather_commands.py
@@ -139,22 +139,23 @@ class GatherCommands(object):
                 self.command_example[command] = examples
 
             all_params = []
-            for param in data[command]['parameters']:
+            command_params = data[command].get('parameters') or []
+            for param in command_params:
                 suppress = False
 
-                if data[command]['parameters'][param]['help'] and \
-                   '==SUPPRESS==' in data[command]['parameters'][param]['help']:
+                if command_params[param]['help'] and \
+                   '==SUPPRESS==' in command_params[param]['help']:
                     suppress = True
-                if data[command]['parameters'][param]['help'] and not suppress:
+                if command_params[param]['help'] and not suppress:
                     param_aliases = set()
 
-                    for par in data[command]['parameters'][param]['name']:
+                    for par in command_params[param]['name']:
                         param_aliases.add(par)
 
                         self.param_descript[command + " " + par] =  \
                             add_new_lines(
-                                data[command]['parameters'][param]['required'] +
-                                " " + data[command]['parameters'][param]['help'],
+                                command_params[param]['required'] +
+                                " " + command_params[param]['help'],
                                 line_min=int(cols) - 2 * TOLERANCE)
                         if par not in self.completable_param:
                             self.completable_param.append(par)

--- a/src/command_modules/azure-cli-interactive/setup.py
+++ b/src/command_modules/azure-cli-interactive/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     cmdclass = {}
 
 # Version is also defined in azclishell.__init__.py.
-VERSION = "0.3.14"
+VERSION = "0.3.15"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-keyvault/HISTORY.rst
+++ b/src/command_modules/azure-cli-keyvault/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.0.17
 ++++++
-* Performance fixes.
+* Minor fixes.
 
 2.0.16
 ++++++

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -59,6 +59,7 @@ helps['keyvault certificate'] = """
 """
 
 helps['keyvault certificate download'] = """
+    type: command
     short-summary: Download the public portion of a Key Vault certificate.
     long-summary: The certificate formatted as either PEM or DER. PEM is the default.
     examples:

--- a/src/command_modules/azure-cli-monitor/HISTORY.rst
+++ b/src/command_modules/azure-cli-monitor/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 0.1.1
 +++++
-* Performance fixes.
+* Minor fixes.
 
 0.1.0
 +++++

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
@@ -193,10 +193,6 @@ helps['monitor metrics list'] = """
 helps['monitor metrics list-definitions'] = """
     type: command
     short-summary: Lists the metric definitions for the resource.
-    parameters:
-        - name: --metric-names
-          type: string
-          short-summary: The list of the metrics definitions to be shown.
 """
 
 # endregion
@@ -219,9 +215,6 @@ helps['monitor diagnostic-settings create'] = """
             parameters:
                 - name: --name -n
                   short-summary: The name of the diagnostic settings.
-                - name: --resource-id
-                  type: string
-                  short-summary: The identifier of the resource.
                 - name: --resource-group -g
                   type: string
                   short-summary: Name of the resource group for the Log Analytics and Storage Account when the name of
@@ -229,9 +222,6 @@ helps['monitor diagnostic-settings create'] = """
                 - name: --logs
                   type: string
                   short-summary: JSON encoded list of logs settings. Use '@{file}' to load from a file.
-                - name: --event-hub-name
-                  type: string
-                  short-summary: The name of the event hub. If none is specified, the default event hub will be selected.
                 - name: --metrics
                   type: string
                   short-summary: JSON encoded list of metric settings. Use '@{file}' to load from a file.
@@ -247,8 +237,6 @@ helps['monitor diagnostic-settings create'] = """
                                  selected.
                 - name: --event-hub-rule
                   short-summary: The resource Id for the event hub authorization rule
-                - name: --tags
-                  short-summary: Space separated tags in 'key[=value]' format. Use the "" value to clear existing tags.
             """
 helps['monitor diagnostic-settings update'] = """
             type: command
@@ -400,8 +388,6 @@ helps['monitor activity-log alert update'] = """
           long-summary: >
             The possible values for the field are 'resourceId', 'category', 'caller', 'level', 'operationName', 'resourceGroup',
             'resourceProvider', 'status', 'subStatus', 'resourceType', or anything beginning with 'properties.'.
-        - name: --enable
-          short-summary: Enable or disable this activity log alert. Takes a boolean value of 'true' or 'false'.
     examples:
         - name: Update the condition
           text: >

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
@@ -114,7 +114,7 @@ def load_arguments(self, _):
 
     # region Diagnostic
     with self.argument_context('monitor diagnostic-settings') as c:
-        c.argument('name', options_list=('-n', '--name'))
+        c.argument('name', options_list=('--name', '-n'))
 
     with self.argument_context('monitor diagnostic-settings show') as c:
         c.resource_parameter_context('resource_uri', required=True, arg_group='Target Resource')

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -13,6 +13,7 @@ Release History
                      Fix issue where long TXT records were incorrectly exported.
                      Fix issue where quoted TXT records were incorrectly exported without escaped quotes.
 * `dns zone import`: Fix issue where certain records were imported twice.
+* Restored `vnet-gateway root-cert` and `vnet-gateway revoked-cert` commands.
 
 2.0.21
 ++++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -618,7 +618,7 @@ for record in dns_record_types:
             az network dns record-set {2} show -g MyResourceGroup -n MyRecordSet -z www.mysite.com
     """.format(record.upper(), indef_article, record)
 
-for record in dns_record_types:
+for record in [r for r in dns_record_types if r != 'cname']:
     indef_article = 'an' if record.startswith('a') else 'a'
 
     helps['network dns record-set {} update'.format(record)] = """
@@ -2200,7 +2200,7 @@ helps['network watcher flow-log show'] = """
 
 # endregion
 
-helps['network vnet list-service-endpoints'] = """
+helps['network vnet list-endpoint-services'] = """
     type: command
     short-summary: List which services support VNET service tunneling for a given region.
 """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -623,6 +623,14 @@ def load_command_table(self, _):
         g.custom_command('generate', 'generate_vpn_client')
         g.command('show-url', 'get_vpn_profile_package_url', min_api='2017-08-01')
 
+    with self.command_group('network vnet-gateway revoked-cert', network_vgw_sdk) as g:
+        g.custom_command('create', 'create_vnet_gateway_revoked_cert')
+        g.custom_command('delete', 'delete_vnet_gateway_revoked_cert')
+
+    with self.command_group('network vnet-gateway root-cert', network_vgw_sdk) as g:
+        g.custom_command('create', 'create_vnet_gateway_root_cert')
+        g.custom_command('delete', 'delete_vnet_gateway_root_cert')
+
     # endregion
 
     # region VirtualNetworkGatewayConnections

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_params.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_params.py
@@ -223,25 +223,6 @@ def load_arguments(self, _):
                    options_list=['--service-objective'],
                    help='Name of the service objective for the new database.')
 
-    with self.argument_context('sql db create-replica') as c:
-        _configure_db_create_params(c, Engine.db, CreateMode.online_secondary)
-
-        c.argument('elastic_pool_name',
-                   help='Name of the elastic pool to create the new database in.')
-
-        c.argument('requested_service_objective_name',
-                   options_list=['--service-objective'],
-                   help='Name of the service objective for the new secondary database.')
-
-        c.argument('secondary_resource_group_name',
-                   options_list=['--secondary-resource-group'],
-                   help='Name of the resource group to create the new secondary database in.'
-                   ' If unspecified, defaults to the origin resource group.')
-
-        c.argument('secondary_server_name',
-                   options_list=['--secondary-server'],
-                   help='Name of the server to create the new secondary database in.')
-
     with self.argument_context('sql db restore') as c:
         _configure_db_create_params(c, Engine.db, CreateMode.point_in_time_restore)
 


### PR DESCRIPTION
Fix #5284.  Fixes the logic to build the command table and merge it with the help files.  Please verify using the PR sample container.

Additionally, over the course of fixing this issue, I discovered numerous other problems with help files that had not been updated and in the case of `vnet-gateway root-cert/revoked-cert` commands that had been lost during the knack conversion. 

These kinds of checks should be part of PR validation. This is tracked under issue #3188.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
