### PR TITLE
[DONT MERGE] matching implementation

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/util.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/util.py
@@ -24,7 +24,7 @@ def collect_blobs(blob_service, container, pattern=None):
         except NameError:
             blob_name = blob.name
 
-        if _match_path(pattern, blob_name):
+        if not pattern or _match_path(blob_name, pattern):
             results.append(blob_name)
 
     return results
@@ -75,9 +75,8 @@ def glob_files_locally(folder_path, pattern):
     len_folder_path = len(folder_path) + 1
     for root, _, files in walk(folder_path):
         for f in files:
-            from fnmatch import fnmatch
             full_path = os.path.join(root, f)
-            if pattern and fnmatch(full_path, pattern):
+            if pattern and _match_path(full_path, pattern):
                 yield (full_path, full_path[len_folder_path:])
             elif not pattern:
                 yield (full_path, full_path[len_folder_path:])
@@ -94,8 +93,7 @@ def glob_files_remotely(cmd, client, share_name, pattern):
         current_dir = queue.pop()
         for f in client.list_directories_and_files(share_name, current_dir):
             if isinstance(f, t_file):
-                from fnmatch import fnmatch
-                if (pattern and fnmatch(os.path.join(current_dir, f.name), pattern)) or (not pattern):
+                if (pattern and _match_path(os.path.join(current_dir, f.name), pattern)) or (not pattern):
                     yield current_dir, f.name
             elif isinstance(f, t_dir):
                 queue.appendleft(os.path.join(current_dir, f.name))
@@ -172,10 +170,16 @@ def _pattern_has_wildcards(p):
     return not p or p.find('*') != -1 or p.find('?') != -1 or p.find('[') != -1
 
 
-def _match_path(pattern, *args):
-    from fnmatch import fnmatch
+def _match_path(path, pattern):
+    from fnmatch import translate
     import os
-    return fnmatch(os.path.join(*args), pattern) if pattern else True
+    import re
+    path = os.path.normcase(path)
+    pattern = os.path.normcase(pattern)
+    regex_non_sep = '[^{}]*'.format(re.escape(os.sep))
+    regex = translate(pattern).replace('.*', regex_non_sep)
+    regex = regex.replace(regex_non_sep*2, '.*')
+    return re.match(regex, path) is not None
 
 
 def guess_content_type(file_path, original, settings_class):


### PR DESCRIPTION
---
This will allow users to use the `--pattern` parameter for the storage batch command (`blob upload-batch, file download-batch`, etc), to match for files both non-recursively and recursively using `*` and `**` respectively. 