### PR TITLE
Make interaction use azureProfile.json from .azure

### DIFF
--- a/src/command_modules/azure-cli-interactive/HISTORY.rst
+++ b/src/command_modules/azure-cli-interactive/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.3.16
+++++++
+* Point to azureProfile.json in .azure directory.
+
 0.3.15
 ++++++
 * Fixed issue where command option completions no longer appeared.

--- a/src/command_modules/azure-cli-interactive/HISTORY.rst
+++ b/src/command_modules/azure-cli-interactive/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 0.3.16
 ++++++
-* Point to azureProfile.json in .azure directory.
+* Fix issue where user is prompted to login when using interactive mode in Cloud Shell.
 
 0.3.15
 ++++++

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -631,10 +631,10 @@ class AzInteractiveShell(object):
                 self.config.set_feedback('yes')
                 self.user_feedback = False
 
-            azure_folder = self.config.config_dir
+            azure_folder = get_config_dir()
             if not os.path.exists(azure_folder):
                 os.makedirs(azure_folder)
-            ACCOUNT.load(os.path.join(get_config_dir(), 'azureProfile.json'))
+            ACCOUNT.load(os.path.join(azure_folder, 'azureProfile.json'))
             CONFIG.load(os.path.join(azure_folder, 'az.json'))
             SESSION.load(os.path.join(azure_folder, 'az.sess'), max_age=3600)
 

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -634,7 +634,7 @@ class AzInteractiveShell(object):
             azure_folder = self.config.config_dir
             if not os.path.exists(azure_folder):
                 os.makedirs(azure_folder)
-            ACCOUNT.load(os.path.join(azure_folder, 'azureProfile.json'))
+            ACCOUNT.load(os.path.join(get_config_dir(), 'azureProfile.json'))
             CONFIG.load(os.path.join(azure_folder, 'az.json'))
             SESSION.load(os.path.join(azure_folder, 'az.sess'), max_age=3600)
 

--- a/src/command_modules/azure-cli-interactive/setup.py
+++ b/src/command_modules/azure-cli-interactive/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     cmdclass = {}
 
 # Version is also defined in azclishell.__init__.py.
-VERSION = "0.3.15"
+VERSION = "0.3.16"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
---
Closes: https://github.com/Azure/azure-cli/issues/5421

- `az login` from the cli caches its subscription and profile inside the ".azure" directory.
- interactive mode would look inside ".azure-shell" and require a separate login from within interactive mode (which is disabled in CloudShell).

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
