### PR TITLE
Trigger 'CommandInvoker.OnPreTruncateCommandTable' event before truncating the command table

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 2.0.27
 ++++++
 * auth: key on both subscription id and name on msi login
-* Add new knack event EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL
+* Raise 'CommandInvoker.OnPreTruncateCommandTable' before truncating command table
 * Minor fixes
 
 2.0.26

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 2.0.27
 ++++++
 * auth: key on both subscription id and name on msi login
+* Add new knack event EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL
 * Minor fixes
 
 2.0.26

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 2.0.27
 ++++++
 * auth: key on both subscription id and name on msi login
-* Raise 'CommandInvoker.OnPreTruncateCommandTable' before truncating command table
+* Add events module in core for EVENT_INVOKER_PRE_CMD_TBL_TRUNCATE
 * Minor fixes
 
 2.0.26

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -194,14 +194,12 @@ class AzCliCommandInvoker(CommandInvoker):
         import knack.events as events
         from knack.util import CommandResultItem, todict
 
-        events.EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL = 'CommandInvoker.OnPreTruncateCommandTable'
-
         # TODO: Can't simply be invoked as an event because args are transformed
         args = _pre_command_table_create(self.cli_ctx, args)
 
         self.cli_ctx.raise_event(events.EVENT_INVOKER_PRE_CMD_TBL_CREATE, args=args)
         self.commands_loader.load_command_table(args)
-        self.cli_ctx.raise_event(events.EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL,
+        self.cli_ctx.raise_event('CommandInvoker.OnPreTruncateCommandTable',
                                  load_cmd_tbl_func=self.commands_loader.load_command_table, args=args)
         command = self._rudimentary_get_command(args)
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -193,13 +193,14 @@ class AzCliCommandInvoker(CommandInvoker):
     def execute(self, args):
         import knack.events as events
         from knack.util import CommandResultItem, todict
+        from azure.cli.core.commands.events import EVENT_INVOKER_PRE_CMD_TBL_TRUNCATE
 
         # TODO: Can't simply be invoked as an event because args are transformed
         args = _pre_command_table_create(self.cli_ctx, args)
 
         self.cli_ctx.raise_event(events.EVENT_INVOKER_PRE_CMD_TBL_CREATE, args=args)
         self.commands_loader.load_command_table(args)
-        self.cli_ctx.raise_event('CommandInvoker.OnPreTruncateCommandTable',
+        self.cli_ctx.raise_event(EVENT_INVOKER_PRE_CMD_TBL_TRUNCATE,
                                  load_cmd_tbl_func=self.commands_loader.load_command_table, args=args)
         command = self._rudimentary_get_command(args)
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -194,11 +194,15 @@ class AzCliCommandInvoker(CommandInvoker):
         import knack.events as events
         from knack.util import CommandResultItem, todict
 
+        events.EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL = 'CommandInvoker.OnPreTruncateCommandTable'
+
         # TODO: Can't simply be invoked as an event because args are transformed
         args = _pre_command_table_create(self.cli_ctx, args)
 
         self.cli_ctx.raise_event(events.EVENT_INVOKER_PRE_CMD_TBL_CREATE, args=args)
         self.commands_loader.load_command_table(args)
+        self.cli_ctx.raise_event(events.EVENT_INVOKER_PRE_TRUNCATE_CMD_TBL,
+                                 load_cmd_tbl_func=self.commands_loader.load_command_table, args=args)
         command = self._rudimentary_get_command(args)
 
         try:

--- a/src/azure-cli-core/azure/cli/core/commands/events.py
+++ b/src/azure-cli-core/azure/cli/core/commands/events.py
@@ -1,1 +1,6 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 EVENT_INVOKER_PRE_CMD_TBL_TRUNCATE = 'CommandInvoker.OnPreCommandTableTruncate'

--- a/src/azure-cli-core/azure/cli/core/commands/events.py
+++ b/src/azure-cli-core/azure/cli/core/commands/events.py
@@ -1,0 +1,1 @@
+EVENT_INVOKER_PRE_CMD_TBL_TRUNCATE = 'CommandInvoker.OnPreCommandTableTruncate'


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
