### PR TITLE
[AKS] improve tab completion for VM sizes

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 2.0.25
 ++++++
 * clarify `--disable-browser` argument
+* improve tab completion for --vm-size arguments
 
 2.0.24
 ++++++

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_completers.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_completers.py
@@ -5,18 +5,20 @@
 
 from azure.cli.core.commands.parameters import get_one_of_subscription_locations
 from azure.cli.core.decorators import Completer
+from azure.mgmt.containerservice.models import ContainerServiceVMSizeTypes
 
 from ._client_factory import cf_compute_service
 
 
 @Completer
 def get_vm_size_completion_list(cmd, prefix, namespace, **kwargs):  # pylint: disable=unused-argument
+    """Return the intersection of the VM sizes allowed by the ACS SDK with those returned by the Compute Service."""
     try:
         location = namespace.location
     except AttributeError:
         location = get_one_of_subscription_locations(cmd.cli_ctx)
     result = get_vm_sizes(cmd.cli_ctx, location)
-    return [r.name for r in result]
+    return sorted(list(set(r.name for r in result) & set(c.value for c in ContainerServiceVMSizeTypes)))
 
 
 def get_vm_sizes(cli_ctx, location):

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_completers.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_completers.py
@@ -16,9 +16,10 @@ def get_vm_size_completion_list(cmd, prefix, namespace, **kwargs):  # pylint: di
     try:
         location = namespace.location
     except AttributeError:
+        # TODO: try the resource group's default location before falling back to this
         location = get_one_of_subscription_locations(cmd.cli_ctx)
     result = get_vm_sizes(cmd.cli_ctx, location)
-    return sorted(list(set(r.name for r in result) & set(c.value for c in ContainerServiceVMSizeTypes)))
+    return sorted(set(r.name for r in result) & set(c.value for c in ContainerServiceVMSizeTypes))
 
 
 def get_vm_sizes(cli_ctx, location):


### PR DESCRIPTION
Currently, hitting [TAB] for a `--vm-size`-type argument returns all VM sizes available for a location, as returned by the Compute Service. But AKS only supports [a subset](https://github.com/Azure/azure-sdk-for-python/blob/master/azure-mgmt-containerservice/azure/mgmt/containerservice/models/container_service_client_enums.py#L21) of those sizes, so the list can be misleading.

This changes the `get_vm_size_completion_list` completer function to return the intersection of the VM sizes allowed by the ACS SDK with those returned by the Compute Service.

```shell
$ az aks create --location eastus -s # [TAB]
$ az aks create --location eastus -s Standard_ # [TAB]
Display all 114 possibilities? (y or n)
Standard_A0             Standard_D12            Standard_D4_v2_Promo    Standard_DS2_v2         Standard_F16
Standard_A1             Standard_D12_v2         Standard_D4_v3          Standard_DS2_v2_Promo   Standard_F16s
Standard_A10            Standard_D12_v2_Promo   Standard_D4s_v3         Standard_DS3            Standard_F1s
Standard_A11            Standard_D13            Standard_D5_v2          Standard_DS3_v2         Standard_F2
Standard_A1_v2          Standard_D13_v2         Standard_D5_v2_Promo    Standard_DS3_v2_Promo   Standard_F2s
Standard_A2             Standard_D13_v2_Promo   Standard_D8_v3          Standard_DS4            Standard_F4
Standard_A2_v2          Standard_D14            Standard_D8s_v3         Standard_DS4_v2         Standard_F4s
Standard_A2m_v2         Standard_D14_v2         Standard_DS1            Standard_DS4_v2_Promo   Standard_F8
Standard_A3             Standard_D14_v2_Promo   Standard_DS11           Standard_DS5_v2         Standard_F8s
Standard_A4             Standard_D15_v2         Standard_DS11_v2        Standard_DS5_v2_Promo   Standard_H16
Standard_A4_v2          Standard_D16_v3         Standard_DS11_v2_Promo  Standard_E16_v3         Standard_H16m
Standard_A4m_v2         Standard_D16s_v3        Standard_DS12           Standard_E16s_v3        Standard_H16mr
Standard_A5             Standard_D1_v2          Standard_DS12_v2        Standard_E2_v3          Standard_H16r
Standard_A6             Standard_D2             Standard_DS12_v2_Promo  Standard_E2s_v3         Standard_H8
Standard_A7             Standard_D2_v2          Standard_DS13           Standard_E32_v3         Standard_H8m
Standard_A8             Standard_D2_v2_Promo    Standard_DS13_v2        Standard_E32s_v3        Standard_NC12
Standard_A8_v2          Standard_D2_v3          Standard_DS13_v2_Promo  Standard_E4_v3          Standard_NC24
Standard_A8m_v2         Standard_D2s_v3         Standard_DS14           Standard_E4s_v3         Standard_NC24r
Standard_A9             Standard_D3             Standard_DS14_v2        Standard_E64_v3         Standard_NC6
Standard_D1             Standard_D3_v2          Standard_DS14_v2_Promo  Standard_E64s_v3        Standard_NV12
Standard_D11            Standard_D3_v2_Promo    Standard_DS15_v2        Standard_E8_v3          Standard_NV24
Standard_D11_v2         Standard_D4             Standard_DS1_v2         Standard_E8s_v3         Standard_NV6
Standard_D11_v2_Promo   Standard_D4_v2          Standard_DS2            Standard_F1   
$ az aks create --location eastus -s Standard_
```

---

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

