### PR TITLE
Add EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL event to core.

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 2.0.27
 ++++++
+* Create ArgumentExtensionsLoader and incorporate it in core
 * Minor fixes
 
 2.0.26

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.0.27
 ++++++
-* Create ArgumentExtensionsLoader and incorporate it in core
+* Add new knack event EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL
 * Minor fixes
 
 2.0.26

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -205,6 +205,52 @@ class MainCommandsLoader(CLICommandsLoader):
                 loader._update_command_definitions()  # pylint: disable=protected-access
 
 
+class ArgumentExtensionsLoader(object):
+    """ Load extenions that would modify the input arguments of the CLI """
+
+    def __init__(self, **kwargs):
+        self.extensions = None
+        self.kwargs = kwargs
+
+    def load_argument_extensions(self):
+        self.extensions = list(ArgumentExtensionsLoader.get_argument_extensions())
+
+    def process(self, args):
+        """ Go through each argument extension and process the input arguments """
+        import traceback
+
+        for ext_name, ext_cls in self.extensions:
+            try:
+                ext_instance = ext_cls(**self.kwargs)
+                args = ext_instance.transform(args)
+            except (TypeError, AttributeError):
+                logger.warning("Unable to process input arguments with extension module '%s'. %s", ext_name,
+                               "Use --debug for more information.")
+                logger.debug(traceback.format_exc())
+        return args
+
+    @staticmethod
+    def get_argument_extensions():
+        import traceback
+        from importlib import import_module
+        from azure.cli.core.extension import (
+            get_extension_names, get_extension_path, get_extension_modname)
+
+        extensions = get_extension_names()
+        for ext_name in extensions:
+            ext_dir = get_extension_path(ext_name)
+            try:
+                ext_mod = get_extension_modname(ext_name, ext_dir=ext_dir)
+                mod = import_module(ext_mod)
+                arg_ext_cls = getattr(mod, 'ARG_EXT_CLS', None)
+                if arg_ext_cls:
+                    yield (ext_name, arg_ext_cls)
+                    logger.debug("Loaded argument extension '%s'", ext_name)
+            except Exception:  # pylint: disable=broad-except
+                logger.warning("Unable to load extension '%s'. Use --debug for more information.", ext_name)
+                logger.debug(traceback.format_exc())
+
+
 class AzCommandsLoader(CLICommandsLoader):
 
     def __init__(self, cli_ctx=None, min_profile=None, max_profile='latest',

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -189,16 +189,20 @@ class AzCliCommand(CLICommand):
 # pylint: disable=too-few-public-methods
 class AzCliCommandInvoker(CommandInvoker):
 
-    # pylint: disable=too-many-statements,too-many-locals
+    # pylint: disable=too-many-statements
     def execute(self, args):
         import knack.events as events
         from knack.util import CommandResultItem, todict
+
+        events.EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL = 'CommandInvoker.OnPreTruncateCommandTable'
 
         # TODO: Can't simply be invoked as an event because args are transformed
         args = _pre_command_table_create(self.cli_ctx, args)
 
         self.cli_ctx.raise_event(events.EVENT_INVOKER_PRE_CMD_TBL_CREATE, args=args)
         self.commands_loader.load_command_table(args)
+        self.cli_ctx.raise_event(events.EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL,
+                                 load_cmd_tbl_func=self.commands_loader.load_command_table, args=args)
         command = self._rudimentary_get_command(args)
 
         try:
@@ -238,8 +242,6 @@ class AzCliCommandInvoker(CommandInvoker):
         self.commands_loader.command_table = self.commands_loader.command_table  # update with the truncated table
         self.commands_loader.command_name = command
         self.commands_loader.load_arguments(command)
-        self.cli_ctx.raise_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE,
-                                 cmd_tbl=self.commands_loader.command_table, args=args)
         self.parser.cli_ctx = self.cli_ctx
         self.parser.load_command_table(self.commands_loader.command_table)
 


### PR DESCRIPTION
Currently, azure-cli only supports command-based extensions. `ArgumentExtensionsLoader` will support non-command-based extensions that modify input arguments in the CLI. The format of the extension is as follow:

```python
class ExampleArgumentExtension:

    def __init__(self, **kwargs):
        pass

    def transform(self, args):
        # Process input argument here
        return processed_args

ARG_EXT_CLS = ExampleArgumentExtension
```
Each argument extension has an export class `ARG_EXT_CLS` and its constructor accepts `**kwargs`. Within the class, it has a function `transform` that accepts the CLI input arguments `args` and output the processed arguments.

@troydai and @derekbekoe, could you please review? Thanks!

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] (N/A) Each command and parameter has a meaningful description.
- [ ] (N/A) Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
