### PR TITLE
Correct usage of "delimiter-separated" in help strings, docs, and comments

### DIFF
--- a/doc/authoring_command_modules/authoring_commands.md
+++ b/doc/authoring_command_modules/authoring_commands.md
@@ -55,7 +55,7 @@ class MyCommandsLoader(AzCommandsLoader):
     def load_arguments(self, command):
         super(MyCommandsLoader, self).load_arguments(command)
         # TODO: Register argument contexts and arguments here
-        
+
 COMMAND_LOADER_CLS = MyCommandsLoader
 ```
 
@@ -177,7 +177,7 @@ For more information:
 argument_context(self, scope, **kwargs):
 ```
 
-- `scope` - This string is the level at which your customizations are applied. For example, consider the case where you have commands `az mypackage command1` and `az mypackage command2`, which both have a parameter `my_param`. 
+- `scope` - This string is the level at which your customizations are applied. For example, consider the case where you have commands `az mypackage command1` and `az mypackage command2`, which both have a parameter `my_param`.
 
 ```Python
 with self.argument_context('my_param', ...) as c:  # applies to BOTH command1 and command2
@@ -311,11 +311,11 @@ The following kwargs may be inherited from the command loader:
 
 Most ARM resources can be identified by an ID. In many cases, for example `show` and `delete` commands, it may be more useful to copy and paste an ID to identify the target resource instead of having to specify the names of the resource group, the resource, and the parent resource (if any).
 
-Azure CLI 2.0 supports exposing an `--ids` parameter that will parse a resource ID into its constituent named parts so that this parsing need not be done as part of a client script. Additionally `--ids` will accept a _list_ of space separated IDs, allowing the client to loop the command over each ID.
+Azure CLI 2.0 supports exposing an `--ids` parameter that will parse a resource ID into its constituent named parts so that this parsing need not be done as part of a client script. Additionally `--ids` will accept a _list_ of space-separated IDs, allowing the client to loop the command over each ID.
 
 Enabling this functionality only requires the command author specify the appropriate values for `id_part` in their calls to `AzArgumentContext.argument`.
 
-Consider the following simplified example for NIC IP config. 
+Consider the following simplified example for NIC IP config.
 
 ```Python
 def show_nic_ip_config(resource_group_name, nic_name, ip_config_name):
@@ -335,7 +335,7 @@ The help output for this command would be:
  Arguments
     --name -n          : The IP config name.
     --nic-name         : The NIC name.
-    --resource-group -g: Name of resource group.   
+    --resource-group -g: Name of resource group.
 ```
 
 Now let's specify values for the `id_part` kwarg in the calls to `argument`:
@@ -361,11 +361,11 @@ Resource Id Arguments
                          should be specified.
     --name -n          : The IP config name.
     --nic-name         : The NIC name.
-    --resource-group -g: Name of resource group. 
+    --resource-group -g: Name of resource group.
 ```
 Now the user may identify the target IP config by specifying either the resource group, NIC and IP config names or by simply pasting in the ID for the IP config itself.
 
-This feature is powered by the `parse_resource_id` helper method within the `msrestazure` package, which parses a resource ID into a dictionary. Specifying `id_part` maps the parsed value for a given key in that dictionary into your argument. 
+This feature is powered by the `parse_resource_id` helper method within the `msrestazure` package, which parses a resource ID into a dictionary. Specifying `id_part` maps the parsed value for a given key in that dictionary into your argument.
 
 For example, consider the following ID of a subnet lock:
 ```
@@ -418,7 +418,7 @@ with self.command_group('test', test_sdk) as g:
 - `setter_type` - A `CliCommandType` object which will be used to locate the setter. Only needed if the setter is a custom command (uncommon).
 - `setter_arg_name` - The name of the argument in the setter which corresponds to the object being updated. If the name if `parameters` (which is the case for most SDKs), this can be omitted.
 - `custom_func_name` (optional) - The name of a method which accepts the object being updated (must be named `instance`), mutates, and returns that object. This is commonly used to add convenience options to the command by listing them in the method signature, similar to a purely custom method. The difference is that a custom command function returns the command result while a generic update custom function returns only the object being updated. A simple custom function might look like:
-  
+
   ```Python
   def my_custom_function(instance, item_name, custom_arg=None):
     if custom_arg:
@@ -435,7 +435,7 @@ Sometimes you will want to write commands that operate on child resources and it
   - `child_collection_prop_name` - the name of the child collection property. For example, if object `my_parent` has a child collection called `my_children` that you would access using `my_parent.my_children` then the name you would use is 'my_children'.
   - `child_collection_key_name` - Most child collections in Azure are lists of objects (as opposed to dictionaries) which will have a property in them that serves as the key. This is the name of that key property. By default it is 'name'. In the above example, if an entry in the `my_children` collection has a key property called `my_identifier` then the value you would supply is 'my_identifier'.
   - `child_arg_name` - If you want to refer the child object key (the property identified by `child_collection_key_name`) inside a custom function, you should specify the argument name you use in your custom function. By default, this is called `item_name`. In the above example, where our child object had a key called `my_identifier`, you could refer to this property within your custom function through the `item_name` property, or specify something different.
-  
+
 **Logic Flow**
 
 A simplified understanding of the flow of the generic update is as follows:
@@ -468,7 +468,7 @@ def transform_foo(result):
 
 A string containing Python dictionary-syntax '{Key:JMESPath path to property, ...}'
 
-Example: 
+Example:
 ```Python
 table_transformer='{Name:name, ResourceGroup:resourceGroup, Location:location, ProvisioningState:provisioningState, PowerState:instanceView.statuses[1].displayStatus}'
 ```
@@ -500,7 +500,7 @@ from azure.cli.core.decorators import Completer
 @Completer
 def get_foo_completion_list(cmd, prefix, namespace, **kwargs):  # pylint: disable=unused-argument
     # TODO: Your custom logic here
-    result = ... 
+    result = ...
     return [r.name for r in result]
 ```
 
@@ -533,7 +533,7 @@ Validators are executed after argument parsing, and thus after the native argpar
 The `validator` keyword applies to commands and arguments. A command can have, at most, one validator. If supplied, then *only* this validator will be executed. Any argument-level validators will be ignored. The reason to use a command validator is if the validation sequence is important.  However, the command validator can and very often is composed to individual argument level validators. You simply define the sequence in which they execute.
 
 ***Argument Validators***
-An argument can be assigned, at most, one validator. However, since a command can have many arguments, this means that a command can have many argument validators. Furthermore, since an argument context may apply to many commands, this means that this argument validator can be reused across many commands. At execution time, argument validators are executed *in random order*, so you should ensure you do not have dependencies between validators. If you do, the a command validator is the appropriate route to take. It is fine to have an argument validator involve several parameters as long as they are interdependent (for example, a validator involving a vnet name and subnet name).  
+An argument can be assigned, at most, one validator. However, since a command can have many arguments, this means that a command can have many argument validators. Furthermore, since an argument context may apply to many commands, this means that this argument validator can be reused across many commands. At execution time, argument validators are executed *in random order*, so you should ensure you do not have dependencies between validators. If you do, the a command validator is the appropriate route to take. It is fine to have an argument validator involve several parameters as long as they are interdependent (for example, a validator involving a vnet name and subnet name).
 
 ## Registering Flags
 

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -242,7 +242,7 @@ def add_id_parameters(_, **kwargs):  # pylint: disable=unused-argument
                              '--ids',
                              metavar='RESOURCE_ID',
                              dest=argparse.SUPPRESS,
-                             help="One or more resource IDs (space delimited). If provided, "
+                             help="One or more resource IDs (space-delimited). If provided, "
                                   "no other 'Resource Id' arguments should be specified.",
                              action=split_action(command.arguments),
                              nargs='+',

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -212,7 +212,7 @@ quote_text = 'Use {} to clear existing tags.'.format(quotes)
 
 tags_type = CLIArgumentType(
     validator=validate_tags,
-    help="space separated tags in 'key[=value]' format. {}".format(quote_text),
+    help="space-separated tags in 'key[=value]' format. {}".format(quote_text),
     nargs='*'
 )
 
@@ -232,7 +232,7 @@ no_wait_type = CLIArgumentType(
 zones_type = CLIArgumentType(
     options_list=['--zones', '-z'],
     nargs='+',
-    help='Space separated list of availability zones into which to provision the resource.',
+    help='Space-separated list of availability zones into which to provision the resource.',
     choices=['1', '2', '3']
 )
 

--- a/src/command_modules/azure-cli-acr/HISTORY.rst
+++ b/src/command_modules/azure-cli-acr/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+2.0.21
+++++++
+* Minor fixes
+
 2.0.20
 ++++++
 * minor fix

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
@@ -67,8 +67,8 @@ def load_arguments(self, _):
         c.argument('registry_name', options_list=['--registry', '-r'], help='The name of the container registry. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr')
         c.argument('webhook_name', options_list=['--name', '-n'], help='The name of the webhook', completer=get_resource_name_completion_list(WEBHOOK_RESOURCE_TYPE))
         c.argument('uri', help='The service URI for the webhook to post notifications.')
-        c.argument('headers', nargs='+', help="Space separated custom headers in 'key[=value]' format that will be added to the webhook notifications. Use {} to clear existing headers.".format(quotes), validator=validate_headers)
-        c.argument('actions', nargs='+', help='Space separated list of actions that trigger the webhook to post notifications.', choices=['push', 'delete'])
+        c.argument('headers', nargs='+', help="Space-separated custom headers in 'key[=value]' format that will be added to the webhook notifications. Use {} to clear existing headers.".format(quotes), validator=validate_headers)
+        c.argument('actions', nargs='+', help='Space-separated list of actions that trigger the webhook to post notifications.', choices=['push', 'delete'])
         c.argument('status', help='Indicates whether the webhook is enabled.', choices=['enabled', 'disabled'])
         c.argument('scope', help="The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means events for all repositories.")
 

--- a/src/command_modules/azure-cli-acr/setup.py
+++ b/src/command_modules/azure-cli-acr/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.20"
+VERSION = "2.0.21"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
@@ -59,7 +59,7 @@ def validate_ssh_key(namespace):
 
 
 def validate_list_of_integers(string):
-    # extract comma separated list of integers
+    # extract comma-separated list of integers
     return list(map(int, string.split(',')))
 
 

--- a/src/command_modules/azure-cli-advisor/HISTORY.rst
+++ b/src/command_modules/azure-cli-advisor/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.2
++++++
+* Minor fixes.
+
 0.1.1
 ++++++
 * Update for CLI core changes.

--- a/src/command_modules/azure-cli-advisor/azure/cli/command_modules/advisor/_params.py
+++ b/src/command_modules/azure-cli-advisor/azure/cli/command_modules/advisor/_params.py
@@ -12,7 +12,7 @@ from ._validators import validate_include_or_exclude, validate_ids_or_resource_g
 
 def load_arguments(self, _):
     ids_arg_type = CLIArgumentType(nargs='+', options_list=['--ids'],
-                                   help='One or more resource IDs (space delimited). If provided, no other '
+                                   help='One or more resource IDs (space-delimited). If provided, no other '
                                         '"Resource Id" arguments should be specified.')
 
     with self.argument_context('advisor recommendation list') as c:

--- a/src/command_modules/azure-cli-advisor/setup.py
+++ b/src/command_modules/azure-cli-advisor/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -82,7 +82,7 @@ def load_arguments(self, _):
         c.argument('linux', action='store_true', help='list runtime stacks for linux based webapps')
 
     with self.argument_context('webapp traffic-routing') as c:
-        c.argument('distribution', options_list=['--distribution', '-d'], nargs='+', help='space separated slot routings in a format of <slot-name>=<percentage> e.g. staging=50. Unused traffic percentage will go to the Production slot')
+        c.argument('distribution', options_list=['--distribution', '-d'], nargs='+', help='space-separated slot routings in a format of <slot-name>=<percentage> e.g. staging=50. Unused traffic percentage will go to the Production slot')
 
     with self.argument_context('webapp update') as c:
         c.argument('client_affinity_enabled', help="Enables sending session affinity cookies.", arg_type=get_three_state_flag(return_label=True))
@@ -108,8 +108,8 @@ def load_arguments(self, _):
         with self.argument_context(scope + ' config ssl') as c:
             c.argument('certificate_thumbprint', help='The ssl cert thumbprint')
         with self.argument_context(scope + ' config appsettings') as c:
-            c.argument('settings', nargs='+', help="space separated app settings in a format of <name>=<value>")
-            c.argument('setting_names', nargs='+', help="space separated app setting names")
+            c.argument('settings', nargs='+', help="space-separated app settings in a format of <name>=<value>")
+            c.argument('setting_names', nargs='+', help="space-separated app setting names")
         with self.argument_context(scope + ' config hostname') as c:
             c.argument('hostname', completer=get_hostname_completion_list, help="hostname assigned to the site, such as custom domains", id_part='child_name_1')
         with self.argument_context(scope + ' deployment user') as c:
@@ -141,7 +141,7 @@ def load_arguments(self, _):
         c.argument('webapp_name', help="webapp name. You can configure the default using 'az configure --defaults web=<name>'", configured_default='web',
                    completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')
     with self.argument_context('webapp config appsettings') as c:
-        c.argument('slot_settings', nargs='+', help="space separated slot app settings in a format of <name>=<value>")
+        c.argument('slot_settings', nargs='+', help="space-separated slot app settings in a format of <name>=<value>")
     with self.argument_context('webapp deployment container config') as c:
         c.argument('enable', options_list=['--enable-cd', '-e'], help='enable/disable continuous deployment', arg_type=get_enum_type(['true', 'false']))
     with self.argument_context('webapp deployment slot') as c:
@@ -171,9 +171,9 @@ def load_arguments(self, _):
 
     for scope in ['appsettings', 'connection-string']:
         with self.argument_context('webapp config ' + scope) as c:
-            c.argument('settings', nargs='+', help="space separated {} in a format of <name>=<value>".format(scope))
-            c.argument('slot_settings', nargs='+', help="space separated slot {} in a format of <name>=<value>".format(scope))
-            c.argument('setting_names', nargs='+', help="space separated {} names".format(scope))
+            c.argument('settings', nargs='+', help="space-separated {} in a format of <name>=<value>".format(scope))
+            c.argument('slot_settings', nargs='+', help="space-separated slot {} in a format of <name>=<value>".format(scope))
+            c.argument('setting_names', nargs='+', help="space-separated {} names".format(scope))
 
     with self.argument_context('webapp config connection-string') as c:
         c.argument('connection_string_type', options_list=['--connection-string-type', '-t'], help='connection string type', arg_type=get_enum_type(ConnectionStringType))
@@ -226,24 +226,24 @@ def load_arguments(self, _):
         c.argument('token_store_enabled', options_list=['--token-store'], arg_type=get_three_state_flag(return_label=True))
         c.argument('action', arg_type=get_enum_type(AUTH_TYPES))
         c.argument('token_refresh_extension_hours', type=float, help="Hours, must be formattable into a float")
-        c.argument('allowed_external_redirect_urls', nargs='+', help="One or more urls (space delimited).")
+        c.argument('allowed_external_redirect_urls', nargs='+', help="One or more urls (space-delimited).")
         c.argument('client_id', options_list=['--aad-client-id'], arg_group='Azure Active Directory')
         c.argument('client_secret', options_list=['--aad-client-secret'], arg_group='Azure Active Directory')
-        c.argument('allowed_audiences', nargs='+', options_list=['--aad-allowed-token-audiences'], arg_group='Azure Active Directory', help="One or more token audiences (space delimited).")
+        c.argument('allowed_audiences', nargs='+', options_list=['--aad-allowed-token-audiences'], arg_group='Azure Active Directory', help="One or more token audiences (space-delimited).")
         c.argument('issuer', options_list=['--aad-token-issuer-url'],
                    help='This url can be found in the JSON output returned from your active directory endpoint using your tenantID. The endpoint can be queried from \'az cloud show\' at \"endpoints.activeDirectory\". '
                         'The tenantID can be found using \'az account show\'. Get the \"issuer\" from the JSON at <active directory endpoint>/<tenantId>/.well-known/openid-configuration.', arg_group='Azure Active Directory')
         c.argument('facebook_app_id', arg_group='Facebook')
         c.argument('facebook_app_secret', arg_group='Facebook')
-        c.argument('facebook_oauth_scopes', nargs='+', help="One or more facebook authentication scopes (space delimited).", arg_group='Facebook')
+        c.argument('facebook_oauth_scopes', nargs='+', help="One or more facebook authentication scopes (space-delimited).", arg_group='Facebook')
         c.argument('twitter_consumer_key', arg_group='Twitter')
         c.argument('twitter_consumer_secret', arg_group='Twitter')
         c.argument('google_client_id', arg_group='Google')
         c.argument('google_client_secret', arg_group='Google')
-        c.argument('google_oauth_scopes', nargs='+', help="One or more Google authentication scopes (space delimited).", arg_group='Google')
+        c.argument('google_oauth_scopes', nargs='+', help="One or more Google authentication scopes (space-delimited).", arg_group='Google')
         c.argument('microsoft_account_client_id', arg_group='Microsoft')
         c.argument('microsoft_account_client_secret', arg_group='Microsoft')
-        c.argument('microsoft_account_oauth_scopes', nargs='+', help="One or more Microsoft authentification scopes (space delimited).", arg_group='Microsoft')
+        c.argument('microsoft_account_oauth_scopes', nargs='+', help="One or more Microsoft authentification scopes (space-delimited).", arg_group='Microsoft')
 
     with self.argument_context('functionapp') as c:
         c.ignore('app_instance', 'slot')

--- a/src/command_modules/azure-cli-batch/HISTORY.rst
+++ b/src/command_modules/azure-cli-batch/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+3.1.10
+++++++
+* Minor fixes
+
 3.1.9
 +++++
 * minor fixes

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_command_type.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_command_type.py
@@ -701,7 +701,7 @@ class AzureBatchDataPlaneCommand(object):
                     # This will fail for 2D arrays - though Batch doesn't have any yet
                     inner_type = details['type'][1:-1]
                     if inner_type in pformat.BASIC_TYPES:
-                        options['help'] += " Space separated values."
+                        options['help'] += " Space-separated values."
                         self._resolve_conflict(
                             param_attr, param_attr, path, options,
                             details['type'], required_attrs, conflict_names)

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_params.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_params.py
@@ -44,7 +44,7 @@ def load_arguments(self, _):
 
     with self.argument_context('batch account create') as c:
         c.argument('location', get_location_type(self.cli_ctx), help='The region in which to create the account.')
-        c.argument('tags', tags_type, help="Space separated tags in 'key[=value]' format.")
+        c.argument('tags', tags_type, help="Space-separated tags in 'key[=value]' format.")
         c.argument('storage_account', help='The storage account name or resource ID to be used for auto storage.', validator=storage_account_id)
         c.argument('keyvault', help='The KeyVault name or resource ID to be used for an account with a pool allocation mode of \'User Subscription\'.', validator=keyvault_id)
         c.ignore('keyvault_url')
@@ -103,7 +103,7 @@ def load_arguments(self, _):
         c.argument('start_task_max_task_retry_count', arg_group='Pool: Start Task',
                    help='The maximum number of times the task may be retried.')
         c.argument('start_task_environment_settings', nargs='+', type=environment_setting_format, arg_group='Pool: Start Task',
-                   help='A list of environment variable settings for the start task. Space separated values in \'key=value\' format.')
+                   help='A list of environment variable settings for the start task. Space-separated values in \'key=value\' format.')
 
     with self.argument_context('batch job list') as c:
         c.argument('filter', help=' An OData $filter clause.', arg_group='Pre-condition and Query')
@@ -132,12 +132,12 @@ def load_arguments(self, _):
 
     with self.argument_context('batch task create') as c:
         c.argument('json_file', type=file_type, help='The file containing the task(s) to create in JSON format, if this parameter is specified, all other parameters are ignored.', validator=validate_json_file, completer=FilesCompleter())
-        c.argument('application_package_references', nargs='+', help='The space separated list of IDs specifying the application packages to be installed. Space separated application IDs with optional version in \'id[#version]\' format.', type=application_package_reference_format)
+        c.argument('application_package_references', nargs='+', help='The space-separated list of IDs specifying the application packages to be installed. Space-separated application IDs with optional version in \'id[#version]\' format.', type=application_package_reference_format)
         c.argument('job_id', help='The ID of the job containing the task.')
         c.argument('task_id', help='The ID of the task.')
         c.argument('command_line', help='The command line of the task. The command line does not run under a shell, and therefore cannot take advantage of shell features such as environment variable expansion. If you want to take advantage of such features, you should invoke the shell in the command line, for example using "cmd /c MyCommand" in Windows or "/bin/sh -c MyCommand" in Linux.')
-        c.argument('environment_settings', nargs='+', help='A list of environment variable settings for the task. Space separated values in \'key=value\' format.', type=environment_setting_format)
-        c.argument('resource_files', nargs='+', help='A list of files that the Batch service will download to the compute node before running the command line. Space separated resource references in filename=blobsource format.', type=resource_file_format)
+        c.argument('environment_settings', nargs='+', help='A list of environment variable settings for the task. Space-separated values in \'key=value\' format.', type=environment_setting_format)
+        c.argument('resource_files', nargs='+', help='A list of files that the Batch service will download to the compute node before running the command line. Space-separated resource references in filename=blobsource format.', type=resource_file_format)
 
     for item in ['batch certificate delete', 'batch certificate create', 'batch pool resize', 'batch pool reset', 'batch job list', 'batch task create']:
         with self.argument_context(item) as c:

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_validators.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_validators.py
@@ -36,7 +36,7 @@ def duration_format(value):
 
 
 def metadata_item_format(value):
-    """Space separated values in 'key=value' format."""
+    """Space-separated values in 'key=value' format."""
     try:
         data_name, data_value = value.split('=')
     except ValueError:
@@ -47,7 +47,7 @@ def metadata_item_format(value):
 
 
 def environment_setting_format(value):
-    """Space separated values in 'key=value' format."""
+    """Space-separated values in 'key=value' format."""
     try:
         env_name, env_value = value.split('=')
     except ValueError:
@@ -58,7 +58,7 @@ def environment_setting_format(value):
 
 
 def application_package_reference_format(value):
-    """Space separated application IDs with optional version in 'id[#version]' format."""
+    """Space-separated application IDs with optional version in 'id[#version]' format."""
     app_reference = value.split('#', 1)
     package = {'application_id': app_reference[0]}
     try:
@@ -69,13 +69,13 @@ def application_package_reference_format(value):
 
 
 def certificate_reference_format(value):
-    """Space separated certificate thumbprints."""
+    """Space-separated certificate thumbprints."""
     cert = {'thumbprint': value, 'thumbprint_algorithm': 'sha1'}
     return cert
 
 
 def task_id_ranges_format(value):
-    """Space separated number ranges in 'start-end' format."""
+    """Space-separated number ranges in 'start-end' format."""
     try:
         start, end = [int(i) for i in value.split('-')]
     except ValueError:
@@ -86,7 +86,7 @@ def task_id_ranges_format(value):
 
 
 def resource_file_format(value):
-    """Space separated resource references in filename=blobsource format."""
+    """Space-separated resource references in filename=blobsource format."""
     try:
         file_name, blob_source = value.split('=', 1)
     except ValueError:

--- a/src/command_modules/azure-cli-batch/setup.py
+++ b/src/command_modules/azure-cli-batch/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "3.1.9"
+VERSION = "3.1.10"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-cdn/HISTORY.rst
+++ b/src/command_modules/azure-cli-cdn/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.13
+++++++
+* Minor fixes.
+
 0.0.12
 ++++++
 * `cdn custom-domain create`: Fixed missing client issue.

--- a/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_params.py
+++ b/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_params.py
@@ -60,7 +60,7 @@ def load_arguments(self, _):
         c.argument('endpoint_name', name_arg_type, id_part='name', help='Name of the CDN endpoint.')
         c.argument('location', validator=get_default_location_from_resource_group)
         c.argument('origins', options_list='--origin', nargs='+', action=OriginType, validator=validate_origin,
-                   help='Endpoint origin specified by the following space delimited 3 '
+                   help='Endpoint origin specified by the following space-delimited 3 '
                         'tuple: `www.example.com http_port https_port`. The HTTP and HTTPs'
                         'ports are optional and will default to 80 and 443 respectively.')
         c.argument('is_http_allowed', arg_type=get_three_state_flag(invert=True), options_list='--no-http',

--- a/src/command_modules/azure-cli-cdn/setup.py
+++ b/src/command_modules/azure-cli-cdn/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.0.12"
+VERSION = "0.0.13"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-configure/HISTORY.rst
+++ b/src/command_modules/azure-cli-configure/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.14
+++++++
+* Minor fixes.
+
 2.0.13
 ++++++
 * Update for CLI core changes.

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_consts.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_consts.py
@@ -8,7 +8,7 @@ OUTPUT_LIST = [
     {'name': 'jsonc',
      'desc': 'Colored JSON formatted output that most closely matches API responses'},
     {'name': 'table', 'desc': 'Human-readable output format'},
-    {'name': 'tsv', 'desc': 'Tab and Newline delimited, great for GREP, AWK, etc.'}
+    {'name': 'tsv', 'desc': 'Tab- and Newline-delimited, great for GREP, AWK, etc.'}
 ]
 
 LOGIN_METHOD_LIST = [

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_help.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_help.py
@@ -12,7 +12,7 @@ helps['configure'] = """
     parameters:
         - name: --defaults -d
           short-summary: >
-            Space separated 'name=value' pairs for common argument defaults.
+            Space-separated 'name=value' pairs for common argument defaults.
     examples:
         - name: Set default resource group, webapp and VM names.
           text: az configure --defaults group=myRG web=myweb vm=myvm

--- a/src/command_modules/azure-cli-configure/setup.py
+++ b/src/command_modules/azure-cli-configure/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.13"
+VERSION = "2.0.14"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-container/HISTORY.rst
+++ b/src/command_modules/azure-cli-container/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.17
+++++++
+* Minor fixes
+
 0.1.16
 ++++++
 * Update for CLI core changes.

--- a/src/command_modules/azure-cli-container/README.rst
+++ b/src/command_modules/azure-cli-container/README.rst
@@ -30,8 +30,8 @@ Commands to create an Azure container group
         --command-line                : The command line to run when the container is started, e.g.
                                         '/bin/bash -c myscript.sh'.
         --cpu                         : The required number of CPU cores of the containers.  Default: 1.
-        --environment-variables -e    : A list of environment variable for the container. Space
-                                        separated values in 'key=value' format.
+        --environment-variables -e    : A list of environment variable for the container.
+                                        Space-separated values in 'key=value' format.
         --ip-address                  : The IP address type of the container group.  Allowed values:
                                         Public.
         --location -l                 : Location. You can configure the default location using `az
@@ -95,7 +95,7 @@ Commands to get an Azure container group
     Arguments
 
     Resource Id Arguments
-        --ids              : One or more resource IDs (space delimited). If provided, no other 'Resource
+        --ids              : One or more resource IDs (space-delimited). If provided, no other 'Resource
                             Id' arguments should be specified.
         --name -n          : The name of the container group.
         --resource-group -g: Name of resource group. You can configure the default group using `az
@@ -120,7 +120,7 @@ Commands to tail the logs of a Azure container group
         --container-name   : The container name to tail the logs.
 
     Resource Id Arguments
-        --ids              : One or more resource IDs (space delimited). If provided, no other 'Resource
+        --ids              : One or more resource IDs (space-delimited). If provided, no other 'Resource
                             Id' arguments should be specified.
         --name -n          : The name of the container group.
         --resource-group -g: Name of resource group. You can configure the default group using `az
@@ -145,7 +145,7 @@ Commands to delete an Azure container group
         --yes -y           : Do not prompt for confirmation.
 
     Resource Id Arguments
-        --ids              : One or more resource IDs (space delimited). If provided, no other 'Resource
+        --ids              : One or more resource IDs (space-delimited). If provided, no other 'Resource
                             Id' arguments should be specified.
         --name -n          : The name of the container group.
         --resource-group -g: Name of resource group. You can configure the default group using `az

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_params.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_params.py
@@ -17,7 +17,7 @@ IP_ADDRESS_TYPES = ['Public']
 
 
 def _environment_variables_type(value):
-    """Space separated values in 'key=value' format."""
+    """Space-separated values in 'key=value' format."""
     try:
         env_name, env_value = value.split('=', 1)
     except ValueError:
@@ -43,7 +43,7 @@ def load_arguments(self, _):
         c.argument('ports', type=int, nargs='+', default=[80], help='The ports to open')
         c.argument('restart_policy', arg_type=get_enum_type(ContainerGroupRestartPolicy), help='Restart policy for all containers within the container group')
         c.argument('command_line', help='The command line to run when the container is started, e.g. \'/bin/bash -c myscript.sh\'')
-        c.argument('environment_variables', nargs='+', options_list=['--environment-variables', '-e'], type=_environment_variables_type, help='A list of environment variable for the container. Space separated values in \'key=value\' format.')
+        c.argument('environment_variables', nargs='+', options_list=['--environment-variables', '-e'], type=_environment_variables_type, help='A list of environment variable for the container. Space-separated values in \'key=value\' format.')
 
     with self.argument_context('container create', arg_group='Image Registry') as c:
         c.argument('registry_login_server', help='The container image registry login server')

--- a/src/command_modules/azure-cli-container/setup.py
+++ b/src/command_modules/azure-cli-container/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.16"
+VERSION = "0.1.17"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-cosmosdb/HISTORY.rst
+++ b/src/command_modules/azure-cli-cosmosdb/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.18
+++++++
+* Minor fixes
+
 0.1.17
 ++++++
 * Fix parameter description for failover policies.

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_params.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_params.py
@@ -26,11 +26,11 @@ def load_arguments(self, _):
         with self.argument_context(scope) as c:
             c.argument('account_name', completer=None)
             c.ignore('resource_group_location')
-            c.argument('locations', nargs='+', validator=validate_locations, help="space separated locations in 'regionName=failoverPriority' format. E.g eastus=0 westus=1. Failover priority values are 0 for write regions and greater than 0 for read regions. A failover priority value must be unique and less than the total number of regions. Default: single region account in the location of the specified resource group.")
+            c.argument('locations', nargs='+', validator=validate_locations, help="space-separated locations in 'regionName=failoverPriority' format. E.g eastus=0 westus=1. Failover priority values are 0 for write regions and greater than 0 for read regions. A failover priority value must be unique and less than the total number of regions. Default: single region account in the location of the specified resource group.")
             c.argument('default_consistency_level', arg_type=get_enum_type(DefaultConsistencyLevel), help="default consistency level of the Cosmos DB database account")
             c.argument('max_staleness_prefix', type=int, help="when used with Bounded Staleness consistency, this value represents the number of stale requests tolerated. Accepted range for this value is 1 - 2,147,483,647")
             c.argument('max_interval', type=int, help="when used with Bounded Staleness consistency, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 1 - 100")
-            c.argument('ip_range_filter', nargs='+', validator=validate_ip_range_filter, help="firewall support. Specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IPs for a given database account. IP addresses/ranges must be comma separated and must not contain any spaces")
+            c.argument('ip_range_filter', nargs='+', validator=validate_ip_range_filter, help="firewall support. Specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IPs for a given database account. IP addresses/ranges must be comma-separated and must not contain any spaces")
             c.argument('kind', arg_type=get_enum_type(DatabaseAccountKind), help='The type of Cosmos DB database account to create')
             c.argument('enable_automatic_failover', arg_type=get_three_state_flag(), help='Enables automatic failover of the write region in the rare event that the region is unavailable due to an outage. Automatic failover will result in a new write region for the account and is chosen based on the failover priorities configured for the account.')
 
@@ -38,7 +38,7 @@ def load_arguments(self, _):
         c.argument('key_kind', arg_type=get_enum_type(KeyKind))
 
     with self.argument_context('cosmosdb failover-priority-change') as c:
-        c.argument('failover_policies', validator=validate_failover_policies, help="space separated failover policies in 'regionName=failoverPriority' format. E.g eastus=0 westus=1", nargs='+')
+        c.argument('failover_policies', validator=validate_failover_policies, help="space-separated failover policies in 'regionName=failoverPriority' format. E.g eastus=0 westus=1", nargs='+')
 
     with self.argument_context('cosmosdb collection') as c:
         c.argument('collection_id', options_list=['--collection-name', '-c'], help='Collection Name')

--- a/src/command_modules/azure-cli-cosmosdb/setup.py
+++ b/src/command_modules/azure-cli-cosmosdb/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.1.17"
+VERSION = "0.1.18"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-eventgrid/HISTORY.rst
+++ b/src/command_modules/azure-cli-eventgrid/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.10
+++++++
+* Minor fixes.
+
 0.1.9
 +++++
 * Minor fixes.

--- a/src/command_modules/azure-cli-eventgrid/azure/cli/command_modules/eventgrid/_params.py
+++ b/src/command_modules/azure-cli-eventgrid/azure/cli/command_modules/eventgrid/_params.py
@@ -18,12 +18,12 @@ from azure.cli.core.commands.parameters import (
 )
 
 included_event_types_type = CLIArgumentType(
-    help="A space separated list of event types. To subscribe to all event types, the string \"All\" should be specified.",
+    help="A space-separated list of event types. To subscribe to all event types, the string \"All\" should be specified.",
     nargs='+'
 )
 
 labels_type = CLIArgumentType(
-    help="A space separated list of labels to associate with this event subscription.",
+    help="A space-separated list of labels to associate with this event subscription.",
     nargs='+'
 )
 

--- a/src/command_modules/azure-cli-eventgrid/setup.py
+++ b/src/command_modules/azure-cli-eventgrid/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.9"
+VERSION = "0.1.10"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/command_modules/azure-cli-iot/HISTORY.rst
+++ b/src/command_modules/azure-cli-iot/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.17
+++++++
+* Minor fixes.
+
 0.1.16
 ++++++
 * Added support for device provisioning service

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -54,14 +54,14 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
     with self.argument_context('iot dps access-policy create') as c:
         c.argument('rights', options_list=['--rights', '-r'], nargs='+',
                    arg_type=get_enum_type(AccessRightsDescription),
-                   help='Access rights for the IoT provisioning service. Use space separated list for multiple rights.')
+                   help='Access rights for the IoT provisioning service. Use space-separated list for multiple rights.')
         c.argument('primary_key', help='Primary SAS key value.')
         c.argument('secondary_key', help='Secondary SAS key value.')
 
     with self.argument_context('iot dps access-policy update') as c:
         c.argument('rights', options_list=['--rights', '-r'], nargs='+',
                    arg_type=get_enum_type(AccessRightsDescription),
-                   help='Access rights for the IoT provisioning service. Use space separated list for multiple rights.')
+                   help='Access rights for the IoT provisioning service. Use space-separated list for multiple rights.')
         c.argument('primary_key', help='Primary SAS key value.')
         c.argument('secondary_key', help='Secondary SAS key value.')
 
@@ -125,7 +125,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    help='Shared access policy name.')
         permission_values = ', '.join([x.value for x in SimpleAccessRights])
         c.argument('permissions', nargs='*', validator=validate_policy_permissions, type=str.lower,
-                   help='Permissions of shared access policy. Use space separated list for multiple permissions. '
+                   help='Permissions of shared access policy. Use space-separated list for multiple permissions. '
                         'Possible values: {}'.format(permission_values))
 
     with self.argument_context('iot hub job') as c:

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
@@ -60,7 +60,7 @@ class KeyType(Enum):
 # This is a work around to simplify the permission parameter for access policy creation, and also align with the other
 # command modules.
 # The original AccessRights enum is a combination of below four basic access rights.
-# In order to avoid asking for comma & space separated string from user, a space separated list is supported for
+# In order to avoid asking for comma- & space-separated strings from the user, a space-separated list is supported for
 # assigning multiple permissions.
 # The underlying IoT SDK should handle this. However it isn't right now. Remove this after it is fixed in IoT SDK.
 class SimpleAccessRights(Enum):

--- a/src/command_modules/azure-cli-iot/setup.py
+++ b/src/command_modules/azure-cli-iot/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.16"
+VERSION = "0.1.17"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-keyvault/HISTORY.rst
+++ b/src/command_modules/azure-cli-keyvault/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.18
+++++++
+* Minor fixes.
+
 2.0.17
 ++++++
 * Minor fixes.

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -70,9 +70,9 @@ def load_arguments(self, _):
         c.argument('object_id', validator=validate_principal)
 
     with self.argument_context('keyvault set-policy', arg_group='Permission') as c:
-        c.argument('key_permissions', arg_type=get_enum_type(KeyPermissions), metavar='PERM', nargs='*', help='Space separated list of key permissions to assign.', validator=validate_policy_permissions)
-        c.argument('secret_permissions', arg_type=get_enum_type(SecretPermissions), metavar='PERM', nargs='*', help='Space separated list of secret permissions to assign.')
-        c.argument('certificate_permissions', arg_type=get_enum_type(CertificatePermissions), metavar='PERM', nargs='*', help='Space separated list of certificate permissions to assign.')
+        c.argument('key_permissions', arg_type=get_enum_type(KeyPermissions), metavar='PERM', nargs='*', help='Space-separated list of key permissions to assign.', validator=validate_policy_permissions)
+        c.argument('secret_permissions', arg_type=get_enum_type(SecretPermissions), metavar='PERM', nargs='*', help='Space-separated list of secret permissions to assign.')
+        c.argument('certificate_permissions', arg_type=get_enum_type(CertificatePermissions), metavar='PERM', nargs='*', help='Space-separated list of certificate permissions to assign.')
     # endregion
 
     # region Shared
@@ -84,7 +84,7 @@ def load_arguments(self, _):
 
     # region keys
     with self.argument_context('keyvault key') as c:
-        c.argument('key_ops', arg_type=get_enum_type(JsonWebKeyOperation), options_list=['--ops'], nargs='*', help='Space separated list of permitted JSON web key operations.')
+        c.argument('key_ops', arg_type=get_enum_type(JsonWebKeyOperation), options_list=['--ops'], nargs='*', help='Space-separated list of permitted JSON web key operations.')
         c.argument('key_version', options_list=['--version', '-v'], help='The key version. If omitted, uses the latest version.', default='', required=False, completer=get_keyvault_version_completion_list('key'))
 
     for scope in ['keyvault key create', 'keyvault key import']:

--- a/src/command_modules/azure-cli-keyvault/setup.py
+++ b/src/command_modules/azure-cli-keyvault/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.17"
+VERSION = "2.0.18"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/command_modules/azure-cli-lab/HISTORY.rst
+++ b/src/command_modules/azure-cli-lab/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.17
+++++++
+* Minor fixes.
+
 0.0.16
 ++++++
 * Performance fixes.
@@ -10,7 +14,7 @@ Release History
 0.0.15
 ++++++
 * Update helpfile
-  
+
 0.0.14
 ++++++
 * Update for CLI core changes.

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/_help.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/_help.py
@@ -57,7 +57,7 @@ helps['lab vm create'] = """
                 - name: --artifacts
                   short-summary: JSON encoded array of artifacts to be applied. Use '@{file}' to load from a file.
                 - name: --tags
-                  short-summary: Space separated tags in `key[=value]` format.
+                  short-summary: Space-separated tags in `key[=value]` format.
                   long-summary: Tags may be cleared by assigning the empty value "" to them.
                 - name: --allow-claim
                   short-summary: Flag indicating if the VM should be created as claimable.
@@ -131,7 +131,7 @@ helps['lab vm claim'] = """
             short-summary: Claim a virtual machine from the Lab.
             parameters:
                 - name: --ids
-                  short-summary: Space separated list of VM IDs to claim.
+                  short-summary: Space-separated list of VM IDs to claim.
                 - name: --resource-group -g
                   short-summary: Name of lab's resource group.
                 - name: --lab-name

--- a/src/command_modules/azure-cli-lab/setup.py
+++ b/src/command_modules/azure-cli-lab/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.16"
+VERSION = "0.0.17"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-monitor/HISTORY.rst
+++ b/src/command_modules/azure-cli-monitor/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.2
++++++
+* Minor fixes.
+
 0.1.1
 +++++
 * Minor fixes.
@@ -59,7 +63,7 @@ Release History
 * BC: `monitor alert-rule-incidents show` renamed `monitor alert show-incident`
 * BC: `monitor metric-defintions list` renamed `monitor metrics list-definitions`
 * BC: `monitor alert-rules` renamed `monitor alert`
-* BC: `monitor alert create` completely revamped. `condition` and `action` no longer accepts JSON. 
+* BC: `monitor alert create` completely revamped. `condition` and `action` no longer accepts JSON.
 	  Adds numerous parameters to simplify the rule creation process. `location` no longer required.
 	  Added name or ID support for target.
 	  `--alert-rule-resource-name` removed. `is-enabled` renamed `enabled` and no longer required.

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
@@ -135,7 +135,7 @@ helps['monitor metrics list'] = """
     parameters:
         - name: --aggregation
           type: string
-          short-summary: The list of aggregation types (space separated) to retrieve.
+          short-summary: The list of aggregation types (space-separated) to retrieve.
         - name: --interval
           type: string
           short-summary: The interval of the metric query. In ISO 8601 duration format, eg "PT1M"
@@ -157,7 +157,7 @@ helps['monitor metrics list'] = """
           short-summary: Returns the metadata values instead of metric data
         - name: --dimension
           type: string
-          short-summary: The list of dimensions (space separated) the metrics are queried into.
+          short-summary: The list of dimensions (space-separated) the metrics are queried into.
     examples:
         - name: List a VM's CPU usage for the past hour
           text: >
@@ -308,7 +308,7 @@ helps['monitor action-group update'] = """
             Webhook: --add-action https://www.contoso.com/alert
             Multiple actions can be specified by using more than one `--add-action` argument.
         - name: --remove-action -r
-          short-summary: Remove receivers from the action group. Accept space separated list of receiver names.
+          short-summary: Remove receivers from the action group. Accept space-separated list of receiver names.
 """
 
 helps['monitor activity-log alert'] = """
@@ -350,11 +350,11 @@ helps['monitor activity-log alert create'] = """
             'resourceProvider', 'status', 'subStatus', 'resourceType', or anything beginning with 'properties.'.
         - name: --action-group -a
           short-summary: >
-            Add an action group. Accepts space separated action group identifiers. The identifier can be the action group's name
+            Add an action group. Accepts space-separated action group identifiers. The identifier can be the action group's name
             or its resource ID.
         - name: --webhook-properties -w
           short-summary: >
-            Space separated webhook properties in 'key[=value]' format. These properties are associated with the action groups
+            Space-separated webhook properties in 'key[=value]' format. These properties are associated with the action groups
             added in this command.
           long-summary: >
             For any webhook receiver in these action group, this data is appended to the webhook payload. To attach different webhook
@@ -416,7 +416,7 @@ helps['monitor activity-log alert action-group add'] = """
           short-summary: Remove all the existing action groups before add new conditions.
         - name: --webhook-properties -w
           short-summary: >
-            Space separated webhook properties in 'key[=value]' format. These properties will be associated with
+            Space-separated webhook properties in 'key[=value]' format. These properties will be associated with
             the action groups added in this command.
           long-summary: >
             For any webhook receiver in these action group, these data are appended to the webhook payload.

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
@@ -150,8 +150,8 @@ def load_arguments(self, _):
         c.expand('parameters', LogProfileResource)
         c.argument('name', options_list=['--log-profile-resource-name'])
         c.argument('log_profile_name', options_list=['--name', '-n'])
-        c.argument('categories', nargs='+', help="Space separated categories of the logs.Some values are: 'Write', 'Delete', and/or 'Action.'")
-        c.argument('locations', nargs='+', help="Space separated list of regions for which Activity Log events should be stored.")
+        c.argument('categories', nargs='+', help="Space-separated categories of the logs.Some values are: 'Write', 'Delete', and/or 'Action.'")
+        c.argument('locations', nargs='+', help="Space-separated list of regions for which Activity Log events should be stored.")
     # endregion
 
     # region ActivityLog

--- a/src/command_modules/azure-cli-monitor/setup.py
+++ b/src/command_modules/azure-cli-monitor/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -518,11 +518,11 @@ helps['network application-gateway waf-config set'] = """
           populator-commands:
           - az network application-gateway waf-config list-rule-sets
         - name: --disabled-rule-groups
-          short-summary: Space separated list of rule groups to disable. To disable individual rules, use `--disabled-rules`.
+          short-summary: Space-separated list of rule groups to disable. To disable individual rules, use `--disabled-rules`.
           populator-commands:
           - az network application-gateway waf-config list-rule-sets
         - name: --disabled-rules
-          short-summary: Space separated list of rule IDs to disable.
+          short-summary: Space-separated list of rule IDs to disable.
           populator-commands:
           - az network application-gateway waf-config list-rule-sets
     examples:
@@ -1576,7 +1576,7 @@ helps['network route-filter rule create'] = """
     short-summary: Create a rule in a route filter.
     parameters:
         - name: --communities
-          short-summary: Space separated list of border gateway protocol (BGP) community values to filter on.
+          short-summary: Space-separated list of border gateway protocol (BGP) community values to filter on.
           populator-commands:
             - az network route-filter rule list-service-communities
 """
@@ -1655,7 +1655,7 @@ helps['network traffic-manager endpoint create'] = """
     short-summary: Create an endpoint.
     parameters:
         - name: --geo-mapping
-          short-summary: Space separated list of country/region codes mapped to this endpoint when using the 'Geographic' routing method.
+          short-summary: Space-separated list of country/region codes mapped to this endpoint when using the 'Geographic' routing method.
           populator-commands:
           - az network traffic-manager endpoint show-geographic-hierarchy
 """
@@ -1743,7 +1743,7 @@ helps['network vnet subnet create'] = """
     short-summary: Create a subnet and associate an existing NSG and route table.
     parameters:
         - name: --service-endpoints
-          short-summary: Space separated list of services allowed private access to this subnet.
+          short-summary: Space-separated list of services allowed private access to this subnet.
           populator-commands:
             - az network vnet list-endpoint-services
     examples:
@@ -1773,7 +1773,7 @@ helps['network vnet subnet update'] = """
     short-summary: Update a subnet.
     parameters:
         - name: --service-endpoints
-          short-summary: Space separated list of services allowed private access to this subnet.
+          short-summary: Space-separated list of services allowed private access to this subnet.
           populator-commands:
             - az network vnet list-endpoint-services
 """
@@ -2053,7 +2053,7 @@ helps['network watcher configure'] = """
         - name: --enabled
           short-summary: Enabled status of Network Watch in the specified regions.
         - name: --locations -l
-          short-summary: Space separated list of locations to configure.
+          short-summary: Space-separated list of locations to configure.
         - name: --resource-group -g
           short-summary: Name of resource group. Required when enabling new regions.
           long-summary: When a previously disabled region is enabled to use Network Watcher, a

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -64,7 +64,7 @@ def load_arguments(self, _):
     private_ip_address_type = CLIArgumentType(help='Static private IP address to use.', validator=validate_private_ip_address)
     cookie_based_affinity_type = CLIArgumentType(arg_type=get_three_state_flag(positive_label='Enabled', negative_label='Disabled', return_label=True))
     http_protocol_type = CLIArgumentType(get_enum_type(ApplicationGatewayProtocol))
-    ag_servers_type = CLIArgumentType(nargs='+', help='Space separated list of IP addresses or DNS names corresponding to backend servers.', validator=get_servers_validator())
+    ag_servers_type = CLIArgumentType(nargs='+', help='Space-separated list of IP addresses or DNS names corresponding to backend servers.', validator=get_servers_validator())
 
     # region NetworkRoot
     with self.argument_context('network') as c:
@@ -216,11 +216,11 @@ def load_arguments(self, _):
 
     with self.argument_context('network application-gateway ssl-policy') as c:
         c.argument('clear', action='store_true', help='Clear SSL policy.')
-        c.argument('disabled_ssl_protocols', nargs='+', help='Space separated list of protocols to disable.', arg_type=get_enum_type(ApplicationGatewaySslProtocol))
+        c.argument('disabled_ssl_protocols', nargs='+', help='Space-separated list of protocols to disable.', arg_type=get_enum_type(ApplicationGatewaySslProtocol))
 
     with self.argument_context('network application-gateway url-path-map') as c:
         c.argument('rule_name', help='The name of the url-path-map rule.', arg_group='First Rule')
-        c.argument('paths', nargs='+', help='Space separated list of paths to associate with the rule. Valid paths start and end with "/" (ex: "/bar/")', arg_group='First Rule')
+        c.argument('paths', nargs='+', help='Space-separated list of paths to associate with the rule. Valid paths start and end with "/" (ex: "/bar/")', arg_group='First Rule')
         c.argument('address_pool', help='The name or ID of the backend address pool to use with the created rule.', completer=get_ag_subresource_completion_list('backend_address_pools'), arg_group='First Rule')
         c.argument('http_settings', help='The name or ID of the HTTP settings to use with the created rule.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'), arg_group='First Rule')
 
@@ -270,7 +270,7 @@ def load_arguments(self, _):
         c.argument('policy_name', name_arg_type)
         c.argument('cipher_suites', nargs='+')
         c.argument('min_protocol_version')
-        c.argument('disabled_ssl_protocols', nargs='+', help='Space separated list of protocols to disable.')
+        c.argument('disabled_ssl_protocols', nargs='+', help='Space-separated list of protocols to disable.')
 
     with self.argument_context('network application-gateway http-settings', min_api='2017-06-01') as c:
         c.argument('host_name', help='Host header sent to the backend servers.')
@@ -320,8 +320,8 @@ def load_arguments(self, _):
 
         # TODO: Uncomment when feature is ready
         # c.argument('zone_type', help='Type of DNS zone to create.', arg_type=get_enum_type(ZoneType))
-        # c.argument('registration_vnets', arg_group='Private Zone', nargs='+', help='Space separated names or IDs of virtual networks that register hostnames in this DNS zone.', validator=get_vnet_validator('registration_vnets'))
-        # c.argument('resolution_vnets', arg_group='Private Zone', nargs='+', help='Space separated names or IDs of virtual networks that resolve records in this DNS zone.', validator=get_vnet_validator('resolution_vnets'))
+        # c.argument('registration_vnets', arg_group='Private Zone', nargs='+', help='Space-separated names or IDs of virtual networks that register hostnames in this DNS zone.', validator=get_vnet_validator('registration_vnets'))
+        # c.argument('resolution_vnets', arg_group='Private Zone', nargs='+', help='Space-separated names or IDs of virtual networks that resolve records in this DNS zone.', validator=get_vnet_validator('resolution_vnets'))
 
     with self.argument_context('network dns zone import') as c:
         c.argument('file_name', options_list=('--file-name', '-f'), type=file_type, completer=FilesCompleter(), help='Path to the DNS zone file to import')
@@ -394,7 +394,7 @@ def load_arguments(self, _):
         c.argument('target', options_list=('--target', '-t'), help='Target domain name.')
 
     with self.argument_context('network dns record-set txt') as c:
-        c.argument('value', options_list=('--value', '-v'), nargs='+', help='Space separated list of text values which will be concatenated together.')
+        c.argument('value', options_list=('--value', '-v'), nargs='+', help='Space-separated list of text values which will be concatenated together.')
 
     # endregion
 
@@ -428,7 +428,7 @@ def load_arguments(self, _):
         c.argument('sku_tier', arg_type=get_enum_type(ExpressRouteCircuitSkuTier))
         c.argument('primary_peer_address_prefix', options_list=['--primary-peer-subnet'], help='/30 subnet used to configure IP addresses for primary interface.')
         c.argument('secondary_peer_address_prefix', options_list=['--secondary-peer-subnet'], help='/30 subnet used to configure IP addresses for secondary interface.')
-        c.argument('advertised_public_prefixes', arg_group='Microsoft Peering', nargs='+', help='Space separated list of prefixes to be advertised through the BGP peering.')
+        c.argument('advertised_public_prefixes', arg_group='Microsoft Peering', nargs='+', help='Space-separated list of prefixes to be advertised through the BGP peering.')
         c.argument('customer_asn', arg_group='Microsoft Peering', help='Autonomous system number of the customer.')
         c.argument('routing_registry_name', arg_group='Microsoft Peering', arg_type=get_enum_type(routing_registry_values), help='Internet Routing Registry / Regional Internet Registry')
         c.argument('route_filter', min_api='2016-12-01', arg_group='Microsoft Peering', help='Name or ID of a route filter to apply to the peering settings.', validator=validate_route_filter)
@@ -529,7 +529,7 @@ def load_arguments(self, _):
         c.argument('enable_accelerated_networking', min_api='2016-09-01', options_list=['--accelerated-networking'], help='Enable accelerated networking.', arg_type=get_three_state_flag())
         c.argument('network_interface_name', nic_type, options_list=('--name', '-n'))
         c.argument('internal_dns_name_label', options_list=('--internal-dns-name',), help='The internal DNS name label.', arg_group='DNS')
-        c.argument('dns_servers', help='Space separated list of DNS server IP addresses.', nargs='+', arg_group='DNS')
+        c.argument('dns_servers', help='Space-separated list of DNS server IP addresses.', nargs='+', arg_group='DNS')
         c.argument('enable_ip_forwarding', options_list=('--ip-forwarding',), help='Enable IP forwarding.', arg_type=get_three_state_flag())
 
     with self.argument_context('network nic create') as c:
@@ -547,14 +547,14 @@ def load_arguments(self, _):
 
     with self.argument_context('network nic update') as c:
         c.argument('network_security_group', help='Name or ID of the associated network security group.', validator=get_nsg_validator(), completer=get_resource_name_completion_list('Microsoft.Network/networkSecurityGroups'))
-        c.argument('dns_servers', help='Space separated list of DNS server IP addresses. Use "" to revert to default Azure servers.', nargs='+', arg_group='DNS')
+        c.argument('dns_servers', help='Space-separated list of DNS server IP addresses. Use "" to revert to default Azure servers.', nargs='+', arg_group='DNS')
 
     for item in ['create', 'ip-config update', 'ip-config create']:
         with self.argument_context('network nic {}'.format(item)) as c:
             c.extra('load_balancer_name', options_list=('--lb-name',), completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'), help='The name of the load balancer to use when adding NAT rules or address pools by name (ignored when IDs are specified).')
-            c.argument('load_balancer_backend_address_pool_ids', options_list=('--lb-address-pools',), nargs='+', validator=validate_address_pool_id_list, help='Space separated list of names or IDs of load balancer address pools to associate with the NIC. If names are used, --lb-name must be specified.', completer=get_lb_subresource_completion_list('backendAddresPools'))
-            c.argument('load_balancer_inbound_nat_rule_ids', options_list=('--lb-inbound-nat-rules',), nargs='+', validator=validate_inbound_nat_rule_id_list, help='Space separated list of names or IDs of load balancer inbound NAT rules to associate with the NIC. If names are used, --lb-name must be specified.', completer=get_lb_subresource_completion_list('inboundNatRules'))
-            c.argument('application_security_groups', min_api='2017-09-01', help='Space separated list of application security groups.', nargs='+', validator=get_asg_validator(self, 'application_security_groups'))
+            c.argument('load_balancer_backend_address_pool_ids', options_list=('--lb-address-pools',), nargs='+', validator=validate_address_pool_id_list, help='Space-separated list of names or IDs of load balancer address pools to associate with the NIC. If names are used, --lb-name must be specified.', completer=get_lb_subresource_completion_list('backendAddresPools'))
+            c.argument('load_balancer_inbound_nat_rule_ids', options_list=('--lb-inbound-nat-rules',), nargs='+', validator=validate_inbound_nat_rule_id_list, help='Space-separated list of names or IDs of load balancer inbound NAT rules to associate with the NIC. If names are used, --lb-name must be specified.', completer=get_lb_subresource_completion_list('inboundNatRules'))
+            c.argument('application_security_groups', min_api='2017-09-01', help='Space-separated list of application security groups.', nargs='+', validator=get_asg_validator(self, 'application_security_groups'))
 
     with self.argument_context('network nic ip-config') as c:
         c.argument('network_interface_name', options_list=('--nic-name',), metavar='NIC_NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
@@ -706,7 +706,7 @@ def load_arguments(self, _):
         c.argument('dns_name', help='Globally unique DNS entry.')
         c.argument('idle_timeout', help='Idle timeout in minutes.')
         c.argument('zone', zone_type, min_api='2017-06-01')
-        c.argument('ip_tags', nargs='+', min_api='2017-11-01', help="Space separated list of IP tags in 'TYPE=VAL' format.", validator=validate_ip_tags)
+        c.argument('ip_tags', nargs='+', min_api='2017-11-01', help="Space-separated list of IP tags in 'TYPE=VAL' format.", validator=validate_ip_tags)
 
     with self.argument_context('network public-ip create') as c:
         c.argument('name', completer=None)
@@ -799,8 +799,8 @@ def load_arguments(self, _):
     # region VirtualNetworks
     with self.argument_context('network vnet') as c:
         c.argument('virtual_network_name', virtual_network_name_type, options_list=('--name', '-n'), id_part='name')
-        c.argument('vnet_prefixes', nargs='+', help='Space separated list of IP address prefixes for the VNet.', options_list=('--address-prefixes',), metavar='PREFIX')
-        c.argument('dns_servers', nargs='+', help='Space separated list of DNS server IP addresses.', metavar='IP')
+        c.argument('vnet_prefixes', nargs='+', help='Space-separated list of IP address prefixes for the VNet.', options_list=('--address-prefixes',), metavar='PREFIX')
+        c.argument('dns_servers', nargs='+', help='Space-separated list of DNS server IP addresses.', metavar='IP')
         c.argument('ddos_protection', arg_type=get_three_state_flag(), help='Enable DDoS protection for protected resources in the VNet.', min_api='2017-09-01')
         c.argument('vm_protection', arg_type=get_three_state_flag(), help='Enable VM protection for all subnets in the VNet.', min_api='2017-09-01')
 
@@ -844,7 +844,7 @@ def load_arguments(self, _):
         c.argument('vpn_type', help='VPN routing type.', arg_type=get_enum_type(VpnType), default=VpnType.route_based.value)
         c.argument('bgp_peering_address', arg_group='BGP Peering', help='IP address to use for BGP peering.')
         c.argument('public_ip_address', options_list=['--public-ip-addresses'], nargs='+', help='Specify a single public IP (name or ID) for an active-standby gateway. Specify two space-separated public IPs for an active-active gateway.', completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'))
-        c.argument('address_prefixes', help='Space separated list of CIDR prefixes representing the address space for the P2S client.', nargs='+', arg_group='VPN Client')
+        c.argument('address_prefixes', help='Space-separated list of CIDR prefixes representing the address space for the P2S client.', nargs='+', arg_group='VPN Client')
         c.argument('radius_server', min_api='2017-06-01', help='Radius server address to connect to.', arg_group='VPN Client')
         c.argument('radius_secret', min_api='2017-06-01', help='Radius secret to use for authentication.', arg_group='VPN Client')
         c.argument('client_protocol', min_api='2017-06-01', help='Protocols to use for connecting', nargs='+', arg_group='VPN Client', arg_type=get_enum_type(VpnClientProtocol))
@@ -870,7 +870,7 @@ def load_arguments(self, _):
         c.argument('processor_architecture', arg_type=get_enum_type(ProcessorArchitecture))
         c.argument('authentication_method', arg_type=get_enum_type(AuthenticationMethod))
         c.argument('radius_server_auth_certificate', help='Public certificate data for the Radius server auth certificate in Base-64 format. Required only if external Radius auth has been configured with EAPTLS auth.')
-        c.argument('client_root_certificates', nargs='+', help='Space separated list of client root certificate public certificate data in Base-64 format. Optional for external Radius-based auth with EAPTLS')
+        c.argument('client_root_certificates', nargs='+', help='Space-separated list of client root certificate public certificate data in Base-64 format. Optional for external Radius-based auth with EAPTLS')
         c.argument('use_legacy', min_api='2017-06-01', help='Generate VPN client package using legacy implementation.', arg_type=get_three_state_flag())
 
     # endregion

--- a/src/command_modules/azure-cli-rdbms/HISTORY.rst
+++ b/src/command_modules/azure-cli-rdbms/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.12
+++++++
+* Minor fixes.
+
 0.0.11
 ++++++
 * Minor fixes.

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_params.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_params.py
@@ -72,7 +72,7 @@ def load_arguments(self, _):
 
     for scope in ['mysql server-logs', 'postgres server-logs']:
         with self.argument_context(scope) as c:
-            c.argument('file_name', options_list=['--name', '-n'], nargs='+', help='Space separated list of log filenames on the server to download.')
+            c.argument('file_name', options_list=['--name', '-n'], nargs='+', help='Space-separated list of log filenames on the server to download.')
             c.argument('max_file_size', type=int, help='The file size limitation to filter files.')
             c.argument('file_last_written', type=int, help='Integer in hours to indicate file last modify time, default value is 72.')
             c.argument('filename_contains', help='The pattern that file name should match.')

--- a/src/command_modules/azure-cli-rdbms/setup.py
+++ b/src/command_modules/azure-cli-rdbms/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.11"
+VERSION = "0.0.12"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.23
+++++++
+* Minor fixes.
+
 2.0.22
 ++++++
 * `deployment create/validate`: Fix bug where warning was incorrectly displayed when a template 'type' field contained
@@ -48,7 +52,7 @@ Release History
 
 2.0.14 (2017-09-11)
 +++++++++++++++++++
-* Allows passing in resource policy parameter definitions in 'policy definition create', and 'policy definition update'. 
+* Allows passing in resource policy parameter definitions in 'policy definition create', and 'policy definition update'.
 * Allows passing in parameter values for 'policy assignment create'.
 * In all cases params can be provided either via json or file.
 * Incremented API version.

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -46,7 +46,7 @@ def load_arguments(self, _):
         c.argument('parent_resource_path', resource_parent_type, arg_group='Resource Id')
         c.argument('tag', tag_type)
         c.argument('tags', tags_type)
-        c.argument('resource_ids', nargs='+', options_list=['--ids'], help='One or more resource IDs (space delimited). If provided, no other "Resource Id" arguments should be specified.', arg_group='Resource Id')
+        c.argument('resource_ids', nargs='+', options_list=['--ids'], help='One or more resource IDs (space-delimited). If provided, no other "Resource Id" arguments should be specified.', arg_group='Resource Id')
         c.argument('include_response_body', arg_type=get_three_state_flag(), help='Use if the default command output doesn\'t capture all of the property data.')
 
     with self.argument_context('resource list') as c:
@@ -161,7 +161,7 @@ def load_arguments(self, _):
         c.argument('resource_provider_namespace', resource_namespace_type)
         c.argument('resource_type', arg_type=resource_type_type, completer=get_resource_types_completion_list)
         c.argument('resource_name', options_list=['--resource', '--resource-name'], help='Name or ID of the resource being locked. If an ID is given, other resource arguments should not be given.')
-        c.argument('ids', nargs='+', options_list=('--ids'), help='One or more resource IDs (space delimited). If provided, no other "Resource Id" arguments should be specified.')
+        c.argument('ids', nargs='+', options_list=('--ids'), help='One or more resource IDs (space-delimited). If provided, no other "Resource Id" arguments should be specified.')
         c.argument('resource_group', resource_group_name_type, validator=validate_lock_parameters)
 
     with self.argument_context('resource lock') as c:
@@ -185,7 +185,7 @@ def load_arguments(self, _):
         with self.argument_context(scope) as c:
             c.argument('lock_name', options_list=('--name', '-n'), help='Name of the lock')
             c.argument('level', options_list=('--lock-type', '-t'), arg_type=get_enum_type([LockLevel.can_not_delete, LockLevel.read_only]))
-            c.argument('ids', nargs='+', options_list=('--ids'), help='One or more resource IDs (space delimited). If provided, no other "Resource Id" arguments should be specified.')
+            c.argument('ids', nargs='+', options_list=('--ids'), help='One or more resource IDs (space-delimited). If provided, no other "Resource Id" arguments should be specified.')
             c.argument('notes', help='Notes about this lock.')
 
     with self.argument_context('managedapp') as c:
@@ -205,6 +205,6 @@ def load_arguments(self, _):
 
     with self.argument_context('managedapp definition create') as c:
         c.argument('lock_level', arg_type=get_enum_type(ApplicationLockLevel))
-        c.argument('authorizations', options_list=('--authorizations', '-a'), nargs='+', help="space separated authorization pairs in a format of <principalId>:<roleDefinitionId>")
+        c.argument('authorizations', options_list=('--authorizations', '-a'), nargs='+', help="space-separated authorization pairs in a format of <principalId>:<roleDefinitionId>")
         c.argument('createUiDefinition', options_list=('--create-ui-definition', '-c'), help='JSON formatted string or a path to a file with such content', type=file_type)
         c.argument('mainTemplate', options_list=('--main-template', '-t'), help='JSON formatted string or a path to a file with such content', type=file_type)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -852,7 +852,7 @@ def show_provider_operations(cmd, resource_provider_namespace, api_version=None)
 def move_resource(cmd, ids, destination_group, destination_subscription_id=None):
     """Moves resources from one resource group to another(can be under different subscription)
 
-    :param ids: the space separated resource ids to be moved
+    :param ids: the space-separated resource ids to be moved
     :param destination_group: the destination resource group name
     :param destination_subscription_id: the destination subscription identifier
     """
@@ -894,7 +894,7 @@ def create_policy_assignment(cmd, policy=None, policy_set_definition=None,
                              resource_group_name=None, scope=None, sku=None,
                              not_scopes=None):
     """Creates a policy assignment
-    :param not_scopes: Space separated scopes where the policy assignment does not apply.
+    :param not_scopes: Space-separated scopes where the policy assignment does not apply.
     """
     if bool(policy) == bool(policy_set_definition):
         raise CLIError('usage error: --policy NAME_OR_ID | '

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.22"
+VERSION = "2.0.23"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+2.0.19
+++++++
+* Minor fixes.
+
 2.0.18
 ++++++
 * ad app update: expose "--available-to-other-tenants"

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -24,8 +24,8 @@ def load_arguments(self, _):
         c.argument('display_name', help='the display name of the application')
         c.argument('homepage', help='the url where users can sign in and use your app.')
         c.argument('identifier', options_list=['--id'], help='identifier uri, application id, or object id')
-        c.argument('identifier_uris', nargs='+', help='space separated unique URIs that Azure AD can use for this app.')
-        c.argument('reply_urls', nargs='+', help='space separated URIs to which Azure AD will redirect in response to an OAuth 2.0 request. The value does not need to be a physical endpoint, but must be a valid URI.')
+        c.argument('identifier_uris', nargs='+', help='space-separated unique URIs that Azure AD can use for this app.')
+        c.argument('reply_urls', nargs='+', help='space-separated URIs to which Azure AD will redirect in response to an OAuth 2.0 request. The value does not need to be a physical endpoint, but must be a valid URI.')
         c.argument('start_date', help="Date or datetime at which credentials become valid(e.g. '2017-01-01T01:00:00+00:00' or '2017-01-01'). Default value is current time")
         c.argument('end_date', help="Date or datetime after which credentials expire(e.g. '2017-12-31T11:59:59+00:00' or '2017-12-31'). Default value is one year after current time")
         c.argument('available_to_other_tenants', help='the application can be used from any Azure AD tenants', arg_type=get_three_state_flag())
@@ -102,7 +102,7 @@ def load_arguments(self, _):
         c.argument('include_inherited', action='store_true', help='include assignments applied on parent scopes')
         c.argument('assignee', help='represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name')
         c.argument('assignee_object_id', help="assignee's graph object id, such as the 'principal id' from a managed service identity. Use this instead of '--assignee' to bypass graph permission issues")
-        c.argument('ids', nargs='+', help='space separated role assignment ids')
+        c.argument('ids', nargs='+', help='space-separated role assignment ids')
         c.argument('include_classic_administrators', arg_type=get_three_state_flag(), help='list default role assignments for subscription classic administrators, aka co-admins')
 
     with self.argument_context('role definition') as c:

--- a/src/command_modules/azure-cli-role/setup.py
+++ b/src/command_modules/azure-cli-role/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.18"
+VERSION = "2.0.19"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-servicefabric/HISTORY.rst
+++ b/src/command_modules/azure-cli-servicefabric/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.10
+++++++
+* Minor fixes.
+
 0.0.9
 ++++++
 * Added detailed errors to validation response when creating cluster.

--- a/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/_params.py
+++ b/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/_params.py
@@ -41,7 +41,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
 
     with self.argument_context('sf client certificate') as c:
         c.argument('certificate_common_name', help='client certificate common name.')
-        c.argument('admin_client_thumbprints', nargs='+', help='Space separated list of client certificate thumbprint that only has admin permission, ')
+        c.argument('admin_client_thumbprints', nargs='+', help='Space-separated list of client certificate thumbprint that only has admin permission, ')
         c.argument('certificate_issuer_thumbprint', help='client certificate issuer thumbprint.')
 
     with self.argument_context('sf cluster certificate') as c:
@@ -52,13 +52,13 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('certificate_issuer_thumbprint', help='client certificate issuer thumbprint.')
         c.argument('certificate_common_name', help='client certificate common name.')
         c.argument('admin_client_thumbprints', nargs='+', help='client certificate thumbprint that only has admin permission.')
-        c.argument('readonly_client_thumbprints', nargs='+', help='Space separated list of client certificate thumbprint that has read only permission.')
+        c.argument('readonly_client_thumbprints', nargs='+', help='Space-separated list of client certificate thumbprint that has read only permission.')
 
     with self.argument_context('sf cluster client-certificate add') as c:
         c.argument('thumbprint', help='client certificate thumbprint.')
 
     with self.argument_context('sf cluster client-certificate remove') as c:
-        c.argument('thumbprints', nargs='+', help='A single or Space separated list of client certificate thumbprint(s) to be remove.')
+        c.argument('thumbprints', nargs='+', help='A single or Space-separated list of client certificate thumbprint(s) to be remove.')
 
     with self.argument_context('sf cluster node') as c:
         c.argument('number_of_nodes_to_add', help='number of nodes to add.')

--- a/src/command_modules/azure-cli-servicefabric/setup.py
+++ b/src/command_modules/azure-cli-servicefabric/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.9"
+VERSION = "0.0.10"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.25
+++++++
+* Minor fixes.
+
 2.0.24
 ++++++
 * `storage account update`: do not create new networkRuleSet if "default_action" arg is not provided.

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -663,7 +663,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.ignore('property_resolver')
         c.argument('entity', options_list=('--entity', '-e'), validator=validate_entity, nargs='+')
         c.argument('select', nargs='+', validator=validate_select,
-                   help='Space separated list of properties to return for each entity.')
+                   help='Space-separated list of properties to return for each entity.')
 
     with self.argument_context('storage entity insert') as c:
         c.argument('if_exists', arg_type=get_enum_type(['fail', 'merge', 'replace']))

--- a/src/command_modules/azure-cli-storage/setup.py
+++ b/src/command_modules/azure-cli-storage/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.24"
+VERSION = "2.0.25"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -46,7 +46,7 @@ Release History
 2.0.18
 ++++++
 * `vmss create`: fix a bug that blocks using Basic tier of VM sizes
-* `vm/vmss create`: expose `plan` arguments for using custom images with billing informations 
+* `vm/vmss create`: expose `plan` arguments for using custom images with billing informations
 * vm : support `vm secret add/remove/list`
 * vm : `vm format-secret` is copied to `vm secret format`. The old one will be removed in future
 * Minor fixes.
@@ -79,14 +79,14 @@ Release History
 * msi: use the same extension naming as portal does
 * msi: remove the useless `subscription` from the `vm/vmss create` commands output
 * `vm/vmss create`: fix a bug that the storage sku is not applied on data disks coming with an image
-* `vm format-secret`: Fix issue where `--secrets` would not accept newline separated IDs.
+* `vm format-secret`: Fix issue where `--secrets` would not accept newline-separated IDs.
 
 2.0.13 (2017-08-28)
 +++++++++++++++++++
 * `vmss get-instance-view`: Fix issue where extra, erroneous information was displayed when using `--instance-id *`
 * `vmss create`: Added support for `--lb-sku`
 * `vm/vmss create`: remove human names from the admin name blacklist
-* `vm/vmss create`: fix issue where the command would throw an error if unable to extract plan information from an image. 
+* `vm/vmss create`: fix issue where the command would throw an error if unable to extract plan information from an image.
 * `vmss create`: fix a crash when create a scaleset with an internal LB
 * `vm availability-set create`: Fix issue where --no-wait argument did not work.
 
@@ -120,7 +120,7 @@ Release History
 
 2.0.9 (2017-06-21)
 ++++++++++++++++++
-* vm/vmss: lower thread number used for 'vm image list --all' to avoid exceeding the OS opened file limits  
+* vm/vmss: lower thread number used for 'vm image list --all' to avoid exceeding the OS opened file limits
 * diagnostics: Fix a typo in default Linux Diagnostic extension config
 * vmss create: fix failure when running with --use-unmanaged-disk
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -96,7 +96,7 @@ def load_arguments(self, _):
         # here we collpase all difference image sources to under 2 common arguments --os-disk-source --data-disk-sources
         c.argument('name', arg_type=name_arg_type, help='new image name')
         c.argument('source', help='OS disk source from the same region, including a virtual machine ID or name, OS disk blob URI, managed OS disk ID or name, or OS snapshot ID or name')
-        c.argument('data_disk_sources', nargs='+', help='Space separated list of data disk sources, including unmanaged blob URI, managed disk ID or name, or snapshot ID or name')
+        c.argument('data_disk_sources', nargs='+', help='Space-separated list of data disk sources, including unmanaged blob URI, managed disk ID or name, or snapshot ID or name')
         c.ignore('source_virtual_machine', 'os_blob_uri', 'os_disk', 'os_snapshot', 'data_blob_uris', 'data_disks', 'data_snapshots')
     # endregion
 
@@ -126,7 +126,7 @@ def load_arguments(self, _):
         c.argument('caching', help='Disk caching policy', arg_type=get_enum_type(CachingTypes))
         c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none.', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
-        c.argument('application_security_groups', min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space separated list of existing application security groups to associate with the VM.', arg_group='Network')
+        c.argument('application_security_groups', min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network')
 
     with self.argument_context('vm capture') as c:
         c.argument('overwrite', action='store_true')
@@ -143,7 +143,7 @@ def load_arguments(self, _):
         c.argument('availability_set', help='Name or ID of an existing availability set to add the VM to. None by default.')
         c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none.', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
-        c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
+        c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
 
     with self.argument_context('vm open-port') as c:
         c.argument('vm_name', name_arg_type, help='The name of the virtual machine to open inbound traffic on.')
@@ -182,7 +182,7 @@ def load_arguments(self, _):
 
     for scope in ['vm format-secret', 'vm secret']:
         with self.argument_context(scope) as c:
-            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='Space separated list of key vault secret URIs. Perhaps, produced by \'az keyvault secret list-versions --vault-name vaultname -n cert1 --query "[?attributes.enabled].id" -o tsv\'')
+            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='Space-separated list of key vault secret URIs. Perhaps, produced by \'az keyvault secret list-versions --vault-name vaultname -n cert1 --query "[?attributes.enabled].id" -o tsv\'')
             c.argument('keyvault', help='Name or ID of the key vault.')
             c.argument('certificate', help='key vault certificate name or its full secret URL')
             c.argument('certificate_store', help='Windows certificate store names. Default: My')
@@ -214,7 +214,7 @@ def load_arguments(self, _):
         c.argument('command_id', completer=get_vm_run_command_completion_list, help="The run command ID")
 
     with self.argument_context('vm run-command invoke') as c:
-        c.argument('parameters', nargs='+', help="space separated parameters in the format of '[name=]value'")
+        c.argument('parameters', nargs='+', help="space-separated parameters in the format of '[name=]value'")
         c.argument('scripts', nargs='+', help="script lines separated by whites spaces. Use @{file} to load from a file")
 
     with self.argument_context('vm unmanaged-disk') as c:
@@ -245,7 +245,7 @@ def load_arguments(self, _):
     with self.argument_context('vmss') as c:
         c.argument('zones', zones_type, min_api='2017-03-30')
         c.argument('instance_id', id_part='child_name_1')
-        c.argument('instance_ids', multi_ids_type, help='Space separated list of IDs (ex: 1 2 3 ...) or * for all instances. If not provided, the action will be applied on the scaleset itself')
+        c.argument('instance_ids', multi_ids_type, help='Space-separated list of IDs (ex: 1 2 3 ...) or * for all instances. If not provided, the action will be applied on the scaleset itself')
         c.argument('tags', tags_type)
         c.argument('caching', help='Disk caching policy', arg_type=get_enum_type(CachingTypes))
         for dest in scaleset_name_aliases:
@@ -286,12 +286,12 @@ def load_arguments(self, _):
     with self.argument_context('vmss create', min_api='2017-03-30', arg_group='Network') as c:
         c.argument('public_ip_per_vm', action='store_true', help="Each VM instance will have a public ip. For security, you can use '--nsg' to apply appropriate rules")
         c.argument('vm_domain_name', help="domain name of VM instances, once configured, the FQDN is 'vm<vm-index>.<vm-domain-name>.<..rest..>'")
-        c.argument('dns_servers', nargs='+', help="space separated IP addresses of DNS servers, e.g. 10.0.0.5 10.0.0.6")
+        c.argument('dns_servers', nargs='+', help="space-separated IP addresses of DNS servers, e.g. 10.0.0.5 10.0.0.6")
         c.argument('accelerated_networking', action='store_true', help="enable accelerated networking")
 
     for scope in ['vmss update-instances', 'vmss delete-instances']:
         with self.argument_context(scope) as c:
-            c.argument('instance_ids', multi_ids_type, help='Space separated list of IDs (ex: 1 2 3 ...) or * for all instances.')
+            c.argument('instance_ids', multi_ids_type, help='Space-separated list of IDs (ex: 1 2 3 ...) or * for all instances.')
 
     with self.argument_context('vmss diagnostics') as c:
         c.argument('vmss_name', id_part=None, help='Scale set name')
@@ -328,7 +328,7 @@ def load_arguments(self, _):
 
     for scope in ['vm remove-identity', 'vmss remove-identity']:
         with self.argument_context(scope) as c:
-            c.argument('identities', nargs='+', help="space separated user assigned identities to remove")
+            c.argument('identities', nargs='+', help="space-separated user assigned identities to remove")
             c.argument('vm_name', existing_vm_name)
             c.argument('vmss_name', vmss_name_type)
 
@@ -343,7 +343,7 @@ def load_arguments(self, _):
             c.argument('custom_data', help='Custom init script file or text (cloud-init, cloud-config, etc..)', completer=FilesCompleter(), type=file_type)
             c.argument('secrets', multi_ids_type, help='One or many Key Vault secrets as JSON strings or files via `@<file path>` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`', type=file_type, completer=FilesCompleter())
             c.argument('license_type', help="license type if the Windows image or disk used was licensed on-premises", arg_type=get_enum_type(['Windows_Server', 'Windows_Client']))
-            c.argument('assign_identity', nargs='*', arg_group='Managed Service Identity', help="accept system or user assigned identities with space separated. Use '[system]' to refer system assigned identity, or a resource id to refer user assigned identity. Check out help for more examples")
+            c.argument('assign_identity', nargs='*', arg_group='Managed Service Identity', help="accept system or user assigned identities separated by spaces. Use '[system]' to refer system assigned identity, or a resource id to refer user assigned identity. Check out help for more examples")
 
         with self.argument_context(scope, arg_group='Authentication') as c:
             c.argument('generate_ssh_keys', action='store_true', help='Generate SSH public and private key files if missing. The keys will be stored in the ~/.ssh directory')
@@ -361,7 +361,7 @@ def load_arguments(self, _):
             c.argument('storage_container_name', help="Only applicable when used with `--use-unmanaged-disk`. Name of the storage container for the VM OS disk. Default: vhds")
             c.ignore('os_publisher', 'os_offer', 'os_sku', 'os_version', 'storage_profile')
             c.argument('use_unmanaged_disk', action='store_true', help='Do not use managed disk to persist VM')
-            c.argument('data_disk_sizes_gb', nargs='+', type=int, help='space separated empty managed data disk sizes in GB to create')
+            c.argument('data_disk_sizes_gb', nargs='+', type=int, help='space-separated empty managed data disk sizes in GB to create')
             c.ignore('image_data_disks', 'storage_account_type', 'public_ip_type', 'nsg_type', 'nic_type', 'vnet_type', 'load_balancer_type', 'app_gateway_type')
             c.argument('os_caching', options_list=['--storage-caching', '--os-disk-caching'], help='Storage caching type for the VM OS disk.', arg_type=get_enum_type([CachingTypes.read_only.value, CachingTypes.read_write.value], default='ReadWrite'))
             c.argument('data_caching', options_list=['--data-disk-caching'], help='Storage caching type for the VM data disk(s).', arg_type=get_enum_type(CachingTypes))

--- a/tools/automation/clibuild/__init__.py
+++ b/tools/automation/clibuild/__init__.py
@@ -141,7 +141,7 @@ def init_args(root):
                           default='https://github.com/Azure/azure-cli.git')
     cli_build_parser.add_argument('-t', '--type', dest='build_types', required=True, nargs='+',
                                   choices=BUILD_TYPES + ['*'],
-                                  help="Space separated list of the artifacts to build. Use '*' for all.")
+                                  help="Space-separated list of the artifacts to build. Use '*' for all.")
     cli_build_parser.add_argument('-c', '--cli-version', dest='cli_version', required=True,
                                   help="The version of the build. (ignored for 'pypi' type)")
     homebrew_args = cli_build_parser.add_argument_group('Homebrew Specific Arguments')

--- a/tools/automation/tests/__init__.py
+++ b/tools/automation/tests/__init__.py
@@ -54,7 +54,7 @@ def setup_arguments(parser):
     parser.add_argument('--module', dest='modules', nargs='+',
                         help='The modules of which the test to be run. Accept short names, except azure-cli, '
                              'azure-cli-core and azure-cli-nspkg. The modules list can also be set through environment '
-                             'variable AZURE_CLI_TEST_MODULES. The value should be a string of space separated module '
+                             'variable AZURE_CLI_TEST_MODULES. The value should be a string of space-separated module '
                              'names. The environment variable will be overwritten by command line parameters.')
     parser.add_argument('--parallel', action='store_true',
                         help='Run the tests in parallel. This will affect the test output file.')


### PR DESCRIPTION
When referencing [delimiter-separated](https://en.wikipedia.org/wiki/Delimiter-separated_values#Delimited_formats) formats, a hyphen is required. Examples are "tab-delimited" and "space-separated."

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [X] Each command and parameter has a meaningful description.
- [X] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
