### PR TITLE
[AKS] fix `az aks browse` if dashboard isn't prefixed by "pods/"

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 2.0.26
 ++++++
 * `aks create` VM node size default changed from "Standard_D1_v2" to "Standard_DS1_v2"
+* improve reliability when locating the dashboard pod for `az aks browse`
 
 2.0.25
 ++++++

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1236,8 +1236,8 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False):
     except subprocess.CalledProcessError as err:
         raise CLIError('Could not find dashboard pod: {}'.format(err))
     if dashboard_pod:
-        # remove the "pods/" prefix from the name
-        dashboard_pod = str(dashboard_pod)[5:].strip()
+        # remove any "pods/" or "pod/" prefix from the name
+        dashboard_pod = str(dashboard_pod).split('/')[-1].strip()
     else:
         raise CLIError("Couldn't find the Kubernetes dashboard pod.")
     # launch kubectl port-forward locally to access the remote dashboard


### PR DESCRIPTION
Makes finding the k8s dashboard pod more robust by returning the last string segment following a `/` character, if there is one.

Closes Azure/AKS#159