### PR TITLE
ad: update help be more accurate

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -223,7 +223,7 @@ helps['role definition update'] = """
 """
 helps['ad'] = """
     type: group
-    short-summary: Synchronize on-premises directories and manage Azure Active Directory resources.
+    short-summary: Manage Azure Active Directory Graph entities needed for Role Based Access Control
 """
 helps['ad app'] = """
     type: group


### PR DESCRIPTION
To avoid confusion, the `ad` commands are only for RBAC, so let us make it clear
@derekbekoe, since it is a low-risk help update, can we merge it for current release? 
//CC: @skwan 


### General Guidelines

- [na] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [na] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
