### PR TITLE
[AKS] change default node size to Standard_DS1_v2

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.26
+++++++
+* `aks create` VM node size default changed from "Standard_D1_v2" to "Standard_DS1_v2"
+
 2.0.25
 ++++++
 * clarify `--disable-browser` argument

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1254,7 +1254,7 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
                location=None,
                admin_username="azureuser",
                kubernetes_version="1.7.7",
-               node_vm_size="Standard_D1_v2",
+               node_vm_size="Standard_DS1_v2",
                node_osdisk_size=0,
                node_count=3,
                service_principal=None, client_secret=None,

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_default_service.yaml
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_default_service.yaml
@@ -20,11 +20,11 @@ interactions:
       cache-control: [no-cache]
       content-length: ['212']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 24 Jan 2018 20:07:28 GMT']
+      date: ['Thu, 25 Jan 2018 22:15:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -48,13 +48,13 @@ interactions:
       content-length: ['166']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:07:29 GMT']
-      duration: ['706262']
+      date: ['Thu, 25 Jan 2018 22:15:02 GMT']
+      duration: ['2169476']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [W84BSgYbONot/wGcipCJje5yMjmT4/Vtu5grWrkQWI0=]
-      ocp-aad-session-key: [cod_fZX6Vrefq6mFNcuT7jQltqVIVpf5jDQvaxtyuMSZvU1rTBFsXjOGPcBxGeRFKpZ2nD15OGDLbdxtFjULee8jpjRyJyiY8Zs9448D_HwYyZo8tVphm5Mlsf1Ia3uLbN-SSxEE5LtgJMbggmWVQ-WBDPQnQkqdRceWqB1buGPDj6aOLeSkVSer4Cg1WOm_zfh1AOQi-VqggXuUoQCX5A.a2L2tDc-5tmkUsEBoBDXpRpuxkjO4PQhSoEsTFJdd64]
+      ocp-aad-diagnostics-server-name: [3fY/YTKtktC55i2uj7nRnEH4MiQwtS8nnnh325mrC/0=]
+      ocp-aad-session-key: [_M_Sxtb77xTqZZiFhAPM5AkHGzKkH0O3pz2Wm9c_hyx8qpuOoDL-Qqz0Do3RdXtRkkaZcozGGbSI4dzUM5dpOW4S1zCpJ5Fi4faC25y1WwfOXtTp4hntvcUrEcY-ICInmjR52F6-9t1mvnDz9jqdcJEDwOYf2eXh-ogy-tvXiyXQZxYIjvwElL3nyZEEYWN26ho50SxygWxxVW3HcKmTBg.6uWwSfi6HSySFSLUOF_5iJBMg3g-ZGxsyafIDdrS2KA]
       pragma: [no-cache]
-      request-id: [79988983-2c63-4942-aa7c-e1142edd5628]
+      request-id: [b88ef430-2079-4976-a4db-6238d25ad3ce]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -63,17 +63,17 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"availableToOtherTenants": false, "displayName": "azure-cli-2018-01-24-20-07-29",
-      "homepage": "http://azure-cli-2018-01-24-20-07-29", "identifierUris": ["http://clitest000002"],
-      "passwordCredentials": [{"startDate": "2018-01-24T20:07:29.5620959999999999Z",
-      "endDate": "2019-01-24T20:07:29.5620959999999999Z", "keyId": "65065340-2837-4143-86be-fbd418bb4c55",
-      "value": "a705dadf-0ed8-447a-b351-f6e91ef33615"}]}'''
+    body: 'b''{"availableToOtherTenants": false, "displayName": "azure-cli-2018-01-25-22-15-03",
+      "homepage": "http://azure-cli-2018-01-25-22-15-03", "identifierUris": ["http://clitest000002"],
+      "passwordCredentials": [{"startDate": "2018-01-25T22:15:03.493191Z", "endDate":
+      "2019-01-25T22:15:03.493191Z", "keyId": "32e60874-1c44-45f8-b40a-9e5f6915a930",
+      "value": "ee58ce03-5826-4a2f-a213-6542a77feac8"}]}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [ad sp create-for-rbac]
       Connection: [keep-alive]
-      Content-Length: ['413']
+      Content-Length: ['393']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
           msrest/0.4.25 msrest_azure/0.4.20 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
@@ -82,25 +82,25 @@ interactions:
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"bd17581c-e17e-4222-b405-d70c860e852c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-24-20-07-29","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-24-20-07-29","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-07-29","id":"67b212f8-d569-4f25-997d-7e7b88a12c47","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-07-29","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-24T20:07:29.562096Z","keyId":"65065340-2837-4143-86be-fbd418bb4c55","startDate":"2018-01-24T20:07:29.562096Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"fad54c6c-e9ad-44e3-9f2a-eb498b7ba2d1","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1f12eaab-6cdd-4c81-b319-fd261d8e0410","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-25-22-15-03","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-25-22-15-03","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-15-03","id":"a61eb23e-944d-466f-bec3-7ff4e56c445d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-15-03","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-25T22:15:03.493191Z","keyId":"32e60874-1c44-45f8-b40a-9e5f6915a930","startDate":"2018-01-25T22:15:03.493191Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1859']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:07:29 GMT']
-      duration: ['3305575']
+      date: ['Thu, 25 Jan 2018 22:15:02 GMT']
+      duration: ['4702458']
       expires: ['-1']
-      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/bd17581c-e17e-4222-b405-d70c860e852c/Microsoft.DirectoryServices.Application']
-      ocp-aad-diagnostics-server-name: [K5m4bGA78osmrX00jymhDrlzv6oPwKc4RHIP3NQMEeg=]
-      ocp-aad-session-key: [ERaohbSoOWu-vVErFyhabG7_3SQgbjD_1eU5pUOFGjfXC-OBi5M8OKQkgbzsvwZwH5f6IzP97uoEYwg5egNs4u1BODU6UxdhDKF783f_RY1ssoHJD-6z03tN2Z0F41RsrtzmZxkYx1O5NYJYyTJjfyXEAaEGrzHvBhpCjCOgg2cS84qr31k1iV_cz_KGAJrRgQZdVV7X2_0WIJPAQ0IR1w.aWX7INzPiE7daovUh2x3tZZKEQFbMXCphFXmYQt246Q]
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/fad54c6c-e9ad-44e3-9f2a-eb498b7ba2d1/Microsoft.DirectoryServices.Application']
+      ocp-aad-diagnostics-server-name: [CCXOF6rt6Xl8XB3GXCt/tnQbRKpxWms12kSO3g305EI=]
+      ocp-aad-session-key: [G9RUv9aF8z_T1BdshttXXW5B0DzumWDr5m8sjhb24HIUC7Nm8ObcDZ071IFmmQduo94rQN01t6xe1H2eTkLoYhVD-0JGg0XEYfC1pBvcCpvO4XcK2MRQUmpyn0BqRnqxzRFzTdB3MIALbCYDowS3TftZRNZ845e8HqAElDqcPx-OGXWoHGrdYTdJUKLVxJ8eogQAMna8WV1a_NSP4tP1Yw.GEO-zK04n8hOOcgjjVhadcIEjrkSCUo2aiuesavsvVY]
       pragma: [no-cache]
-      request-id: [7e7172b3-3e02-44d6-a0c3-4a83141e868b]
+      request-id: [fb6d769f-7e9e-4b73-9b3f-85dee628b6fe]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -109,7 +109,7 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"appId": "2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe", "accountEnabled": true}'
+    body: '{"appId": "1f12eaab-6cdd-4c81-b319-fd261d8e0410", "accountEnabled": true}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -124,25 +124,25 @@ interactions:
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"ac65e734-16ee-4c34-82ee-a22e9918012f","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-24-20-07-29","appId":"2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-24-20-07-29","errorUrl":null,"homepage":"http://azure-cli-2018-01-24-20-07-29","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-07-29","id":"67b212f8-d569-4f25-997d-7e7b88a12c47","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-07-29","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe","http://clitest000002"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f898c2dc-31eb-4014-b636-d2c3d70fbcc7","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-25-22-15-03","appId":"1f12eaab-6cdd-4c81-b319-fd261d8e0410","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-25-22-15-03","errorUrl":null,"homepage":"http://azure-cli-2018-01-25-22-15-03","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-15-03","id":"a61eb23e-944d-466f-bec3-7ff4e56c445d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-15-03","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["1f12eaab-6cdd-4c81-b319-fd261d8e0410","http://clitest000002"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1523']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:07:30 GMT']
-      duration: ['4256818']
+      date: ['Thu, 25 Jan 2018 22:15:03 GMT']
+      duration: ['2648780']
       expires: ['-1']
-      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/ac65e734-16ee-4c34-82ee-a22e9918012f/Microsoft.DirectoryServices.ServicePrincipal']
-      ocp-aad-diagnostics-server-name: [QOIMKIIdK/ceXUr9GAU3ThLEQHRhyDj1NpVX1Mv+k1o=]
-      ocp-aad-session-key: [m7nTgHq7wwIfc-507RdzCQTBv4CaLWbWmzdmTQSduze6QZylwG8SwovTMICBTnChReO0QYh5rbvc-u31aysa1GTX91t3p4Csvqd-Vkblb0X8FczM-QB6wTkQfh4VCgJtagejKZpeozQ0uoCBuQ6DZr5LYTARHak7Tuqo5d1IKzgZJVRphFCnbI8Se207jVLpfU8PmbrYsEPalYgFQ3Q5bQ.lbbPT533QixKeOkIaXD7W7EjCDzaxUbFwCetoBfLwFc]
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/f898c2dc-31eb-4014-b636-d2c3d70fbcc7/Microsoft.DirectoryServices.ServicePrincipal']
+      ocp-aad-diagnostics-server-name: [PsQ9Z9cw9lW/SAFMwFi8L+ljoU1+bKSpefQx7+tAUAQ=]
+      ocp-aad-session-key: [lW-68RiBAb2txaPkExMuS4HhNQ1xHuKPPm2x_6vYbRO3wPuVBssT9mFQVFpW2TD6bFWf7TXPOaGc0nSHk8Xj1mQMVMoBX3RZT7MKhTImM3aaSyBufxONbPJg0JsiCqNRbwglRFtv0jMEfi2OV4c2MOFc0_ZYBX9IhVsTqHhOK8DJTx4l6M71MSoaiSYuxzmZ-brDKk6T3qmnRqNGoa_GwA.fWaA6RTK9SLnigGyNTrbowAfJZKoduNzuBo2ZcXY3k8]
       pragma: [no-cache]
-      request-id: [9cb40661-a557-4f65-bf96-754c9784bcb9]
+      request-id: [525e3158-d55e-4b88-b199-bcb1728b8d36]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -170,7 +170,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['212']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 24 Jan 2018 20:07:35 GMT']
+      date: ['Thu, 25 Jan 2018 22:15:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -179,20 +179,279 @@ interactions:
 - request:
     body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
       "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      3, "vmSize": "Standard_D1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      3, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
       "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
       "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
       test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
-      "secret": "a705dadf-0ed8-447a-b351-f6e91ef33615"}}}\'''''
+      "secret": "ee58ce03-5826-4a2f-a213-6542a77feac8"}}}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Length: ['1225']
+      Content-Length: ['1226']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:15:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      3, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "ee58ce03-5826-4a2f-a213-6542a77feac8"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1226']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:15:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      3, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "ee58ce03-5826-4a2f-a213-6542a77feac8"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1226']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:15:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      3, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "ee58ce03-5826-4a2f-a213-6542a77feac8"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1226']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:15:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      3, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "ee58ce03-5826-4a2f-a213-6542a77feac8"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1226']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:15:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      3, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "ee58ce03-5826-4a2f-a213-6542a77feac8"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1226']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:15:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      3, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "ee58ce03-5826-4a2f-a213-6542a77feac8"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1226']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:15:45 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      3, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "ee58ce03-5826-4a2f-a213-6542a77feac8"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1226']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
@@ -204,23 +463,23 @@ interactions:
         \  \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"1.7.7\"\
         ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"agentPoolProfiles\": [\n \
         \   {\n     \"name\": \"nodepool1\",\n     \"count\": 3,\n     \"vmSize\"\
-        : \"Standard_D1_v2\",\n     \"storageProfile\": \"ManagedDisks\",\n     \"\
+        : \"Standard_DS1_v2\",\n     \"storageProfile\": \"ManagedDisks\",\n     \"\
         osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\"\
         : \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n      \
         \ \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
         \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31']
       cache-control: [no-cache]
-      content-length: ['1557']
+      content-length: ['1558']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:07:40 GMT']
+      date: ['Thu, 25 Jan 2018 22:15:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -229,22 +488,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:08:10 GMT']
+      date: ['Thu, 25 Jan 2018 22:16:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -259,22 +516,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:08:41 GMT']
+      date: ['Thu, 25 Jan 2018 22:16:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -289,22 +544,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:09:11 GMT']
+      date: ['Thu, 25 Jan 2018 22:17:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -319,22 +572,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:09:42 GMT']
+      date: ['Thu, 25 Jan 2018 22:18:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -349,22 +600,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:10:12 GMT']
+      date: ['Thu, 25 Jan 2018 22:18:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -379,22 +628,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:10:44 GMT']
+      date: ['Thu, 25 Jan 2018 22:19:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -409,22 +656,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:11:15 GMT']
+      date: ['Thu, 25 Jan 2018 22:19:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -439,22 +684,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:11:46 GMT']
+      date: ['Thu, 25 Jan 2018 22:20:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -469,22 +712,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:12:16 GMT']
+      date: ['Thu, 25 Jan 2018 22:20:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -499,22 +740,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:12:47 GMT']
+      date: ['Thu, 25 Jan 2018 22:21:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -529,22 +768,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:13:18 GMT']
+      date: ['Thu, 25 Jan 2018 22:21:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -559,22 +796,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:13:49 GMT']
+      date: ['Thu, 25 Jan 2018 22:22:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -589,22 +824,132 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/865da6e2-9cd6-4593-9dad-bdc3d4d2061c?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"e2a65d86-d69c-9345-9dad-bdc3d4d2061c\",\n  \"\
-        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-24T20:07:42.0008205Z\"\
-        ,\n  \"endTime\": \"2018-01-24T20:14:06.2405042Z\"\n }"}
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:22:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:23:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:23:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:24:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/c29692cc-dc0a-4503-a4c5-00bec3470f7b?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"cc9296c2-0adc-0345-a4c5-00bec3470f7b\",\n  \"\
+        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-25T22:15:55.2528174Z\"\
+        ,\n  \"endTime\": \"2018-01-25T22:24:31.2888528Z\"\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['170']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:19 GMT']
+      date: ['Thu, 25 Jan 2018 22:24:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -619,11 +964,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
   response:
@@ -631,9 +974,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 3,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 3,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -641,9 +984,9 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1619']
+      content-length: ['1620']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:20 GMT']
+      date: ['Thu, 25 Jan 2018 22:24:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -660,7 +1003,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -671,9 +1014,9 @@ interactions:
         \  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n    \"properties\"\
         : {\n     \"provisioningState\": \"Succeeded\",\n     \"kubernetesVersion\"\
         : \"1.7.7\",\n     \"dnsPrefix\": \"cliaksdns000004\",\n     \"fqdn\": \"\
-        cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\",\n     \"agentPoolProfiles\"\
+        cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\",\n     \"agentPoolProfiles\"\
         : [\n      {\n       \"name\": \"nodepool1\",\n       \"count\": 3,\n    \
-        \   \"vmSize\": \"Standard_D1_v2\",\n       \"storageProfile\": \"ManagedDisks\"\
+        \   \"vmSize\": \"Standard_DS1_v2\",\n       \"storageProfile\": \"ManagedDisks\"\
         ,\n       \"osType\": \"Linux\"\n      }\n     ],\n     \"linuxProfile\":\
         \ {\n      \"adminUsername\": \"azureuser\",\n      \"ssh\": {\n       \"\
         publicKeys\": [\n        {\n         \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -682,9 +1025,9 @@ interactions:
         \ ]\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1710']
+      content-length: ['1711']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:21 GMT']
+      date: ['Thu, 25 Jan 2018 22:24:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -701,7 +1044,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -712,9 +1055,9 @@ interactions:
         \  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n    \"properties\"\
         : {\n     \"provisioningState\": \"Succeeded\",\n     \"kubernetesVersion\"\
         : \"1.7.7\",\n     \"dnsPrefix\": \"cliaksdns000004\",\n     \"fqdn\": \"\
-        cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\",\n     \"agentPoolProfiles\"\
+        cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\",\n     \"agentPoolProfiles\"\
         : [\n      {\n       \"name\": \"nodepool1\",\n       \"count\": 3,\n    \
-        \   \"vmSize\": \"Standard_D1_v2\",\n       \"storageProfile\": \"ManagedDisks\"\
+        \   \"vmSize\": \"Standard_DS1_v2\",\n       \"storageProfile\": \"ManagedDisks\"\
         ,\n       \"osType\": \"Linux\"\n      }\n     ],\n     \"linuxProfile\":\
         \ {\n      \"adminUsername\": \"azureuser\",\n      \"ssh\": {\n       \"\
         publicKeys\": [\n        {\n         \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -723,9 +1066,9 @@ interactions:
         \ ]\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1710']
+      content-length: ['1711']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:21 GMT']
+      date: ['Thu, 25 Jan 2018 22:24:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -742,7 +1085,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -752,9 +1095,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 3,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 3,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -762,9 +1105,9 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1619']
+      content-length: ['1620']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:26 GMT']
+      date: ['Thu, 25 Jan 2018 22:24:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -781,7 +1124,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -790,13 +1133,13 @@ interactions:
     body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003/accessProfiles/clusterUser\"\
         ,\n  \"location\": \"eastus\",\n  \"name\": \"clusterUser\",\n  \"type\":\
         \ \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\"\
-        : {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNGVrTkRRWEVyWjBGM1NVSkJaMGxSVTJGd1dtVnZSRkp4Tm0xbWJXb3hPQ3RUUWtwUVJFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMFJCZUUxcVVYbE5SRUUwVFZSa1lVWjNNSGxOUkVGNFRXcFJlVTFFUVRSTlZHUmhUVUV3ZUFwRGVrRktRbWRPVmtKQlRWUkJiVTVvVFVsSlEwbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGbk9FRk5TVWxEUTJkTFEwRm5SVUZ5VTBsc0Nra3ljWFpLY1RreFlqTlBXRms1UXpoWlNIVmFaMlJMVkdJNVNsRlRNVFI1V1VkSlJGTndNM0UzV2sxalFXaFJOekJRU1VaUU1sUnJZWFJYVEV0T1ZVd0thbUUzYURJNFJrNDRNVmxRTjB4c1owWnlXa2xDWTNSSk5IYzNRekpxT0RSS1NFSklhWFJCVDBwbFpVRlRSMWc0WVd4b1owazFTQ3QyTTJSellXUTBTd28xYTNKRFdIb3daM0Y0Y3pCcmFscFNjalJqVERWeUx6Z3dMMjVoV1doU1NVMXlVV05LVlVodk5tZ3hURGRHTUhWVFVrdHZORFJRVWxsRlNIVjBiekZXQ21KWlpVbEZhalJ3TUhJNVRFRklORzlJYVdzd1EyaFRjbUpUV1U1cWJsaEdMM2xSZUZSU1YwbFBaa1l3U1ZaSVlURkpSa3gxZWs1aGNDdFNaMHhWZDJnS1UzZEJUVzlIYlRKaGRrMXNUVnBqTkdSaFVEQjNWQ3RwVVhKTk5IZzBNRFZrYlRoNFEwczRTRUU1SzJkR1V6TTBkRGxpVFRoRlptNTJZbGhKZDJ4TWR3cHJTVkpWWlVNMlZHSlVPRlpCVTNVMU0zRnJNbXRZS3psd0wwUkpOV1ZLVldRMFZtVjVWV0ZoYVhOeGJucHdOa1JXTmpWNFdGaHphekF2WW5KalQzbEJDbXBSUzBwelVYYzVTMlJYUlRCalFscDZkamhrU0hKVWFreExaVTFwWXk4eldXeHphWE5VZURSM2JHaEVaVmN6TVdGVUsyVnhWeXMzZEVsekswNDNURGtLTVZGTk0ybHVaVzl0YjJkdVVrUmhhVU5KVlUxMGNFczBVMFp3Y1dJclRuWjVSRFV2TjNOdGIzbHJOMlZtZUdWaGJqaFBiVU51VVZSaE5Tc3JhRTVRYUFwd1pTdDBUbll3VTFOeFZubFRhMHhyWjFkbWIzQnZNMk5EZDFkYVJsRlBjMDE2TjBjclpXcERPR281YVhsVlRURlRNa2hUYnpKaFdVMVlhbWxWTjAxaENtTjFTV0UyVG1ZM1VVdzVhVVF4YzBSYWQyeHpRaTl6T0VOcVVrbDVjSFpRV1dveVIwMXZSRWRRY21OelVXRTFjbEI1UldORlV6QkJVRmcyVW0xNWVUSUtOR3N6VW5aUWVFWnFNbEJtV1VWeGNYVjRRMmNyU1V4SlRtSmxkSEJtZFhnclNGcHZaMlJWUTBGM1JVRkJZVTFxVFVORmQwUm5XVVJXVWpCUVFWRklMd3BDUVZGRVFXZExhMDFCT0VkQk1WVmtSWGRGUWk5M1VVWk5RVTFDUVdZNGQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV4Q1VVRkVaMmRKUWtGRUsydExSazlTQ2pGelNXdE1MM050TTJNMGNsWjNZbFpWY0ZkWGNuaElMMFJPTld4VGNtWTJiMEpUUjNoM01rcEVlVzFhVXk5b1RuWndLMlIwY201aFdIRXlSRkYxZFhVS05GZDZUVkZqVkdab2JVaExMM1F4YjAxYVkxcEhhV1pYT0hWemNrTlJTWEExUjNkbE5EZFVkbGhUVEhOTWRWTjBLemx6VDJJMGJsTjJabWgxTXpsTGJBcFdSMnhZZUdjME9WaEdXV055TkhObFpWVjZiWEkxV1RKVVJGSnlUMnN4ZFcxRVVtdHlSbGgxUkc1bFpDdFpMMkYxTjNwV1oySk1NRTVaU0ZaSVQyNUdDblIzT1RWTVFUUkRhVmhNVjJZeGRrSnZabTVuY1VwWGNtTk1TRmcyU1RRd2VtTmFPVzV3ZW5SaGFpOHhTMjVCTkVSdVdXUndWVmRKZG5SeVpteGxlVTRLTUdaV1pXRlZWRGxFZGs0eVVrMWpiMUppZEdSMFExZEpXbXRSV1VaWFJXdFFkWFJHVlV0UWExVXJNemRGZDFvNVF6TmFlVEJqVjBGTlZVdG9NRmczYVFvdmEwdzVSVlp4UjJjMlkweEtSMWhQZDFNNU5tUlNjbTl0YWpCRlJEUjVNMmRMVEVKRU5tUmxaMjFwZEhaM04wNUNNbVF6YkN0TmJscHVNMmx1TDJ0RENuRnhZWGRJZVRoWGFERkpTMHgyTTFCWllrNTZNRFV5VVdaR1pGTlBRbUZVY1hKdmJVUnNaWEF5UjFSaWEwOVlSamR6ZW1aNWRsWmFVVUZJVms5R1MxZ0tVa1ZPVmsxcGNVWmxRMEZGVVU1bksyaHZUV3QxUVRkeldYRTRaV3RpY1RBd2EySXlhRkJaYUVSRFZIRkZVV1Y0UldWUlIwcFFkVzQxVW0xbVpEVlRRUXBhTUVkd01ETkJZMWxOT0hCVWFua3lZMFZ4VmpGMWVFUmtkRmxyYkd0RU5IbHdZbUpTU25ZM1NETnJhRzF1VlVzMlFreFBaek5NVWpGRlNIUnNRMk4xQ21Wa09WZFlTSGs1WTIxaE5FSlRaSEp5Y1RCRE56WTJlVXhoTld4bk5FUlBPVmgzWkRkRVNHeHljbUY0Y0daak5tVjJSblJ6U21OM2IydGhLM2c0TVZNS2FrOVRjMVZHVTFoblRXTkRTSGhDY1VSQlJIRjZjblJOUmpkalIzZHdUSFpvSzBkWENpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovL2NsaWFrc2RuczI1bDRpd3UtYWUyZTJkZDEuaGNwLmVhc3R1cy5hem1rOHMuaW86NDQzCiAgbmFtZTogY2xpYWtzdGVzdGhhZGZ5eQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogY2xpYWtzdGVzdGhhZGZ5eQogICAgdXNlcjogY2x1c3RlclVzZXJfY2xpdGVzdHlpaTdpZ3VsdHVfY2xpYWtzdGVzdGhhZGZ5eQogIG5hbWU6IGNsaWFrc3Rlc3RoYWRmeXkKY3VycmVudC1jb250ZXh0OiBjbGlha3N0ZXN0aGFkZnl5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlclVzZXJfY2xpdGVzdHlpaTdpZ3VsdHVfY2xpYWtzdGVzdGhhZGZ5eQogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVTVla05EUVhRclowRjNTVUpCWjBsU1FVdE5hMmRhUWtseVZsSjZaMU14VUV0VlprMVFWa2wzUkZGWlNrdHZXa2xvZG1OT1FWRkZURUpSUVhjS1JGUkZURTFCYTBkQk1WVkZRWGhOUTFreVJYZElhR05PVFZSbmQwMVVTVEJOYWtGM1QwUkZORmRvWTA1TmFrRjNUVlJKTUUxcVFYZFBSRVUwVjJwQmNRcE5VbU4zUmxGWlJGWlJVVXRGZHpWNlpWaE9NRnBYTURaaVYwWjZaRWRXZVdONlJWQk5RVEJIUVRGVlJVRjRUVWRaTW5od1dsYzFNRTFKU1VOSmFrRk9Da0puYTNGb2EybEhPWGN3UWtGUlJVWkJRVTlEUVdjNFFVMUpTVU5EWjB0RFFXZEZRV3g2TUZoYWVFNU5iM2xpV2tsMGVFTlRWVmx6Ym0weVRGVjNOMUlLVFZBd2FuWm1hV2MxUlVSdmR6Z3hRbTg0Vm0xeWNIWnlNQ3RIUmxSSFdDdEhNekU1UWt0RU5rcDFOMkpHWlVrMmRWUlhTazFpUWtNd1ZFMUNWbEZ3Y2dwdFMweG9lRGxpTUdGalMxSTJjR3QwY21SVlNXc3JSMHBQTTB0RGFVbDRNVkZsVGxocGMyVXdNRFExU1ROdWVIa3dNRlZtUlM5cVVEWndSRlJLVjFSQkNtdFhiekppUVZOQ1dEUnVUVXRaVGsxV2RXb3pjbk40VlU1YU5YWTFRV2ROTTJSelp6ZERUVlpRU0U5NFRIbDVjVU1yZG1wQ1JFdFZlRkZ2Y1hWNEswOEtMM05UY1VGbGNGcE9jRWRMT1ZOWldUVjFXbXd3TWtob1QxaG9hVGRhWTBoNmJ6WnFiaTlJTUc5NmJXbzJWRUp0YW1oWVNVa3haMGRIVTFCbFF5dGFkZ3B3UW1KTFptMHpkMnBwTW5aeWNsbG9MMnh4VW1SeFVGbERValpYZVU1cGFVSlpablZSVUdOUVRsZzVPRU16VjBGcVprSjFhRk5hY1hwU2VuZHJhMWwzQ2pKb1drOTBZa3hZVFM5cVZGZDZhVUZvVGpGbldYbHpTRGRYUzNZMVRHVTRRVkJQVGxsbVExTlVXSHBDZWtkU2EyRnRTbE12YWxvNE1EbE9WbFpwY1dJS2FYUkxjMHhoY210NmMwdDVhMjFwVjA5WFVDOW9SMk52V2tnd1NEYzRRbkI2TkVOeVFVcE5kM0ZhYkhWWWFFUkRWM0k0VjBkRGNYQjFUVEEzVnpocVlncHdiSFZNTVVZcksxRjJORUZ1WWtkRVREUm1WMncwTkhoUFNtcE5kVlZyYUVSalNYTmxhMHRXVFcweU1Dc3pSMVJrSzJoQ1drUjZjbWxaWjI5bE5sSkVDbE54WlhjMGVtTklWMVp2YjNsRUsyMDRaVVJJWTFwcmVEUjZSRFpOVDJGU1VVZHBialpvTUhkaVVFOXFiamxYTTBKWlZtZDJURk5oY21sVVN6WkdVVE1LVFRoTFRFZEpNV0V2TTFCd1IwcFRZMXB6ZG10amVreEpTM0pHYkVnNGN6aG1kRWRUYzFscWEzVk1TWGhEWldad1MzQjFjbTFaVnl0SWQxSllSalpuUkFwWFJrb3dOV3RQWkU5TGRIZEtSM05EUVhkRlFVRmhUVEZOUkUxM1JHZFpSRlpTTUZCQlVVZ3ZRa0ZSUkVGblYyZE5RazFIUVRGVlpFcFJVVTFOUVc5SENrTkRjMGRCVVZWR1FuZE5RMDFCZDBkQk1WVmtSWGRGUWk5M1VVTk5RVUYzUkZGWlNrdHZXa2xvZG1OT1FWRkZURUpSUVVSblowbENRVWxKVkdFMlR6UUtNWFZoWTNoNU5UazBOM1pqYmpKNEt6UlpWR0Z5Ym1KbWVteERhRlV5TldaRlMxaHBRbTgzYTFGdVpqTTNPU3QwUmxaWmRWVk9Uek5yVWxkMEx6bEpVQXB6VlVGSFZrRjRPVUpWWkU1UFJVMHJUMGRKU3pCa2VtaHNXQzgyZDBnMWNrSjZNMDFLT1c0NVpEbFhaa1ZGWlU1Q0wxWnRVSHB0T1ZkYWVXRjBWVE5aQ2xvMVV6aHZjaTg1Y3pGdE5uVnlRaTlTVUZsclNXeGxNMGxJU1VSNWFuSTRaR3B0UzJvelZuWnlTSGhIYUZCRFEwdHBOSE54ZEU4eFMyVkVlbGRNT0U0S2VpdHlUa2xGVVZaT05WUXJiSGhhYVRBM1UxRjZVVWhsYnpnMWJFeHRlbGRuUVZJek1XeEtVRFJCTW1SWFIyUXdZVEkxVmtZMVMyYzRabFZ0ZWk5dFZ3cG9aVTAyYjIxVWQwc3hVSFp6Wm01VldVTnVNRmhvU2xWQ01rVXpSRzVCYzNncmJEZGpTR1ZMTUM5MWJGRjBOR05xWmt4bUswaEVOMDV1VjNCblJsSkZDbFJ4Wm1RM2FrSnpWVEZZZG5FMlFrNDRlbHB1TmxodFdtaEdVRGw0ZEZWeFZGaHJTRzVWVm5aMFQwNUxNemhTTkRRNGNtMUthbFZsV0ZsMk1pOU9UbG9LUzBWdVJESnFOelV2VkRVM2JFbHJNWGtyTUZSNVdTOVNNblZDUTI1eGFFMHlSVEpyV1hKRE4xUXlNazVaTUc1UUswczRhRkJTWTB4UFIyWkdhWE52ZEFwUlRYQTFSazlKY214U1NUZEtjemsyUWxCdmVXUmtORFpuTkZSWVFVbGtSek5LVm5WU1ZGWjBXVFVyU1hOWFNqQlVkblpxWlhvMGVIWXJZaTlIWld3MUNuTkxLMGhxUTJsV2FIUm9SMDVEWjJWdmNrY3ZXblJ5WVhjeVptTldVa3R3WTJabU5FbFBUMHRVYTFaeFNrNUZSalJDTlc1V2NWUm5NSEpZV2tWcmRtNEtjVVZSYkZaQ1draDZLMFVyVXpGcmVGQndRVlJMU1doTGRUZEVjMjFMU2tzM00zRnJTWEJ0TmpOSFZEWk1VR2xOY0hGcUswNXBLemhXVjBsMU56VmlSZ3BIUWtsUlZsbFhZVVZvUzNCRmEzcFZUV1ZtTmtrMFVqUjVVMkpSZGpONlZVbGFkRUlLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MyZEpRa0ZCUzBOQlowVkJiSG93V0ZwNFRrMXZlV0phU1hSNFExTlZXWE51YlRKTVZYYzNVazFRTUdwMlptbG5OVVZFYjNjNE1VSnZPRlp0Q25Kd2RuSXdLMGRHVkVkWUswY3pNVGxDUzBRMlNuVTNZa1psU1RaMVZGZEtUV0pDUXpCVVRVSldVWEJ5YlV0TWFIZzVZakJoWTB0U05uQnJkSEprVlVrS2F5dEhTazh6UzBOcFNYZ3hVV1ZPV0dselpUQXdORFZKTTI1NGVUQXdWV1pGTDJwUU5uQkVWRXBYVkVGclYyOHlZa0ZUUWxnMGJrMUxXVTVOVm5WcU13cHljM2hWVGxvMWRqVkJaMDB6WkhObk4wTk5WbEJJVDNoTWVYbHhReXQyYWtKRVMxVjRVVzl4ZFhnclR5OXpVM0ZCWlhCYVRuQkhTemxUV1ZrMWRWcHNDakF5U0doUFdHaHBOMXBqU0hwdk5tcHVMMGd3YjNwdGFqWlVRbTFxYUZoSlNURm5SMGRUVUdWREsxcDJjRUppUzJadE0zZHFhVEoyY25KWmFDOXNjVklLWkhGUVdVTlNObGQ1VG1scFFsbG1kVkZRWTFCT1dEazRRek5YUVdwbVFuVm9VMXB4ZWxKNmQydHJXWGN5YUZwUGRHSk1XRTB2YWxSWGVtbEJhRTR4WndwWmVYTklOMWRMZGpWTVpUaEJVRTlPV1daRFUxUllla0o2UjFKcllXMUtVeTlxV2pnd09VNVdWbWx4WW1sMFMzTk1ZWEpyZW5OTGVXdHRhVmRQVjFBdkNtaEhZMjlhU0RCSU56aENjSG8wUTNKQlNrMTNjVnBzZFZob1JFTlhjamhYUjBOeGNIVk5NRGRYT0dwaWNHeDFUREZHS3l0UmRqUkJibUpIUkV3MFpsY0tiRFEwZUU5S2FrMTFWV3RvUkdOSmMyVnJTMVpOYlRJd0t6TkhWR1FyYUVKYVJIcHlhVmxuYjJVMlVrUlRjV1YzTkhwalNGZFdiMjk1UkN0dE9HVkVTQXBqV210NE5IcEVOazFQWVZKUlIybHVObWd3ZDJKUVQycHVPVmN6UWxsV1ozWk1VMkZ5YVZSTE5rWlJNMDA0UzB4SFNURmhMek5RY0VkS1UyTmFjM1pyQ21ONlRFbExja1pzU0Roek9HWjBSMU56V1dwcmRVeEplRU5sWm5CTGNIVnliVmxYSzBoM1VsaEdObWRFVjBaS01EVnJUMlJQUzNSM1NrZHpRMEYzUlVFS1FWRkxRMEZuUlVGcFpEbGxhekZCVEhkSWVITXpTbEJTVG1ZeGMwNWhNa1p2ZERGVFNsbG1VRFp4U21KQmJIRlBSamx1Y0hGblVVOVFUVmhXT0d3eVdRcGhTRXBsWldVNGJscHRNMlZRYkc1dWFtZGhhMHBETTBNcldFcElTak5IU2tkR05tTm5hRk5VU1dSM04wTnhUV1UxVEVKd04xSjJWbUYzVEdwWFZHUnNDaXRzWlZwdFkzaEpRbFJPVlVSTWVXTm1NemhUUzNKdVRIZERhRWRYZGpsWFJHSlFVWFpaUVVoU2RXWkJhbFJyVVhwNFRuTktOWEpSUjFORllUYzFjVllLVWtaME1sb3hXVnB4UlhVdlZURklaM2xFUnl0bU5HMHlaR2xCY1dOWmNEUk9RV2h6UlhGT01HNU1VbTlUWnk5aGFuVjNRa3hhV1VOWkwySkxTRTV6TndwNlNEWjJNV3RXUVhNeFNXWkNRMHBMTlVFeVJXOUxhMGwyTDJaQ056STRPRkZNY2psTllXazFVbmhMZDJoMGVuUlhTMlZtVXpoTFF6ZzFXV2RJZDJkekNuazRTalY1WmsxSFdqSkZWRVV5UlRVd2VsSXlWVzA1UzFGaldXOHJOV1JETkZGRE1HVTJUbEE1YURkbFMzTnFNbU4wUW10R1MycGtjMDkwT0dodlRrRUtaVnAyU21KV2ExWTJVelJqWlhwd2IycE9lVTFPTmpWNlRGRXpWMUl4YWxSbmNXRTBjelpEVVhScFVXZG5UVUp1YW5sNVZXbG5Xa3BwWkVsemQxRTNNZ3BKVmtzMlRra3ZNazlXYlZaTlZHTkJRM0pFVkdwQ1JVVTFNVWhXUmpNeVFVUm5Sak5tYzIxRFYyTnpSMGQ1VGs1VkswWXJhRXhqY0V4b1RXTmpRVnBUQ2t0eGRDdEtkazR2Y25NNGRHVnZWazlxY2s0ek1rdHNSRXN4Y2s5cVNUTmxjbEUzYlVGNmVEVllUSHByVGxBNGExQlJhbTVvVmpWWloxRmtZbTkxYzNJS1RsWlpkRVlyWm5FMmRVaHRRa2RMU1U1TlkwRTVPRUo0ZERrMVNISjNNMUpTV0ROd01WVmFlbWRuTkhwQlYxbHhVRmxhWm1wSVpsRTFkbmRoYVc5c1p3cGFOaXR1VDNObE5qaGllbkl3ZFdad1RpdExTR3hCUm14aWNpc3JSV2RDV1c4MWRWWmFkalE0VVZBd05XUjJRemh4VW10RFoyZEZRa0ZOUmxrdlprTTBDbEV5UmtWbFExbFhWM1VyTVhGeGJuSXZhMGg1UjBaTFJXUTBabEIxTWtsYVNGbzJWR0YyVkhGeFZWQlhkM3BYYWxGSmJuVmpRemQzY0hRM2RYbHRaM1FLUlhocWJXVXJXVmc0VmtSVmQwMW9ZMGt5YmtoV1JFSnJOV2wyUW1kVmFHTjJiWGx2TDFsM01ESkVVbmxpT0dwdE9TODJPVVpyZGpCdlQzSnpjbkZtY2dvMVRrRlNTa1pHVURWNVpTOHhOV3B0YXpsNVozaFhORWw1YVVWUVRsRTJObEJ6TUU5aU4wWk5hVXBLV1c1TlpqVjBhMk5ZUVVScVNFVlpPRkptVWxabUNrZFRlazQ0YlVWeWJqSktZVk00UWpOR2FqaFNiMmxCTDFKWWRsZFJPRFp2TW5KSVN6UTBLek55VGpOUmNEWk5ZMGRIVlRrMGRUbFRhUzh6YWxGRFFsb0thMUpCZGxWdGVUWkVUSGd6UjNGUlprcEdMelpPWjJadVYxVjRWbXA1UjNJMWRIWjNkMDFJTVhGdGJrRkhVbTlqWm5nM2VUVmFWMGhVZG5CUlFXOVhZZ3BMU1hoNlN6a3hSRk5WTlhOc2VEaERaMmRGUWtGTlp5c3JkRzU0ZWtRNWFrNXpkM1ZZWkVOWk9HWlJWWEkyS3l0amFtOTNhbTV6Y2t4WGNUUXhZV05GQ210eEwxTnJabkJTU25WUGJrNVlPVTlrSzJkWVVXWldkRGw0TWpWUVpHZHhOM3ByWjNKSFpXVjFUR1ZuZFdvd2NrWktZM1E0TUVSRk1uZHJWMkpJVUZRS2R6UnFiMU4xYlhKS1FXWm1lVmR2YVRGcFFubzJhVmxxYW1rMVdXdzVSMVpaY1M5bmFUZFlTamR3VTFkek9UaEVlbGQwY0U5b1RFUkdhamRRZG10RFZBcFhkMjVDYkRkVlFuSlNRVlJVVUdJMGEyNUtPSEpuZG1Wc1NHMWFaV3BCYVZoV1kyRmpaRmMyVjNVM1NqSmtiVWwyU0djMFoxZG5haXR6ZVZCcFIzWTFDa2RrYTJ0dWNUSlJPRE54YjBRemNtSnRjM1UxVkhaWlNURkZhbVJWTkV4UFZFVmxXRkZOTjBsUmNqVk1kMk5sUjB0d05VVm9NVVo1TDB0RVVIRlRNR2tLZDJ4T1NGQlZUakZGTlVKaldtdFpVSHBSZDBkRk9YRnZOMnc1V1hOaU5YaFpUa3RKYzA0MFYzaFVWVU5uWjBWQlVEQk1hREkxWnl0dE5USjFabWt2UlFwVmVtZHhabVY0TUZKYWJIcHpaRkZpTUM5cU5VRTFSR0ZMZURseE1raFlURXRwU1dwMmRrbExWazVqUzBvMlIyWjRPRTU2ZDBsQk0wSnRaWEpXUlRaNkNrc3hTbWhRVnpGQlVGRlVNa2M1ZEROdlFYUjRVa2czY2pReGRYSnJaWFJqWW14VFprWkxibFp5UzJseWJXWkRVbXRwZDJOMlZqWnRaMEp0VEhVemMyTUtWVGx2YlV4aFdVdzNVakZDVnpnMVQySkhRM2RoU1VGNGRXbEJiVVpYYmtsTFlrbExiMnBsYmtaNk1rVlhaemwzVWtaS2FHcGtUMDk0YVZWblZVRkVXUW8xYmtwTE5VMDVVMGhTUzJzM1JUUnVZWFY0YUZKVldHdFJSbGd3TDFCdlNTdHZObWgxZGtkbVdHTnFVVGR4VFdkdlRrcDRSV1ZUWTFoVFNrOXZjbkZDQ2tock1FOUVNMDFPUlUxWmNWWlpNbmh1ZUU1RVowc3phRWhGWkRadGFuWkxTbFV5ZDB0UFdEUkNaVlpPYW5jME1XNW9jamx4UkRseVJtZEZPRGhsYkhBS1J6bHlWakozUzBOQlVVVkJibmhsUzJKVlZubEtTbkJMYlhkWWNtVjVUa2xrT0dSSWJtSlZUbEUzV0RSUVZuTmphR3RITjFoVGNVRTRSR1V6ZVhONFZ3cDJWaTlJV0ZKSFYzRnJjSGRIVUVnME9YbERTbEpuYXpKaWIycExPRXhvYkhkV05YUkhUbEF4VlM5amNEUkVaVWRZYWpNeWFFUXJiV2hyYzI0eVYxbHFDa0pwTmtJNE1WVnBSV28yUm5SVE9XbGpkV1p2Um5Cak9VSk5ZVGwxVUhoeFJrcDBNalZMVVRoMlF6SndLMlZaVFRodVNsTnJWRTlDYWsxeVIwbFJWRzRLTTI1SE0wbEVRakZEV1dsT1RIUnFlakZZYUdWWU5HVjBOazV2Vm5aMGVVVkRiSFJOVUZWM2NHdE5iM28xWlRGUlFVNHlORmxVUWxSdVVGVXZURVkyVWdwVmN6TmlTSEF3UXpaM1EyRXZNVmxqWTNCbFJrWmtUMXBRZG1WdloyRkZVbWhsWW1sWFoySTJURk4yT0RWdVZWbDVVbkY2UzJrd1NHWjFjVWRtWlZkNUNsZFhkRkI0YWtsbWEyOUllRzVFVUVONmRsaEZiMkV5Y1ZsNGJ5dHBkbEpGVlZGTFEwRlJSVUZzT0RseWREVjFVSEI1TldkeFRVVm5RMEpIVDJwWmNsY0tUVmR2VVdGM1NFOTRibGd4U2pGWWFtczVUa2h3ZFcxSFEwSm1kVTVNWVhNdmJUVk1RWEUwV1hkemQxWnBkVXhDV0UxRFRVRTRTa1JZTDJ0R2RWUlZMd296Yld0emNrdEVPWEJVTURkSWFEVm9SRXcyTDJaUWIxTkllRFVyYmtsM05FeHFXVmRHVlUwMldGbEJkU3N4VG5aNU4yaElMMGd6UzNOQ09VTXlNMEUyQ25aRFZDc3ZSSGxCY1VSUlJHaHpVaTlCT0UxTlFWQllia1p0YkU5dVJERldRa296WlZSTWJsWjZVR05TWTJkM1RraG9VRXR4VVc1WFowbHNRMUpOU0VJS1ZDdEdTbkIxSzFKak9YSk5Va0ZpWkhKRFlsZFBVRTV1ZHpFd1MwdHZkakF2WlZRMmRWUkpZMGQyS3k5b01HbFdibU5XZFRjclRIRk9ZMHBKY0VFMWRBcG9PVzFpY2sxWVVWcFVlREJsY0VKQ2F6Wk1kVFJJUVhsbGVqVk9OelJyZGs0eldUaFlUSE56Y2pnMVRrTkNjMVI0VjJWSWEycFViR3BEWkdNeWR6MDlDaTB0TFMwdFJVNUVJRkpUUVNCUVVrbFdRVlJGSUV0RldTMHRMUzB0Q2c9PQogICAgdG9rZW46IGNhMWY3YjE1ZjNkZmVlYzU5ODZmOWI2ZTE2OTJlZTMzCg==\"\
+        : {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVJFTkRRWEpEWjBGM1NVSkJaMGxTUVV0WWVGaERZbWhpWkhGb2RtTjJVVXhtUm05S2VXZDNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJuZDAxVVNURk5ha2w0VG1wQmVsZG9ZMDVOYWtGM1RWUkpNVTFxU1hoT2FrRjZWMnBCVGdwTlVYTjNRMUZaUkZaUlVVUkZkMHBxV1ZSRFEwRnBTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblNWQkJSRU5EUVdkdlEyZG5TVUpCVFVKbENtZHdZMDh2UVhOTWIydE1SMGw0T1VwU1N6RXlielp6WnpOMlpVdGpOSGcwTDNSV056QkVUWEpGYlV4emRuRTNUbXhFV0VJMVRGTlVkbnBHWTIxTVVIZ0tURVptU21sUmMyWnVVMjlYUTFneEwxVnlUWHBVU0hCTVdIQndXV3cwT1RaeFdXVnNiVUpEYkU0NGJHTlVibE56T1VoVU4wUldaR1Y1WW1FclRqTTNMd3B6Y0VkQ2JHUTBkV3BNZW5KSWRrODVSMmM1TTJsUFMySlljVkFyUlZCRFVXOURaV1ZRWVc1WmNYaENReXR0Vm1aS1dHMTJWbGN6U2xWc1oydGhiVkEwQ213ck0wOTVTVFZKYzJack9HUXZNbWh4YjNrcmEyVTFaVXRIWmpGNmVYb3dhVXBpVUZCck9VSjFMM1pqZDNWa2RuazRSM2MzTVZWbE1XRnBZbVpSWjIwS2RraGthRVIzTldod2RVdDFWMjF5Ym5KYVRVSkpORlUxU0dNNVJqUTRTa3RCYlVsMlpHMUxjMDFKV2poMlJsTk5TR0Z5V2xwRllsRmpVa1UxTDJRd1J3cG5kMFpNYnpSbVpWTmxTMDVrVUdwMllrNW5lbEJHUlU4ME9YZDFUa3hhYkdSNFptWmlUVTlzT1U4ek5YRXZLemxoTWpOSFkwVlBhVGRUYVU4NVNGVnJDbnA1VGtOUWEyaEpObU5JV0ZFeFZUUllUbE5pY0d0amJGUnZhRFZZU1VJeloxZzNXVWhQVVdnNGRrbEZVRWt3YVhoM2VIZFJOM05NWlUxaWJqVkpkMmNLWldnMGNsaFNWV053VlRsQ01UTXdZbFF2YmxoTlZHcDBUVU4yTURabmRsTnZWbWwxWmpFdlVVczFjMjVYVVN0dlltODRSMjV2UzBkV00wVlNOM2x4TmdvMFV6ZHdablpNVFc1aWQwRk1Ta0ZEYW05Q0wyZHBWR0pZU2xkeVZrZE9PVVpCT1RCd2RGRmxhRGs1Y0hsNE1EUm9SMjVPWnpGSlNGVm9UMk5YY25wSENuWkVNMU5YYm5GME4zaFVUMlp3YW1OVE56QkdOSFZ2TjJzNFRVdExiMDF3U1V0RWJFOWhhSGRKVTAxdGMxaGxhbGhRYjNsTlQwOU9MM1ZFVkZOeGQwRUtWRFJMTXpWWWFFUmtXR0Y2UkZsM2JVMTBRMWxIUW1GNVF6bEJSa3RoU1RjeU16UjFiaXRtUmtGblRVSkJRVWRxU1hwQmFFMUJORWRCTVZWa1JIZEZRZ292ZDFGRlFYZEpRM0JFUVZCQ1owNVdTRkpOUWtGbU9FVkNWRUZFUVZGSUwwMUJNRWREVTNGSFUwbGlNMFJSUlVKRGQxVkJRVFJKUTBGUlFWUlNlVE5zQ2sxV0wyczBhRXB1WkdkdFNYYzJLM3AyVDNKck1VY3llWEp3WmpoRmVWWXJXV1I1UTJkTlExSk5VVWhJWmtSaFNrbFRTWEZFUlhGaFZrVnpTemhLYm1rS2FsQlBjSGRGZWtsNWRqSkxWalYxU1ZaaFZYSlVOSFpJVVZaNGRVcFJaMUpST1Vnd2QyNUlTREUyTjJ4cmJHY3dWM05ZYmxkVWNURmhNMGRqTjJadWR3cGpMMFZsWXpNclIzWlBURXBqTmxvNFYxWlllVVZOYUZWdVZHc3dObkJLVGxCc1ZuTm9XV3QwWlZGdU1WcG9iM1UwV2pWc01HNXROMnBNZFVWcmNtNXBDazlzWjFwUllWVlRjVE5CYTNjMWJFcEtkams0VGs1a1dISlZiMmhWYms1R1FsSllZVkZSV2xobGJXbG1VMkZrZUZONmEyOUtjR1JtZVdKeVNERlphVVlLZUUxcVlWUjVUbFIwZEhKblRtZDFjbWMzUzB4R1ozbDVSVEF4Tlc5T1pYWk9RV3huYjBoWlMyd3pZak1yY2psU2FuWnFWbXAyYWtjMlJWSjFhMDF3YXdvdlpUQlRXR2RQYVdwSWFsQjVLMk5OZFhSdk1XdFlWVW8yWWs5Wk9VOUpURkZ6Ym1WRWFqRlROVGQzTXpCdlUweGlSbGhDYzNFNWFqZDZRaXREWlVsVENqVjVhamd6VGxaVVpDOWpNVTEyVVVzd2QwSkRVazFDVVZWRk1VNXRXVFZZVUV0NFQzYzNhbGxLY21SVGVTdHRTbFJSWVc5aGJIRjVlbnBQVWtaS1QyZ0tNMk5LT0VWUFlrWkhaRVZEUm1sMVprMWxhelJIVGpGeE9UUlpZMFI0VkVadFlVeEtSblUwZFU5b2NUZFhUSE5hWWxGeVMwNTBTalpLTUUxRVRqWmlWQXBwTTBKME4xRlVVbEpoTmtobWNWRXJRa3BPZVZRNVEyVnlla2hJTm1OVGVWWTNVSEIyVG5SWlRFUTBWMHhOU1djMlNHWldaV0pyVEZvMlZtNHJlbWhVQ25WUWMyNXNaMjlsY2s5bmJFNXpPRWcyWnpSeVNWZEJTRm8zTURWemVTOTNlR0pTUWpCRVNHRTRTemwxYUhKSWQwMHlNREZDTDNWTVJVcGxiVEIwY0d3S2FUYzJlbWR0VUZkNlQzWjNaWEZPY2xKdmNuVjJUekZCUm5SdmNsUlRWV2xwWkdaTFFuYzlQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2xpYWtzZG5zN2J0a3E2NS1kYWYzZWRmYS5oY3AuZWFzdHVzLmF6bWs4cy5pbzo0NDMKICBuYW1lOiBjbGlha3N0ZXN0aGFtbW5yCmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBjbGlha3N0ZXN0aGFtbW5yCiAgICB1c2VyOiBjbHVzdGVyVXNlcl9jbGl0ZXN0cjZtd3F0eXJwaV9jbGlha3N0ZXN0aGFtbW5yCiAgbmFtZTogY2xpYWtzdGVzdGhhbW1ucgpjdXJyZW50LWNvbnRleHQ6IGNsaWFrc3Rlc3RoYW1tbnIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyVXNlcl9jbGl0ZXN0cjZtd3F0eXJwaV9jbGlha3N0ZXN0aGFtbW5yCiAgdXNlcjoKICAgIGNsaWVudC1jZXJ0aWZpY2F0ZS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VVNWVrTkRRWFFyWjBGM1NVSkJaMGxTUVV0aU1FVmpPVmhwTkV4bU5WSldVR3RCV2pOdFkxRjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJuZDAxVVNURk5ha2w0VG1wQk1sZG9ZMDVOYWtGM1RWUkpNVTFxU1hoT2FrRXlWMnBCY1FwTlVtTjNSbEZaUkZaUlVVdEZkelY2WlZoT01GcFhNRFppVjBaNlpFZFdlV042UlZCTlFUQkhRVEZWUlVGNFRVZFpNbmh3V2xjMU1FMUpTVU5KYWtGT0NrSm5hM0ZvYTJsSE9YY3dRa0ZSUlVaQlFVOURRV2M0UVUxSlNVTkRaMHREUVdkRlFYcEtkMWRXY0V0UloyUk9SRWRtVWtaeFJWcFVlSEJpTlVoR1V6a0tZMlZJVWpOUk9HaHFaak0zTlVkME1uTkdLM2RyTHpOeUszRnVla1JwTjBKRGFXMW9WRkVyVjFBMmFFbGlZazVCT0RWVFVIWmplRVpNVjBaaGRYcE1Vd3BwZEd0V1ZHMVlhRnBvZERaVVpFMDRORXBsU0N0Nk5XbDBWMk54ZFZsM1drZDVNbmswUlRreVNVZGxSMWhIVTFOQk1YcHdjRXhSUkRjelJtaFJNM0pYQ214UFpTczJZVXh0U0VveVQwNVFhalZoTUZjM00wa3piSGN6UVRCWlNEVnFUVGhUUkVOeUwyTnFSbVpZYjFObGVHSXZhRVpEZDFkU1QzYzBja29yU0VJS1QzSm1PRVZwU3pGcFQwMTFSRzR6V2xsMGVIUmhhSGN3ZW1GSGMySTVUSFZMWTA1dFIyVTVWbHBMVTA1VUsyRmxZMUJ4WVVOTVUwWjJNVVV4VDJ4UmJRbzBNbVZrUzNnclRGQjNWMEpQTTI1TVRqbDJSVlJhWTJsbk9ITXpaMlJ1VHpGTlZ6TkllVVIzVm1SU01ETTBOV0ZNUjFaa2NuQkNLMWRNSzIwemN6WnNDbE5LZVhoYU9WY3ZOVVYxVGpVclVVTkdWakYzYW5GaFowMTBWMGxrYlVWSGRESXJkR1pxVWtsRlVHdFhaVlZpVUN0UU1ISjVZbWRSYUcxb2RYUjBXV3dLTmxaMFprTlZhM2g1VlZGeVEyZDVPR3A2YlVKdWNITlZjVlkzUjFGcVQzVnFTWFJpUXpaS2JqZHJNREZDU0hCWWRGZzNUM01yZEdkV1dGTkpWMGRpZVFwQlFVTXpLM052UjBWelNHbFJiamxNY2tOek9FOHliSFZHUVZCekx6SnROekU1TVVOMU56SnlNM0prYlVkNlEyNXdkM1JSTlVFelFrMTFiMjR5UkRNeENucGFOVGhGZEhoS1ZFMDVlR3hpU1ZCbmNHa3JkWFJ3YVhaRlF6SlhhbE1yYlZwWlRFdGphRTVsUVdOeWNYTjRPRzFVYkdKRVdVbFBMelExTjNjMFZ6QUtXWEpXYURKR1VFVldUa2hwVm5aT2FWSktlRlZ4Y25wRU5taDNMMElyTWxWWlZUQmlWRUY2TlZOTmFIb3dLMnRDVFRoTVZrVjNjbEpqZVM5T2VIaGlkUXBVVjFKSFVUbHdVbVpYV0dSMmNWVkRRWGRGUVVGaFRURk5SRTEzUkdkWlJGWlNNRkJCVVVndlFrRlJSRUZuVjJkTlFrMUhRVEZWWkVwUlVVMU5RVzlIQ2tORGMwZEJVVlZHUW5kTlEwMUJkMGRCTVZWa1JYZEZRaTkzVVVOTlFVRjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRVVJuWjBsQ1FVbGtkbUpFZEVVS1UzVXlkaTlNTUc1aU5Hc3dkVEJKZVRaNU1ITTBUWFZ0WkV4VFFqSnNiM3BRTTFGWVIybzVhMlpzVTNKcllqWXJlRWwyV1dGMmJtTXpTVEJsUkRkTWNncEpXVTh2ZUU5aFQwOWxhVkJHUTFKUGVrVjZaR0ZZVDJkMWJUQlVkbkpaVEUwNE1tcEVNV1JrVTJsQmRYaFJRM0l3VW5keE4wOWxhbmxJWTNsdVVWVk1Dbk5DYzNKNFVDdFViMmxwV1cxRldVNHhWM2xOY2s1eFlYbFJVazlsU2xWNFMydDJiemczYTNSYU9Wb3pkVWxrWVdka2JXUjNabGhTU2pndlVrMWpRVGtLTDJzd1VFVjJiVE54YTFGek0wbFZWbWgzY2paSlltaHRZV2N3UVVKeGNraEdMemg2VTBKaFJYcE1OalJpUXpaa1l6ZHFRbFI2UTBscmNHbEdOUzlYWkFvNVpEWlpVR2hGVEN0bFJDdFlVV1J2UkU5dGRsa3plVkJRTlhSMVlWVnpka3hOZVdjeVJ6VmhVVVZzZG5BeWFITnJNSGRHYlZaTGVERnVaQ3RXY1dWNENqRjBjRFY1U2pobWRVTnlMMGN6UWtabWFuVnNWR3NyWW1nNGJtNUdWU3N2ZEhOc1YzRk5OVGhpTjJSeFdXZFhTRGt2WlZaTlZUSk1Xa3RzT0UxeGEzRUtRakphVGxvNWNsWXhNa0V2Unl0RGNXZFBSazFCTmpsUVZFdEVSRFJXYlhRME5saEdNRTVzU1hwSlFuTmxXbHBEV0RGblVYSXhXRU4wUmlzMmJIcElWQXBwTnpSNE1GRTBka1ZITWxsNU5GZDNSRTloUkdKYVVsbEROVFl3VmpGV2FGZENNemhhUVhwNmQyWXhLM2hQZVU5dldrcDVRMWxxVDI5NmJFSjBPRmxZQ2xVMGRtZFNkRU53U3pWclZrdzFObmhDZGsxcmRFNVJSWEV4VG1OQ2FXWjRiekExZWs5UWVGcDFRblZKVjBWdlN6bFhlbGRpUnlzME5GZEVibEZMYVZNS1YxUTJWbFpETDA5MlpURXhRMUJWVFhWalpsWXdjV3BRWkZSaVVqSktXVWRaUlZOTFFsTllMMVp4VGtsUlQzSlZjRTEzWlhkTlR6SmlRVWhQZFVoeVZBcFRiRWRUZFdWemFuTnRNSGhRYzBOSlIzVlhXVVZLV1V0Mkx5dEZTRU42V0ZkU1ltNEtMUzB0TFMxRlRrUWdRMFZTVkVsR1NVTkJWRVV0TFMwdExRbz0KICAgIGNsaWVudC1rZXktZGF0YTogTFMwdExTMUNSVWRKVGlCU1UwRWdVRkpKVmtGVVJTQkxSVmt0TFMwdExRcE5TVWxLU25kSlFrRkJTME5CWjBWQmVrcDNWMVp3UzFGblpFNUVSMlpTUm5GRldsUjRjR0kxU0VaVE9XTmxTRkl6VVRob2FtWXpOelZIZERKelJpdDNDbXN2TTNJcmNXNTZSR2szUWtOcGJXaFVVU3RYVURab1NXSmlUa0U0TlZOUWRtTjRSa3hYUm1GMWVreFRhWFJyVmxSdFdHaGFhSFEyVkdSTk9EUktaVWdLSzNvMWFYUlhZM0YxV1hkYVIza3llVFJGT1RKSlIyVkhXRWRUVTBFeGVuQndURkZFTnpOR2FGRXpjbGRzVDJVck5tRk1iVWhLTWs5T1VHbzFZVEJYTndvelNUTnNkek5CTUZsSU5XcE5PRk5FUTNJdlkycEdabGh2VTJWNFlpOW9Sa04zVjFKUGR6UnlTaXRJUWs5eVpqaEZhVXN4YVU5TmRVUnVNMXBaZEhoMENtRm9kekI2WVVkellqbE1kVXRqVG0xSFpUbFdXa3RUVGxRcllXVmpVSEZoUTB4VFJuWXhSVEZQYkZGdE5ESmxaRXQ0SzB4UWQxZENUek51VEU0NWRrVUtWRnBqYVdjNGN6Tm5aRzVQTVUxWE0waDVSSGRXWkZJd016UTFZVXhIVm1SeWNFSXJWMHdyYlROek5teFRTbmw0V2psWEx6VkZkVTQxSzFGRFJsWXhkd3BxY1dGblRYUlhTV1J0UlVkME1pdDBabXBTU1VWUWExZGxWV0pRSzFBd2NubGlaMUZvYldoMWRIUlpiRFpXZEdaRFZXdDRlVlZSY2tObmVUaHFlbTFDQ201d2MxVnhWamRIVVdwUGRXcEpkR0pETmtwdU4yc3dNVUpJY0ZoMFdEZFBjeXQwWjFaWVUwbFhSMko1UVVGRE15dHpiMGRGYzBocFVXNDVUSEpEY3pnS1R6SnNkVVpCVUhNdk1tMDNNVGt4UTNVM01uSXpjbVJ0UjNwRGJuQjNkRkUxUVROQ1RYVnZiakpFTXpGNldqVTRSWFI0U2xSTk9YaHNZa2xRWjNCcEt3cDFkSEJwZGtWRE1sZHFVeXR0V2xsTVMyTm9UbVZCWTNKeGMzZzRiVlJzWWtSWlNVOHZORFUzZHpSWE1GbHlWbWd5UmxCRlZrNUlhVloyVG1sU1NuaFZDbkZ5ZWtRMmFIY3ZRaXN5VlZsVk1HSlVRWG8xVTAxb2VqQXJhMEpOT0V4V1JYZHlVbU41TDA1NGVHSjFWRmRTUjFFNWNGSm1WMWhrZG5GVlEwRjNSVUVLUVZGTFEwRm5RVVV2TldOdlNFVktPV1ZYZVRsUFNrNTJSR1pFUkM5RVNYWjBMelE0ZUhab05tWjNSV2d4T1N0TllpOWxhRlJYVldnMlIxVlpXbGxvZWdwbmVqZHBRV0Y0V1Vad1dtdEVZbVJtVUhFM1MyaEpiVk5oUjJkVlQweHRabk40YTJwdVZGRkNRekJ2WWxaWVlVTmhhazlzYUU4MGEyWkNlWEpOT0RjckNsa3lZa1p1UkUxMlpXRkdORWg1T1ZGSFNVUmpjR2wwY2tFMU4wa3ZZWE5VYlNzclkwTmhSa2hWWkhoMlVFbFpXakI1T0RoeFMwcDZUeXRCZFVONFMzTUtaazF1ZEc1T1NtRnpPVGgxWVc5TWVFRXJaelI0VVdKcGQzZHpUMDR3Vm10dWQxazJZV1kwTVdKNlYybEdNMHR5YkdaV01tcGpNelprY0M5MmJXaENPUXBXZEdwTmJXMUtia3BqY1daUU9HNVlPWFJzVDBJd1JUSkVlbkp3VG5CSGJsVkRSRE5GZWxCeGRITlhVRVExU21SdmNHTk9WVlZuVmxsVGFrNXpWM2N3Q25SME5YWnZhbXBqUVU1RUswNDRaRE5KY1VsbVZGbGhhRmRvVWsxRFdHOVhZbkZMZVRoM1ptaDFORmRYUTFwS0sxaHRiVGQzZFZGaVkxUk5ZMjlXYURjS1drNUJZVmhQYVN0dE1VVnZVVTFQUlhJcmJub3pZMk5DYm1OTk5pdDBWbGhCUTFsNVUybHVZMGxDU1RnMlYwWmpiRXBGVkVaQ2FuVnlPVzAwYVZWWFJBcFhOSGx6ZUd4MFkyRkVWVE5qYUhrMVJqSkdkazFDZUcxVFZrbHlXRzl6VVhadlYxVjRWa0ZPVVM5bGVXaHJjRE5RZDB4a1VYTnlRakJRUW5WR1drSlFDamc0YW5JclFsQTFTR0ZPYmxCTFVFVTNlRnBMV1hWSVJEZHBNVUoxV2xkcGVtdzRTVXg2WXpsd2JsTkpaRzh2WTNOV05GWnZWbmRES3pGSFozRlNXQzhLYldWMFJrdFJiRGg2U2s5a1pWRkRNVGhYZEVVMkwwVnFVRVpGZGtaRlJURk5OMEZ4WkhRMVNubHFNamRSVVZSNWVHdERRM2hQYXk5YWVXb3lTRkZpVkFwRE5IWm9kRGxEVGpGVmNUWXhTalJOT0M5NmFsaERSRmsxUW5kdWNGaFhNMlpFZVM4MVltbHFhVVYzVTBaV1dYSjNVVXREUVZGRlFYcE1ZVTl0VjJwc0NrcHpWMk14TkRaQlp6Tm5ORXNyYlcxSk1TdGFNRlJtU0dkR2VEVndhRzk0UzFWeFJYWnpNVTluWjNGWWNUTmhUMlY0TDJVNFkwcDFaSEV6WjBacGJqWUtOVXhpV1ZsV1lTdEhSM1F2Vm1WS2VsVlNlVlpDZUVOcllrSk9XSFJITUZWUE1rTkdhWEZzTW5oM1ZuWnVaRXR5U1RORFMyWjZPWGxMYlZNd01sZFFRUXBYV1ZjellYaElWWEJDYjFCNFNXOXBVMWRyY21oNk1UZHBiV1F4VGxGV2NuQnhNREJsYjFkcmRuTlhRbXBqSzB0RFpIUlZjMWRtYlU5Q05sbHRhMmxOQ25oQ055dEZLMHBwWjNGWmRuRk1lVk4zV0V4S04yaEVhSEJRVFVOdVozSjVjR0pEVkVaSFptSnFTbVpITUdkd01WZzFTbUpRTkdKR05EVkdhSGxtZGpjS2RrOXFkRzVUU0VORlRHMHlOWEJVUm5wM1ZFMXdibkpMWkdjcmEyaENWRFJ2WVhKVVZsSm5OMjVTS3pKTFRGZFpaVUYwTm1KVWFtTTRRemt6UzA1T2Rnb3ZhMDlJTUZaMVdFVmtaekJPVVV0RFFWRkZRUzg1TjIxR1FqSlpTRWRrZFM5SFNWSTBlVGROTVdaeU9FdExhRGxDVUdkNVZtTnphRWtyV1Zwek1uWlpDbkV5WkZORlYwd3dXaXQwU0hOWFZ6TjZZVGxoYmsxMVZVcDZPUzkzVlRWM05FaEZlRk5qVVVkbVVWZzJaR2hDT0VkbVNtVldWbXgxV2pWWVdXRkZUQzhLUXpndlMyNXdLMnBxYWpaWU9GQkROa0pGWmt4Q09UY3JOMEZGY21oak5EZHpWVGM0ZFVKYVRuSlRWMWh6UlVOdUx6QkRWVGxVYVV4dlUxVmpOWGc1T1FwMWRqTkxja2xQVWtKclVXaFROa1J6VWxwNmVpdGxOekphTW5WaEwzcDFSME50YkZSeFN6bG5SbFp2YUN0dlozSlBPWEJCWjNKaFdtOHZOVFF2Tlc1SENtZExiV3RFYVV4YWEwZFlkVFE1YTJwUVNYZzJjbFZUYlM5S1V6Ulhja1JIZWpabWRWRmthVTFYWVhSR0swWkxTa2hYZUVOQ05Vd3JibUZOUjA5RlUwOEtTekpYVjNsaFdVNTNWV1V5YjJWYVowSktRalJyV21KUFVXbDZRV2x2Y2tVeGRtMTBUR05RVDNOUlMwTkJVVUpHY21OSE9UTXJSbGh2UWpKNGJGUlRWQXBETUVZM1YwOHdUM293VTBrelVXRlFNekp2WTNGdUsyWlJWbXRNY0U1QllraFZXR2QxT1hKc1pEaFRiak16YXk4NWFFUXpSMnhVYlhOdlNGZEtMMDVQQ2xad1EybERRa1ZsVVRZNVMwWXhWVkEwUlcxVVFsTnVSWGxEWWsxUGMwSlBTRGhEVGtwS04xSXdhMWRvTmtaUFVYTklVMHRLYUZSaWJ6bE1OVzgzYTFFS1NHcHlUblZCVEZKdUwxZE1PRGxhZDBaeFZHcGFhbEIwUzB4c1lrWjBRWEpwZDJnNE16STFjSGx1YWpaYVdsbE1PV2RaVmxKaGNEaFBkSGhoYjJ0NlRBcHJXWFJhVlUwMVdFRkNOVkphVUdWWk9FbHZjMmg1WkhWV1JISk1NRVZ1TDJkak0xQjNibGRRUlZRM2VqQlphbUl5Tm14QlYyWXJiVzVzV0RacVVHOUZDbEJYU2s4ck9HRlZiakZ4VmswcmFHbzFVa1Z1VlVGblRUVjRkRVowU21wa09ESlNTMWRRTVV4d2QxTkdNWEozUmtkUVRHcE9OSHBCU3k5Wk0zZFpaMklLVERnNFpFRnZTVUpCUkdrcllpOTJjVVJFTDFGWFNHRXdUVkU1VnpRMmNGbDJUemgyV0c1d2NIRktRVXRQYkVaQ2VVWldXVUl6WTB4MFRrZFRVbTB4T1FwaGFYSllVMmR1WkZvMVZEWlBUMHg2V0VKMU9HbzFMMWQxYmpKSVkxbEVjMmRJTUV0aWRITTJUM1F4YlhSbGRGY3JaVlV4V20xYWVVMUtZelZDUVdGYUNuSjNlVW81YkdKWmNsSm5WSGhwYTBWdlYyaE9UV3RRUTBwd01sVndTMnhRWlhaS2JHaEdlRUpOUldWd2Qwb3hLMGswYWtkSVVsbEtSSEJrZG01bmRuSUtkRUUyV0c4ME5WVnViVGRDU21ablRtcDRVVzVYVkZOYU5IbHRNM0YyUmxKVFpGQk1kWFp5VGtSb01YVTNWMlpJUjFsS2JEQm1XR0Z4VkRGU1ZWUnhTd3AzU1ROaVN6aDBWSGhEYTBVemNIVktVamxGYXk5NFNYbFNZelZ2Wm1ObGRFTm9iRzFDUnpVMFFXSlRORlJ4YzJFMmJHY3dTeXQwU0ROclltVkJjRXh2Q20xdlNWSkhlRFJ2UVM5VlZtOXhlR1ZVUm5wMFNsaFpabUpPTmtoWVEwVkRaMmRGUVVaU1MzQXpWR3h5VW14R2JYTnlSbkp3YURNd1puRlZWSEpaY21FS01qRjBiRTlOWVdoeFlVcFBSMVZ6TVVJeGRGbzRialpqZVVSQlVHeHRhazl2WW0xdVVuQlJiREIxT1hJeGJtc3ZXVk5NZWt0QlpGVnJSWGxFVjNGVGNBcHdjMmxuVkd4Nk1EQm9kaTlwZFd3M05rUjFOVmhpZGxjdlV6ZEplWG8xZVhCWk0ydHVZekZDTnpOdFdtOVBUV0ZHYWtscWJYQTBaVTVwYVZSTGNrRk5DbTlxZGswNVJGbHlhelptTVVkeVNGcFRiVWsxZFVObU0xTjJjRko1ZUZKMGJsZzRNU3Q1UzBORVQyVlRMM2RwTVhndmNXZGlUazFwZG5Wak5YUjNOWElLYlVoWk1pOWxVekpqWkhaMFFYcHVNbVJ5TVhScFozaDFZbU5JVmk5RFpFTlBaeXRZSzJwQlYwbEpkRTluTWxwWlNYWTNXVXBhTjJVeVp6SjBSV2hwZGdwM1l6QXpkVUZDZUZFNFJDdDNVR2RZT1dad1lreDJMM1ZxVDJsT2VsUkxWMlJtU0ZOTWJVdEVZa1pLV25SelJuQk5NV1ZaWms5alQzTkJQVDBLTFMwdExTMUZUa1FnVWxOQklGQlNTVlpCVkVVZ1MwVlpMUzB0TFMwSwogICAgdG9rZW46IDk1NWI3NzgxNjBlZWZjODU4M2FjMDViYTVlM2VlYTE4Cg==\"\
         \n  }\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['13059']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:27 GMT']
+      date: ['Thu, 25 Jan 2018 22:24:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -813,7 +1156,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -822,13 +1165,13 @@ interactions:
     body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003/accessProfiles/clusterUser\"\
         ,\n  \"location\": \"eastus\",\n  \"name\": \"clusterUser\",\n  \"type\":\
         \ \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\"\
-        : {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNGVrTkRRWEVyWjBGM1NVSkJaMGxSVTJGd1dtVnZSRkp4Tm0xbWJXb3hPQ3RUUWtwUVJFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMFJCZUUxcVVYbE5SRUUwVFZSa1lVWjNNSGxOUkVGNFRXcFJlVTFFUVRSTlZHUmhUVUV3ZUFwRGVrRktRbWRPVmtKQlRWUkJiVTVvVFVsSlEwbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGbk9FRk5TVWxEUTJkTFEwRm5SVUZ5VTBsc0Nra3ljWFpLY1RreFlqTlBXRms1UXpoWlNIVmFaMlJMVkdJNVNsRlRNVFI1V1VkSlJGTndNM0UzV2sxalFXaFJOekJRU1VaUU1sUnJZWFJYVEV0T1ZVd0thbUUzYURJNFJrNDRNVmxRTjB4c1owWnlXa2xDWTNSSk5IYzNRekpxT0RSS1NFSklhWFJCVDBwbFpVRlRSMWc0WVd4b1owazFTQ3QyTTJSellXUTBTd28xYTNKRFdIb3daM0Y0Y3pCcmFscFNjalJqVERWeUx6Z3dMMjVoV1doU1NVMXlVV05LVlVodk5tZ3hURGRHTUhWVFVrdHZORFJRVWxsRlNIVjBiekZXQ21KWlpVbEZhalJ3TUhJNVRFRklORzlJYVdzd1EyaFRjbUpUV1U1cWJsaEdMM2xSZUZSU1YwbFBaa1l3U1ZaSVlURkpSa3gxZWs1aGNDdFNaMHhWZDJnS1UzZEJUVzlIYlRKaGRrMXNUVnBqTkdSaFVEQjNWQ3RwVVhKTk5IZzBNRFZrYlRoNFEwczRTRUU1SzJkR1V6TTBkRGxpVFRoRlptNTJZbGhKZDJ4TWR3cHJTVkpWWlVNMlZHSlVPRlpCVTNVMU0zRnJNbXRZS3psd0wwUkpOV1ZLVldRMFZtVjVWV0ZoYVhOeGJucHdOa1JXTmpWNFdGaHphekF2WW5KalQzbEJDbXBSUzBwelVYYzVTMlJYUlRCalFscDZkamhrU0hKVWFreExaVTFwWXk4eldXeHphWE5VZURSM2JHaEVaVmN6TVdGVUsyVnhWeXMzZEVsekswNDNURGtLTVZGTk0ybHVaVzl0YjJkdVVrUmhhVU5KVlUxMGNFczBVMFp3Y1dJclRuWjVSRFV2TjNOdGIzbHJOMlZtZUdWaGJqaFBiVU51VVZSaE5Tc3JhRTVRYUFwd1pTdDBUbll3VTFOeFZubFRhMHhyWjFkbWIzQnZNMk5EZDFkYVJsRlBjMDE2TjBjclpXcERPR281YVhsVlRURlRNa2hUYnpKaFdVMVlhbWxWTjAxaENtTjFTV0UyVG1ZM1VVdzVhVVF4YzBSYWQyeHpRaTl6T0VOcVVrbDVjSFpRV1dveVIwMXZSRWRRY21OelVXRTFjbEI1UldORlV6QkJVRmcyVW0xNWVUSUtOR3N6VW5aUWVFWnFNbEJtV1VWeGNYVjRRMmNyU1V4SlRtSmxkSEJtZFhnclNGcHZaMlJWUTBGM1JVRkJZVTFxVFVORmQwUm5XVVJXVWpCUVFWRklMd3BDUVZGRVFXZExhMDFCT0VkQk1WVmtSWGRGUWk5M1VVWk5RVTFDUVdZNGQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV4Q1VVRkVaMmRKUWtGRUsydExSazlTQ2pGelNXdE1MM050TTJNMGNsWjNZbFpWY0ZkWGNuaElMMFJPTld4VGNtWTJiMEpUUjNoM01rcEVlVzFhVXk5b1RuWndLMlIwY201aFdIRXlSRkYxZFhVS05GZDZUVkZqVkdab2JVaExMM1F4YjAxYVkxcEhhV1pYT0hWemNrTlJTWEExUjNkbE5EZFVkbGhUVEhOTWRWTjBLemx6VDJJMGJsTjJabWgxTXpsTGJBcFdSMnhZZUdjME9WaEdXV055TkhObFpWVjZiWEkxV1RKVVJGSnlUMnN4ZFcxRVVtdHlSbGgxUkc1bFpDdFpMMkYxTjNwV1oySk1NRTVaU0ZaSVQyNUdDblIzT1RWTVFUUkRhVmhNVjJZeGRrSnZabTVuY1VwWGNtTk1TRmcyU1RRd2VtTmFPVzV3ZW5SaGFpOHhTMjVCTkVSdVdXUndWVmRKZG5SeVpteGxlVTRLTUdaV1pXRlZWRGxFZGs0eVVrMWpiMUppZEdSMFExZEpXbXRSV1VaWFJXdFFkWFJHVlV0UWExVXJNemRGZDFvNVF6TmFlVEJqVjBGTlZVdG9NRmczYVFvdmEwdzVSVlp4UjJjMlkweEtSMWhQZDFNNU5tUlNjbTl0YWpCRlJEUjVNMmRMVEVKRU5tUmxaMjFwZEhaM04wNUNNbVF6YkN0TmJscHVNMmx1TDJ0RENuRnhZWGRJZVRoWGFERkpTMHgyTTFCWllrNTZNRFV5VVdaR1pGTlBRbUZVY1hKdmJVUnNaWEF5UjFSaWEwOVlSamR6ZW1aNWRsWmFVVUZJVms5R1MxZ0tVa1ZPVmsxcGNVWmxRMEZGVVU1bksyaHZUV3QxUVRkeldYRTRaV3RpY1RBd2EySXlhRkJaYUVSRFZIRkZVV1Y0UldWUlIwcFFkVzQxVW0xbVpEVlRRUXBhTUVkd01ETkJZMWxOT0hCVWFua3lZMFZ4VmpGMWVFUmtkRmxyYkd0RU5IbHdZbUpTU25ZM1NETnJhRzF1VlVzMlFreFBaek5NVWpGRlNIUnNRMk4xQ21Wa09WZFlTSGs1WTIxaE5FSlRaSEp5Y1RCRE56WTJlVXhoTld4bk5FUlBPVmgzWkRkRVNHeHljbUY0Y0daak5tVjJSblJ6U21OM2IydGhLM2c0TVZNS2FrOVRjMVZHVTFoblRXTkRTSGhDY1VSQlJIRjZjblJOUmpkalIzZHdUSFpvSzBkWENpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovL2NsaWFrc2RuczI1bDRpd3UtYWUyZTJkZDEuaGNwLmVhc3R1cy5hem1rOHMuaW86NDQzCiAgbmFtZTogY2xpYWtzdGVzdGhhZGZ5eQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogY2xpYWtzdGVzdGhhZGZ5eQogICAgdXNlcjogY2x1c3RlclVzZXJfY2xpdGVzdHlpaTdpZ3VsdHVfY2xpYWtzdGVzdGhhZGZ5eQogIG5hbWU6IGNsaWFrc3Rlc3RoYWRmeXkKY3VycmVudC1jb250ZXh0OiBjbGlha3N0ZXN0aGFkZnl5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlclVzZXJfY2xpdGVzdHlpaTdpZ3VsdHVfY2xpYWtzdGVzdGhhZGZ5eQogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVTVla05EUVhRclowRjNTVUpCWjBsU1FVdE5hMmRhUWtseVZsSjZaMU14VUV0VlprMVFWa2wzUkZGWlNrdHZXa2xvZG1OT1FWRkZURUpSUVhjS1JGUkZURTFCYTBkQk1WVkZRWGhOUTFreVJYZElhR05PVFZSbmQwMVVTVEJOYWtGM1QwUkZORmRvWTA1TmFrRjNUVlJKTUUxcVFYZFBSRVUwVjJwQmNRcE5VbU4zUmxGWlJGWlJVVXRGZHpWNlpWaE9NRnBYTURaaVYwWjZaRWRXZVdONlJWQk5RVEJIUVRGVlJVRjRUVWRaTW5od1dsYzFNRTFKU1VOSmFrRk9Da0puYTNGb2EybEhPWGN3UWtGUlJVWkJRVTlEUVdjNFFVMUpTVU5EWjB0RFFXZEZRV3g2TUZoYWVFNU5iM2xpV2tsMGVFTlRWVmx6Ym0weVRGVjNOMUlLVFZBd2FuWm1hV2MxUlVSdmR6Z3hRbTg0Vm0xeWNIWnlNQ3RIUmxSSFdDdEhNekU1UWt0RU5rcDFOMkpHWlVrMmRWUlhTazFpUWtNd1ZFMUNWbEZ3Y2dwdFMweG9lRGxpTUdGalMxSTJjR3QwY21SVlNXc3JSMHBQTTB0RGFVbDRNVkZsVGxocGMyVXdNRFExU1ROdWVIa3dNRlZtUlM5cVVEWndSRlJLVjFSQkNtdFhiekppUVZOQ1dEUnVUVXRaVGsxV2RXb3pjbk40VlU1YU5YWTFRV2ROTTJSelp6ZERUVlpRU0U5NFRIbDVjVU1yZG1wQ1JFdFZlRkZ2Y1hWNEswOEtMM05UY1VGbGNGcE9jRWRMT1ZOWldUVjFXbXd3TWtob1QxaG9hVGRhWTBoNmJ6WnFiaTlJTUc5NmJXbzJWRUp0YW1oWVNVa3haMGRIVTFCbFF5dGFkZ3B3UW1KTFptMHpkMnBwTW5aeWNsbG9MMnh4VW1SeFVGbERValpYZVU1cGFVSlpablZSVUdOUVRsZzVPRU16VjBGcVprSjFhRk5hY1hwU2VuZHJhMWwzQ2pKb1drOTBZa3hZVFM5cVZGZDZhVUZvVGpGbldYbHpTRGRYUzNZMVRHVTRRVkJQVGxsbVExTlVXSHBDZWtkU2EyRnRTbE12YWxvNE1EbE9WbFpwY1dJS2FYUkxjMHhoY210NmMwdDVhMjFwVjA5WFVDOW9SMk52V2tnd1NEYzRRbkI2TkVOeVFVcE5kM0ZhYkhWWWFFUkRWM0k0VjBkRGNYQjFUVEEzVnpocVlncHdiSFZNTVVZcksxRjJORUZ1WWtkRVREUm1WMncwTkhoUFNtcE5kVlZyYUVSalNYTmxhMHRXVFcweU1Dc3pSMVJrSzJoQ1drUjZjbWxaWjI5bE5sSkVDbE54WlhjMGVtTklWMVp2YjNsRUsyMDRaVVJJWTFwcmVEUjZSRFpOVDJGU1VVZHBialpvTUhkaVVFOXFiamxYTTBKWlZtZDJURk5oY21sVVN6WkdVVE1LVFRoTFRFZEpNV0V2TTFCd1IwcFRZMXB6ZG10amVreEpTM0pHYkVnNGN6aG1kRWRUYzFscWEzVk1TWGhEWldad1MzQjFjbTFaVnl0SWQxSllSalpuUkFwWFJrb3dOV3RQWkU5TGRIZEtSM05EUVhkRlFVRmhUVEZOUkUxM1JHZFpSRlpTTUZCQlVVZ3ZRa0ZSUkVGblYyZE5RazFIUVRGVlpFcFJVVTFOUVc5SENrTkRjMGRCVVZWR1FuZE5RMDFCZDBkQk1WVmtSWGRGUWk5M1VVTk5RVUYzUkZGWlNrdHZXa2xvZG1OT1FWRkZURUpSUVVSblowbENRVWxKVkdFMlR6UUtNWFZoWTNoNU5UazBOM1pqYmpKNEt6UlpWR0Z5Ym1KbWVteERhRlV5TldaRlMxaHBRbTgzYTFGdVpqTTNPU3QwUmxaWmRWVk9Uek5yVWxkMEx6bEpVQXB6VlVGSFZrRjRPVUpWWkU1UFJVMHJUMGRKU3pCa2VtaHNXQzgyZDBnMWNrSjZNMDFLT1c0NVpEbFhaa1ZGWlU1Q0wxWnRVSHB0T1ZkYWVXRjBWVE5aQ2xvMVV6aHZjaTg1Y3pGdE5uVnlRaTlTVUZsclNXeGxNMGxJU1VSNWFuSTRaR3B0UzJvelZuWnlTSGhIYUZCRFEwdHBOSE54ZEU4eFMyVkVlbGRNT0U0S2VpdHlUa2xGVVZaT05WUXJiSGhhYVRBM1UxRjZVVWhsYnpnMWJFeHRlbGRuUVZJek1XeEtVRFJCTW1SWFIyUXdZVEkxVmtZMVMyYzRabFZ0ZWk5dFZ3cG9aVTAyYjIxVWQwc3hVSFp6Wm01VldVTnVNRmhvU2xWQ01rVXpSRzVCYzNncmJEZGpTR1ZMTUM5MWJGRjBOR05xWmt4bUswaEVOMDV1VjNCblJsSkZDbFJ4Wm1RM2FrSnpWVEZZZG5FMlFrNDRlbHB1TmxodFdtaEdVRGw0ZEZWeFZGaHJTRzVWVm5aMFQwNUxNemhTTkRRNGNtMUthbFZsV0ZsMk1pOU9UbG9LUzBWdVJESnFOelV2VkRVM2JFbHJNWGtyTUZSNVdTOVNNblZDUTI1eGFFMHlSVEpyV1hKRE4xUXlNazVaTUc1UUswczRhRkJTWTB4UFIyWkdhWE52ZEFwUlRYQTFSazlKY214U1NUZEtjemsyUWxCdmVXUmtORFpuTkZSWVFVbGtSek5LVm5WU1ZGWjBXVFVyU1hOWFNqQlVkblpxWlhvMGVIWXJZaTlIWld3MUNuTkxLMGhxUTJsV2FIUm9SMDVEWjJWdmNrY3ZXblJ5WVhjeVptTldVa3R3WTJabU5FbFBUMHRVYTFaeFNrNUZSalJDTlc1V2NWUm5NSEpZV2tWcmRtNEtjVVZSYkZaQ1draDZLMFVyVXpGcmVGQndRVlJMU1doTGRUZEVjMjFMU2tzM00zRnJTWEJ0TmpOSFZEWk1VR2xOY0hGcUswNXBLemhXVjBsMU56VmlSZ3BIUWtsUlZsbFhZVVZvUzNCRmEzcFZUV1ZtTmtrMFVqUjVVMkpSZGpONlZVbGFkRUlLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MyZEpRa0ZCUzBOQlowVkJiSG93V0ZwNFRrMXZlV0phU1hSNFExTlZXWE51YlRKTVZYYzNVazFRTUdwMlptbG5OVVZFYjNjNE1VSnZPRlp0Q25Kd2RuSXdLMGRHVkVkWUswY3pNVGxDUzBRMlNuVTNZa1psU1RaMVZGZEtUV0pDUXpCVVRVSldVWEJ5YlV0TWFIZzVZakJoWTB0U05uQnJkSEprVlVrS2F5dEhTazh6UzBOcFNYZ3hVV1ZPV0dselpUQXdORFZKTTI1NGVUQXdWV1pGTDJwUU5uQkVWRXBYVkVGclYyOHlZa0ZUUWxnMGJrMUxXVTVOVm5WcU13cHljM2hWVGxvMWRqVkJaMDB6WkhObk4wTk5WbEJJVDNoTWVYbHhReXQyYWtKRVMxVjRVVzl4ZFhnclR5OXpVM0ZCWlhCYVRuQkhTemxUV1ZrMWRWcHNDakF5U0doUFdHaHBOMXBqU0hwdk5tcHVMMGd3YjNwdGFqWlVRbTFxYUZoSlNURm5SMGRUVUdWREsxcDJjRUppUzJadE0zZHFhVEoyY25KWmFDOXNjVklLWkhGUVdVTlNObGQ1VG1scFFsbG1kVkZRWTFCT1dEazRRek5YUVdwbVFuVm9VMXB4ZWxKNmQydHJXWGN5YUZwUGRHSk1XRTB2YWxSWGVtbEJhRTR4WndwWmVYTklOMWRMZGpWTVpUaEJVRTlPV1daRFUxUllla0o2UjFKcllXMUtVeTlxV2pnd09VNVdWbWx4WW1sMFMzTk1ZWEpyZW5OTGVXdHRhVmRQVjFBdkNtaEhZMjlhU0RCSU56aENjSG8wUTNKQlNrMTNjVnBzZFZob1JFTlhjamhYUjBOeGNIVk5NRGRYT0dwaWNHeDFUREZHS3l0UmRqUkJibUpIUkV3MFpsY0tiRFEwZUU5S2FrMTFWV3RvUkdOSmMyVnJTMVpOYlRJd0t6TkhWR1FyYUVKYVJIcHlhVmxuYjJVMlVrUlRjV1YzTkhwalNGZFdiMjk1UkN0dE9HVkVTQXBqV210NE5IcEVOazFQWVZKUlIybHVObWd3ZDJKUVQycHVPVmN6UWxsV1ozWk1VMkZ5YVZSTE5rWlJNMDA0UzB4SFNURmhMek5RY0VkS1UyTmFjM1pyQ21ONlRFbExja1pzU0Roek9HWjBSMU56V1dwcmRVeEplRU5sWm5CTGNIVnliVmxYSzBoM1VsaEdObWRFVjBaS01EVnJUMlJQUzNSM1NrZHpRMEYzUlVFS1FWRkxRMEZuUlVGcFpEbGxhekZCVEhkSWVITXpTbEJTVG1ZeGMwNWhNa1p2ZERGVFNsbG1VRFp4U21KQmJIRlBSamx1Y0hGblVVOVFUVmhXT0d3eVdRcGhTRXBsWldVNGJscHRNMlZRYkc1dWFtZGhhMHBETTBNcldFcElTak5IU2tkR05tTm5hRk5VU1dSM04wTnhUV1UxVEVKd04xSjJWbUYzVEdwWFZHUnNDaXRzWlZwdFkzaEpRbFJPVlVSTWVXTm1NemhUUzNKdVRIZERhRWRYZGpsWFJHSlFVWFpaUVVoU2RXWkJhbFJyVVhwNFRuTktOWEpSUjFORllUYzFjVllLVWtaME1sb3hXVnB4UlhVdlZURklaM2xFUnl0bU5HMHlaR2xCY1dOWmNEUk9RV2h6UlhGT01HNU1VbTlUWnk5aGFuVjNRa3hhV1VOWkwySkxTRTV6TndwNlNEWjJNV3RXUVhNeFNXWkNRMHBMTlVFeVJXOUxhMGwyTDJaQ056STRPRkZNY2psTllXazFVbmhMZDJoMGVuUlhTMlZtVXpoTFF6ZzFXV2RJZDJkekNuazRTalY1WmsxSFdqSkZWRVV5UlRVd2VsSXlWVzA1UzFGaldXOHJOV1JETkZGRE1HVTJUbEE1YURkbFMzTnFNbU4wUW10R1MycGtjMDkwT0dodlRrRUtaVnAyU21KV2ExWTJVelJqWlhwd2IycE9lVTFPTmpWNlRGRXpWMUl4YWxSbmNXRTBjelpEVVhScFVXZG5UVUp1YW5sNVZXbG5Xa3BwWkVsemQxRTNNZ3BKVmtzMlRra3ZNazlXYlZaTlZHTkJRM0pFVkdwQ1JVVTFNVWhXUmpNeVFVUm5Sak5tYzIxRFYyTnpSMGQ1VGs1VkswWXJhRXhqY0V4b1RXTmpRVnBUQ2t0eGRDdEtkazR2Y25NNGRHVnZWazlxY2s0ek1rdHNSRXN4Y2s5cVNUTmxjbEUzYlVGNmVEVllUSHByVGxBNGExQlJhbTVvVmpWWloxRmtZbTkxYzNJS1RsWlpkRVlyWm5FMmRVaHRRa2RMU1U1TlkwRTVPRUo0ZERrMVNISjNNMUpTV0ROd01WVmFlbWRuTkhwQlYxbHhVRmxhWm1wSVpsRTFkbmRoYVc5c1p3cGFOaXR1VDNObE5qaGllbkl3ZFdad1RpdExTR3hCUm14aWNpc3JSV2RDV1c4MWRWWmFkalE0VVZBd05XUjJRemh4VW10RFoyZEZRa0ZOUmxrdlprTTBDbEV5UmtWbFExbFhWM1VyTVhGeGJuSXZhMGg1UjBaTFJXUTBabEIxTWtsYVNGbzJWR0YyVkhGeFZWQlhkM3BYYWxGSmJuVmpRemQzY0hRM2RYbHRaM1FLUlhocWJXVXJXVmc0VmtSVmQwMW9ZMGt5YmtoV1JFSnJOV2wyUW1kVmFHTjJiWGx2TDFsM01ESkVVbmxpT0dwdE9TODJPVVpyZGpCdlQzSnpjbkZtY2dvMVRrRlNTa1pHVURWNVpTOHhOV3B0YXpsNVozaFhORWw1YVVWUVRsRTJObEJ6TUU5aU4wWk5hVXBLV1c1TlpqVjBhMk5ZUVVScVNFVlpPRkptVWxabUNrZFRlazQ0YlVWeWJqSktZVk00UWpOR2FqaFNiMmxCTDFKWWRsZFJPRFp2TW5KSVN6UTBLek55VGpOUmNEWk5ZMGRIVlRrMGRUbFRhUzh6YWxGRFFsb0thMUpCZGxWdGVUWkVUSGd6UjNGUlprcEdMelpPWjJadVYxVjRWbXA1UjNJMWRIWjNkMDFJTVhGdGJrRkhVbTlqWm5nM2VUVmFWMGhVZG5CUlFXOVhZZ3BMU1hoNlN6a3hSRk5WTlhOc2VEaERaMmRGUWtGTlp5c3JkRzU0ZWtRNWFrNXpkM1ZZWkVOWk9HWlJWWEkyS3l0amFtOTNhbTV6Y2t4WGNUUXhZV05GQ210eEwxTnJabkJTU25WUGJrNVlPVTlrSzJkWVVXWldkRGw0TWpWUVpHZHhOM3ByWjNKSFpXVjFUR1ZuZFdvd2NrWktZM1E0TUVSRk1uZHJWMkpJVUZRS2R6UnFiMU4xYlhKS1FXWm1lVmR2YVRGcFFubzJhVmxxYW1rMVdXdzVSMVpaY1M5bmFUZFlTamR3VTFkek9UaEVlbGQwY0U5b1RFUkdhamRRZG10RFZBcFhkMjVDYkRkVlFuSlNRVlJVVUdJMGEyNUtPSEpuZG1Wc1NHMWFaV3BCYVZoV1kyRmpaRmMyVjNVM1NqSmtiVWwyU0djMFoxZG5haXR6ZVZCcFIzWTFDa2RrYTJ0dWNUSlJPRE54YjBRemNtSnRjM1UxVkhaWlNURkZhbVJWTkV4UFZFVmxXRkZOTjBsUmNqVk1kMk5sUjB0d05VVm9NVVo1TDB0RVVIRlRNR2tLZDJ4T1NGQlZUakZGTlVKaldtdFpVSHBSZDBkRk9YRnZOMnc1V1hOaU5YaFpUa3RKYzA0MFYzaFVWVU5uWjBWQlVEQk1hREkxWnl0dE5USjFabWt2UlFwVmVtZHhabVY0TUZKYWJIcHpaRkZpTUM5cU5VRTFSR0ZMZURseE1raFlURXRwU1dwMmRrbExWazVqUzBvMlIyWjRPRTU2ZDBsQk0wSnRaWEpXUlRaNkNrc3hTbWhRVnpGQlVGRlVNa2M1ZEROdlFYUjRVa2czY2pReGRYSnJaWFJqWW14VFprWkxibFp5UzJseWJXWkRVbXRwZDJOMlZqWnRaMEp0VEhVemMyTUtWVGx2YlV4aFdVdzNVakZDVnpnMVQySkhRM2RoU1VGNGRXbEJiVVpYYmtsTFlrbExiMnBsYmtaNk1rVlhaemwzVWtaS2FHcGtUMDk0YVZWblZVRkVXUW8xYmtwTE5VMDVVMGhTUzJzM1JUUnVZWFY0YUZKVldHdFJSbGd3TDFCdlNTdHZObWgxZGtkbVdHTnFVVGR4VFdkdlRrcDRSV1ZUWTFoVFNrOXZjbkZDQ2tock1FOUVNMDFPUlUxWmNWWlpNbmh1ZUU1RVowc3phRWhGWkRadGFuWkxTbFV5ZDB0UFdEUkNaVlpPYW5jME1XNW9jamx4UkRseVJtZEZPRGhsYkhBS1J6bHlWakozUzBOQlVVVkJibmhsUzJKVlZubEtTbkJMYlhkWWNtVjVUa2xrT0dSSWJtSlZUbEUzV0RSUVZuTmphR3RITjFoVGNVRTRSR1V6ZVhONFZ3cDJWaTlJV0ZKSFYzRnJjSGRIVUVnME9YbERTbEpuYXpKaWIycExPRXhvYkhkV05YUkhUbEF4VlM5amNEUkVaVWRZYWpNeWFFUXJiV2hyYzI0eVYxbHFDa0pwTmtJNE1WVnBSV28yUm5SVE9XbGpkV1p2Um5Cak9VSk5ZVGwxVUhoeFJrcDBNalZMVVRoMlF6SndLMlZaVFRodVNsTnJWRTlDYWsxeVIwbFJWRzRLTTI1SE0wbEVRakZEV1dsT1RIUnFlakZZYUdWWU5HVjBOazV2Vm5aMGVVVkRiSFJOVUZWM2NHdE5iM28xWlRGUlFVNHlORmxVUWxSdVVGVXZURVkyVWdwVmN6TmlTSEF3UXpaM1EyRXZNVmxqWTNCbFJrWmtUMXBRZG1WdloyRkZVbWhsWW1sWFoySTJURk4yT0RWdVZWbDVVbkY2UzJrd1NHWjFjVWRtWlZkNUNsZFhkRkI0YWtsbWEyOUllRzVFVUVONmRsaEZiMkV5Y1ZsNGJ5dHBkbEpGVlZGTFEwRlJSVUZzT0RseWREVjFVSEI1TldkeFRVVm5RMEpIVDJwWmNsY0tUVmR2VVdGM1NFOTRibGd4U2pGWWFtczVUa2h3ZFcxSFEwSm1kVTVNWVhNdmJUVk1RWEUwV1hkemQxWnBkVXhDV0UxRFRVRTRTa1JZTDJ0R2RWUlZMd296Yld0emNrdEVPWEJVTURkSWFEVm9SRXcyTDJaUWIxTkllRFVyYmtsM05FeHFXVmRHVlUwMldGbEJkU3N4VG5aNU4yaElMMGd6UzNOQ09VTXlNMEUyQ25aRFZDc3ZSSGxCY1VSUlJHaHpVaTlCT0UxTlFWQllia1p0YkU5dVJERldRa296WlZSTWJsWjZVR05TWTJkM1RraG9VRXR4VVc1WFowbHNRMUpOU0VJS1ZDdEdTbkIxSzFKak9YSk5Va0ZpWkhKRFlsZFBVRTV1ZHpFd1MwdHZkakF2WlZRMmRWUkpZMGQyS3k5b01HbFdibU5XZFRjclRIRk9ZMHBKY0VFMWRBcG9PVzFpY2sxWVVWcFVlREJsY0VKQ2F6Wk1kVFJJUVhsbGVqVk9OelJyZGs0eldUaFlUSE56Y2pnMVRrTkNjMVI0VjJWSWEycFViR3BEWkdNeWR6MDlDaTB0TFMwdFJVNUVJRkpUUVNCUVVrbFdRVlJGSUV0RldTMHRMUzB0Q2c9PQogICAgdG9rZW46IGNhMWY3YjE1ZjNkZmVlYzU5ODZmOWI2ZTE2OTJlZTMzCg==\"\
+        : {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVJFTkRRWEpEWjBGM1NVSkJaMGxTUVV0WWVGaERZbWhpWkhGb2RtTjJVVXhtUm05S2VXZDNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJuZDAxVVNURk5ha2w0VG1wQmVsZG9ZMDVOYWtGM1RWUkpNVTFxU1hoT2FrRjZWMnBCVGdwTlVYTjNRMUZaUkZaUlVVUkZkMHBxV1ZSRFEwRnBTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblNWQkJSRU5EUVdkdlEyZG5TVUpCVFVKbENtZHdZMDh2UVhOTWIydE1SMGw0T1VwU1N6RXlielp6WnpOMlpVdGpOSGcwTDNSV056QkVUWEpGYlV4emRuRTNUbXhFV0VJMVRGTlVkbnBHWTIxTVVIZ0tURVptU21sUmMyWnVVMjlYUTFneEwxVnlUWHBVU0hCTVdIQndXV3cwT1RaeFdXVnNiVUpEYkU0NGJHTlVibE56T1VoVU4wUldaR1Y1WW1FclRqTTNMd3B6Y0VkQ2JHUTBkV3BNZW5KSWRrODVSMmM1TTJsUFMySlljVkFyUlZCRFVXOURaV1ZRWVc1WmNYaENReXR0Vm1aS1dHMTJWbGN6U2xWc1oydGhiVkEwQ213ck0wOTVTVFZKYzJack9HUXZNbWh4YjNrcmEyVTFaVXRIWmpGNmVYb3dhVXBpVUZCck9VSjFMM1pqZDNWa2RuazRSM2MzTVZWbE1XRnBZbVpSWjIwS2RraGthRVIzTldod2RVdDFWMjF5Ym5KYVRVSkpORlUxU0dNNVJqUTRTa3RCYlVsMlpHMUxjMDFKV2poMlJsTk5TR0Z5V2xwRllsRmpVa1UxTDJRd1J3cG5kMFpNYnpSbVpWTmxTMDVrVUdwMllrNW5lbEJHUlU4ME9YZDFUa3hhYkdSNFptWmlUVTlzT1U4ek5YRXZLemxoTWpOSFkwVlBhVGRUYVU4NVNGVnJDbnA1VGtOUWEyaEpObU5JV0ZFeFZUUllUbE5pY0d0amJGUnZhRFZZU1VJeloxZzNXVWhQVVdnNGRrbEZVRWt3YVhoM2VIZFJOM05NWlUxaWJqVkpkMmNLWldnMGNsaFNWV053VlRsQ01UTXdZbFF2YmxoTlZHcDBUVU4yTURabmRsTnZWbWwxWmpFdlVVczFjMjVYVVN0dlltODRSMjV2UzBkV00wVlNOM2x4TmdvMFV6ZHdablpNVFc1aWQwRk1Ta0ZEYW05Q0wyZHBWR0pZU2xkeVZrZE9PVVpCT1RCd2RGRmxhRGs1Y0hsNE1EUm9SMjVPWnpGSlNGVm9UMk5YY25wSENuWkVNMU5YYm5GME4zaFVUMlp3YW1OVE56QkdOSFZ2TjJzNFRVdExiMDF3U1V0RWJFOWhhSGRKVTAxdGMxaGxhbGhRYjNsTlQwOU9MM1ZFVkZOeGQwRUtWRFJMTXpWWWFFUmtXR0Y2UkZsM2JVMTBRMWxIUW1GNVF6bEJSa3RoU1RjeU16UjFiaXRtUmtGblRVSkJRVWRxU1hwQmFFMUJORWRCTVZWa1JIZEZRZ292ZDFGRlFYZEpRM0JFUVZCQ1owNVdTRkpOUWtGbU9FVkNWRUZFUVZGSUwwMUJNRWREVTNGSFUwbGlNMFJSUlVKRGQxVkJRVFJKUTBGUlFWUlNlVE5zQ2sxV0wyczBhRXB1WkdkdFNYYzJLM3AyVDNKck1VY3llWEp3WmpoRmVWWXJXV1I1UTJkTlExSk5VVWhJWmtSaFNrbFRTWEZFUlhGaFZrVnpTemhLYm1rS2FsQlBjSGRGZWtsNWRqSkxWalYxU1ZaaFZYSlVOSFpJVVZaNGRVcFJaMUpST1Vnd2QyNUlTREUyTjJ4cmJHY3dWM05ZYmxkVWNURmhNMGRqTjJadWR3cGpMMFZsWXpNclIzWlBURXBqTmxvNFYxWlllVVZOYUZWdVZHc3dObkJLVGxCc1ZuTm9XV3QwWlZGdU1WcG9iM1UwV2pWc01HNXROMnBNZFVWcmNtNXBDazlzWjFwUllWVlRjVE5CYTNjMWJFcEtkams0VGs1a1dISlZiMmhWYms1R1FsSllZVkZSV2xobGJXbG1VMkZrZUZONmEyOUtjR1JtZVdKeVNERlphVVlLZUUxcVlWUjVUbFIwZEhKblRtZDFjbWMzUzB4R1ozbDVSVEF4Tlc5T1pYWk9RV3huYjBoWlMyd3pZak1yY2psU2FuWnFWbXAyYWtjMlJWSjFhMDF3YXdvdlpUQlRXR2RQYVdwSWFsQjVLMk5OZFhSdk1XdFlWVW8yWWs5Wk9VOUpURkZ6Ym1WRWFqRlROVGQzTXpCdlUweGlSbGhDYzNFNWFqZDZRaXREWlVsVENqVjVhamd6VGxaVVpDOWpNVTEyVVVzd2QwSkRVazFDVVZWRk1VNXRXVFZZVUV0NFQzYzNhbGxLY21SVGVTdHRTbFJSWVc5aGJIRjVlbnBQVWtaS1QyZ0tNMk5LT0VWUFlrWkhaRVZEUm1sMVprMWxhelJIVGpGeE9UUlpZMFI0VkVadFlVeEtSblUwZFU5b2NUZFhUSE5hWWxGeVMwNTBTalpLTUUxRVRqWmlWQXBwTTBKME4xRlVVbEpoTmtobWNWRXJRa3BPZVZRNVEyVnlla2hJTm1OVGVWWTNVSEIyVG5SWlRFUTBWMHhOU1djMlNHWldaV0pyVEZvMlZtNHJlbWhVQ25WUWMyNXNaMjlsY2s5bmJFNXpPRWcyWnpSeVNWZEJTRm8zTURWemVTOTNlR0pTUWpCRVNHRTRTemwxYUhKSWQwMHlNREZDTDNWTVJVcGxiVEIwY0d3S2FUYzJlbWR0VUZkNlQzWjNaWEZPY2xKdmNuVjJUekZCUm5SdmNsUlRWV2xwWkdaTFFuYzlQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2xpYWtzZG5zN2J0a3E2NS1kYWYzZWRmYS5oY3AuZWFzdHVzLmF6bWs4cy5pbzo0NDMKICBuYW1lOiBjbGlha3N0ZXN0aGFtbW5yCmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBjbGlha3N0ZXN0aGFtbW5yCiAgICB1c2VyOiBjbHVzdGVyVXNlcl9jbGl0ZXN0cjZtd3F0eXJwaV9jbGlha3N0ZXN0aGFtbW5yCiAgbmFtZTogY2xpYWtzdGVzdGhhbW1ucgpjdXJyZW50LWNvbnRleHQ6IGNsaWFrc3Rlc3RoYW1tbnIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyVXNlcl9jbGl0ZXN0cjZtd3F0eXJwaV9jbGlha3N0ZXN0aGFtbW5yCiAgdXNlcjoKICAgIGNsaWVudC1jZXJ0aWZpY2F0ZS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VVNWVrTkRRWFFyWjBGM1NVSkJaMGxTUVV0aU1FVmpPVmhwTkV4bU5WSldVR3RCV2pOdFkxRjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJuZDAxVVNURk5ha2w0VG1wQk1sZG9ZMDVOYWtGM1RWUkpNVTFxU1hoT2FrRXlWMnBCY1FwTlVtTjNSbEZaUkZaUlVVdEZkelY2WlZoT01GcFhNRFppVjBaNlpFZFdlV042UlZCTlFUQkhRVEZWUlVGNFRVZFpNbmh3V2xjMU1FMUpTVU5KYWtGT0NrSm5hM0ZvYTJsSE9YY3dRa0ZSUlVaQlFVOURRV2M0UVUxSlNVTkRaMHREUVdkRlFYcEtkMWRXY0V0UloyUk9SRWRtVWtaeFJWcFVlSEJpTlVoR1V6a0tZMlZJVWpOUk9HaHFaak0zTlVkME1uTkdLM2RyTHpOeUszRnVla1JwTjBKRGFXMW9WRkVyVjFBMmFFbGlZazVCT0RWVFVIWmplRVpNVjBaaGRYcE1Vd3BwZEd0V1ZHMVlhRnBvZERaVVpFMDRORXBsU0N0Nk5XbDBWMk54ZFZsM1drZDVNbmswUlRreVNVZGxSMWhIVTFOQk1YcHdjRXhSUkRjelJtaFJNM0pYQ214UFpTczJZVXh0U0VveVQwNVFhalZoTUZjM00wa3piSGN6UVRCWlNEVnFUVGhUUkVOeUwyTnFSbVpZYjFObGVHSXZhRVpEZDFkU1QzYzBja29yU0VJS1QzSm1PRVZwU3pGcFQwMTFSRzR6V2xsMGVIUmhhSGN3ZW1GSGMySTVUSFZMWTA1dFIyVTVWbHBMVTA1VUsyRmxZMUJ4WVVOTVUwWjJNVVV4VDJ4UmJRbzBNbVZrUzNnclRGQjNWMEpQTTI1TVRqbDJSVlJhWTJsbk9ITXpaMlJ1VHpGTlZ6TkllVVIzVm1SU01ETTBOV0ZNUjFaa2NuQkNLMWRNSzIwemN6WnNDbE5LZVhoYU9WY3ZOVVYxVGpVclVVTkdWakYzYW5GaFowMTBWMGxrYlVWSGRESXJkR1pxVWtsRlVHdFhaVlZpVUN0UU1ISjVZbWRSYUcxb2RYUjBXV3dLTmxaMFprTlZhM2g1VlZGeVEyZDVPR3A2YlVKdWNITlZjVlkzUjFGcVQzVnFTWFJpUXpaS2JqZHJNREZDU0hCWWRGZzNUM01yZEdkV1dGTkpWMGRpZVFwQlFVTXpLM052UjBWelNHbFJiamxNY2tOek9FOHliSFZHUVZCekx6SnROekU1TVVOMU56SnlNM0prYlVkNlEyNXdkM1JSTlVFelFrMTFiMjR5UkRNeENucGFOVGhGZEhoS1ZFMDVlR3hpU1ZCbmNHa3JkWFJ3YVhaRlF6SlhhbE1yYlZwWlRFdGphRTVsUVdOeWNYTjRPRzFVYkdKRVdVbFBMelExTjNjMFZ6QUtXWEpXYURKR1VFVldUa2hwVm5aT2FWSktlRlZ4Y25wRU5taDNMMElyTWxWWlZUQmlWRUY2TlZOTmFIb3dLMnRDVFRoTVZrVjNjbEpqZVM5T2VIaGlkUXBVVjFKSFVUbHdVbVpYV0dSMmNWVkRRWGRGUVVGaFRURk5SRTEzUkdkWlJGWlNNRkJCVVVndlFrRlJSRUZuVjJkTlFrMUhRVEZWWkVwUlVVMU5RVzlIQ2tORGMwZEJVVlZHUW5kTlEwMUJkMGRCTVZWa1JYZEZRaTkzVVVOTlFVRjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRVVJuWjBsQ1FVbGtkbUpFZEVVS1UzVXlkaTlNTUc1aU5Hc3dkVEJKZVRaNU1ITTBUWFZ0WkV4VFFqSnNiM3BRTTFGWVIybzVhMlpzVTNKcllqWXJlRWwyV1dGMmJtTXpTVEJsUkRkTWNncEpXVTh2ZUU5aFQwOWxhVkJHUTFKUGVrVjZaR0ZZVDJkMWJUQlVkbkpaVEUwNE1tcEVNV1JrVTJsQmRYaFJRM0l3VW5keE4wOWxhbmxJWTNsdVVWVk1Dbk5DYzNKNFVDdFViMmxwV1cxRldVNHhWM2xOY2s1eFlYbFJVazlsU2xWNFMydDJiemczYTNSYU9Wb3pkVWxrWVdka2JXUjNabGhTU2pndlVrMWpRVGtLTDJzd1VFVjJiVE54YTFGek0wbFZWbWgzY2paSlltaHRZV2N3UVVKeGNraEdMemg2VTBKaFJYcE1OalJpUXpaa1l6ZHFRbFI2UTBscmNHbEdOUzlYWkFvNVpEWlpVR2hGVEN0bFJDdFlVV1J2UkU5dGRsa3plVkJRTlhSMVlWVnpka3hOZVdjeVJ6VmhVVVZzZG5BeWFITnJNSGRHYlZaTGVERnVaQ3RXY1dWNENqRjBjRFY1U2pobWRVTnlMMGN6UWtabWFuVnNWR3NyWW1nNGJtNUdWU3N2ZEhOc1YzRk5OVGhpTjJSeFdXZFhTRGt2WlZaTlZUSk1Xa3RzT0UxeGEzRUtRakphVGxvNWNsWXhNa0V2Unl0RGNXZFBSazFCTmpsUVZFdEVSRFJXYlhRME5saEdNRTVzU1hwSlFuTmxXbHBEV0RGblVYSXhXRU4wUmlzMmJIcElWQXBwTnpSNE1GRTBka1ZITWxsNU5GZDNSRTloUkdKYVVsbEROVFl3VmpGV2FGZENNemhhUVhwNmQyWXhLM2hQZVU5dldrcDVRMWxxVDI5NmJFSjBPRmxZQ2xVMGRtZFNkRU53U3pWclZrdzFObmhDZGsxcmRFNVJSWEV4VG1OQ2FXWjRiekExZWs5UWVGcDFRblZKVjBWdlN6bFhlbGRpUnlzME5GZEVibEZMYVZNS1YxUTJWbFpETDA5MlpURXhRMUJWVFhWalpsWXdjV3BRWkZSaVVqSktXVWRaUlZOTFFsTllMMVp4VGtsUlQzSlZjRTEzWlhkTlR6SmlRVWhQZFVoeVZBcFRiRWRUZFdWemFuTnRNSGhRYzBOSlIzVlhXVVZLV1V0Mkx5dEZTRU42V0ZkU1ltNEtMUzB0TFMxRlRrUWdRMFZTVkVsR1NVTkJWRVV0TFMwdExRbz0KICAgIGNsaWVudC1rZXktZGF0YTogTFMwdExTMUNSVWRKVGlCU1UwRWdVRkpKVmtGVVJTQkxSVmt0TFMwdExRcE5TVWxLU25kSlFrRkJTME5CWjBWQmVrcDNWMVp3UzFGblpFNUVSMlpTUm5GRldsUjRjR0kxU0VaVE9XTmxTRkl6VVRob2FtWXpOelZIZERKelJpdDNDbXN2TTNJcmNXNTZSR2szUWtOcGJXaFVVU3RYVURab1NXSmlUa0U0TlZOUWRtTjRSa3hYUm1GMWVreFRhWFJyVmxSdFdHaGFhSFEyVkdSTk9EUktaVWdLSzNvMWFYUlhZM0YxV1hkYVIza3llVFJGT1RKSlIyVkhXRWRUVTBFeGVuQndURkZFTnpOR2FGRXpjbGRzVDJVck5tRk1iVWhLTWs5T1VHbzFZVEJYTndvelNUTnNkek5CTUZsSU5XcE5PRk5FUTNJdlkycEdabGh2VTJWNFlpOW9Sa04zVjFKUGR6UnlTaXRJUWs5eVpqaEZhVXN4YVU5TmRVUnVNMXBaZEhoMENtRm9kekI2WVVkellqbE1kVXRqVG0xSFpUbFdXa3RUVGxRcllXVmpVSEZoUTB4VFJuWXhSVEZQYkZGdE5ESmxaRXQ0SzB4UWQxZENUek51VEU0NWRrVUtWRnBqYVdjNGN6Tm5aRzVQTVUxWE0waDVSSGRXWkZJd016UTFZVXhIVm1SeWNFSXJWMHdyYlROek5teFRTbmw0V2psWEx6VkZkVTQxSzFGRFJsWXhkd3BxY1dGblRYUlhTV1J0UlVkME1pdDBabXBTU1VWUWExZGxWV0pRSzFBd2NubGlaMUZvYldoMWRIUlpiRFpXZEdaRFZXdDRlVlZSY2tObmVUaHFlbTFDQ201d2MxVnhWamRIVVdwUGRXcEpkR0pETmtwdU4yc3dNVUpJY0ZoMFdEZFBjeXQwWjFaWVUwbFhSMko1UVVGRE15dHpiMGRGYzBocFVXNDVUSEpEY3pnS1R6SnNkVVpCVUhNdk1tMDNNVGt4UTNVM01uSXpjbVJ0UjNwRGJuQjNkRkUxUVROQ1RYVnZiakpFTXpGNldqVTRSWFI0U2xSTk9YaHNZa2xRWjNCcEt3cDFkSEJwZGtWRE1sZHFVeXR0V2xsTVMyTm9UbVZCWTNKeGMzZzRiVlJzWWtSWlNVOHZORFUzZHpSWE1GbHlWbWd5UmxCRlZrNUlhVloyVG1sU1NuaFZDbkZ5ZWtRMmFIY3ZRaXN5VlZsVk1HSlVRWG8xVTAxb2VqQXJhMEpOT0V4V1JYZHlVbU41TDA1NGVHSjFWRmRTUjFFNWNGSm1WMWhrZG5GVlEwRjNSVUVLUVZGTFEwRm5RVVV2TldOdlNFVktPV1ZYZVRsUFNrNTJSR1pFUkM5RVNYWjBMelE0ZUhab05tWjNSV2d4T1N0TllpOWxhRlJYVldnMlIxVlpXbGxvZWdwbmVqZHBRV0Y0V1Vad1dtdEVZbVJtVUhFM1MyaEpiVk5oUjJkVlQweHRabk40YTJwdVZGRkNRekJ2WWxaWVlVTmhhazlzYUU4MGEyWkNlWEpOT0RjckNsa3lZa1p1UkUxMlpXRkdORWg1T1ZGSFNVUmpjR2wwY2tFMU4wa3ZZWE5VYlNzclkwTmhSa2hWWkhoMlVFbFpXakI1T0RoeFMwcDZUeXRCZFVONFMzTUtaazF1ZEc1T1NtRnpPVGgxWVc5TWVFRXJaelI0VVdKcGQzZHpUMDR3Vm10dWQxazJZV1kwTVdKNlYybEdNMHR5YkdaV01tcGpNelprY0M5MmJXaENPUXBXZEdwTmJXMUtia3BqY1daUU9HNVlPWFJzVDBJd1JUSkVlbkp3VG5CSGJsVkRSRE5GZWxCeGRITlhVRVExU21SdmNHTk9WVlZuVmxsVGFrNXpWM2N3Q25SME5YWnZhbXBqUVU1RUswNDRaRE5KY1VsbVZGbGhhRmRvVWsxRFdHOVhZbkZMZVRoM1ptaDFORmRYUTFwS0sxaHRiVGQzZFZGaVkxUk5ZMjlXYURjS1drNUJZVmhQYVN0dE1VVnZVVTFQUlhJcmJub3pZMk5DYm1OTk5pdDBWbGhCUTFsNVUybHVZMGxDU1RnMlYwWmpiRXBGVkVaQ2FuVnlPVzAwYVZWWFJBcFhOSGx6ZUd4MFkyRkVWVE5qYUhrMVJqSkdkazFDZUcxVFZrbHlXRzl6VVhadlYxVjRWa0ZPVVM5bGVXaHJjRE5RZDB4a1VYTnlRakJRUW5WR1drSlFDamc0YW5JclFsQTFTR0ZPYmxCTFVFVTNlRnBMV1hWSVJEZHBNVUoxV2xkcGVtdzRTVXg2WXpsd2JsTkpaRzh2WTNOV05GWnZWbmRES3pGSFozRlNXQzhLYldWMFJrdFJiRGg2U2s5a1pWRkRNVGhYZEVVMkwwVnFVRVpGZGtaRlJURk5OMEZ4WkhRMVNubHFNamRSVVZSNWVHdERRM2hQYXk5YWVXb3lTRkZpVkFwRE5IWm9kRGxEVGpGVmNUWXhTalJOT0M5NmFsaERSRmsxUW5kdWNGaFhNMlpFZVM4MVltbHFhVVYzVTBaV1dYSjNVVXREUVZGRlFYcE1ZVTl0VjJwc0NrcHpWMk14TkRaQlp6Tm5ORXNyYlcxSk1TdGFNRlJtU0dkR2VEVndhRzk0UzFWeFJYWnpNVTluWjNGWWNUTmhUMlY0TDJVNFkwcDFaSEV6WjBacGJqWUtOVXhpV1ZsV1lTdEhSM1F2Vm1WS2VsVlNlVlpDZUVOcllrSk9XSFJITUZWUE1rTkdhWEZzTW5oM1ZuWnVaRXR5U1RORFMyWjZPWGxMYlZNd01sZFFRUXBYV1ZjellYaElWWEJDYjFCNFNXOXBVMWRyY21oNk1UZHBiV1F4VGxGV2NuQnhNREJsYjFkcmRuTlhRbXBqSzB0RFpIUlZjMWRtYlU5Q05sbHRhMmxOQ25oQ055dEZLMHBwWjNGWmRuRk1lVk4zV0V4S04yaEVhSEJRVFVOdVozSjVjR0pEVkVaSFptSnFTbVpITUdkd01WZzFTbUpRTkdKR05EVkdhSGxtZGpjS2RrOXFkRzVUU0VORlRHMHlOWEJVUm5wM1ZFMXdibkpMWkdjcmEyaENWRFJ2WVhKVVZsSm5OMjVTS3pKTFRGZFpaVUYwTm1KVWFtTTRRemt6UzA1T2Rnb3ZhMDlJTUZaMVdFVmtaekJPVVV0RFFWRkZRUzg1TjIxR1FqSlpTRWRrZFM5SFNWSTBlVGROTVdaeU9FdExhRGxDVUdkNVZtTnphRWtyV1Zwek1uWlpDbkV5WkZORlYwd3dXaXQwU0hOWFZ6TjZZVGxoYmsxMVZVcDZPUzkzVlRWM05FaEZlRk5qVVVkbVVWZzJaR2hDT0VkbVNtVldWbXgxV2pWWVdXRkZUQzhLUXpndlMyNXdLMnBxYWpaWU9GQkROa0pGWmt4Q09UY3JOMEZGY21oak5EZHpWVGM0ZFVKYVRuSlRWMWh6UlVOdUx6QkRWVGxVYVV4dlUxVmpOWGc1T1FwMWRqTkxja2xQVWtKclVXaFROa1J6VWxwNmVpdGxOekphTW5WaEwzcDFSME50YkZSeFN6bG5SbFp2YUN0dlozSlBPWEJCWjNKaFdtOHZOVFF2Tlc1SENtZExiV3RFYVV4YWEwZFlkVFE1YTJwUVNYZzJjbFZUYlM5S1V6Ulhja1JIZWpabWRWRmthVTFYWVhSR0swWkxTa2hYZUVOQ05Vd3JibUZOUjA5RlUwOEtTekpYVjNsaFdVNTNWV1V5YjJWYVowSktRalJyV21KUFVXbDZRV2x2Y2tVeGRtMTBUR05RVDNOUlMwTkJVVUpHY21OSE9UTXJSbGh2UWpKNGJGUlRWQXBETUVZM1YwOHdUM293VTBrelVXRlFNekp2WTNGdUsyWlJWbXRNY0U1QllraFZXR2QxT1hKc1pEaFRiak16YXk4NWFFUXpSMnhVYlhOdlNGZEtMMDVQQ2xad1EybERRa1ZsVVRZNVMwWXhWVkEwUlcxVVFsTnVSWGxEWWsxUGMwSlBTRGhEVGtwS04xSXdhMWRvTmtaUFVYTklVMHRLYUZSaWJ6bE1OVzgzYTFFS1NHcHlUblZCVEZKdUwxZE1PRGxhZDBaeFZHcGFhbEIwUzB4c1lrWjBRWEpwZDJnNE16STFjSGx1YWpaYVdsbE1PV2RaVmxKaGNEaFBkSGhoYjJ0NlRBcHJXWFJhVlUwMVdFRkNOVkphVUdWWk9FbHZjMmg1WkhWV1JISk1NRVZ1TDJkak0xQjNibGRRUlZRM2VqQlphbUl5Tm14QlYyWXJiVzVzV0RacVVHOUZDbEJYU2s4ck9HRlZiakZ4VmswcmFHbzFVa1Z1VlVGblRUVjRkRVowU21wa09ESlNTMWRRTVV4d2QxTkdNWEozUmtkUVRHcE9OSHBCU3k5Wk0zZFpaMklLVERnNFpFRnZTVUpCUkdrcllpOTJjVVJFTDFGWFNHRXdUVkU1VnpRMmNGbDJUemgyV0c1d2NIRktRVXRQYkVaQ2VVWldXVUl6WTB4MFRrZFRVbTB4T1FwaGFYSllVMmR1WkZvMVZEWlBUMHg2V0VKMU9HbzFMMWQxYmpKSVkxbEVjMmRJTUV0aWRITTJUM1F4YlhSbGRGY3JaVlV4V20xYWVVMUtZelZDUVdGYUNuSjNlVW81YkdKWmNsSm5WSGhwYTBWdlYyaE9UV3RRUTBwd01sVndTMnhRWlhaS2JHaEdlRUpOUldWd2Qwb3hLMGswYWtkSVVsbEtSSEJrZG01bmRuSUtkRUUyV0c4ME5WVnViVGRDU21ablRtcDRVVzVYVkZOYU5IbHRNM0YyUmxKVFpGQk1kWFp5VGtSb01YVTNWMlpJUjFsS2JEQm1XR0Z4VkRGU1ZWUnhTd3AzU1ROaVN6aDBWSGhEYTBVemNIVktVamxGYXk5NFNYbFNZelZ2Wm1ObGRFTm9iRzFDUnpVMFFXSlRORlJ4YzJFMmJHY3dTeXQwU0ROclltVkJjRXh2Q20xdlNWSkhlRFJ2UVM5VlZtOXhlR1ZVUm5wMFNsaFpabUpPTmtoWVEwVkRaMmRGUVVaU1MzQXpWR3h5VW14R2JYTnlSbkp3YURNd1puRlZWSEpaY21FS01qRjBiRTlOWVdoeFlVcFBSMVZ6TVVJeGRGbzRialpqZVVSQlVHeHRhazl2WW0xdVVuQlJiREIxT1hJeGJtc3ZXVk5NZWt0QlpGVnJSWGxFVjNGVGNBcHdjMmxuVkd4Nk1EQm9kaTlwZFd3M05rUjFOVmhpZGxjdlV6ZEplWG8xZVhCWk0ydHVZekZDTnpOdFdtOVBUV0ZHYWtscWJYQTBaVTVwYVZSTGNrRk5DbTlxZGswNVJGbHlhelptTVVkeVNGcFRiVWsxZFVObU0xTjJjRko1ZUZKMGJsZzRNU3Q1UzBORVQyVlRMM2RwTVhndmNXZGlUazFwZG5Wak5YUjNOWElLYlVoWk1pOWxVekpqWkhaMFFYcHVNbVJ5TVhScFozaDFZbU5JVmk5RFpFTlBaeXRZSzJwQlYwbEpkRTluTWxwWlNYWTNXVXBhTjJVeVp6SjBSV2hwZGdwM1l6QXpkVUZDZUZFNFJDdDNVR2RZT1dad1lreDJMM1ZxVDJsT2VsUkxWMlJtU0ZOTWJVdEVZa1pLV25SelJuQk5NV1ZaWms5alQzTkJQVDBLTFMwdExTMUZUa1FnVWxOQklGQlNTVlpCVkVVZ1MwVlpMUzB0TFMwSwogICAgdG9rZW46IDk1NWI3NzgxNjBlZWZjODU4M2FjMDViYTVlM2VlYTE4Cg==\"\
         \n  }\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['13059']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:28 GMT']
+      date: ['Thu, 25 Jan 2018 22:24:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -845,7 +1188,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -854,13 +1197,13 @@ interactions:
     body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003/accessProfiles/clusterUser\"\
         ,\n  \"location\": \"eastus\",\n  \"name\": \"clusterUser\",\n  \"type\":\
         \ \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\"\
-        : {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNGVrTkRRWEVyWjBGM1NVSkJaMGxSVTJGd1dtVnZSRkp4Tm0xbWJXb3hPQ3RUUWtwUVJFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMFJCZUUxcVVYbE5SRUUwVFZSa1lVWjNNSGxOUkVGNFRXcFJlVTFFUVRSTlZHUmhUVUV3ZUFwRGVrRktRbWRPVmtKQlRWUkJiVTVvVFVsSlEwbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGbk9FRk5TVWxEUTJkTFEwRm5SVUZ5VTBsc0Nra3ljWFpLY1RreFlqTlBXRms1UXpoWlNIVmFaMlJMVkdJNVNsRlRNVFI1V1VkSlJGTndNM0UzV2sxalFXaFJOekJRU1VaUU1sUnJZWFJYVEV0T1ZVd0thbUUzYURJNFJrNDRNVmxRTjB4c1owWnlXa2xDWTNSSk5IYzNRekpxT0RSS1NFSklhWFJCVDBwbFpVRlRSMWc0WVd4b1owazFTQ3QyTTJSellXUTBTd28xYTNKRFdIb3daM0Y0Y3pCcmFscFNjalJqVERWeUx6Z3dMMjVoV1doU1NVMXlVV05LVlVodk5tZ3hURGRHTUhWVFVrdHZORFJRVWxsRlNIVjBiekZXQ21KWlpVbEZhalJ3TUhJNVRFRklORzlJYVdzd1EyaFRjbUpUV1U1cWJsaEdMM2xSZUZSU1YwbFBaa1l3U1ZaSVlURkpSa3gxZWs1aGNDdFNaMHhWZDJnS1UzZEJUVzlIYlRKaGRrMXNUVnBqTkdSaFVEQjNWQ3RwVVhKTk5IZzBNRFZrYlRoNFEwczRTRUU1SzJkR1V6TTBkRGxpVFRoRlptNTJZbGhKZDJ4TWR3cHJTVkpWWlVNMlZHSlVPRlpCVTNVMU0zRnJNbXRZS3psd0wwUkpOV1ZLVldRMFZtVjVWV0ZoYVhOeGJucHdOa1JXTmpWNFdGaHphekF2WW5KalQzbEJDbXBSUzBwelVYYzVTMlJYUlRCalFscDZkamhrU0hKVWFreExaVTFwWXk4eldXeHphWE5VZURSM2JHaEVaVmN6TVdGVUsyVnhWeXMzZEVsekswNDNURGtLTVZGTk0ybHVaVzl0YjJkdVVrUmhhVU5KVlUxMGNFczBVMFp3Y1dJclRuWjVSRFV2TjNOdGIzbHJOMlZtZUdWaGJqaFBiVU51VVZSaE5Tc3JhRTVRYUFwd1pTdDBUbll3VTFOeFZubFRhMHhyWjFkbWIzQnZNMk5EZDFkYVJsRlBjMDE2TjBjclpXcERPR281YVhsVlRURlRNa2hUYnpKaFdVMVlhbWxWTjAxaENtTjFTV0UyVG1ZM1VVdzVhVVF4YzBSYWQyeHpRaTl6T0VOcVVrbDVjSFpRV1dveVIwMXZSRWRRY21OelVXRTFjbEI1UldORlV6QkJVRmcyVW0xNWVUSUtOR3N6VW5aUWVFWnFNbEJtV1VWeGNYVjRRMmNyU1V4SlRtSmxkSEJtZFhnclNGcHZaMlJWUTBGM1JVRkJZVTFxVFVORmQwUm5XVVJXVWpCUVFWRklMd3BDUVZGRVFXZExhMDFCT0VkQk1WVmtSWGRGUWk5M1VVWk5RVTFDUVdZNGQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV4Q1VVRkVaMmRKUWtGRUsydExSazlTQ2pGelNXdE1MM050TTJNMGNsWjNZbFpWY0ZkWGNuaElMMFJPTld4VGNtWTJiMEpUUjNoM01rcEVlVzFhVXk5b1RuWndLMlIwY201aFdIRXlSRkYxZFhVS05GZDZUVkZqVkdab2JVaExMM1F4YjAxYVkxcEhhV1pYT0hWemNrTlJTWEExUjNkbE5EZFVkbGhUVEhOTWRWTjBLemx6VDJJMGJsTjJabWgxTXpsTGJBcFdSMnhZZUdjME9WaEdXV055TkhObFpWVjZiWEkxV1RKVVJGSnlUMnN4ZFcxRVVtdHlSbGgxUkc1bFpDdFpMMkYxTjNwV1oySk1NRTVaU0ZaSVQyNUdDblIzT1RWTVFUUkRhVmhNVjJZeGRrSnZabTVuY1VwWGNtTk1TRmcyU1RRd2VtTmFPVzV3ZW5SaGFpOHhTMjVCTkVSdVdXUndWVmRKZG5SeVpteGxlVTRLTUdaV1pXRlZWRGxFZGs0eVVrMWpiMUppZEdSMFExZEpXbXRSV1VaWFJXdFFkWFJHVlV0UWExVXJNemRGZDFvNVF6TmFlVEJqVjBGTlZVdG9NRmczYVFvdmEwdzVSVlp4UjJjMlkweEtSMWhQZDFNNU5tUlNjbTl0YWpCRlJEUjVNMmRMVEVKRU5tUmxaMjFwZEhaM04wNUNNbVF6YkN0TmJscHVNMmx1TDJ0RENuRnhZWGRJZVRoWGFERkpTMHgyTTFCWllrNTZNRFV5VVdaR1pGTlBRbUZVY1hKdmJVUnNaWEF5UjFSaWEwOVlSamR6ZW1aNWRsWmFVVUZJVms5R1MxZ0tVa1ZPVmsxcGNVWmxRMEZGVVU1bksyaHZUV3QxUVRkeldYRTRaV3RpY1RBd2EySXlhRkJaYUVSRFZIRkZVV1Y0UldWUlIwcFFkVzQxVW0xbVpEVlRRUXBhTUVkd01ETkJZMWxOT0hCVWFua3lZMFZ4VmpGMWVFUmtkRmxyYkd0RU5IbHdZbUpTU25ZM1NETnJhRzF1VlVzMlFreFBaek5NVWpGRlNIUnNRMk4xQ21Wa09WZFlTSGs1WTIxaE5FSlRaSEp5Y1RCRE56WTJlVXhoTld4bk5FUlBPVmgzWkRkRVNHeHljbUY0Y0daak5tVjJSblJ6U21OM2IydGhLM2c0TVZNS2FrOVRjMVZHVTFoblRXTkRTSGhDY1VSQlJIRjZjblJOUmpkalIzZHdUSFpvSzBkWENpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovL2NsaWFrc2RuczI1bDRpd3UtYWUyZTJkZDEuaGNwLmVhc3R1cy5hem1rOHMuaW86NDQzCiAgbmFtZTogY2xpYWtzdGVzdGhhZGZ5eQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogY2xpYWtzdGVzdGhhZGZ5eQogICAgdXNlcjogY2x1c3RlclVzZXJfY2xpdGVzdHlpaTdpZ3VsdHVfY2xpYWtzdGVzdGhhZGZ5eQogIG5hbWU6IGNsaWFrc3Rlc3RoYWRmeXkKY3VycmVudC1jb250ZXh0OiBjbGlha3N0ZXN0aGFkZnl5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlclVzZXJfY2xpdGVzdHlpaTdpZ3VsdHVfY2xpYWtzdGVzdGhhZGZ5eQogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVTVla05EUVhRclowRjNTVUpCWjBsU1FVdE5hMmRhUWtseVZsSjZaMU14VUV0VlprMVFWa2wzUkZGWlNrdHZXa2xvZG1OT1FWRkZURUpSUVhjS1JGUkZURTFCYTBkQk1WVkZRWGhOUTFreVJYZElhR05PVFZSbmQwMVVTVEJOYWtGM1QwUkZORmRvWTA1TmFrRjNUVlJKTUUxcVFYZFBSRVUwVjJwQmNRcE5VbU4zUmxGWlJGWlJVVXRGZHpWNlpWaE9NRnBYTURaaVYwWjZaRWRXZVdONlJWQk5RVEJIUVRGVlJVRjRUVWRaTW5od1dsYzFNRTFKU1VOSmFrRk9Da0puYTNGb2EybEhPWGN3UWtGUlJVWkJRVTlEUVdjNFFVMUpTVU5EWjB0RFFXZEZRV3g2TUZoYWVFNU5iM2xpV2tsMGVFTlRWVmx6Ym0weVRGVjNOMUlLVFZBd2FuWm1hV2MxUlVSdmR6Z3hRbTg0Vm0xeWNIWnlNQ3RIUmxSSFdDdEhNekU1UWt0RU5rcDFOMkpHWlVrMmRWUlhTazFpUWtNd1ZFMUNWbEZ3Y2dwdFMweG9lRGxpTUdGalMxSTJjR3QwY21SVlNXc3JSMHBQTTB0RGFVbDRNVkZsVGxocGMyVXdNRFExU1ROdWVIa3dNRlZtUlM5cVVEWndSRlJLVjFSQkNtdFhiekppUVZOQ1dEUnVUVXRaVGsxV2RXb3pjbk40VlU1YU5YWTFRV2ROTTJSelp6ZERUVlpRU0U5NFRIbDVjVU1yZG1wQ1JFdFZlRkZ2Y1hWNEswOEtMM05UY1VGbGNGcE9jRWRMT1ZOWldUVjFXbXd3TWtob1QxaG9hVGRhWTBoNmJ6WnFiaTlJTUc5NmJXbzJWRUp0YW1oWVNVa3haMGRIVTFCbFF5dGFkZ3B3UW1KTFptMHpkMnBwTW5aeWNsbG9MMnh4VW1SeFVGbERValpYZVU1cGFVSlpablZSVUdOUVRsZzVPRU16VjBGcVprSjFhRk5hY1hwU2VuZHJhMWwzQ2pKb1drOTBZa3hZVFM5cVZGZDZhVUZvVGpGbldYbHpTRGRYUzNZMVRHVTRRVkJQVGxsbVExTlVXSHBDZWtkU2EyRnRTbE12YWxvNE1EbE9WbFpwY1dJS2FYUkxjMHhoY210NmMwdDVhMjFwVjA5WFVDOW9SMk52V2tnd1NEYzRRbkI2TkVOeVFVcE5kM0ZhYkhWWWFFUkRWM0k0VjBkRGNYQjFUVEEzVnpocVlncHdiSFZNTVVZcksxRjJORUZ1WWtkRVREUm1WMncwTkhoUFNtcE5kVlZyYUVSalNYTmxhMHRXVFcweU1Dc3pSMVJrSzJoQ1drUjZjbWxaWjI5bE5sSkVDbE54WlhjMGVtTklWMVp2YjNsRUsyMDRaVVJJWTFwcmVEUjZSRFpOVDJGU1VVZHBialpvTUhkaVVFOXFiamxYTTBKWlZtZDJURk5oY21sVVN6WkdVVE1LVFRoTFRFZEpNV0V2TTFCd1IwcFRZMXB6ZG10amVreEpTM0pHYkVnNGN6aG1kRWRUYzFscWEzVk1TWGhEWldad1MzQjFjbTFaVnl0SWQxSllSalpuUkFwWFJrb3dOV3RQWkU5TGRIZEtSM05EUVhkRlFVRmhUVEZOUkUxM1JHZFpSRlpTTUZCQlVVZ3ZRa0ZSUkVGblYyZE5RazFIUVRGVlpFcFJVVTFOUVc5SENrTkRjMGRCVVZWR1FuZE5RMDFCZDBkQk1WVmtSWGRGUWk5M1VVTk5RVUYzUkZGWlNrdHZXa2xvZG1OT1FWRkZURUpSUVVSblowbENRVWxKVkdFMlR6UUtNWFZoWTNoNU5UazBOM1pqYmpKNEt6UlpWR0Z5Ym1KbWVteERhRlV5TldaRlMxaHBRbTgzYTFGdVpqTTNPU3QwUmxaWmRWVk9Uek5yVWxkMEx6bEpVQXB6VlVGSFZrRjRPVUpWWkU1UFJVMHJUMGRKU3pCa2VtaHNXQzgyZDBnMWNrSjZNMDFLT1c0NVpEbFhaa1ZGWlU1Q0wxWnRVSHB0T1ZkYWVXRjBWVE5aQ2xvMVV6aHZjaTg1Y3pGdE5uVnlRaTlTVUZsclNXeGxNMGxJU1VSNWFuSTRaR3B0UzJvelZuWnlTSGhIYUZCRFEwdHBOSE54ZEU4eFMyVkVlbGRNT0U0S2VpdHlUa2xGVVZaT05WUXJiSGhhYVRBM1UxRjZVVWhsYnpnMWJFeHRlbGRuUVZJek1XeEtVRFJCTW1SWFIyUXdZVEkxVmtZMVMyYzRabFZ0ZWk5dFZ3cG9aVTAyYjIxVWQwc3hVSFp6Wm01VldVTnVNRmhvU2xWQ01rVXpSRzVCYzNncmJEZGpTR1ZMTUM5MWJGRjBOR05xWmt4bUswaEVOMDV1VjNCblJsSkZDbFJ4Wm1RM2FrSnpWVEZZZG5FMlFrNDRlbHB1TmxodFdtaEdVRGw0ZEZWeFZGaHJTRzVWVm5aMFQwNUxNemhTTkRRNGNtMUthbFZsV0ZsMk1pOU9UbG9LUzBWdVJESnFOelV2VkRVM2JFbHJNWGtyTUZSNVdTOVNNblZDUTI1eGFFMHlSVEpyV1hKRE4xUXlNazVaTUc1UUswczRhRkJTWTB4UFIyWkdhWE52ZEFwUlRYQTFSazlKY214U1NUZEtjemsyUWxCdmVXUmtORFpuTkZSWVFVbGtSek5LVm5WU1ZGWjBXVFVyU1hOWFNqQlVkblpxWlhvMGVIWXJZaTlIWld3MUNuTkxLMGhxUTJsV2FIUm9SMDVEWjJWdmNrY3ZXblJ5WVhjeVptTldVa3R3WTJabU5FbFBUMHRVYTFaeFNrNUZSalJDTlc1V2NWUm5NSEpZV2tWcmRtNEtjVVZSYkZaQ1draDZLMFVyVXpGcmVGQndRVlJMU1doTGRUZEVjMjFMU2tzM00zRnJTWEJ0TmpOSFZEWk1VR2xOY0hGcUswNXBLemhXVjBsMU56VmlSZ3BIUWtsUlZsbFhZVVZvUzNCRmEzcFZUV1ZtTmtrMFVqUjVVMkpSZGpONlZVbGFkRUlLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MyZEpRa0ZCUzBOQlowVkJiSG93V0ZwNFRrMXZlV0phU1hSNFExTlZXWE51YlRKTVZYYzNVazFRTUdwMlptbG5OVVZFYjNjNE1VSnZPRlp0Q25Kd2RuSXdLMGRHVkVkWUswY3pNVGxDUzBRMlNuVTNZa1psU1RaMVZGZEtUV0pDUXpCVVRVSldVWEJ5YlV0TWFIZzVZakJoWTB0U05uQnJkSEprVlVrS2F5dEhTazh6UzBOcFNYZ3hVV1ZPV0dselpUQXdORFZKTTI1NGVUQXdWV1pGTDJwUU5uQkVWRXBYVkVGclYyOHlZa0ZUUWxnMGJrMUxXVTVOVm5WcU13cHljM2hWVGxvMWRqVkJaMDB6WkhObk4wTk5WbEJJVDNoTWVYbHhReXQyYWtKRVMxVjRVVzl4ZFhnclR5OXpVM0ZCWlhCYVRuQkhTemxUV1ZrMWRWcHNDakF5U0doUFdHaHBOMXBqU0hwdk5tcHVMMGd3YjNwdGFqWlVRbTFxYUZoSlNURm5SMGRUVUdWREsxcDJjRUppUzJadE0zZHFhVEoyY25KWmFDOXNjVklLWkhGUVdVTlNObGQ1VG1scFFsbG1kVkZRWTFCT1dEazRRek5YUVdwbVFuVm9VMXB4ZWxKNmQydHJXWGN5YUZwUGRHSk1XRTB2YWxSWGVtbEJhRTR4WndwWmVYTklOMWRMZGpWTVpUaEJVRTlPV1daRFUxUllla0o2UjFKcllXMUtVeTlxV2pnd09VNVdWbWx4WW1sMFMzTk1ZWEpyZW5OTGVXdHRhVmRQVjFBdkNtaEhZMjlhU0RCSU56aENjSG8wUTNKQlNrMTNjVnBzZFZob1JFTlhjamhYUjBOeGNIVk5NRGRYT0dwaWNHeDFUREZHS3l0UmRqUkJibUpIUkV3MFpsY0tiRFEwZUU5S2FrMTFWV3RvUkdOSmMyVnJTMVpOYlRJd0t6TkhWR1FyYUVKYVJIcHlhVmxuYjJVMlVrUlRjV1YzTkhwalNGZFdiMjk1UkN0dE9HVkVTQXBqV210NE5IcEVOazFQWVZKUlIybHVObWd3ZDJKUVQycHVPVmN6UWxsV1ozWk1VMkZ5YVZSTE5rWlJNMDA0UzB4SFNURmhMek5RY0VkS1UyTmFjM1pyQ21ONlRFbExja1pzU0Roek9HWjBSMU56V1dwcmRVeEplRU5sWm5CTGNIVnliVmxYSzBoM1VsaEdObWRFVjBaS01EVnJUMlJQUzNSM1NrZHpRMEYzUlVFS1FWRkxRMEZuUlVGcFpEbGxhekZCVEhkSWVITXpTbEJTVG1ZeGMwNWhNa1p2ZERGVFNsbG1VRFp4U21KQmJIRlBSamx1Y0hGblVVOVFUVmhXT0d3eVdRcGhTRXBsWldVNGJscHRNMlZRYkc1dWFtZGhhMHBETTBNcldFcElTak5IU2tkR05tTm5hRk5VU1dSM04wTnhUV1UxVEVKd04xSjJWbUYzVEdwWFZHUnNDaXRzWlZwdFkzaEpRbFJPVlVSTWVXTm1NemhUUzNKdVRIZERhRWRYZGpsWFJHSlFVWFpaUVVoU2RXWkJhbFJyVVhwNFRuTktOWEpSUjFORllUYzFjVllLVWtaME1sb3hXVnB4UlhVdlZURklaM2xFUnl0bU5HMHlaR2xCY1dOWmNEUk9RV2h6UlhGT01HNU1VbTlUWnk5aGFuVjNRa3hhV1VOWkwySkxTRTV6TndwNlNEWjJNV3RXUVhNeFNXWkNRMHBMTlVFeVJXOUxhMGwyTDJaQ056STRPRkZNY2psTllXazFVbmhMZDJoMGVuUlhTMlZtVXpoTFF6ZzFXV2RJZDJkekNuazRTalY1WmsxSFdqSkZWRVV5UlRVd2VsSXlWVzA1UzFGaldXOHJOV1JETkZGRE1HVTJUbEE1YURkbFMzTnFNbU4wUW10R1MycGtjMDkwT0dodlRrRUtaVnAyU21KV2ExWTJVelJqWlhwd2IycE9lVTFPTmpWNlRGRXpWMUl4YWxSbmNXRTBjelpEVVhScFVXZG5UVUp1YW5sNVZXbG5Xa3BwWkVsemQxRTNNZ3BKVmtzMlRra3ZNazlXYlZaTlZHTkJRM0pFVkdwQ1JVVTFNVWhXUmpNeVFVUm5Sak5tYzIxRFYyTnpSMGQ1VGs1VkswWXJhRXhqY0V4b1RXTmpRVnBUQ2t0eGRDdEtkazR2Y25NNGRHVnZWazlxY2s0ek1rdHNSRXN4Y2s5cVNUTmxjbEUzYlVGNmVEVllUSHByVGxBNGExQlJhbTVvVmpWWloxRmtZbTkxYzNJS1RsWlpkRVlyWm5FMmRVaHRRa2RMU1U1TlkwRTVPRUo0ZERrMVNISjNNMUpTV0ROd01WVmFlbWRuTkhwQlYxbHhVRmxhWm1wSVpsRTFkbmRoYVc5c1p3cGFOaXR1VDNObE5qaGllbkl3ZFdad1RpdExTR3hCUm14aWNpc3JSV2RDV1c4MWRWWmFkalE0VVZBd05XUjJRemh4VW10RFoyZEZRa0ZOUmxrdlprTTBDbEV5UmtWbFExbFhWM1VyTVhGeGJuSXZhMGg1UjBaTFJXUTBabEIxTWtsYVNGbzJWR0YyVkhGeFZWQlhkM3BYYWxGSmJuVmpRemQzY0hRM2RYbHRaM1FLUlhocWJXVXJXVmc0VmtSVmQwMW9ZMGt5YmtoV1JFSnJOV2wyUW1kVmFHTjJiWGx2TDFsM01ESkVVbmxpT0dwdE9TODJPVVpyZGpCdlQzSnpjbkZtY2dvMVRrRlNTa1pHVURWNVpTOHhOV3B0YXpsNVozaFhORWw1YVVWUVRsRTJObEJ6TUU5aU4wWk5hVXBLV1c1TlpqVjBhMk5ZUVVScVNFVlpPRkptVWxabUNrZFRlazQ0YlVWeWJqSktZVk00UWpOR2FqaFNiMmxCTDFKWWRsZFJPRFp2TW5KSVN6UTBLek55VGpOUmNEWk5ZMGRIVlRrMGRUbFRhUzh6YWxGRFFsb0thMUpCZGxWdGVUWkVUSGd6UjNGUlprcEdMelpPWjJadVYxVjRWbXA1UjNJMWRIWjNkMDFJTVhGdGJrRkhVbTlqWm5nM2VUVmFWMGhVZG5CUlFXOVhZZ3BMU1hoNlN6a3hSRk5WTlhOc2VEaERaMmRGUWtGTlp5c3JkRzU0ZWtRNWFrNXpkM1ZZWkVOWk9HWlJWWEkyS3l0amFtOTNhbTV6Y2t4WGNUUXhZV05GQ210eEwxTnJabkJTU25WUGJrNVlPVTlrSzJkWVVXWldkRGw0TWpWUVpHZHhOM3ByWjNKSFpXVjFUR1ZuZFdvd2NrWktZM1E0TUVSRk1uZHJWMkpJVUZRS2R6UnFiMU4xYlhKS1FXWm1lVmR2YVRGcFFubzJhVmxxYW1rMVdXdzVSMVpaY1M5bmFUZFlTamR3VTFkek9UaEVlbGQwY0U5b1RFUkdhamRRZG10RFZBcFhkMjVDYkRkVlFuSlNRVlJVVUdJMGEyNUtPSEpuZG1Wc1NHMWFaV3BCYVZoV1kyRmpaRmMyVjNVM1NqSmtiVWwyU0djMFoxZG5haXR6ZVZCcFIzWTFDa2RrYTJ0dWNUSlJPRE54YjBRemNtSnRjM1UxVkhaWlNURkZhbVJWTkV4UFZFVmxXRkZOTjBsUmNqVk1kMk5sUjB0d05VVm9NVVo1TDB0RVVIRlRNR2tLZDJ4T1NGQlZUakZGTlVKaldtdFpVSHBSZDBkRk9YRnZOMnc1V1hOaU5YaFpUa3RKYzA0MFYzaFVWVU5uWjBWQlVEQk1hREkxWnl0dE5USjFabWt2UlFwVmVtZHhabVY0TUZKYWJIcHpaRkZpTUM5cU5VRTFSR0ZMZURseE1raFlURXRwU1dwMmRrbExWazVqUzBvMlIyWjRPRTU2ZDBsQk0wSnRaWEpXUlRaNkNrc3hTbWhRVnpGQlVGRlVNa2M1ZEROdlFYUjRVa2czY2pReGRYSnJaWFJqWW14VFprWkxibFp5UzJseWJXWkRVbXRwZDJOMlZqWnRaMEp0VEhVemMyTUtWVGx2YlV4aFdVdzNVakZDVnpnMVQySkhRM2RoU1VGNGRXbEJiVVpYYmtsTFlrbExiMnBsYmtaNk1rVlhaemwzVWtaS2FHcGtUMDk0YVZWblZVRkVXUW8xYmtwTE5VMDVVMGhTUzJzM1JUUnVZWFY0YUZKVldHdFJSbGd3TDFCdlNTdHZObWgxZGtkbVdHTnFVVGR4VFdkdlRrcDRSV1ZUWTFoVFNrOXZjbkZDQ2tock1FOUVNMDFPUlUxWmNWWlpNbmh1ZUU1RVowc3phRWhGWkRadGFuWkxTbFV5ZDB0UFdEUkNaVlpPYW5jME1XNW9jamx4UkRseVJtZEZPRGhsYkhBS1J6bHlWakozUzBOQlVVVkJibmhsUzJKVlZubEtTbkJMYlhkWWNtVjVUa2xrT0dSSWJtSlZUbEUzV0RSUVZuTmphR3RITjFoVGNVRTRSR1V6ZVhONFZ3cDJWaTlJV0ZKSFYzRnJjSGRIVUVnME9YbERTbEpuYXpKaWIycExPRXhvYkhkV05YUkhUbEF4VlM5amNEUkVaVWRZYWpNeWFFUXJiV2hyYzI0eVYxbHFDa0pwTmtJNE1WVnBSV28yUm5SVE9XbGpkV1p2Um5Cak9VSk5ZVGwxVUhoeFJrcDBNalZMVVRoMlF6SndLMlZaVFRodVNsTnJWRTlDYWsxeVIwbFJWRzRLTTI1SE0wbEVRakZEV1dsT1RIUnFlakZZYUdWWU5HVjBOazV2Vm5aMGVVVkRiSFJOVUZWM2NHdE5iM28xWlRGUlFVNHlORmxVUWxSdVVGVXZURVkyVWdwVmN6TmlTSEF3UXpaM1EyRXZNVmxqWTNCbFJrWmtUMXBRZG1WdloyRkZVbWhsWW1sWFoySTJURk4yT0RWdVZWbDVVbkY2UzJrd1NHWjFjVWRtWlZkNUNsZFhkRkI0YWtsbWEyOUllRzVFVUVONmRsaEZiMkV5Y1ZsNGJ5dHBkbEpGVlZGTFEwRlJSVUZzT0RseWREVjFVSEI1TldkeFRVVm5RMEpIVDJwWmNsY0tUVmR2VVdGM1NFOTRibGd4U2pGWWFtczVUa2h3ZFcxSFEwSm1kVTVNWVhNdmJUVk1RWEUwV1hkemQxWnBkVXhDV0UxRFRVRTRTa1JZTDJ0R2RWUlZMd296Yld0emNrdEVPWEJVTURkSWFEVm9SRXcyTDJaUWIxTkllRFVyYmtsM05FeHFXVmRHVlUwMldGbEJkU3N4VG5aNU4yaElMMGd6UzNOQ09VTXlNMEUyQ25aRFZDc3ZSSGxCY1VSUlJHaHpVaTlCT0UxTlFWQllia1p0YkU5dVJERldRa296WlZSTWJsWjZVR05TWTJkM1RraG9VRXR4VVc1WFowbHNRMUpOU0VJS1ZDdEdTbkIxSzFKak9YSk5Va0ZpWkhKRFlsZFBVRTV1ZHpFd1MwdHZkakF2WlZRMmRWUkpZMGQyS3k5b01HbFdibU5XZFRjclRIRk9ZMHBKY0VFMWRBcG9PVzFpY2sxWVVWcFVlREJsY0VKQ2F6Wk1kVFJJUVhsbGVqVk9OelJyZGs0eldUaFlUSE56Y2pnMVRrTkNjMVI0VjJWSWEycFViR3BEWkdNeWR6MDlDaTB0TFMwdFJVNUVJRkpUUVNCUVVrbFdRVlJGSUV0RldTMHRMUzB0Q2c9PQogICAgdG9rZW46IGNhMWY3YjE1ZjNkZmVlYzU5ODZmOWI2ZTE2OTJlZTMzCg==\"\
+        : {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVJFTkRRWEpEWjBGM1NVSkJaMGxTUVV0WWVGaERZbWhpWkhGb2RtTjJVVXhtUm05S2VXZDNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJuZDAxVVNURk5ha2w0VG1wQmVsZG9ZMDVOYWtGM1RWUkpNVTFxU1hoT2FrRjZWMnBCVGdwTlVYTjNRMUZaUkZaUlVVUkZkMHBxV1ZSRFEwRnBTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblNWQkJSRU5EUVdkdlEyZG5TVUpCVFVKbENtZHdZMDh2UVhOTWIydE1SMGw0T1VwU1N6RXlielp6WnpOMlpVdGpOSGcwTDNSV056QkVUWEpGYlV4emRuRTNUbXhFV0VJMVRGTlVkbnBHWTIxTVVIZ0tURVptU21sUmMyWnVVMjlYUTFneEwxVnlUWHBVU0hCTVdIQndXV3cwT1RaeFdXVnNiVUpEYkU0NGJHTlVibE56T1VoVU4wUldaR1Y1WW1FclRqTTNMd3B6Y0VkQ2JHUTBkV3BNZW5KSWRrODVSMmM1TTJsUFMySlljVkFyUlZCRFVXOURaV1ZRWVc1WmNYaENReXR0Vm1aS1dHMTJWbGN6U2xWc1oydGhiVkEwQ213ck0wOTVTVFZKYzJack9HUXZNbWh4YjNrcmEyVTFaVXRIWmpGNmVYb3dhVXBpVUZCck9VSjFMM1pqZDNWa2RuazRSM2MzTVZWbE1XRnBZbVpSWjIwS2RraGthRVIzTldod2RVdDFWMjF5Ym5KYVRVSkpORlUxU0dNNVJqUTRTa3RCYlVsMlpHMUxjMDFKV2poMlJsTk5TR0Z5V2xwRllsRmpVa1UxTDJRd1J3cG5kMFpNYnpSbVpWTmxTMDVrVUdwMllrNW5lbEJHUlU4ME9YZDFUa3hhYkdSNFptWmlUVTlzT1U4ek5YRXZLemxoTWpOSFkwVlBhVGRUYVU4NVNGVnJDbnA1VGtOUWEyaEpObU5JV0ZFeFZUUllUbE5pY0d0amJGUnZhRFZZU1VJeloxZzNXVWhQVVdnNGRrbEZVRWt3YVhoM2VIZFJOM05NWlUxaWJqVkpkMmNLWldnMGNsaFNWV053VlRsQ01UTXdZbFF2YmxoTlZHcDBUVU4yTURabmRsTnZWbWwxWmpFdlVVczFjMjVYVVN0dlltODRSMjV2UzBkV00wVlNOM2x4TmdvMFV6ZHdablpNVFc1aWQwRk1Ta0ZEYW05Q0wyZHBWR0pZU2xkeVZrZE9PVVpCT1RCd2RGRmxhRGs1Y0hsNE1EUm9SMjVPWnpGSlNGVm9UMk5YY25wSENuWkVNMU5YYm5GME4zaFVUMlp3YW1OVE56QkdOSFZ2TjJzNFRVdExiMDF3U1V0RWJFOWhhSGRKVTAxdGMxaGxhbGhRYjNsTlQwOU9MM1ZFVkZOeGQwRUtWRFJMTXpWWWFFUmtXR0Y2UkZsM2JVMTBRMWxIUW1GNVF6bEJSa3RoU1RjeU16UjFiaXRtUmtGblRVSkJRVWRxU1hwQmFFMUJORWRCTVZWa1JIZEZRZ292ZDFGRlFYZEpRM0JFUVZCQ1owNVdTRkpOUWtGbU9FVkNWRUZFUVZGSUwwMUJNRWREVTNGSFUwbGlNMFJSUlVKRGQxVkJRVFJKUTBGUlFWUlNlVE5zQ2sxV0wyczBhRXB1WkdkdFNYYzJLM3AyVDNKck1VY3llWEp3WmpoRmVWWXJXV1I1UTJkTlExSk5VVWhJWmtSaFNrbFRTWEZFUlhGaFZrVnpTemhLYm1rS2FsQlBjSGRGZWtsNWRqSkxWalYxU1ZaaFZYSlVOSFpJVVZaNGRVcFJaMUpST1Vnd2QyNUlTREUyTjJ4cmJHY3dWM05ZYmxkVWNURmhNMGRqTjJadWR3cGpMMFZsWXpNclIzWlBURXBqTmxvNFYxWlllVVZOYUZWdVZHc3dObkJLVGxCc1ZuTm9XV3QwWlZGdU1WcG9iM1UwV2pWc01HNXROMnBNZFVWcmNtNXBDazlzWjFwUllWVlRjVE5CYTNjMWJFcEtkams0VGs1a1dISlZiMmhWYms1R1FsSllZVkZSV2xobGJXbG1VMkZrZUZONmEyOUtjR1JtZVdKeVNERlphVVlLZUUxcVlWUjVUbFIwZEhKblRtZDFjbWMzUzB4R1ozbDVSVEF4Tlc5T1pYWk9RV3huYjBoWlMyd3pZak1yY2psU2FuWnFWbXAyYWtjMlJWSjFhMDF3YXdvdlpUQlRXR2RQYVdwSWFsQjVLMk5OZFhSdk1XdFlWVW8yWWs5Wk9VOUpURkZ6Ym1WRWFqRlROVGQzTXpCdlUweGlSbGhDYzNFNWFqZDZRaXREWlVsVENqVjVhamd6VGxaVVpDOWpNVTEyVVVzd2QwSkRVazFDVVZWRk1VNXRXVFZZVUV0NFQzYzNhbGxLY21SVGVTdHRTbFJSWVc5aGJIRjVlbnBQVWtaS1QyZ0tNMk5LT0VWUFlrWkhaRVZEUm1sMVprMWxhelJIVGpGeE9UUlpZMFI0VkVadFlVeEtSblUwZFU5b2NUZFhUSE5hWWxGeVMwNTBTalpLTUUxRVRqWmlWQXBwTTBKME4xRlVVbEpoTmtobWNWRXJRa3BPZVZRNVEyVnlla2hJTm1OVGVWWTNVSEIyVG5SWlRFUTBWMHhOU1djMlNHWldaV0pyVEZvMlZtNHJlbWhVQ25WUWMyNXNaMjlsY2s5bmJFNXpPRWcyWnpSeVNWZEJTRm8zTURWemVTOTNlR0pTUWpCRVNHRTRTemwxYUhKSWQwMHlNREZDTDNWTVJVcGxiVEIwY0d3S2FUYzJlbWR0VUZkNlQzWjNaWEZPY2xKdmNuVjJUekZCUm5SdmNsUlRWV2xwWkdaTFFuYzlQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2xpYWtzZG5zN2J0a3E2NS1kYWYzZWRmYS5oY3AuZWFzdHVzLmF6bWs4cy5pbzo0NDMKICBuYW1lOiBjbGlha3N0ZXN0aGFtbW5yCmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBjbGlha3N0ZXN0aGFtbW5yCiAgICB1c2VyOiBjbHVzdGVyVXNlcl9jbGl0ZXN0cjZtd3F0eXJwaV9jbGlha3N0ZXN0aGFtbW5yCiAgbmFtZTogY2xpYWtzdGVzdGhhbW1ucgpjdXJyZW50LWNvbnRleHQ6IGNsaWFrc3Rlc3RoYW1tbnIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyVXNlcl9jbGl0ZXN0cjZtd3F0eXJwaV9jbGlha3N0ZXN0aGFtbW5yCiAgdXNlcjoKICAgIGNsaWVudC1jZXJ0aWZpY2F0ZS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VVNWVrTkRRWFFyWjBGM1NVSkJaMGxTUVV0aU1FVmpPVmhwTkV4bU5WSldVR3RCV2pOdFkxRjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJuZDAxVVNURk5ha2w0VG1wQk1sZG9ZMDVOYWtGM1RWUkpNVTFxU1hoT2FrRXlWMnBCY1FwTlVtTjNSbEZaUkZaUlVVdEZkelY2WlZoT01GcFhNRFppVjBaNlpFZFdlV042UlZCTlFUQkhRVEZWUlVGNFRVZFpNbmh3V2xjMU1FMUpTVU5KYWtGT0NrSm5hM0ZvYTJsSE9YY3dRa0ZSUlVaQlFVOURRV2M0UVUxSlNVTkRaMHREUVdkRlFYcEtkMWRXY0V0UloyUk9SRWRtVWtaeFJWcFVlSEJpTlVoR1V6a0tZMlZJVWpOUk9HaHFaak0zTlVkME1uTkdLM2RyTHpOeUszRnVla1JwTjBKRGFXMW9WRkVyVjFBMmFFbGlZazVCT0RWVFVIWmplRVpNVjBaaGRYcE1Vd3BwZEd0V1ZHMVlhRnBvZERaVVpFMDRORXBsU0N0Nk5XbDBWMk54ZFZsM1drZDVNbmswUlRreVNVZGxSMWhIVTFOQk1YcHdjRXhSUkRjelJtaFJNM0pYQ214UFpTczJZVXh0U0VveVQwNVFhalZoTUZjM00wa3piSGN6UVRCWlNEVnFUVGhUUkVOeUwyTnFSbVpZYjFObGVHSXZhRVpEZDFkU1QzYzBja29yU0VJS1QzSm1PRVZwU3pGcFQwMTFSRzR6V2xsMGVIUmhhSGN3ZW1GSGMySTVUSFZMWTA1dFIyVTVWbHBMVTA1VUsyRmxZMUJ4WVVOTVUwWjJNVVV4VDJ4UmJRbzBNbVZrUzNnclRGQjNWMEpQTTI1TVRqbDJSVlJhWTJsbk9ITXpaMlJ1VHpGTlZ6TkllVVIzVm1SU01ETTBOV0ZNUjFaa2NuQkNLMWRNSzIwemN6WnNDbE5LZVhoYU9WY3ZOVVYxVGpVclVVTkdWakYzYW5GaFowMTBWMGxrYlVWSGRESXJkR1pxVWtsRlVHdFhaVlZpVUN0UU1ISjVZbWRSYUcxb2RYUjBXV3dLTmxaMFprTlZhM2g1VlZGeVEyZDVPR3A2YlVKdWNITlZjVlkzUjFGcVQzVnFTWFJpUXpaS2JqZHJNREZDU0hCWWRGZzNUM01yZEdkV1dGTkpWMGRpZVFwQlFVTXpLM052UjBWelNHbFJiamxNY2tOek9FOHliSFZHUVZCekx6SnROekU1TVVOMU56SnlNM0prYlVkNlEyNXdkM1JSTlVFelFrMTFiMjR5UkRNeENucGFOVGhGZEhoS1ZFMDVlR3hpU1ZCbmNHa3JkWFJ3YVhaRlF6SlhhbE1yYlZwWlRFdGphRTVsUVdOeWNYTjRPRzFVYkdKRVdVbFBMelExTjNjMFZ6QUtXWEpXYURKR1VFVldUa2hwVm5aT2FWSktlRlZ4Y25wRU5taDNMMElyTWxWWlZUQmlWRUY2TlZOTmFIb3dLMnRDVFRoTVZrVjNjbEpqZVM5T2VIaGlkUXBVVjFKSFVUbHdVbVpYV0dSMmNWVkRRWGRGUVVGaFRURk5SRTEzUkdkWlJGWlNNRkJCVVVndlFrRlJSRUZuVjJkTlFrMUhRVEZWWkVwUlVVMU5RVzlIQ2tORGMwZEJVVlZHUW5kTlEwMUJkMGRCTVZWa1JYZEZRaTkzVVVOTlFVRjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRVVJuWjBsQ1FVbGtkbUpFZEVVS1UzVXlkaTlNTUc1aU5Hc3dkVEJKZVRaNU1ITTBUWFZ0WkV4VFFqSnNiM3BRTTFGWVIybzVhMlpzVTNKcllqWXJlRWwyV1dGMmJtTXpTVEJsUkRkTWNncEpXVTh2ZUU5aFQwOWxhVkJHUTFKUGVrVjZaR0ZZVDJkMWJUQlVkbkpaVEUwNE1tcEVNV1JrVTJsQmRYaFJRM0l3VW5keE4wOWxhbmxJWTNsdVVWVk1Dbk5DYzNKNFVDdFViMmxwV1cxRldVNHhWM2xOY2s1eFlYbFJVazlsU2xWNFMydDJiemczYTNSYU9Wb3pkVWxrWVdka2JXUjNabGhTU2pndlVrMWpRVGtLTDJzd1VFVjJiVE54YTFGek0wbFZWbWgzY2paSlltaHRZV2N3UVVKeGNraEdMemg2VTBKaFJYcE1OalJpUXpaa1l6ZHFRbFI2UTBscmNHbEdOUzlYWkFvNVpEWlpVR2hGVEN0bFJDdFlVV1J2UkU5dGRsa3plVkJRTlhSMVlWVnpka3hOZVdjeVJ6VmhVVVZzZG5BeWFITnJNSGRHYlZaTGVERnVaQ3RXY1dWNENqRjBjRFY1U2pobWRVTnlMMGN6UWtabWFuVnNWR3NyWW1nNGJtNUdWU3N2ZEhOc1YzRk5OVGhpTjJSeFdXZFhTRGt2WlZaTlZUSk1Xa3RzT0UxeGEzRUtRakphVGxvNWNsWXhNa0V2Unl0RGNXZFBSazFCTmpsUVZFdEVSRFJXYlhRME5saEdNRTVzU1hwSlFuTmxXbHBEV0RGblVYSXhXRU4wUmlzMmJIcElWQXBwTnpSNE1GRTBka1ZITWxsNU5GZDNSRTloUkdKYVVsbEROVFl3VmpGV2FGZENNemhhUVhwNmQyWXhLM2hQZVU5dldrcDVRMWxxVDI5NmJFSjBPRmxZQ2xVMGRtZFNkRU53U3pWclZrdzFObmhDZGsxcmRFNVJSWEV4VG1OQ2FXWjRiekExZWs5UWVGcDFRblZKVjBWdlN6bFhlbGRpUnlzME5GZEVibEZMYVZNS1YxUTJWbFpETDA5MlpURXhRMUJWVFhWalpsWXdjV3BRWkZSaVVqSktXVWRaUlZOTFFsTllMMVp4VGtsUlQzSlZjRTEzWlhkTlR6SmlRVWhQZFVoeVZBcFRiRWRUZFdWemFuTnRNSGhRYzBOSlIzVlhXVVZLV1V0Mkx5dEZTRU42V0ZkU1ltNEtMUzB0TFMxRlRrUWdRMFZTVkVsR1NVTkJWRVV0TFMwdExRbz0KICAgIGNsaWVudC1rZXktZGF0YTogTFMwdExTMUNSVWRKVGlCU1UwRWdVRkpKVmtGVVJTQkxSVmt0TFMwdExRcE5TVWxLU25kSlFrRkJTME5CWjBWQmVrcDNWMVp3UzFGblpFNUVSMlpTUm5GRldsUjRjR0kxU0VaVE9XTmxTRkl6VVRob2FtWXpOelZIZERKelJpdDNDbXN2TTNJcmNXNTZSR2szUWtOcGJXaFVVU3RYVURab1NXSmlUa0U0TlZOUWRtTjRSa3hYUm1GMWVreFRhWFJyVmxSdFdHaGFhSFEyVkdSTk9EUktaVWdLSzNvMWFYUlhZM0YxV1hkYVIza3llVFJGT1RKSlIyVkhXRWRUVTBFeGVuQndURkZFTnpOR2FGRXpjbGRzVDJVck5tRk1iVWhLTWs5T1VHbzFZVEJYTndvelNUTnNkek5CTUZsSU5XcE5PRk5FUTNJdlkycEdabGh2VTJWNFlpOW9Sa04zVjFKUGR6UnlTaXRJUWs5eVpqaEZhVXN4YVU5TmRVUnVNMXBaZEhoMENtRm9kekI2WVVkellqbE1kVXRqVG0xSFpUbFdXa3RUVGxRcllXVmpVSEZoUTB4VFJuWXhSVEZQYkZGdE5ESmxaRXQ0SzB4UWQxZENUek51VEU0NWRrVUtWRnBqYVdjNGN6Tm5aRzVQTVUxWE0waDVSSGRXWkZJd016UTFZVXhIVm1SeWNFSXJWMHdyYlROek5teFRTbmw0V2psWEx6VkZkVTQxSzFGRFJsWXhkd3BxY1dGblRYUlhTV1J0UlVkME1pdDBabXBTU1VWUWExZGxWV0pRSzFBd2NubGlaMUZvYldoMWRIUlpiRFpXZEdaRFZXdDRlVlZSY2tObmVUaHFlbTFDQ201d2MxVnhWamRIVVdwUGRXcEpkR0pETmtwdU4yc3dNVUpJY0ZoMFdEZFBjeXQwWjFaWVUwbFhSMko1UVVGRE15dHpiMGRGYzBocFVXNDVUSEpEY3pnS1R6SnNkVVpCVUhNdk1tMDNNVGt4UTNVM01uSXpjbVJ0UjNwRGJuQjNkRkUxUVROQ1RYVnZiakpFTXpGNldqVTRSWFI0U2xSTk9YaHNZa2xRWjNCcEt3cDFkSEJwZGtWRE1sZHFVeXR0V2xsTVMyTm9UbVZCWTNKeGMzZzRiVlJzWWtSWlNVOHZORFUzZHpSWE1GbHlWbWd5UmxCRlZrNUlhVloyVG1sU1NuaFZDbkZ5ZWtRMmFIY3ZRaXN5VlZsVk1HSlVRWG8xVTAxb2VqQXJhMEpOT0V4V1JYZHlVbU41TDA1NGVHSjFWRmRTUjFFNWNGSm1WMWhrZG5GVlEwRjNSVUVLUVZGTFEwRm5RVVV2TldOdlNFVktPV1ZYZVRsUFNrNTJSR1pFUkM5RVNYWjBMelE0ZUhab05tWjNSV2d4T1N0TllpOWxhRlJYVldnMlIxVlpXbGxvZWdwbmVqZHBRV0Y0V1Vad1dtdEVZbVJtVUhFM1MyaEpiVk5oUjJkVlQweHRabk40YTJwdVZGRkNRekJ2WWxaWVlVTmhhazlzYUU4MGEyWkNlWEpOT0RjckNsa3lZa1p1UkUxMlpXRkdORWg1T1ZGSFNVUmpjR2wwY2tFMU4wa3ZZWE5VYlNzclkwTmhSa2hWWkhoMlVFbFpXakI1T0RoeFMwcDZUeXRCZFVONFMzTUtaazF1ZEc1T1NtRnpPVGgxWVc5TWVFRXJaelI0VVdKcGQzZHpUMDR3Vm10dWQxazJZV1kwTVdKNlYybEdNMHR5YkdaV01tcGpNelprY0M5MmJXaENPUXBXZEdwTmJXMUtia3BqY1daUU9HNVlPWFJzVDBJd1JUSkVlbkp3VG5CSGJsVkRSRE5GZWxCeGRITlhVRVExU21SdmNHTk9WVlZuVmxsVGFrNXpWM2N3Q25SME5YWnZhbXBqUVU1RUswNDRaRE5KY1VsbVZGbGhhRmRvVWsxRFdHOVhZbkZMZVRoM1ptaDFORmRYUTFwS0sxaHRiVGQzZFZGaVkxUk5ZMjlXYURjS1drNUJZVmhQYVN0dE1VVnZVVTFQUlhJcmJub3pZMk5DYm1OTk5pdDBWbGhCUTFsNVUybHVZMGxDU1RnMlYwWmpiRXBGVkVaQ2FuVnlPVzAwYVZWWFJBcFhOSGx6ZUd4MFkyRkVWVE5qYUhrMVJqSkdkazFDZUcxVFZrbHlXRzl6VVhadlYxVjRWa0ZPVVM5bGVXaHJjRE5RZDB4a1VYTnlRakJRUW5WR1drSlFDamc0YW5JclFsQTFTR0ZPYmxCTFVFVTNlRnBMV1hWSVJEZHBNVUoxV2xkcGVtdzRTVXg2WXpsd2JsTkpaRzh2WTNOV05GWnZWbmRES3pGSFozRlNXQzhLYldWMFJrdFJiRGg2U2s5a1pWRkRNVGhYZEVVMkwwVnFVRVpGZGtaRlJURk5OMEZ4WkhRMVNubHFNamRSVVZSNWVHdERRM2hQYXk5YWVXb3lTRkZpVkFwRE5IWm9kRGxEVGpGVmNUWXhTalJOT0M5NmFsaERSRmsxUW5kdWNGaFhNMlpFZVM4MVltbHFhVVYzVTBaV1dYSjNVVXREUVZGRlFYcE1ZVTl0VjJwc0NrcHpWMk14TkRaQlp6Tm5ORXNyYlcxSk1TdGFNRlJtU0dkR2VEVndhRzk0UzFWeFJYWnpNVTluWjNGWWNUTmhUMlY0TDJVNFkwcDFaSEV6WjBacGJqWUtOVXhpV1ZsV1lTdEhSM1F2Vm1WS2VsVlNlVlpDZUVOcllrSk9XSFJITUZWUE1rTkdhWEZzTW5oM1ZuWnVaRXR5U1RORFMyWjZPWGxMYlZNd01sZFFRUXBYV1ZjellYaElWWEJDYjFCNFNXOXBVMWRyY21oNk1UZHBiV1F4VGxGV2NuQnhNREJsYjFkcmRuTlhRbXBqSzB0RFpIUlZjMWRtYlU5Q05sbHRhMmxOQ25oQ055dEZLMHBwWjNGWmRuRk1lVk4zV0V4S04yaEVhSEJRVFVOdVozSjVjR0pEVkVaSFptSnFTbVpITUdkd01WZzFTbUpRTkdKR05EVkdhSGxtZGpjS2RrOXFkRzVUU0VORlRHMHlOWEJVUm5wM1ZFMXdibkpMWkdjcmEyaENWRFJ2WVhKVVZsSm5OMjVTS3pKTFRGZFpaVUYwTm1KVWFtTTRRemt6UzA1T2Rnb3ZhMDlJTUZaMVdFVmtaekJPVVV0RFFWRkZRUzg1TjIxR1FqSlpTRWRrZFM5SFNWSTBlVGROTVdaeU9FdExhRGxDVUdkNVZtTnphRWtyV1Zwek1uWlpDbkV5WkZORlYwd3dXaXQwU0hOWFZ6TjZZVGxoYmsxMVZVcDZPUzkzVlRWM05FaEZlRk5qVVVkbVVWZzJaR2hDT0VkbVNtVldWbXgxV2pWWVdXRkZUQzhLUXpndlMyNXdLMnBxYWpaWU9GQkROa0pGWmt4Q09UY3JOMEZGY21oak5EZHpWVGM0ZFVKYVRuSlRWMWh6UlVOdUx6QkRWVGxVYVV4dlUxVmpOWGc1T1FwMWRqTkxja2xQVWtKclVXaFROa1J6VWxwNmVpdGxOekphTW5WaEwzcDFSME50YkZSeFN6bG5SbFp2YUN0dlozSlBPWEJCWjNKaFdtOHZOVFF2Tlc1SENtZExiV3RFYVV4YWEwZFlkVFE1YTJwUVNYZzJjbFZUYlM5S1V6Ulhja1JIZWpabWRWRmthVTFYWVhSR0swWkxTa2hYZUVOQ05Vd3JibUZOUjA5RlUwOEtTekpYVjNsaFdVNTNWV1V5YjJWYVowSktRalJyV21KUFVXbDZRV2x2Y2tVeGRtMTBUR05RVDNOUlMwTkJVVUpHY21OSE9UTXJSbGh2UWpKNGJGUlRWQXBETUVZM1YwOHdUM293VTBrelVXRlFNekp2WTNGdUsyWlJWbXRNY0U1QllraFZXR2QxT1hKc1pEaFRiak16YXk4NWFFUXpSMnhVYlhOdlNGZEtMMDVQQ2xad1EybERRa1ZsVVRZNVMwWXhWVkEwUlcxVVFsTnVSWGxEWWsxUGMwSlBTRGhEVGtwS04xSXdhMWRvTmtaUFVYTklVMHRLYUZSaWJ6bE1OVzgzYTFFS1NHcHlUblZCVEZKdUwxZE1PRGxhZDBaeFZHcGFhbEIwUzB4c1lrWjBRWEpwZDJnNE16STFjSGx1YWpaYVdsbE1PV2RaVmxKaGNEaFBkSGhoYjJ0NlRBcHJXWFJhVlUwMVdFRkNOVkphVUdWWk9FbHZjMmg1WkhWV1JISk1NRVZ1TDJkak0xQjNibGRRUlZRM2VqQlphbUl5Tm14QlYyWXJiVzVzV0RacVVHOUZDbEJYU2s4ck9HRlZiakZ4VmswcmFHbzFVa1Z1VlVGblRUVjRkRVowU21wa09ESlNTMWRRTVV4d2QxTkdNWEozUmtkUVRHcE9OSHBCU3k5Wk0zZFpaMklLVERnNFpFRnZTVUpCUkdrcllpOTJjVVJFTDFGWFNHRXdUVkU1VnpRMmNGbDJUemgyV0c1d2NIRktRVXRQYkVaQ2VVWldXVUl6WTB4MFRrZFRVbTB4T1FwaGFYSllVMmR1WkZvMVZEWlBUMHg2V0VKMU9HbzFMMWQxYmpKSVkxbEVjMmRJTUV0aWRITTJUM1F4YlhSbGRGY3JaVlV4V20xYWVVMUtZelZDUVdGYUNuSjNlVW81YkdKWmNsSm5WSGhwYTBWdlYyaE9UV3RRUTBwd01sVndTMnhRWlhaS2JHaEdlRUpOUldWd2Qwb3hLMGswYWtkSVVsbEtSSEJrZG01bmRuSUtkRUUyV0c4ME5WVnViVGRDU21ablRtcDRVVzVYVkZOYU5IbHRNM0YyUmxKVFpGQk1kWFp5VGtSb01YVTNWMlpJUjFsS2JEQm1XR0Z4VkRGU1ZWUnhTd3AzU1ROaVN6aDBWSGhEYTBVemNIVktVamxGYXk5NFNYbFNZelZ2Wm1ObGRFTm9iRzFDUnpVMFFXSlRORlJ4YzJFMmJHY3dTeXQwU0ROclltVkJjRXh2Q20xdlNWSkhlRFJ2UVM5VlZtOXhlR1ZVUm5wMFNsaFpabUpPTmtoWVEwVkRaMmRGUVVaU1MzQXpWR3h5VW14R2JYTnlSbkp3YURNd1puRlZWSEpaY21FS01qRjBiRTlOWVdoeFlVcFBSMVZ6TVVJeGRGbzRialpqZVVSQlVHeHRhazl2WW0xdVVuQlJiREIxT1hJeGJtc3ZXVk5NZWt0QlpGVnJSWGxFVjNGVGNBcHdjMmxuVkd4Nk1EQm9kaTlwZFd3M05rUjFOVmhpZGxjdlV6ZEplWG8xZVhCWk0ydHVZekZDTnpOdFdtOVBUV0ZHYWtscWJYQTBaVTVwYVZSTGNrRk5DbTlxZGswNVJGbHlhelptTVVkeVNGcFRiVWsxZFVObU0xTjJjRko1ZUZKMGJsZzRNU3Q1UzBORVQyVlRMM2RwTVhndmNXZGlUazFwZG5Wak5YUjNOWElLYlVoWk1pOWxVekpqWkhaMFFYcHVNbVJ5TVhScFozaDFZbU5JVmk5RFpFTlBaeXRZSzJwQlYwbEpkRTluTWxwWlNYWTNXVXBhTjJVeVp6SjBSV2hwZGdwM1l6QXpkVUZDZUZFNFJDdDNVR2RZT1dad1lreDJMM1ZxVDJsT2VsUkxWMlJtU0ZOTWJVdEVZa1pLV25SelJuQk5NV1ZaWms5alQzTkJQVDBLTFMwdExTMUZUa1FnVWxOQklGQlNTVlpCVkVVZ1MwVlpMUzB0TFMwSwogICAgdG9rZW46IDk1NWI3NzgxNjBlZWZjODU4M2FjMDViYTVlM2VlYTE4Cg==\"\
         \n  }\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['13059']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:28 GMT']
+      date: ['Thu, 25 Jan 2018 22:24:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -877,7 +1220,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -887,9 +1230,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 3,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 3,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -897,9 +1240,9 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1619']
+      content-length: ['1620']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:30 GMT']
+      date: ['Thu, 25 Jan 2018 22:24:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -910,19 +1253,19 @@ interactions:
 - request:
     body: 'b''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
       "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      5, "vmSize": "Standard_D1_v2", "storageProfile": "ManagedDisks", "osType": "Linux"}],
-      "linuxProfile": {"adminUsername": "azureuser", "ssh": {"publicKeys": [{"keyData":
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      5, "vmSize": "Standard_DS1_v2", "storageProfile": "ManagedDisks", "osType":
+      "Linux"}], "linuxProfile": {"adminUsername": "azureuser", "ssh": {"publicKeys":
+      [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
       test@example.com\\n"}]}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Length: ['1073']
+      Content-Length: ['1074']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
@@ -932,394 +1275,20 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Updating\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 5,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 5,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
         \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/44b726d3-c94c-4cbe-8ed4-8609fe6365f6?api-version=2017-08-31']
-      cache-control: [no-cache]
-      content-length: ['1618']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:14:32 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/44b726d3-c94c-4cbe-8ed4-8609fe6365f6?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"d326b744-4cc9-be4c-8ed4-8609fe6365f6\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:14:35.0204074Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:15:08 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/44b726d3-c94c-4cbe-8ed4-8609fe6365f6?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"d326b744-4cc9-be4c-8ed4-8609fe6365f6\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:14:35.0204074Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:15:38 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/44b726d3-c94c-4cbe-8ed4-8609fe6365f6?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"d326b744-4cc9-be4c-8ed4-8609fe6365f6\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:14:35.0204074Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:16:09 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/44b726d3-c94c-4cbe-8ed4-8609fe6365f6?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"d326b744-4cc9-be4c-8ed4-8609fe6365f6\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:14:35.0204074Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:16:40 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/44b726d3-c94c-4cbe-8ed4-8609fe6365f6?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"d326b744-4cc9-be4c-8ed4-8609fe6365f6\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:14:35.0204074Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:17:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/44b726d3-c94c-4cbe-8ed4-8609fe6365f6?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"d326b744-4cc9-be4c-8ed4-8609fe6365f6\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:14:35.0204074Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:17:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/44b726d3-c94c-4cbe-8ed4-8609fe6365f6?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"d326b744-4cc9-be4c-8ed4-8609fe6365f6\",\n  \"\
-        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-24T20:14:35.0204074Z\"\
-        ,\n  \"endTime\": \"2018-01-24T20:17:58.2579655Z\"\n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['170']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:18:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003\"\
-        ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
-        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
-        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
-        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 5,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
-        : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
-        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
-        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
-        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
-        : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
-    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/aec70ba2-921c-4562-8042-a908034d1dea?api-version=2017-08-31']
       cache-control: [no-cache]
       content-length: ['1619']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:18:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks show]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003\"\
-        ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
-        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
-        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
-        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 5,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
-        : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
-        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
-        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
-        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
-        : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['1619']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:18:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003\"\
-        ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
-        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
-        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
-        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 5,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
-        : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
-        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
-        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
-        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
-        : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['1619']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:18:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: 'b''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
-      "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      1, "vmSize": "Standard_D1_v2", "storageProfile": "ManagedDisks", "osType": "Linux"}],
-      "linuxProfile": {"adminUsername": "azureuser", "ssh": {"publicKeys": [{"keyData":
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-      test@example.com\\n"}]}}}}'''
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Length: ['1073']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003\"\
-        ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
-        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
-        \  \"provisioningState\": \"Updating\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
-        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 1,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
-        : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
-        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
-        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
-        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
-        : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31']
-      cache-control: [no-cache]
-      content-length: ['1618']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:18:19 GMT']
+      date: ['Thu, 25 Jan 2018 22:25:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1335,22 +1304,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/aec70ba2-921c-4562-8042-a908034d1dea?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
+    body: {string: "{\n  \"name\": \"a20bc7ae-1c92-6245-8042-a908034d1dea\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:25:02.8779785Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:18:50 GMT']
+      date: ['Thu, 25 Jan 2018 22:25:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1365,22 +1332,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/aec70ba2-921c-4562-8042-a908034d1dea?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
+    body: {string: "{\n  \"name\": \"a20bc7ae-1c92-6245-8042-a908034d1dea\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:25:02.8779785Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:19:24 GMT']
+      date: ['Thu, 25 Jan 2018 22:26:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1395,22 +1360,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/aec70ba2-921c-4562-8042-a908034d1dea?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
+    body: {string: "{\n  \"name\": \"a20bc7ae-1c92-6245-8042-a908034d1dea\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:25:02.8779785Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:19:56 GMT']
+      date: ['Thu, 25 Jan 2018 22:26:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1425,22 +1388,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/aec70ba2-921c-4562-8042-a908034d1dea?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
+    body: {string: "{\n  \"name\": \"a20bc7ae-1c92-6245-8042-a908034d1dea\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:25:02.8779785Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:20:27 GMT']
+      date: ['Thu, 25 Jan 2018 22:27:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1455,22 +1416,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/aec70ba2-921c-4562-8042-a908034d1dea?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
+    body: {string: "{\n  \"name\": \"a20bc7ae-1c92-6245-8042-a908034d1dea\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:25:02.8779785Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:20:58 GMT']
+      date: ['Thu, 25 Jan 2018 22:27:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1485,22 +1444,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/aec70ba2-921c-4562-8042-a908034d1dea?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
+    body: {string: "{\n  \"name\": \"a20bc7ae-1c92-6245-8042-a908034d1dea\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:25:02.8779785Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:21:28 GMT']
+      date: ['Thu, 25 Jan 2018 22:28:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1515,22 +1472,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/aec70ba2-921c-4562-8042-a908034d1dea?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
+    body: {string: "{\n  \"name\": \"a20bc7ae-1c92-6245-8042-a908034d1dea\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:25:02.8779785Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:21:59 GMT']
+      date: ['Thu, 25 Jan 2018 22:28:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1545,172 +1500,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/aec70ba2-921c-4562-8042-a908034d1dea?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:22:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:23:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:23:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:24:03 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:24:33 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks scale]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8976b5f1-0654-4bf0-b7a9-3b5ba15f7040?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"f1b57689-5406-f04b-b7a9-3b5ba15f7040\",\n  \"\
-        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-24T20:18:21.6326908Z\"\
-        ,\n  \"endTime\": \"2018-01-24T20:24:50.1473315Z\"\n }"}
+    body: {string: "{\n  \"name\": \"a20bc7ae-1c92-6245-8042-a908034d1dea\",\n  \"\
+        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-25T22:25:02.8779785Z\"\
+        ,\n  \"endTime\": \"2018-01-25T22:28:59.5894798Z\"\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['170']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:25:04 GMT']
+      date: ['Thu, 25 Jan 2018 22:29:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1725,11 +1528,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks scale]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
   response:
@@ -1737,9 +1538,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 1,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 5,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -1747,9 +1548,9 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1619']
+      content-length: ['1620']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:25:05 GMT']
+      date: ['Thu, 25 Jan 2018 22:29:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1766,7 +1567,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -1776,9 +1577,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-ae2e2dd1.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 1,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 5,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -1786,9 +1587,591 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
+      content-length: ['1620']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:29:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003\"\
+        ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
+        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
+        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
+        \  \"count\": 5,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
+        : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
+        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
+        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1620']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:29:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.7", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      1, "vmSize": "Standard_DS1_v2", "storageProfile": "ManagedDisks", "osType":
+      "Linux"}], "linuxProfile": {"adminUsername": "azureuser", "ssh": {"publicKeys":
+      [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\n"}]}}}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      Content-Length: ['1074']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003\"\
+        ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
+        \  \"provisioningState\": \"Updating\",\n   \"kubernetesVersion\": \"1.7.7\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
+        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
+        : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
+        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
+        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31']
+      cache-control: [no-cache]
       content-length: ['1619']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:25:06 GMT']
+      date: ['Thu, 25 Jan 2018 22:29:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:29:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:30:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:30:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:31:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:31:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:32:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:32:59 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:33:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:34:01 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:34:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:35:02 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:35:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:36:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        \n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:36:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/160a961a-0f6b-4469-89da-35810389bda4?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"name\": \"1a960a16-6b0f-6944-89da-35810389bda4\",\n  \"\
+        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-25T22:29:21.9678175Z\"\
+        ,\n  \"endTime\": \"2018-01-25T22:37:01.7299199Z\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['170']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:37:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks scale]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003\"\
+        ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
+        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
+        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
+        : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
+        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
+        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1620']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:37:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003\"\
+        ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
+        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.7\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-daf3edfa.hcp.eastus.azmk8s.io\"\
+        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
+        : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
+        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
+        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1620']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:37:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1806,7 +2189,7 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: DELETE
@@ -1814,13 +2197,13 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31']
       cache-control: [no-cache]
       content-length: ['0']
       content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 24 Jan 2018 20:25:08 GMT']
+      date: ['Thu, 25 Jan 2018 22:37:13 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31']
       pragma: [no-cache]
       server: [nginx]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1833,22 +2216,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:25:40 GMT']
+      date: ['Thu, 25 Jan 2018 22:37:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1863,22 +2244,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:26:10 GMT']
+      date: ['Thu, 25 Jan 2018 22:38:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1893,22 +2272,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:26:41 GMT']
+      date: ['Thu, 25 Jan 2018 22:38:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1923,22 +2300,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:27:12 GMT']
+      date: ['Thu, 25 Jan 2018 22:39:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1953,22 +2328,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:27:42 GMT']
+      date: ['Thu, 25 Jan 2018 22:39:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1983,22 +2356,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:28:13 GMT']
+      date: ['Thu, 25 Jan 2018 22:40:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2013,22 +2384,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:28:44 GMT']
+      date: ['Thu, 25 Jan 2018 22:40:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2043,22 +2412,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:29:15 GMT']
+      date: ['Thu, 25 Jan 2018 22:41:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2073,22 +2440,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:29:45 GMT']
+      date: ['Thu, 25 Jan 2018 22:41:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2103,22 +2468,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:30:16 GMT']
+      date: ['Thu, 25 Jan 2018 22:42:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2133,22 +2496,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:30:47 GMT']
+      date: ['Thu, 25 Jan 2018 22:42:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2163,22 +2524,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:31:18 GMT']
+      date: ['Thu, 25 Jan 2018 22:43:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2193,22 +2552,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:31:48 GMT']
+      date: ['Thu, 25 Jan 2018 22:43:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2223,22 +2580,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:32:19 GMT']
+      date: ['Thu, 25 Jan 2018 22:44:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2253,22 +2608,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:32:50 GMT']
+      date: ['Thu, 25 Jan 2018 22:45:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2283,142 +2636,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/010c77c1-76a0-495e-a0f2-8bb313d05f7c?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:33:20 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:33:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:34:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:34:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/34513a95-0a12-410f-9088-0e7f4d7fad3b?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"953a5134-120a-0f41-9088-0e7f4d7fad3b\",\n  \"\
-        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-24T20:25:09.8929061Z\"\
-        ,\n  \"endTime\": \"2018-01-24T20:35:04.005935Z\"\n }"}
+    body: {string: "{\n  \"name\": \"c1770c01-a076-5e49-a0f2-8bb313d05f7c\",\n  \"\
+        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-25T22:37:15.6652613Z\"\
+        ,\n  \"endTime\": \"2018-01-25T22:45:03.385188Z\"\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['169']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:35:23 GMT']
+      date: ['Thu, 25 Jan 2018 22:45:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2435,7 +2666,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -2447,7 +2678,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['180']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 24 Jan 2018 20:35:24 GMT']
+      date: ['Thu, 25 Jan 2018 22:45:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -2466,26 +2697,26 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%272fe95da7-8f35-4ba0-83a2-d1c496c5b3fe%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%271f12eaab-6cdd-4c81-b319-fd261d8e0410%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"ac65e734-16ee-4c34-82ee-a22e9918012f","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-24-20-07-29","appId":"2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-24-20-07-29","errorUrl":null,"homepage":"http://azure-cli-2018-01-24-20-07-29","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-07-29","id":"67b212f8-d569-4f25-997d-7e7b88a12c47","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-07-29","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f898c2dc-31eb-4014-b636-d2c3d70fbcc7","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-25-22-15-03","appId":"1f12eaab-6cdd-4c81-b319-fd261d8e0410","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-25-22-15-03","errorUrl":null,"homepage":"http://azure-cli-2018-01-25-22-15-03","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-15-03","id":"a61eb23e-944d-466f-bec3-7ff4e56c445d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-15-03","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","1f12eaab-6cdd-4c81-b319-fd261d8e0410"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1526']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:35:26 GMT']
-      duration: ['1091266']
+      date: ['Thu, 25 Jan 2018 22:45:33 GMT']
+      duration: ['1057977']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [FOJvei39+0RRAEZx+MJDWbFlWIOKl/laHJPN6//+pmE=]
-      ocp-aad-session-key: [EO0eu3goYScF7Zr_-5411QIFheVTjclGewzyr99ywwa2OM1eb-fbm5RZApsbfAtMrvlaj3DGF9LKgL4DS2FhUE2vT_dGhkQEaQorh9nEMSfPmjdnz8-mG7cIhsXmUXf6cdtmz__tGIXJUi6aM_2yk976arJ3HpsfBmg2xWOjvFTR6PSwEN1a6YolrYwFAHbwb_Q6tsAmWcR1X0hd55686Q.8SmSdz0HREcB7QKNo43MOm7FHnKsRz4pfkpUIVvRy6s]
+      ocp-aad-diagnostics-server-name: [jcmitHpCXKQNp4j4byjSZn2ouY7K1b70bP8n4o3+984=]
+      ocp-aad-session-key: [3FUfs9mCzbaxaChXEGEpYXA4r8hLpKv_5UaFSd4dwBXsKckPwPjjn_uYeFfryluqu9yt6L6P949ycK2Ri6C6xU125ur4Grj5cZTe2QCKy9ENFBX-WaoTyF_S2jkHgWTE0RPLsSlxQCcTxXfjYDJSqNB4YoYJ3X7LN7qimvlof2Rn85lwx7yy8G1-P25SzbmCdekEYUR06mFA5Yvaceam9Q.4lWIZk7iyDhC7Pfr_UuW7V1EovZNI4-e5_j-Mentjlg]
       pragma: [no-cache]
-      request-id: [51eb733f-81bb-41ed-840f-c046af96e2ad]
+      request-id: [776b1d0d-f521-49d0-9fe7-af4acd8968b3]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2506,26 +2737,26 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/ac65e734-16ee-4c34-82ee-a22e9918012f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/f898c2dc-31eb-4014-b636-d2c3d70fbcc7?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"ac65e734-16ee-4c34-82ee-a22e9918012f","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-24-20-07-29","appId":"2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-24-20-07-29","errorUrl":null,"homepage":"http://azure-cli-2018-01-24-20-07-29","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-07-29","id":"67b212f8-d569-4f25-997d-7e7b88a12c47","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-07-29","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f898c2dc-31eb-4014-b636-d2c3d70fbcc7","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-25-22-15-03","appId":"1f12eaab-6cdd-4c81-b319-fd261d8e0410","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-25-22-15-03","errorUrl":null,"homepage":"http://azure-cli-2018-01-25-22-15-03","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-15-03","id":"a61eb23e-944d-466f-bec3-7ff4e56c445d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-15-03","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","1f12eaab-6cdd-4c81-b319-fd261d8e0410"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1523']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:35:26 GMT']
-      duration: ['1312795']
+      date: ['Thu, 25 Jan 2018 22:45:34 GMT']
+      duration: ['697292']
       expires: ['-1']
       ocp-aad-diagnostics-server-name: [UUsoRVZx52dAfTb5wv/hhWzDqbmsJKcNRViHoL4/1IY=]
-      ocp-aad-session-key: [IWGAb2cpIztzHDtV9RGLVbfPEPT5q5TcUE6viW7Wvj6erlDZLDmRE7vUzPtUu6Onctm03GmKhTUL3m3-wTm_G1HB6lH78x0IL2bEgho-bPbxUAud6t3CKYav3BEUntHJI7FKB7yuuC4tbE_8HJmn1WvQHWDrxHgGGfUVeQjeoSWR2A_Tvptm_qVcYY0Y0PbeJtA4PXjlSF4-SMKb5B1jnw.FUeBEdagYGBMSgXaRwRsuGtiYTwx0oSHCuYL6qrZBnA]
+      ocp-aad-session-key: [kC1ycMexJW4HPXGd6AGUfyI0IaZWMsuZHFv5GT6UvW7_xT2nYbvNxzfYTyvBmjYbEMrb1xfr4-fbGNbeTnpkEwfXwPHFv5qhBfDO6kasy5qy3nFMa8efUD2yPAzm4M7SKTyN8JsxTW3lqDuq2r3ZmT7xTUljAIj5ufpIG8MKU9Vpi37XY3id1Fm58cvdYGDHiMTIs1FmSlQSfwNBk1qvUg.uYXdpqIX6BfAZxJj-A9njNiRBGIhuUV3-x0dt4Wtcvo]
       pragma: [no-cache]
-      request-id: [2d39aeb9-dcab-4e5e-a7fc-42f0a372b8df]
+      request-id: [51beffe5-8905-4f2b-8893-6c19abec4ab3]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2548,24 +2779,24 @@ interactions:
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fclitest000002%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"bd17581c-e17e-4222-b405-d70c860e852c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-24-20-07-29","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-24-20-07-29","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-07-29","id":"67b212f8-d569-4f25-997d-7e7b88a12c47","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-07-29","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-24T20:07:29.562096Z","keyId":"65065340-2837-4143-86be-fbd418bb4c55","startDate":"2018-01-24T20:07:29.562096Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"fad54c6c-e9ad-44e3-9f2a-eb498b7ba2d1","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1f12eaab-6cdd-4c81-b319-fd261d8e0410","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-25-22-15-03","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-25-22-15-03","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-15-03","id":"a61eb23e-944d-466f-bec3-7ff4e56c445d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-15-03","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-25T22:15:03.493191Z","keyId":"32e60874-1c44-45f8-b40a-9e5f6915a930","startDate":"2018-01-25T22:15:03.493191Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1862']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:35:27 GMT']
-      duration: ['842716']
+      date: ['Thu, 25 Jan 2018 22:45:35 GMT']
+      duration: ['711861']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [xIuw/bjp1m+FmuGFABwVtmA1fSSJJ+nF3+G3Tmx0epc=]
-      ocp-aad-session-key: [ceHA9Yo9C3e63aBz-yUpQURfyNxPsiG3dq2zq63rZAPp7AOYAlAApCG9pA6NFjmsSUiJTfSTCm3P_J-6FovN-_c2kASxWh7wfQs978thjJDZjjQNvl6nPkjprXPgQhXJmLA1yvpdYvTXDyGq__DQM7AsdGMbKGeyJMDAK7n4QpNWlDtsxX1utrkORWWUFPtM2ki9iWQEvvZtO57uA8sddQ.TYgvbtuWSdOSYZcyM6MspfaEFhI2S1uSgpZyopFh1ms]
+      ocp-aad-diagnostics-server-name: [WVFBMbnJaGfSvrLnzaJuh45OLLjoRA9sY9NDxBQIhgw=]
+      ocp-aad-session-key: [UQyPIQ14umXJaKmjnS1nqscwOQ86CEGHfvIU6Rihp121U02nZefaLrKO_xmsmLe8EFDbhyaQNlqbThz5Gx-Sl3LP3me6rWTfHGrlvwzWnMnuG4ReTnOIiFS_xnP0OBntNZpT2CqrPMCHmiKGQqhGzyPNVOktxEIQiYZX3lGqjNX5pZpfY94zd_WvFk2U_dtK8WYTyHXxL9Bv6xX4yqim4w.epimnVpYckPa0bYZstAoN78KQjRaQzKxbQku6i-SzS0]
       pragma: [no-cache]
-      request-id: [db61edc7-fdde-475d-9927-6b65bb8e801e]
+      request-id: [48164ba6-8f04-456d-a110-363a09b23793]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2586,26 +2817,26 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%272fe95da7-8f35-4ba0-83a2-d1c496c5b3fe%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%271f12eaab-6cdd-4c81-b319-fd261d8e0410%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"ac65e734-16ee-4c34-82ee-a22e9918012f","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-24-20-07-29","appId":"2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-24-20-07-29","errorUrl":null,"homepage":"http://azure-cli-2018-01-24-20-07-29","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-07-29","id":"67b212f8-d569-4f25-997d-7e7b88a12c47","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-07-29 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-07-29","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","2fe95da7-8f35-4ba0-83a2-d1c496c5b3fe"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f898c2dc-31eb-4014-b636-d2c3d70fbcc7","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-25-22-15-03","appId":"1f12eaab-6cdd-4c81-b319-fd261d8e0410","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-25-22-15-03","errorUrl":null,"homepage":"http://azure-cli-2018-01-25-22-15-03","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-15-03","id":"a61eb23e-944d-466f-bec3-7ff4e56c445d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-15-03 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-15-03","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","1f12eaab-6cdd-4c81-b319-fd261d8e0410"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1526']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:35:32 GMT']
-      duration: ['755893']
+      date: ['Thu, 25 Jan 2018 22:45:41 GMT']
+      duration: ['1018883']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [4faI+PQU6I9bj2peJs4PPsoHg3OyFdftj7Uo0GY4ujA=]
-      ocp-aad-session-key: [QJMWWNRjqp3oWi1OaGY-UJcPoCfBMReP29WGTyhMaeYC1YzvITwtOl-6izzGwtndMmcuk0cWYM175zoTu72wX1vnl_eHVGVUlUiSVHutBuZcXx6RdyJFcevuPe3Rz0Wc0cLMhYG5ujSiYkof9MFm9Gw9Fjk3pasHjSDLpEmA3XzVykroGu5mQbrQsiF1vneIDf6XeQ7sS27XvHXSN5bdrg.Y9kZQG1X4sY9-0xjKRciP0dcSgMU3u9nwxPkNv-i-UQ]
+      ocp-aad-diagnostics-server-name: [cfnZyxQgV11jokDDHNQ9KBHdkjg3J6BRZzXT/71HQG4=]
+      ocp-aad-session-key: [pEtRMlZ9IFlcPnnMcYwt2x8uI5F1teoDJeJW_61PVKY9buwr3BptgOoAVGjE8Wld28Lh_dIiVDtW3IKIILpKwe-yywL80hzlQf1XnqwSe5au8BiCONqkbfwTTtYZ0kd4GoLghCLEFFcZBZTjju4wBQWBi3QuwychAD68Ad74cDnwcZXOx29zmRqpfKgkr5L5hd5rikMYbY06Cz_nRVIdxQ.TrT3MK3jH7sugmXm6-dm6VsA5nQjD5mkLbJfEzdpgi4]
       pragma: [no-cache]
-      request-id: [cf87291d-eeb2-4280-a67f-f3e3ab2da331]
+      request-id: [2f59d873-df4a-43d4-bfd5-385e6f493535]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2626,14 +2857,14 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%27ac65e734-16ee-4c34-82ee-a22e9918012f%27&api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%27f898c2dc-31eb-4014-b636-d2c3d70fbcc7%27&api-version=2015-07-01
   response:
     body: {string: '{"value":[]}'}
     headers:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 24 Jan 2018 20:35:32 GMT']
+      date: ['Thu, 25 Jan 2018 22:45:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -2659,20 +2890,20 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/bd17581c-e17e-4222-b405-d70c860e852c?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/fad54c6c-e9ad-44e3-9f2a-eb498b7ba2d1?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       dataserviceversion: [1.0;]
-      date: ['Wed, 24 Jan 2018 20:35:34 GMT']
-      duration: ['2786367']
+      date: ['Thu, 25 Jan 2018 22:45:41 GMT']
+      duration: ['2469108']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [SU5fdDwsCqc7z2lm5DqXdq4BDcpBb/7KVd8B1LQCIVs=]
-      ocp-aad-session-key: [l638ReRH6FXbuDTzYEaqzbg-QPgMrmR0Nrr22Rn_biWyLUPYNOGlYh4nfBYX46YZgRtOtvlCthnJi_7DTiNLE7HCIoh5UmCq51_CEng7uwCW5Q3_g_n4EXDojE1lukfu2LGPp2_Rrj1EzRkKCVJEecK5fDuhH9Z1-4sBzMT24TMfsAmrgBTW_AEfo3XjBxTTuZuGN24gLWZLFwKDNfBDEg.Yltgm54u_D3zjUBgJDwehjRSFww-MuEmaFy01bkQn18]
+      ocp-aad-diagnostics-server-name: [/QkbbxZfyhW9slqPlub3XcBNO9jE7EivLDzFDO23uzo=]
+      ocp-aad-session-key: [BUtGtk8dDYNkfNieOXu76IVG2OspSgChQZbQixCXIGy_QMAS88_SFnDKt7tojNLNGZS_wEm-klNe-tG8zPRQUySMukK2RnQeMlrJM6daHhqS3eA5ky51Gt5-ygEiJn2HYF8e1uAdGoVMkzlQ0RSYdIRNh2Pkmj5UfZdTcM61utmXKZ9QLrGRRZCbZeq8bAdnX17rTao6VGBnBNaWTJgX0Q.0hEvtQ2oCvvHZ0KAzOQmpzmzgUGCUsM-jTVEZa0W4Og]
       pragma: [no-cache]
-      request-id: [8c58cbaf-f473-46df-bf85-a532fae9fd52]
+      request-id: [324ecc88-9f11-42f8-adf2-a5176ee14fcc]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2700,11 +2931,11 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 24 Jan 2018 20:35:35 GMT']
+      date: ['Thu, 25 Jan 2018 22:45:44 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUWUlJN0lHVUxUVS1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUUjZNV1FUWVJQSS1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_with_upgrade.yaml
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_with_upgrade.yaml
@@ -20,11 +20,11 @@ interactions:
       cache-control: [no-cache]
       content-length: ['212']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 24 Jan 2018 20:58:47 GMT']
+      date: ['Thu, 25 Jan 2018 22:46:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -48,13 +48,13 @@ interactions:
       content-length: ['166']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:58:51 GMT']
-      duration: ['760438']
+      date: ['Thu, 25 Jan 2018 22:46:06 GMT']
+      duration: ['703695']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [v9AUKJfmZmF+If7I4skLsbYB6uuGyxntFS/INLlTpmQ=]
-      ocp-aad-session-key: [KKtRQjrTkupVM6J9Fvdn5X8BM4i036zLqptpsRS2eIon1kzPwkSB_xOQZNF_aKx84QoiYOMcO3zpQxCfsv-n6a6X3gI8DErWNOBtgqS9VZ1BPRsRAF_puIOS1-0h5F32_gLD5gFsBiLhslq7iuW4fNg7YEyMm8wBTCKCjEAblqK963qggnSAomXVuX99TXtLMAP6gx5hP1iqZVLXCIaR2w.gF5T_TElF0iO_vfCqZyFU8d1cwG_T-u1mFtedqJHi70]
+      ocp-aad-diagnostics-server-name: [/QkbbxZfyhW9slqPlub3XcBNO9jE7EivLDzFDO23uzo=]
+      ocp-aad-session-key: [OWQUWFiAaGBFgHitJPpjkW0IHsNTJrz5RAZAOjze6oPTytp4oN61p3_mgWXw5tqFpdrDyRPB7likeJJNJ8VLhYNKpEESUXZpqykPscPLh3HtNFHVPG0V85MXLjmR4ABHlzBS-4MUnq1_qZwHVwBi7J3X5ai_WoGyO98xCX6j7wiM69n62914Bdl9p6frbkCEFdPpoZoZC-uLMPgZN1c8jw.0fQkeXI126gvK_PUdO3cBlqqiL-4KpfJs5hHC7f_jIk]
       pragma: [no-cache]
-      request-id: [e4a0cfe2-c2d6-4df2-b934-b6a08746c462]
+      request-id: [48cf7558-0dbc-4625-83ec-c99cf637318b]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -63,17 +63,17 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"availableToOtherTenants": false, "displayName": "azure-cli-2018-01-24-20-58-52",
-      "homepage": "http://azure-cli-2018-01-24-20-58-52", "identifierUris": ["http://clitest000002"],
-      "passwordCredentials": [{"startDate": "2018-01-24T20:58:52.591455Z", "endDate":
-      "2019-01-24T20:58:52.591455Z", "keyId": "f3ec154f-a589-4f79-a4a0-320b1c244689",
-      "value": "823ed7a1-51b0-41cb-a84e-a4583a3ffbae"}]}'''
+    body: 'b''{"availableToOtherTenants": false, "displayName": "azure-cli-2018-01-25-22-46-05",
+      "homepage": "http://azure-cli-2018-01-25-22-46-05", "identifierUris": ["http://clitest000002"],
+      "passwordCredentials": [{"startDate": "2018-01-25T22:46:05.45386099999999996Z",
+      "endDate": "2019-01-25T22:46:05.45386099999999996Z", "keyId": "a6a6b577-101b-44db-8098-7cad410b4f26",
+      "value": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}]}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [ad sp create-for-rbac]
       Connection: [keep-alive]
-      Content-Length: ['393']
+      Content-Length: ['415']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
           msrest/0.4.25 msrest_azure/0.4.20 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
@@ -82,25 +82,25 @@ interactions:
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"741411ab-9820-4b84-8270-e261134809d6","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a9300b01-278f-4696-9171-ae183f3a14b0","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-24-20-58-52","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-24-20-58-52","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-58-52","id":"79b68d23-09e9-49bd-9134-e7c4927bcff5","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-58-52","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-24T20:58:52.591455Z","keyId":"f3ec154f-a589-4f79-a4a0-320b1c244689","startDate":"2018-01-24T20:58:52.591455Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1089ed57-d68d-4db0-b908-5ec9cf9fb5ce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"06276dfc-3ed2-42bd-915c-42ee91e9bd37","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-25-22-46-05","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-25-22-46-05","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-46-05","id":"2c062277-8fbd-48de-8399-87ad0c8bf97b","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-46-05","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-25T22:46:05.453861Z","keyId":"a6a6b577-101b-44db-8098-7cad410b4f26","startDate":"2018-01-25T22:46:05.453861Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1859']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:58:52 GMT']
-      duration: ['3236709']
+      date: ['Thu, 25 Jan 2018 22:46:07 GMT']
+      duration: ['4938316']
       expires: ['-1']
-      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/741411ab-9820-4b84-8270-e261134809d6/Microsoft.DirectoryServices.Application']
-      ocp-aad-diagnostics-server-name: [xIuw/bjp1m+FmuGFABwVtmA1fSSJJ+nF3+G3Tmx0epc=]
-      ocp-aad-session-key: [BxWKIitsbpwMUEETnh8xhxB20GeWk_4evRuN3Nsy4BHsaZRqNmPy-nRlN-Tphs-nhPKuy_g9pvzdJtfP_3PCpWI239sibLpCaDiSJE3Q7V03u3IysOUi9pWUilkG7EtiqTWXSyiTER4-feVQgUxwg92iFWg6-oNKVuCSge9vECzHlS0clVAle4mYCacM-PAHI6as5Z0oyXm4Lhx4TLJkSg.rMPmI2ICNT9UGuwrj_1MHdXgw3JpSTHyRyF-V0TWSEY]
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/1089ed57-d68d-4db0-b908-5ec9cf9fb5ce/Microsoft.DirectoryServices.Application']
+      ocp-aad-diagnostics-server-name: [EmAW/3cq3T9S4P42xbgMBExuBExGKCe4J4aWuRotPBI=]
+      ocp-aad-session-key: [58L-JQ6j5XyMmc99sfyfgc4pO-ZJ0mKbspnxi1rX5dPX1vQd89a4Ja1GcAAtZJuU8cGXRe867vsEoh3DLt2lIXv4RWhpIugnlnALA7Tj4RZpbg_jX_X8SZfasaG-1B-GL9moPUF126bi0YaDEOvnQFKXyyB5po1k82Qfe-4wvB1Nt1P_gBYp7TEJmRwHj92x2nEKdRWVuCOW8bgCJWpD5A.5n0kdcRietY8Tw8Zuy1a1uAnnu12o1AWs4PyErqagBs]
       pragma: [no-cache]
-      request-id: [5ed11e65-a6c7-469d-8a10-8f1ec31ef425]
+      request-id: [c691e757-53e4-4af6-b55b-cf96f26aa883]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -109,7 +109,7 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"appId": "a9300b01-278f-4696-9171-ae183f3a14b0", "accountEnabled": true}'
+    body: '{"appId": "06276dfc-3ed2-42bd-915c-42ee91e9bd37", "accountEnabled": true}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -124,25 +124,25 @@ interactions:
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"ea699829-be23-479c-93c3-bb2588e825e8","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-24-20-58-52","appId":"a9300b01-278f-4696-9171-ae183f3a14b0","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-24-20-58-52","errorUrl":null,"homepage":"http://azure-cli-2018-01-24-20-58-52","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-58-52","id":"79b68d23-09e9-49bd-9134-e7c4927bcff5","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-58-52","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["a9300b01-278f-4696-9171-ae183f3a14b0","http://clitest000002"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"e745a8fc-84f2-4a80-aa29-1d38f77fcadb","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-25-22-46-05","appId":"06276dfc-3ed2-42bd-915c-42ee91e9bd37","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-25-22-46-05","errorUrl":null,"homepage":"http://azure-cli-2018-01-25-22-46-05","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-46-05","id":"2c062277-8fbd-48de-8399-87ad0c8bf97b","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-46-05","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["06276dfc-3ed2-42bd-915c-42ee91e9bd37","http://clitest000002"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1523']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 20:58:54 GMT']
-      duration: ['6828548']
+      date: ['Thu, 25 Jan 2018 22:46:09 GMT']
+      duration: ['2713736']
       expires: ['-1']
-      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/ea699829-be23-479c-93c3-bb2588e825e8/Microsoft.DirectoryServices.ServicePrincipal']
-      ocp-aad-diagnostics-server-name: [fwLzwlr74d9qZYN1xnQoE/OQ9gmvnh4lYeuFbQl0HKk=]
-      ocp-aad-session-key: [FSYkkii2L3_Nn9uz803vmGZafh04XD_JvDVlwpVcKTJsvHJCxfDW-i5tJqQfS8c47jwxSHKytXb5uX1oucGY4CZS8iHtKBO0DrxqcLEGzDGp8b8N3IJb_koCXiSCnDzM885NR1Y0oJ615y7VvOq1Vs-2Y6SzBYmbiHRD-aSeDdWN97SKbVnC-10EIcmXMilNK2n2DoYFbJ0-5fWhPoImvQ.5PcQe0Z8TptCNE3kxwTho3OGLHi2YH83qvuMlMRc7Lo]
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/e745a8fc-84f2-4a80-aa29-1d38f77fcadb/Microsoft.DirectoryServices.ServicePrincipal']
+      ocp-aad-diagnostics-server-name: [KslFvWWZrwibsXDcyqbxKKwRFbYUBYT2pMGGsSqjmZ0=]
+      ocp-aad-session-key: [PmkddCtiYq5QlhxfVg_4n3dzZZWLAzvgxMrWn6qo2QMqDhj9Q1EBvSJ8K0SZzs9it-KGtgDbtGgh0ExTyB60rXby3TCnUQS5T9D2OXvnu3QLb9HAmOB5X7JEc1ZdHnbRTlzMXXw5W0cyhTJkCTokB4EHySthN_qLV_TsaYSjloCwYl7znzMlO8UbBoJc0R8Q5oWmAa9ePk2ZhgPnTtdAKg.CzuUW5gv3pyz_VVAse2LbdigueCyanfob4f64FjT7qE]
       pragma: [no-cache]
-      request-id: [8263154c-7194-4af3-9e21-ee9b5b22d42d]
+      request-id: [76587941-9ac7-4852-bc7c-0b613ba66642]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -170,7 +170,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['212']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 24 Jan 2018 20:58:54 GMT']
+      date: ['Thu, 25 Jan 2018 22:46:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -179,20 +179,20 @@ interactions:
 - request:
     body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
       "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      1, "vmSize": "Standard_D1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      1, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
       "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
       "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
       test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
-      "secret": "823ed7a1-51b0-41cb-a84e-a4583a3ffbae"}}}\'''''
+      "secret": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}}}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Length: ['1226']
+      Content-Length: ['1227']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
@@ -206,7 +206,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['241']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:58:57 GMT']
+      date: ['Thu, 25 Jan 2018 22:46:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -216,20 +216,20 @@ interactions:
 - request:
     body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
       "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      1, "vmSize": "Standard_D1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      1, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
       "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
       "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
       test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
-      "secret": "823ed7a1-51b0-41cb-a84e-a4583a3ffbae"}}}\'''''
+      "secret": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}}}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Length: ['1226']
+      Content-Length: ['1227']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
@@ -243,44 +243,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['241']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:59:03 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 400, message: Bad Request}
-- request:
-    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
-      "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      1, "vmSize": "Standard_D1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
-      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
-      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
-      "secret": "823ed7a1-51b0-41cb-a84e-a4583a3ffbae"}}}\'''''
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks create]
-      Connection: [keep-alive]
-      Content-Length: ['1226']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
-        Service principal clientID: http://clitest000002 not found in Active Directory\
-        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
-        \ for more details.\"\n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['241']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:59:08 GMT']
+      date: ['Thu, 25 Jan 2018 22:46:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -290,20 +253,20 @@ interactions:
 - request:
     body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
       "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      1, "vmSize": "Standard_D1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      1, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
       "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
       "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
       test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
-      "secret": "823ed7a1-51b0-41cb-a84e-a4583a3ffbae"}}}\'''''
+      "secret": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}}}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Length: ['1226']
+      Content-Length: ['1227']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
@@ -317,7 +280,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['241']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:59:14 GMT']
+      date: ['Thu, 25 Jan 2018 22:46:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -327,20 +290,20 @@ interactions:
 - request:
     body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
       "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      1, "vmSize": "Standard_D1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      1, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
       "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
       "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
       test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
-      "secret": "823ed7a1-51b0-41cb-a84e-a4583a3ffbae"}}}\'''''
+      "secret": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}}}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Length: ['1226']
+      Content-Length: ['1227']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
@@ -354,44 +317,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['241']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:59:24 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 400, message: Bad Request}
-- request:
-    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
-      "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      1, "vmSize": "Standard_D1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
-      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
-      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
-      "secret": "823ed7a1-51b0-41cb-a84e-a4583a3ffbae"}}}\'''''
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks create]
-      Connection: [keep-alive]
-      Content-Length: ['1226']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
-        Service principal clientID: http://clitest000002 not found in Active Directory\
-        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
-        \ for more details.\"\n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['241']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:59:29 GMT']
+      date: ['Thu, 25 Jan 2018 22:46:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -401,20 +327,168 @@ interactions:
 - request:
     body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
       "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      1, "vmSize": "Standard_D1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      1, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
       "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
       "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
       test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
-      "secret": "823ed7a1-51b0-41cb-a84e-a4583a3ffbae"}}}\'''''
+      "secret": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}}}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Length: ['1226']
+      Content-Length: ['1227']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:46:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      1, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1227']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:46:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      1, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1227']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:46:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      1, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1227']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
+          AZURECLI/2.0.26]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
+  response:
+    body: {string: "{\n  \"code\": \"ServicePrincipalNotFound\",\n  \"message\": \"\
+        Service principal clientID: http://clitest000002 not found in Active Directory\
+        \ tenant 72f988bf-86f1-41af-91ab-2d7cd011db47, Please see https://aka.ms/acs-sp-help\
+        \ for more details.\"\n }"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['241']
+      content-type: [application/json]
+      date: ['Thu, 25 Jan 2018 22:46:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: 'b''b\''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
+      "kubernetesVersion": "1.7.12", "agentPoolProfiles": [{"name": "nodepool1", "count":
+      1, "vmSize": "Standard_DS1_v2", "dnsPrefix": "cliaksdns000004", "storageProfile":
+      "ManagedDisks", "osType": "Linux"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\\\n"}]}}, "servicePrincipalProfile": {"clientId": "http://clitest000002",
+      "secret": "aabb0d5c-93f8-4e1f-8ce1-62f494a3ff77"}}}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [aks create]
+      Connection: [keep-alive]
+      Content-Length: ['1227']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
@@ -426,18 +500,18 @@ interactions:
         \  \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"1.7.12\"\
         ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"agentPoolProfiles\": [\n \
         \   {\n     \"name\": \"nodepool1\",\n     \"count\": 1,\n     \"vmSize\"\
-        : \"Standard_D1_v2\",\n     \"storageProfile\": \"ManagedDisks\",\n     \"\
+        : \"Standard_DS1_v2\",\n     \"storageProfile\": \"ManagedDisks\",\n     \"\
         osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\"\
         : \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n      \
         \ \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
         \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/725fbc41-0cb4-4735-8801-0591adf2a353?api-version=2017-08-31']
       cache-control: [no-cache]
-      content-length: ['1558']
+      content-length: ['1559']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 20:59:38 GMT']
+      date: ['Thu, 25 Jan 2018 22:47:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -451,22 +525,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/725fbc41-0cb4-4735-8801-0591adf2a353?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"aafd4585-2e61-a849-8968-de3b33903a57\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:59:39.7620204Z\"\
+    body: {string: "{\n  \"name\": \"41bc5f72-b40c-3547-8801-0591adf2a353\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:47:07.9476913Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:00:12 GMT']
+      date: ['Thu, 25 Jan 2018 22:47:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -481,22 +553,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/725fbc41-0cb4-4735-8801-0591adf2a353?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"aafd4585-2e61-a849-8968-de3b33903a57\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:59:39.7620204Z\"\
+    body: {string: "{\n  \"name\": \"41bc5f72-b40c-3547-8801-0591adf2a353\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:47:07.9476913Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:00:43 GMT']
+      date: ['Thu, 25 Jan 2018 22:48:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -511,22 +581,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/725fbc41-0cb4-4735-8801-0591adf2a353?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"aafd4585-2e61-a849-8968-de3b33903a57\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:59:39.7620204Z\"\
+    body: {string: "{\n  \"name\": \"41bc5f72-b40c-3547-8801-0591adf2a353\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:47:07.9476913Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:01:15 GMT']
+      date: ['Thu, 25 Jan 2018 22:48:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -541,22 +609,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/725fbc41-0cb4-4735-8801-0591adf2a353?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"aafd4585-2e61-a849-8968-de3b33903a57\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:59:39.7620204Z\"\
+    body: {string: "{\n  \"name\": \"41bc5f72-b40c-3547-8801-0591adf2a353\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:47:07.9476913Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:01:46 GMT']
+      date: ['Thu, 25 Jan 2018 22:49:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -571,22 +637,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/725fbc41-0cb4-4735-8801-0591adf2a353?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"aafd4585-2e61-a849-8968-de3b33903a57\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:59:39.7620204Z\"\
+    body: {string: "{\n  \"name\": \"41bc5f72-b40c-3547-8801-0591adf2a353\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:47:07.9476913Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:02:16 GMT']
+      date: ['Thu, 25 Jan 2018 22:49:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -601,22 +665,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/725fbc41-0cb4-4735-8801-0591adf2a353?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"aafd4585-2e61-a849-8968-de3b33903a57\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:59:39.7620204Z\"\
+    body: {string: "{\n  \"name\": \"41bc5f72-b40c-3547-8801-0591adf2a353\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:47:07.9476913Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:02:47 GMT']
+      date: ['Thu, 25 Jan 2018 22:50:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -631,22 +693,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/725fbc41-0cb4-4735-8801-0591adf2a353?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"aafd4585-2e61-a849-8968-de3b33903a57\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:59:39.7620204Z\"\
+    body: {string: "{\n  \"name\": \"41bc5f72-b40c-3547-8801-0591adf2a353\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:47:07.9476913Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:03:18 GMT']
+      date: ['Thu, 25 Jan 2018 22:50:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -661,52 +721,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/725fbc41-0cb4-4735-8801-0591adf2a353?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"aafd4585-2e61-a849-8968-de3b33903a57\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T20:59:39.7620204Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:03:49 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/8545fdaa-612e-49a8-8968-de3b33903a57?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"aafd4585-2e61-a849-8968-de3b33903a57\",\n  \"\
-        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-24T20:59:39.7620204Z\"\
-        ,\n  \"endTime\": \"2018-01-24T21:03:50.6671415Z\"\n }"}
+    body: {string: "{\n  \"name\": \"41bc5f72-b40c-3547-8801-0591adf2a353\",\n  \"\
+        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-25T22:47:07.9476913Z\"\
+        ,\n  \"endTime\": \"2018-01-25T22:51:13.1032859Z\"\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['170']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:04:19 GMT']
+      date: ['Thu, 25 Jan 2018 22:51:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -721,11 +749,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
   response:
@@ -733,9 +759,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.12\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-c3acf229.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-fa99621e.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 1,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -743,9 +769,9 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1620']
+      content-length: ['1621']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:04:20 GMT']
+      date: ['Thu, 25 Jan 2018 22:51:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -762,7 +788,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -772,9 +798,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.12\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-c3acf229.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-fa99621e.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 1,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -782,9 +808,9 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1620']
+      content-length: ['1621']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:04:22 GMT']
+      date: ['Thu, 25 Jan 2018 22:51:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -801,7 +827,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -810,16 +836,16 @@ interactions:
     body: {string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003/upgradeprofiles/default\"\
         ,\n  \"name\": \"default\",\n  \"type\": \"Microsoft.ContainerService/managedClusters/upgradeprofiles\"\
         ,\n  \"properties\": {\n   \"controlPlaneProfile\": {\n    \"kubernetesVersion\"\
-        : \"1.7.12\",\n    \"osType\": \"Linux\",\n    \"upgrades\": [\n     \"1.8.1\"\
-        ,\n     \"1.8.2\",\n     \"1.8.6\"\n    ]\n   },\n   \"agentPoolProfiles\"\
+        : \"1.7.12\",\n    \"osType\": \"Linux\",\n    \"upgrades\": [\n     \"1.8.6\"\
+        ,\n     \"1.8.1\",\n     \"1.8.2\"\n    ]\n   },\n   \"agentPoolProfiles\"\
         : [\n    {\n     \"kubernetesVersion\": \"1.7.12\",\n     \"osType\": \"Linux\"\
-        ,\n     \"upgrades\": [\n      \"1.8.1\",\n      \"1.8.2\",\n      \"1.8.6\"\
+        ,\n     \"upgrades\": [\n      \"1.8.6\",\n      \"1.8.1\",\n      \"1.8.2\"\
         \n     ]\n    }\n   ]\n  }\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['639']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:04:23 GMT']
+      date: ['Thu, 25 Jan 2018 22:51:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -836,7 +862,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -846,9 +872,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.7.12\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-c3acf229.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-fa99621e.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 1,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -856,9 +882,9 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1620']
+      content-length: ['1621']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:04:24 GMT']
+      date: ['Thu, 25 Jan 2018 22:51:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -869,19 +895,19 @@ interactions:
 - request:
     body: 'b''{"location": "eastus", "properties": {"dnsPrefix": "cliaksdns000004",
       "kubernetesVersion": "1.8.6", "agentPoolProfiles": [{"name": "nodepool1", "count":
-      1, "vmSize": "Standard_D1_v2", "storageProfile": "ManagedDisks", "osType": "Linux"}],
-      "linuxProfile": {"adminUsername": "azureuser", "ssh": {"publicKeys": [{"keyData":
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      1, "vmSize": "Standard_DS1_v2", "storageProfile": "ManagedDisks", "osType":
+      "Linux"}], "linuxProfile": {"adminUsername": "azureuser", "ssh": {"publicKeys":
+      [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
       test@example.com\\n"}]}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Length: ['1073']
+      Content-Length: ['1074']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: PUT
@@ -891,27 +917,27 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Upgrading\",\n   \"kubernetesVersion\": \"1.8.6\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-c3acf229.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-fa99621e.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 1,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
         \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31']
       cache-control: [no-cache]
-      content-length: ['1619']
+      content-length: ['1620']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:04:26 GMT']
+      date: ['Thu, 25 Jan 2018 22:51:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -920,22 +946,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:05:00 GMT']
+      date: ['Thu, 25 Jan 2018 22:51:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -950,22 +974,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:05:32 GMT']
+      date: ['Thu, 25 Jan 2018 22:52:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -980,22 +1002,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:06:02 GMT']
+      date: ['Thu, 25 Jan 2018 22:52:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1010,22 +1030,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:06:32 GMT']
+      date: ['Thu, 25 Jan 2018 22:53:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1040,22 +1058,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:07:04 GMT']
+      date: ['Thu, 25 Jan 2018 22:54:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1070,22 +1086,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:07:34 GMT']
+      date: ['Thu, 25 Jan 2018 22:54:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1100,22 +1114,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:08:05 GMT']
+      date: ['Thu, 25 Jan 2018 22:55:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1130,22 +1142,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:08:36 GMT']
+      date: ['Thu, 25 Jan 2018 22:55:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1160,22 +1170,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:09:07 GMT']
+      date: ['Thu, 25 Jan 2018 22:56:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1190,22 +1198,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:09:38 GMT']
+      date: ['Thu, 25 Jan 2018 22:56:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1220,22 +1226,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:10:08 GMT']
+      date: ['Thu, 25 Jan 2018 22:57:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1250,22 +1254,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:10:39 GMT']
+      date: ['Thu, 25 Jan 2018 22:57:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1280,22 +1282,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:11:10 GMT']
+      date: ['Thu, 25 Jan 2018 22:58:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1310,22 +1310,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:11:42 GMT']
+      date: ['Thu, 25 Jan 2018 22:58:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1340,22 +1338,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:12:13 GMT']
+      date: ['Thu, 25 Jan 2018 22:59:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1370,52 +1366,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/e63bbd72-7884-4f74-bd39-c9c35d5d69f6?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:12:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks upgrade]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a520f38d-9a3f-4b9e-85ef-88443b38c739?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"8df320a5-3f9a-9e4b-85ef-88443b38c739\",\n  \"\
-        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-24T21:04:28.1372348Z\"\
-        ,\n  \"endTime\": \"2018-01-24T21:12:47.3361074Z\"\n }"}
+    body: {string: "{\n  \"name\": \"72bd3be6-8478-744f-bd39-c9c35d5d69f6\",\n  \"\
+        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-25T22:51:28.7259545Z\"\
+        ,\n  \"endTime\": \"2018-01-25T22:59:24.1154109Z\"\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['170']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:13:15 GMT']
+      date: ['Thu, 25 Jan 2018 22:59:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1430,11 +1394,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks upgrade]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000003?api-version=2017-08-31
   response:
@@ -1442,9 +1404,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.8.6\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-c3acf229.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-fa99621e.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 1,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -1452,9 +1414,9 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1619']
+      content-length: ['1620']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:13:16 GMT']
+      date: ['Thu, 25 Jan 2018 22:59:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1471,7 +1433,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
@@ -1481,9 +1443,9 @@ interactions:
         ,\n  \"location\": \"eastus\",\n  \"name\": \"cliakstest000003\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.8.6\"\
-        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-c3acf229.hcp.eastus.azmk8s.io\"\
+        ,\n   \"dnsPrefix\": \"cliaksdns000004\",\n   \"fqdn\": \"cliaksdns000004-fa99621e.hcp.eastus.azmk8s.io\"\
         ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
-        \  \"count\": 1,\n     \"vmSize\": \"Standard_D1_v2\",\n     \"storageProfile\"\
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS1_v2\",\n     \"storageProfile\"\
         : \"ManagedDisks\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
         : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
@@ -1491,9 +1453,9 @@ interactions:
         : {\n    \"clientId\": \"http://clitest000002\"\n   }\n  }\n }"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1619']
+      content-length: ['1620']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:13:17 GMT']
+      date: ['Thu, 25 Jan 2018 22:59:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1511,7 +1473,7 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: DELETE
@@ -1519,13 +1481,13 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31']
       cache-control: [no-cache]
       content-length: ['0']
       content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 24 Jan 2018 21:13:18 GMT']
+      date: ['Thu, 25 Jan 2018 22:59:53 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31']
       pragma: [no-cache]
       server: [nginx]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1538,22 +1500,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:13:50 GMT']
+      date: ['Thu, 25 Jan 2018 23:00:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1568,22 +1528,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:14:21 GMT']
+      date: ['Thu, 25 Jan 2018 23:00:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1598,22 +1556,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:14:51 GMT']
+      date: ['Thu, 25 Jan 2018 23:01:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1628,22 +1584,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:15:23 GMT']
+      date: ['Thu, 25 Jan 2018 23:01:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1658,22 +1612,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:15:57 GMT']
+      date: ['Thu, 25 Jan 2018 23:02:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1688,22 +1640,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:16:28 GMT']
+      date: ['Thu, 25 Jan 2018 23:02:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1718,22 +1668,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:16:59 GMT']
+      date: ['Thu, 25 Jan 2018 23:03:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1748,22 +1696,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:17:30 GMT']
+      date: ['Thu, 25 Jan 2018 23:03:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1778,22 +1724,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:18:00 GMT']
+      date: ['Thu, 25 Jan 2018 23:04:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1808,22 +1752,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:18:32 GMT']
+      date: ['Thu, 25 Jan 2018 23:05:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1838,22 +1780,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"InProgress\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
         \n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['126']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:19:03 GMT']
+      date: ['Thu, 25 Jan 2018 23:05:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -1868,202 +1808,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [aks delete]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
+          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.1 Azure-SDK-For-Python
           AZURECLI/2.0.26]
-      accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b6e7218b-e19e-4ff7-8efc-c1c5e03bf9c2?api-version=2017-08-31
   response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:19:33 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:20:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:20:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:21:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:21:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"InProgress\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
-        \n }"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['126']
-      content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:22:08 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [nginx]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [aks delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.4 (Darwin-17.3.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.25 msrest_azure/0.4.20 azure-mgmt-containerservice/3.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/1658b861-ac2d-4e1d-bbbf-34442f11fe04?api-version=2017-08-31
-  response:
-    body: {string: "{\n  \"name\": \"61b85816-2dac-1d4e-bbbf-34442f11fe04\",\n  \"\
-        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-24T21:13:21.2658599Z\"\
-        ,\n  \"endTime\": \"2018-01-24T21:22:25.9767707Z\"\n }"}
+    body: {string: "{\n  \"name\": \"8b21e7b6-9ee1-f74f-8efc-c1c5e03bf9c2\",\n  \"\
+        status\": \"Succeeded\",\n  \"startTime\": \"2018-01-25T22:59:54.6130238Z\"\
+        ,\n  \"endTime\": \"2018-01-25T23:05:40.4861909Z\"\n }"}
     headers:
       cache-control: [no-cache]
       content-length: ['170']
       content-type: [application/json]
-      date: ['Wed, 24 Jan 2018 21:22:39 GMT']
+      date: ['Thu, 25 Jan 2018 23:06:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [nginx]
@@ -2084,26 +1842,26 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27a9300b01-278f-4696-9171-ae183f3a14b0%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%2706276dfc-3ed2-42bd-915c-42ee91e9bd37%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"ea699829-be23-479c-93c3-bb2588e825e8","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-24-20-58-52","appId":"a9300b01-278f-4696-9171-ae183f3a14b0","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-24-20-58-52","errorUrl":null,"homepage":"http://azure-cli-2018-01-24-20-58-52","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-58-52","id":"79b68d23-09e9-49bd-9134-e7c4927bcff5","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-58-52","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","a9300b01-278f-4696-9171-ae183f3a14b0"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"e745a8fc-84f2-4a80-aa29-1d38f77fcadb","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-25-22-46-05","appId":"06276dfc-3ed2-42bd-915c-42ee91e9bd37","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-25-22-46-05","errorUrl":null,"homepage":"http://azure-cli-2018-01-25-22-46-05","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-46-05","id":"2c062277-8fbd-48de-8399-87ad0c8bf97b","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-46-05","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","06276dfc-3ed2-42bd-915c-42ee91e9bd37"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1526']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 21:22:41 GMT']
-      duration: ['2674105']
+      date: ['Thu, 25 Jan 2018 23:06:09 GMT']
+      duration: ['970998']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [cdP/N8qzarHjQw/ApAeRoBEHex0bhF7YQ6PS2eacDYQ=]
-      ocp-aad-session-key: [POy9H2xU6ImYtW-aByiGkOzm2Z5dCYQ0yfm6Jd3gF9idJeX0Mqsp3aBRgSzKOMaC3zKugum-4a_OqlA1aUpY-s0MTs9QopcJZvcp8rKxnE70L06D8c-5jSE6U8BmLow7lKRDp54nOaoKeJGo1EZkDLbgHQvZa-IRrPDeOgf4h2p7JTjlOX-GT2b1A6qsKpgS9zKBuskTU0UWB0BfHt4cAQ.ENA7zq4lc7KGrrsDqyrrCTblQDUtYq1drhhWqOd_5WM]
+      ocp-aad-diagnostics-server-name: [iaSFgYC+tqsHdxf0PYhhSBaccCVQl9a2v/hX0IE9E2Q=]
+      ocp-aad-session-key: [Gc54FgcTzBcgBXy2ercv8DyHFMjt0herHtnZh8sMRFJxq3rx0qP7DXaoEgpnXVF6PL4MFcClcEp_EuOiWYu4ZQbHpYEOFhVX9ztO8g0ciZ80cO2mjbPuCeTg6siYPO-iBaMk0c4RdY-myoh18F70ef9tOtqe0EdVPDK53yM-H3i3xqwqpxnhHnqOVlNZ8dryVQ84edaEMIb5KsnId1Q6hQ.OnVcVsXKd9OXGE2d52ZFAyPLYBmvK27rg1fwQ1A8vvs]
       pragma: [no-cache]
-      request-id: [9897e743-d7c3-47e1-9147-20c14559fe7b]
+      request-id: [b82dde3c-2705-4bdf-adb6-1138370c3c6d]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2124,26 +1882,26 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/ea699829-be23-479c-93c3-bb2588e825e8?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/e745a8fc-84f2-4a80-aa29-1d38f77fcadb?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"ea699829-be23-479c-93c3-bb2588e825e8","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-24-20-58-52","appId":"a9300b01-278f-4696-9171-ae183f3a14b0","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-24-20-58-52","errorUrl":null,"homepage":"http://azure-cli-2018-01-24-20-58-52","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-58-52","id":"79b68d23-09e9-49bd-9134-e7c4927bcff5","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-58-52","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","a9300b01-278f-4696-9171-ae183f3a14b0"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"e745a8fc-84f2-4a80-aa29-1d38f77fcadb","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-25-22-46-05","appId":"06276dfc-3ed2-42bd-915c-42ee91e9bd37","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-25-22-46-05","errorUrl":null,"homepage":"http://azure-cli-2018-01-25-22-46-05","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-46-05","id":"2c062277-8fbd-48de-8399-87ad0c8bf97b","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-46-05","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","06276dfc-3ed2-42bd-915c-42ee91e9bd37"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1523']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 21:22:41 GMT']
-      duration: ['805276']
+      date: ['Thu, 25 Jan 2018 23:06:09 GMT']
+      duration: ['679512']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [uWh47T9cQylboVyeD3aWIImoO8tOo13UeQFaz8gobJo=]
-      ocp-aad-session-key: [O1VooQJUBliIYFqP8OgqT13ZMZnqrJ6Le50z6c2hhLyi1utxBB97KrdMTMh8tww58ZcJkG3z5zMN3TCm-fJtxyoDQxVyWIhgIc_8gV5XN4R6lorThsn0OZyefWJjDMk0yvDUmu-tgqWTY-c4MiCUhtQfAly9ui4WD3GE3CReXEMewTPgEm5wYfmyfLPGK39VBIdQD-4pjPKZXxaAIdtP0A.oZLseH-UQAj6G2yPWOgmoy34v2poOMieUSoZnACnSvM]
+      ocp-aad-diagnostics-server-name: [cLyvU3O8ZUHAvmjMvKrFcIIEwrInuHwzeMh0tDW5BVk=]
+      ocp-aad-session-key: [dFNWjvUYR6b6YgeMWr54VIW_JupbCeJkpHQgzf7pv3hT-H57YJgZsvMeo9-uOHk85j3kl0bwtUJMI1oX4AbCawpPSTV5U-JdMJDez8HraDcCWErDVOkx5ntuT9EGvpfEmwTofy0hwZr4yDX1vKm6UpD-Vcq_ScV8ffJ1IfkZ1tFBPhwW3XAUV0XTPtvLLDCMqXnvvOnjOA7AtR-PgYr87A.F7DXK2MY1m5iEt2GQtdQT8XjVCFAv8Y2Nr6-1glSYUA]
       pragma: [no-cache]
-      request-id: [63a9051e-c31a-4140-8397-887179f44492]
+      request-id: [ad23421e-38de-4959-ab58-8dd92a1f7eca]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2166,24 +1924,24 @@ interactions:
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fclitest000002%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"741411ab-9820-4b84-8270-e261134809d6","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a9300b01-278f-4696-9171-ae183f3a14b0","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-24-20-58-52","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-24-20-58-52","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-58-52","id":"79b68d23-09e9-49bd-9134-e7c4927bcff5","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-58-52","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-24T20:58:52.591455Z","keyId":"f3ec154f-a589-4f79-a4a0-320b1c244689","startDate":"2018-01-24T20:58:52.591455Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1089ed57-d68d-4db0-b908-5ec9cf9fb5ce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"06276dfc-3ed2-42bd-915c-42ee91e9bd37","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2018-01-25-22-46-05","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2018-01-25-22-46-05","identifierUris":["http://clitest000002"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-46-05","id":"2c062277-8fbd-48de-8399-87ad0c8bf97b","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-46-05","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2019-01-25T22:46:05.453861Z","keyId":"a6a6b577-101b-44db-8098-7cad410b4f26","startDate":"2018-01-25T22:46:05.453861Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null,"isDeviceOnlyAuthSupported":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1862']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 21:22:41 GMT']
-      duration: ['971865']
+      date: ['Thu, 25 Jan 2018 23:06:12 GMT']
+      duration: ['828770']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [j4TfrIcuXv6cz1XEFyVQir6Ee64fZtWPXl/gd62UzeM=]
-      ocp-aad-session-key: [BeY_rH4fwmmnH42GfInYxDf7CFrFhuKf5eziBSp8isG23h7BLz2if2iHRpLvObD-ZVQLwuhvd-BBn3NtWAN5Mox-tGXM_2Bvnrj-KUJRGdZbdkZYzN2gNX2YdQeMuu5g_gNFROyNynNDd14-FBrP2ImDkp_xubNjEUgnT9toCUh7BNuSYsAevK8JuiMqze3_jet8sbli1CtVLshT9IvklQ.CZktJgYes1PSVA1RYK_yz2q8RLCzatcFzTrxB7MYL_I]
+      ocp-aad-diagnostics-server-name: [O3zUwAi8QzcuoWXYo3P9BPa+vEau9l2qX1zs2MJrpKg=]
+      ocp-aad-session-key: [jNCAAg-26s8KRGAaxU1v8ln7_zFEnBE5O9TuuBmY_GVBBpXIpTX-FyZavf49aUzL0qYHtTtFQGQpY47Ye03D5j-CGsvUQ0epYIv7NEyr7cAfrwvSdal4NZZPTfSg1bL5b48YabRC6XDE1D04DgeOGNMvAZKHqlsPfVa60N7Dw7dfNlAsXe2syefOnuMxOFchOPuArPlRzXFsKbaLnpr6Xw.ZdsXINkL9Xo-JSDXDZgtBc2IU3aQqOGtYVrbt8hr3AI]
       pragma: [no-cache]
-      request-id: [14dca72d-5fb6-4235-8fc5-3c4f076fb096]
+      request-id: [85b8a2e5-866a-4cb0-a644-091a6d7664c0]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2204,26 +1962,26 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27a9300b01-278f-4696-9171-ae183f3a14b0%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%2706276dfc-3ed2-42bd-915c-42ee91e9bd37%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"ea699829-be23-479c-93c3-bb2588e825e8","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-24-20-58-52","appId":"a9300b01-278f-4696-9171-ae183f3a14b0","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-24-20-58-52","errorUrl":null,"homepage":"http://azure-cli-2018-01-24-20-58-52","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2018-01-24-20-58-52","id":"79b68d23-09e9-49bd-9134-e7c4927bcff5","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2018-01-24-20-58-52 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2018-01-24-20-58-52","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","a9300b01-278f-4696-9171-ae183f3a14b0"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"e745a8fc-84f2-4a80-aa29-1d38f77fcadb","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2018-01-25-22-46-05","appId":"06276dfc-3ed2-42bd-915c-42ee91e9bd37","appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2018-01-25-22-46-05","errorUrl":null,"homepage":"http://azure-cli-2018-01-25-22-46-05","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2018-01-25-22-46-05","id":"2c062277-8fbd-48de-8399-87ad0c8bf97b","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2018-01-25-22-46-05 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2018-01-25-22-46-05","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://clitest000002","06276dfc-3ed2-42bd-915c-42ee91e9bd37"],"servicePrincipalType":"Application","tags":[],"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1526']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Wed, 24 Jan 2018 21:22:44 GMT']
-      duration: ['684796']
+      date: ['Thu, 25 Jan 2018 23:06:15 GMT']
+      duration: ['690455']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [4QNX61j6pooq22+BFVvaz7k51+Cai/QsoVwfLYwcLzM=]
-      ocp-aad-session-key: [noJhpi-ncvxWmyc7nWP_i9avc5e9z2nIq34A82J3nlhxfG0ruxNeuOA0joHJWDo558bYUhj_eQKEk0rknj5n7_yc1Kpk2-VF3hUePhPcDpFFjDLei1VoerKB6UfzNBBVXLLyEbk9J7y6yCZejI-jd1nzxgV6VPUxKUXhnuBbWZKCWYPg12P8mUnyrIc68cudTMqNLWvN2oCiHa2ZdmD11g.s99fp68zLOLpxBAAJpMpOGGSaUcGDntny1SvuQLG39M]
+      ocp-aad-diagnostics-server-name: [7akEoJBB3jXdCcddmuqIriGupZolWpVIrAvUTJndNgo=]
+      ocp-aad-session-key: [8EyxHnoTbJlhKHRHGwVXwr_aBmaH2oQgCsNFX-hcKG7orJIC_tFlBfABwpvM3X4jKVie_r3m3vNoVTpGibLYP9Nma7iwtYIX82504Rj3SDGwMhwlf42wceRIEz5TVfm5LJd8Tm7uCqrIA0JSGTI-mese1hdMxQ0-cF88TA1mpxgWeHbHZfRerIVWa_7DQkZ6IF79f_mGZZ8-ArVx2nYi_w.gg8fWC-f3AxoIMB2_Ax3TMra0i8r5dk4tamxDHPuGtA]
       pragma: [no-cache]
-      request-id: [0bcda134-7e82-4206-bdde-d36114498b51]
+      request-id: [c7e4a8f7-cd40-4a3f-904a-6ff3d3788eb2]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2244,14 +2002,14 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%27ea699829-be23-479c-93c3-bb2588e825e8%27&api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%27e745a8fc-84f2-4a80-aa29-1d38f77fcadb%27&api-version=2015-07-01
   response:
     body: {string: '{"value":[]}'}
     headers:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 24 Jan 2018 21:22:42 GMT']
+      date: ['Thu, 25 Jan 2018 23:06:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -2277,20 +2035,20 @@ interactions:
           AZURECLI/2.0.26]
       accept-language: [en-US]
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/741411ab-9820-4b84-8270-e261134809d6?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1089ed57-d68d-4db0-b908-5ec9cf9fb5ce?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       dataserviceversion: [1.0;]
-      date: ['Wed, 24 Jan 2018 21:22:47 GMT']
-      duration: ['2207684']
+      date: ['Thu, 25 Jan 2018 23:06:16 GMT']
+      duration: ['9904851']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [2DD9Uu67ybR8Pd6jBxWLoYGX++26Si/Rh4KiODEAByo=]
-      ocp-aad-session-key: [ZcXHz6nIWCYFkMZtIdh7iyoaqDHB7LcIIAjQgMop3bJ-Rg6aLpV-y7dDMKChzm_sCBj1uMybQvKilu_IE1lJKWge1AaRAA3r8pBiRddKZKRH93W6SECCKf9gOw96nNxEVkcKzg2aqygkJLYbLj7OVBIajQxymcEJ-NmOj8JBVYid96wMk8BTEeE4ljjnnTP333snfYYVoo4dBNKpk5yGGA.fWRwYZ97IM6YX6ki1fK4SjSzfMy3CCstlCTeVE2WKCM]
+      ocp-aad-diagnostics-server-name: [EeI8gQHBp2jVlJYTfebjSX2Tr+jMBmDC10RD24sUO18=]
+      ocp-aad-session-key: [VUAxLLmqAEVkDa5LCKoBDf6I5pC_iRUZrt0yhdE14k43acq0Xrwd4B7XVlO8XbznFjgCsYLR_yggGMpJhat2hVcRkTlg7B0Yf-Cm1qfkGSvJXNW0Knhv0dN5nuuvfx-qDbbSF_8ApSr-obJhhdDDYbY6EurSSyiYVM9co9JKIjF3xVtawg7sfAgsjR4HHmksrBl0VarjnDMaKkS9kyOtzg.rF1z763ZKk61hWm9F2potlVTikmGRDXjgU0xAU5asW8]
       pragma: [no-cache]
-      request-id: [f0651a6d-4aa5-402e-b0f3-1465c7d0a7e6]
+      request-id: [a336ca16-f92f-49ea-bc55-773fff654048]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -2318,11 +2076,11 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 24 Jan 2018 21:22:50 GMT']
+      date: ['Thu, 25 Jan 2018 23:06:19 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUUU9DSUJaWVhHRy1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUNjNJVkFIT0ZWMy1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -60,7 +60,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             self.check('resourceGroup', '{resource_group}'),
             self.check('agentPoolProfiles[0].count', 3),
             self.check('agentPoolProfiles[0].osType', 'Linux'),
-            self.check('agentPoolProfiles[0].vmSize', 'Standard_D1_v2'),
+            self.check('agentPoolProfiles[0].vmSize', 'Standard_DS1_v2'),
             self.check('dnsPrefix', '{dns_name_prefix}'),
             self.exists('kubernetesVersion')
         ])
@@ -169,7 +169,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             self.check('name', '{name}'),
             self.check('resourceGroup', '{resource_group}'),
             self.check('agentPoolProfiles[0].count', 1),
-            self.check('agentPoolProfiles[0].vmSize', 'Standard_D1_v2'),
+            self.check('agentPoolProfiles[0].vmSize', 'Standard_DS1_v2'),
             self.check('dnsPrefix', '{dns_name_prefix}'),
             self.check('provisioningState', 'Succeeded'),
             self.check('kubernetesVersion', '{k8s_version}')

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.25"
+VERSION = "2.0.26"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Changes the default Kubernetes VM node size for `az aks create` to `Standard_DS1_v2`.

cc: @sauryadas @slack 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [X] Each command and parameter has a meaningful description.
- [X] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
