### PR TITLE
auth: key on both subscription id and name on msi login

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,9 +2,9 @@
 
 Release History
 ===============
-
 2.0.27
 ++++++
+auth: key on both subscription id and name on msi login
 * Minor fixes
 
 2.0.26

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 2.0.27
 ++++++
-auth: key on both subscription id and name on msi login
+* auth: key on both subscription id and name on msi login
 * Minor fixes
 
 2.0.26

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -280,9 +280,13 @@ class Profile(object):
 
     def _set_subscriptions(self, new_subscriptions, merge=True, secondary_key_name=None):
 
-        def _get_key_name(x, secondary_key_name):
-            return (x[_SUBSCRIPTION_ID] if secondary_key_name is None
-                    else '{}-{}'.format(x[_SUBSCRIPTION_ID], x[secondary_key_name]))
+        def _get_key_name(account, secondary_key_name):
+            return (account[_SUBSCRIPTION_ID] if secondary_key_name is None
+                    else '{}-{}'.format(account[_SUBSCRIPTION_ID], account[secondary_key_name]))
+
+        def _match_account(account, subscription_id, secondary_key_name, secondary_key_val):
+            return (account[_SUBSCRIPTION_ID] == subscription_id and
+                    (secondary_key_val is None or account[secondary_key_name] == secondary_key_val))
 
         existing_ones = self.load_cached_subscriptions(all_clouds=True)
         active_one = next((x for x in existing_ones if x.get(_IS_DEFAULT_SUBSCRIPTION)), None)
@@ -302,9 +306,8 @@ class Profile(object):
         if subscriptions:
             if active_one:
                 new_active_one = next(
-                    (x for x in new_subscriptions if x[_SUBSCRIPTION_ID] == active_subscription_id and
-                     (active_secondary_key_val is None or x[secondary_key_name] == active_secondary_key_val)),
-                    None)
+                    (x for x in new_subscriptions if _match_account(x, active_subscription_id, secondary_key_name,
+                                                                    active_secondary_key_val)), None)
 
                 for s in subscriptions:
                     s[_IS_DEFAULT_SUBSCRIPTION] = False

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -506,7 +506,7 @@ class TestProfile(unittest.TestCase):
         test_client_id = '12345678-38d6-4fb2-bad9-b7b93a3e8888'
         msi_subscription = SubscriptionStub('/subscriptions/' + test_subscription_id, 'MSIClient-{}@{}'.format(test_client_id, test_port), self.state1, test_tenant_id)
         consolidated = profile._normalize_properties(test_user, [msi_subscription], True)
-        profile._set_subscriptions(consolidated, key_name='name')
+        profile._set_subscriptions(consolidated, secondary_key_name='name')
 
         # setup a response for the token request
         test_token_entry = {
@@ -551,7 +551,7 @@ class TestProfile(unittest.TestCase):
                                             'MSIObject-{}@12345'.format(test_object_id),
                                             self.state1, '12345678-38d6-4fb2-bad9-b7b93a3e1234')
         consolidated = profile._normalize_properties('userAssignedIdentity', [msi_subscription], True)
-        profile._set_subscriptions(consolidated, key_name='name')
+        profile._set_subscriptions(consolidated, secondary_key_name='name')
 
         # setup a response for the token request
         test_token_entry = {
@@ -592,7 +592,7 @@ class TestProfile(unittest.TestCase):
                                             'MSIResource-{}@12345'.format(test_res_id),
                                             self.state1, '12345678-38d6-4fb2-bad9-b7b93a3e1234')
         consolidated = profile._normalize_properties('userAssignedIdentity', [msi_subscription], True)
-        profile._set_subscriptions(consolidated, key_name='name')
+        profile._set_subscriptions(consolidated, secondary_key_name='name')
 
         # setup a response for the token request
         test_token_entry = {


### PR DESCRIPTION
Fix #5402 

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
