### PR TITLE
ad app update: expose '--available-to-other-tenants'

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.18
+++++++
+* ad app update: expose "--available-to-other-tenants"
 
 2.0.17
 ++++++

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -33,6 +33,7 @@ def load_arguments(self, _):
         # TODO: Update these with **enum_choice_list(...) when SDK supports proper enums
         c.argument('key_type', help='the type of the key credentials associated with the application', arg_type=get_enum_type(['AsymmetricX509Cert', 'Password', 'Symmetric'], default='AsymmetricX509Cert'))
         c.argument('key_usage', help='the usage of the key credentials associated with the application.', arg_type=get_enum_type(['Sign', 'Verify'], default='Verify'))
+        c.argument('password', help="app password, aka 'client secret'")
 
     with self.argument_context('ad sp') as c:
         c.argument('identifier', options_list=['--id'], help='service principal name, or object id')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -437,17 +437,20 @@ def create_application(client, display_name, homepage, identifier_uris,
 
 def update_application(client, identifier, display_name=None, homepage=None,
                        identifier_uris=None, password=None, reply_urls=None, key_value=None,
-                       key_type=None, key_usage=None, start_date=None, end_date=None):
+                       key_type=None, key_usage=None, start_date=None, end_date=None, available_to_other_tenants=None):
     object_id = _resolve_application(client, identifier)
-    password_creds, key_creds = _build_application_creds(password, key_value, key_type,
-                                                         key_usage, start_date, end_date)
 
+    password_creds, key_creds = None, None
+    if any([key_value, key_type, key_usage, start_date, end_date]):
+        password_creds, key_creds = _build_application_creds(password, key_value, key_type,
+                                                             key_usage, start_date, end_date)
     app_patch_param = ApplicationUpdateParameters(display_name=display_name,
                                                   homepage=homepage,
                                                   identifier_uris=identifier_uris,
                                                   reply_urls=reply_urls,
                                                   key_credentials=key_creds,
-                                                  password_credentials=password_creds)
+                                                  password_credentials=password_creds,
+                                                  available_to_other_tenants=available_to_other_tenants)
     return client.patch(object_id, app_patch_param)
 
 

--- a/src/command_modules/azure-cli-role/setup.py
+++ b/src/command_modules/azure-cli-role/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.17"
+VERSION = "2.0.18"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fix #5425

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
