### PR TITLE
vm boot-diagnostic: fix the broken get log command

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.26
+++++++
+* vm boot-diagnostic: fix the broken get log command
 
 2.0.25
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1005,7 +1005,6 @@ class BootLogStreamWriter(object):  # pylint: disable=too-few-public-methods
 
     def __init__(self, out):
         self.out = out
-        self.unicode_ignored = False
 
     def write(self, str_or_bytes):
         content = str_or_bytes
@@ -1018,7 +1017,6 @@ class BootLogStreamWriter(object):  # pylint: disable=too-few-public-methods
             import unicodedata
             ascii_content = unicodedata.normalize('NFKD', content).encode('ascii', 'ignore')
             self.out.write(ascii_content.decode())
-            self.unicode_ignored = True
             logger.warning("A few unicode characters have been ignored because the shell is not able to display. "
                            "To see the full log, use a shell with unicode capacity")
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -429,10 +429,10 @@ class TestVMBootLog(unittest.TestCase):
     def test_vm_boot_log_handle_unicode(self, logger_warning__mock):
         import sys
         writer = BootLogStreamWriter(sys.stdout)
+        writer.write('hello')
         writer.write(u'\u54c8')  # a random unicode trying to fail default output
-        logger_warning__mock.assert_called_with(
-            "A few unicode characters have been ignored because the shell is not able to display. "
-            "To see the full log, use a shell with unicode capacity")
+
+        # we are good once we are here 
 
     @mock.patch('azure.cli.core.profiles.get_sdk', autospec=True)
     def test_vm_boot_log_init_storage_sdk(self, get_sdk_mock):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -425,11 +425,14 @@ class TestVmCustom(unittest.TestCase):
 
 class TestVMBootLog(unittest.TestCase):
 
-    def test_vm_boot_log_handle_unicode(self):
+    @mock.patch('azure.cli.command_modules.vm.custom.logger.warning')
+    def test_vm_boot_log_handle_unicode(self, logger_warning__mock):
         import sys
         writer = BootLogStreamWriter(sys.stdout)
         writer.write(u'\u54c8')  # a random unicode trying to fail default output
-        self.assertTrue(writer.unicode_ignored)
+        logger_warning__mock.assert_called_with(
+            "A few unicode characters have been ignored because the shell is not able to display. "
+            "To see the full log, use a shell with unicode capacity")
 
     @mock.patch('azure.cli.core.profiles.get_sdk', autospec=True)
     def test_vm_boot_log_init_storage_sdk(self, get_sdk_mock):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -437,18 +437,18 @@ class TestVMBootLog(unittest.TestCase):
     @mock.patch('azure.cli.core.profiles.get_sdk', autospec=True)
     def test_vm_boot_log_init_storage_sdk(self, get_sdk_mock):
 
-        class ErrorToExitInfiniteLoop(Exception):
+        class ErrorToExitCommandEarly(Exception):
             pass
 
         cmd_mock = mock.MagicMock()
         cli_ctx_mock = mock.MagicMock()
         cmd_mock.cli_ctx = cli_ctx_mock
-        get_sdk_mock.side_effect = ErrorToExitInfiniteLoop()
+        get_sdk_mock.side_effect = ErrorToExitCommandEarly()
 
         try:
             get_boot_log(cmd_mock, 'rg1', 'vm1')
             self.fail("'get_boot_log' didn't exit early")
-        except ErrorToExitInfiniteLoop:
+        except ErrorToExitCommandEarly:
             get_sdk_mock.assert_called_with(cli_ctx_mock, ResourceType.DATA_STORAGE, 'blob.blockblobservice#BlockBlobService')
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -432,7 +432,7 @@ class TestVMBootLog(unittest.TestCase):
         writer.write('hello')
         writer.write(u'\u54c8')  # a random unicode trying to fail default output
 
-        # we are good once we are here 
+        # we are good once we are here
 
     @mock.patch('azure.cli.core.profiles.get_sdk', autospec=True)
     def test_vm_boot_log_init_storage_sdk(self, get_sdk_mock):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -8,12 +8,13 @@ import mock
 
 from knack.util import CLIError
 
-from azure.cli.command_modules.vm.custom import enable_boot_diagnostics, disable_boot_diagnostics, \
-    _merge_secrets
-from azure.cli.command_modules.vm.custom import (_get_access_extension_upgrade_info,
+from azure.cli.command_modules.vm.custom import (enable_boot_diagnostics, disable_boot_diagnostics,
+                                                 _merge_secrets, BootLogStreamWriter,
+                                                 _get_access_extension_upgrade_info,
                                                  _LINUX_ACCESS_EXT,
                                                  _WINDOWS_ACCESS_EXT,
-                                                 _get_extension_instance_name)
+                                                 _get_extension_instance_name,
+                                                 get_boot_log)
 from azure.cli.command_modules.vm.custom import \
     (attach_unmanaged_data_disk, detach_data_disk, get_vmss_instance_view)
 
@@ -420,6 +421,32 @@ class TestVmCustom(unittest.TestCase):
 
         # assert
         self.assertEqual(result, 'extension-name')
+
+
+class TestVMBootLog(unittest.TestCase):
+
+    def test_vm_boot_log_handle_unicode(self):
+        import sys
+        writer = BootLogStreamWriter(sys.stdout)
+        writer.write(u'\u54c8')  # a random unicode trying to fail default output
+        self.assertTrue(writer.unicode_ignored)
+
+    @mock.patch('azure.cli.core.profiles.get_sdk', autospec=True)
+    def test_vm_boot_log_init_storage_sdk(self, get_sdk_mock):
+
+        class ErrorToExitInfiniteLoop(Exception):
+            pass
+
+        cmd_mock = mock.MagicMock()
+        cli_ctx_mock = mock.MagicMock()
+        cmd_mock.cli_ctx = cli_ctx_mock
+        get_sdk_mock.side_effect = ErrorToExitInfiniteLoop()
+
+        try:
+            get_boot_log(cmd_mock, 'rg1', 'vm1')
+            self.fail("'get_boot_log' didn't exit early")
+        except ErrorToExitInfiniteLoop:
+            get_sdk_mock.assert_called_with(cli_ctx_mock, ResourceType.DATA_STORAGE, 'blob.blockblobservice#BlockBlobService')
 
 
 class FakedVM(object):  # pylint: disable=too-few-public-methods

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.25"
+VERSION = "2.0.26"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Also fix #5395

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
