### PR TITLE
vm encryption: avoid the crash when vm encryption setting might not be fully initialized

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.0.26
 ++++++
+* vm encryption: avoid the crash when vm encryption setting might not be fully initialized
 * msi: output principal id on enabling system assigned identity
 * vm boot-diagnostic: fix the broken get log command
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -293,9 +293,9 @@ def show_vm_encryption_status(cmd, resource_group_name, vm_name):
     else:
         # Windows - get os and data volume encryption state from the vm model
         if (encryption_status['osDiskEncryptionSettings'] and
-            encryption_status['osDiskEncryptionSettings'].enabled and
-            encryption_status['osDiskEncryptionSettings'].disk_encryption_key and
-            encryption_status['osDiskEncryptionSettings'].disk_encryption_key.secret_url):
+                encryption_status['osDiskEncryptionSettings'].enabled and
+                encryption_status['osDiskEncryptionSettings'].disk_encryption_key and
+                encryption_status['osDiskEncryptionSettings'].disk_encryption_key.secret_url):
             encryption_status['osDisk'] = _STATUS_ENCRYPTED
         else:
             encryption_status['osDisk'] = 'Unknown'

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -292,9 +292,13 @@ def show_vm_encryption_status(cmd, resource_group_name, vm_name):
             encryption_status['dataDisk'] = 'Unknown'
     else:
         # Windows - get os and data volume encryption state from the vm model
-        if (encryption_status['osDiskEncryptionSettings'].enabled and
-                encryption_status['osDiskEncryptionSettings'].disk_encryption_key.secret_url):
+        if (encryption_status['osDiskEncryptionSettings'] and
+            encryption_status['osDiskEncryptionSettings'].enabled and
+            encryption_status['osDiskEncryptionSettings'].disk_encryption_key and
+            encryption_status['osDiskEncryptionSettings'].disk_encryption_key.secret_url):
             encryption_status['osDisk'] = _STATUS_ENCRYPTED
+        else:
+            encryption_status['osDisk'] = 'Unknown'
 
         if extension_result.provisioning_state == 'Succeeded':
             volume_type = extension_result.settings.get('VolumeType', None)


### PR DESCRIPTION
Fix #5436 
This is a mitigation level of fix, as most likely the service end has a bug. It is a windows VM being encrypted and the encryption setting is supposed to be available immediately. But nonetheless, this PR avoids the unhandled exception. 

I manually tested the change and will add automation once confirmed the glitch is by-design

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na] Each command and parameter has a meaningful description.
- [na] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
