### PR TITLE
Add module loading performance check to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ jobs:
       script: ./scripts/ci/test_integration.sh
       env: PURPOSE='Integration'
       python: 2.7
+    - stage: verify
+      script: ./scripts/ci/test_perf.sh
+      env: PURPOSE='Module Load Performance'
+      python: 3.6
     - stage: publish
       script: ./scripts/ci/publish.sh
       python: 3.6

--- a/scripts/ci/test_perf.sh
+++ b/scripts/ci/test_perf.sh
@@ -14,12 +14,6 @@ pip install $ALL_MODULES
 echo '=== List installed packages'
 pip freeze
 
-echo '=== Begin testing'
+echo '=== Test Module Loading Performance'
 unset AZURE_CLI_DIAGNOSTICS_TELEMETRY
-azdev verify package $share_folder/build/
-
-echo '= Verify Commands with -h'
-azdev verify commands
-
-echo '= Verify Dependencies'
-azdev verify dependencies
+azdev verify module-load-perf


### PR DESCRIPTION
Closes #5326. 

This PR runs `azdev verify module-load-perf` on a separate stage to detect and prevent significant performance regressions. 

I will remove the DNM label once I have done the following:

- [x] Verified the thresholds are sufficiently high so that modules don't sporadically fail
- [x] Verified that pushing changes which negatively impact performance cause the CI stage to fail.