### PR TITLE
[AKS] remove k8s default version from CLI 

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 2.0.26
 ++++++
+* `aks create` defaults to letting the server choose the version of Kubernetes
 * `aks create` VM node size default changed from "Standard_D1_v2" to "Standard_DS1_v2"
 
 2.0.25

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -166,7 +166,7 @@ helps['aks create'] = """
           short-summary: Size in GB of the OS disk for each node in the node pool.
         - name: --kubernetes-version -k
           type: string
-          short-summary: Version of Kubernetes to use for creating the cluster, such as "1.7.7" or "1.8.2".
+          short-summary: Version of Kubernetes to use for creating the cluster, such as "1.7.12" or "1.8.6".
         - name: --ssh-key-value
           type: string
           short-summary: Public key path or key contents to install on node VMs for SSH access. For example,

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
@@ -80,7 +80,7 @@ def validate_k8s_version(namespace):
             namespace.kubernetes_version = found[0]
         else:
             raise CLIError('--kubernetes-version should be the full version number, '
-                        'such as "1.7.12" or "1.8.6"')
+                           'such as "1.7.12" or "1.8.6"')
 
 
 def validate_k8s_client_version(namespace):

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
@@ -71,14 +71,16 @@ def validate_create_parameters(namespace):
 
 
 def validate_k8s_version(namespace):
-    """Validates a string as a possible Kubernetes version."""
-    k8s_release_regex = re.compile(r'^[v|V]?(\d+\.\d+\.\d+.*)$')
-    found = k8s_release_regex.findall(namespace.kubernetes_version)
-    if found:
-        namespace.kubernetes_version = found[0]
-    else:
-        raise CLIError('--kubernetes-version should be the full version number, '
-                       'such as "1.7.7" or "1.8.1"')
+    """Validates a string as a possible Kubernetes version. An empty string is also valid, which tells the server
+    to use its default version."""
+    if namespace.kubernetes_version:
+        k8s_release_regex = re.compile(r'^[v|V]?(\d+\.\d+\.\d+.*)$')
+        found = k8s_release_regex.findall(namespace.kubernetes_version)
+        if found:
+            namespace.kubernetes_version = found[0]
+        else:
+            raise CLIError('--kubernetes-version should be the full version number, '
+                        'such as "1.7.12" or "1.8.6"')
 
 
 def validate_k8s_client_version(namespace):

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1253,7 +1253,7 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
                dns_name_prefix=None,
                location=None,
                admin_username="azureuser",
-               kubernetes_version="1.7.7",
+               kubernetes_version='',
                node_vm_size="Standard_DS1_v2",
                node_osdisk_size=0,
                node_count=3,


### PR DESCRIPTION
This allows the RP to set the default version if the user doesn't supply one explicitly. Currently that's Kubernetes 1.7.9, but should bump up to 1.7.12 soon.

Setting the default on the server lets us to stop updating the CLI just to chase newer versions.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [X] Each command and parameter has a meaningful description.
- [X] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
