### PR TITLE
Fix the tags option of the "az network public-ip create" command.

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.23
+++++++
+* `network public-ip create`: Fix `--tags` option.
+
 2.0.22
 ++++++
 * `application-gateway create`: `--cert-password` protected using secureString.
@@ -14,7 +18,6 @@ Release History
                      Fix issue where quoted TXT records were incorrectly exported without escaped quotes.
 * `dns zone import`: Fix issue where certain records were imported twice.
 * Restored `vnet-gateway root-cert` and `vnet-gateway revoked-cert` commands.
-* `network public-ip create`: Fix `--tags` option.
 
 2.0.21
 ++++++

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -6,6 +6,11 @@ Release History
 2.0.23
 ++++++
 * `network public-ip create`: Fix `--tags` option.
+* `network lb create`: Fix `--tags` option.
+* `network local-gateway create`: Fix `--tags` option.
+* `network nic create`: Fix `--tags` option.
+* `network vnet-gateway create`: Fix `--tags` option.
+* `network vpn-connection create`: Fix `--tags` option.
 
 2.0.22
 ++++++

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -14,6 +14,7 @@ Release History
                      Fix issue where quoted TXT records were incorrectly exported without escaped quotes.
 * `dns zone import`: Fix issue where certain records were imported twice.
 * Restored `vnet-gateway root-cert` and `vnet-gateway revoked-cert` commands.
+* `network public-ip create`: Fix `--tags` option.
 
 2.0.21
 ++++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -594,6 +594,7 @@ def process_nic_create_namespace(cmd, namespace):
 
 def process_public_ip_create_namespace(cmd, namespace):
     get_default_location_from_resource_group(cmd, namespace)
+    validate_tags(namespace)
 
 
 def process_route_table_create_namespace(cmd, namespace):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -531,6 +531,7 @@ def process_auth_create_namespace(namespace):
 
 def process_lb_create_namespace(cmd, namespace):
     get_default_location_from_resource_group(cmd, namespace)
+    validate_tags(namespace)
 
     if namespace.subnet and namespace.public_ip_address:
         raise ValueError(
@@ -573,6 +574,8 @@ def process_lb_frontend_ip_namespace(namespace):
 def process_local_gateway_create_namespace(cmd, namespace):
     ns = namespace
     get_default_location_from_resource_group(cmd, ns)
+    validate_tags(ns)
+
     use_bgp_settings = any([ns.asn or ns.bgp_peering_address or ns.peer_weight])
     if use_bgp_settings and (not ns.asn or not ns.bgp_peering_address):
         raise ValueError(
@@ -581,6 +584,7 @@ def process_local_gateway_create_namespace(cmd, namespace):
 
 def process_nic_create_namespace(cmd, namespace):
     get_default_location_from_resource_group(cmd, namespace)
+    validate_tags(namespace)
 
     validate_address_pool_id_list(namespace)
     validate_inbound_nat_rule_id_list(namespace)
@@ -679,6 +683,8 @@ def process_vnet_create_namespace(cmd, namespace):
 def process_vnet_gateway_create_namespace(cmd, namespace):
     ns = namespace
     get_default_location_from_resource_group(cmd, ns)
+    validate_tags(ns)
+
     get_virtual_network_validator()(ns)
 
     get_public_ip_validator()(ns)
@@ -706,6 +712,7 @@ def process_vnet_gateway_update_namespace(namespace):
 def process_vpn_connection_create_namespace(cmd, namespace):
     from msrestazure.tools import is_valid_resource_id, resource_id
     get_default_location_from_resource_group(cmd, namespace)
+    validate_tags(namespace)
 
     args = [a for a in [namespace.express_route_circuit2,
                         namespace.local_gateway2,

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.22"
+VERSION = "2.0.23"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
It wasn't possible to specify tags when creating a public IP. The tags
weren't parsed in the command callback resulting in an incorrect
format (array instead of object) and a python error on validation.
The fix is a one-liner adding the missing validate_tags() call.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
