### PR TITLE
Improve core error handling

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -17,6 +17,7 @@ from knack.arguments import CLICommandArgument, ignore_type, ArgumentsContext
 from knack.commands import CLICommand, CommandGroup
 from knack.invocation import CommandInvoker
 from knack.log import get_logger
+from knack.parser import ARGPARSE_SUPPORTED_KWARGS
 from knack.util import CLIError
 
 from azure.cli.core import EXCLUDED_PARAMS
@@ -24,9 +25,16 @@ import azure.cli.core.telemetry as telemetry
 
 logger = get_logger(__name__)
 
-CLI_COMMAND_KWARGS = ['transform', 'table_transformer', 'confirmation', 'exception_handler', 'min_api', 'max_api',
-                      'client_factory', 'operations_tmpl', 'no_wait_param', 'validator', 'resource_type',
-                      'client_arg_name', 'operation_group']
+CLI_COMMON_KWARGS = ['min_api', 'max_api', 'resource_type', 'operation_group',
+                     'custom_command_type', 'command_type']
+
+CLI_COMMAND_KWARGS = ['transform', 'table_transformer', 'confirmation', 'exception_handler',
+                      'client_factory', 'operations_tmpl', 'no_wait_param', 'validator',
+                      'client_arg_name', 'doc_string_source', 'deprecate_info'] + CLI_COMMON_KWARGS
+CLI_PARAM_KWARGS = \
+    ['id_part', 'completer', 'validator', 'options_list', 'configured_default', 'arg_group', 'arg_type'] \
+    + CLI_COMMON_KWARGS + ARGPARSE_SUPPORTED_KWARGS
+
 
 CONFIRM_PARAM_NAME = 'yes'
 
@@ -597,9 +605,12 @@ def _is_poller(obj):
     return False
 
 
-def _merge_kwargs(patch_kwargs, base_kwargs):
+def _merge_kwargs(patch_kwargs, base_kwargs, supported_kwargs=None):
     merged_kwargs = base_kwargs.copy()
     merged_kwargs.update(patch_kwargs)
+    unrecognized_kwargs = [x for x in merged_kwargs if x not in (supported_kwargs or CLI_COMMON_KWARGS)]
+    if unrecognized_kwargs:
+        raise TypeError('unrecognized kwargs: {}'.format(unrecognized_kwargs))
     return merged_kwargs
 
 
@@ -609,9 +620,6 @@ class CliCommandType(object):
     def __init__(self, overrides=None, **kwargs):
         if isinstance(overrides, str):
             raise ValueError("Overrides has to be a {} (cannot be a string)".format(CliCommandType.__name__))
-        unrecognized_kwargs = [x for x in kwargs if x not in CLI_COMMAND_KWARGS]
-        if unrecognized_kwargs:
-            raise TypeError('unrecognized kwargs: {}'.format(unrecognized_kwargs))
         self.settings = {}
         self.update(overrides, **kwargs)
 
@@ -651,7 +659,7 @@ class AzCommandGroup(CommandGroup):
 
     def _merge_kwargs(self, kwargs, base_kwargs=None):
         base = base_kwargs if base_kwargs is not None else getattr(self, 'group_kwargs')
-        return _merge_kwargs(kwargs, base)
+        return _merge_kwargs(kwargs, base, CLI_COMMAND_KWARGS)
 
     def _flatten_kwargs(self, kwargs, default_source_name):
         merged_kwargs = self._merge_kwargs(kwargs)
@@ -761,7 +769,7 @@ class AzCommandGroup(CommandGroup):
         from azure.cli.core.commands.arm import _cli_generic_update_command
 
         self._check_stale()
-        merged_kwargs = _merge_kwargs(kwargs, self.group_kwargs)
+        merged_kwargs = _merge_kwargs(kwargs, self.group_kwargs, CLI_COMMAND_KWARGS)
 
         getter_op = self._resolve_operation(merged_kwargs, getter_name, getter_type)
         setter_op = self._resolve_operation(merged_kwargs, setter_name, setter_type)
@@ -783,9 +791,9 @@ class AzCommandGroup(CommandGroup):
     def generic_wait_command(self, name, getter_name='get', getter_type=None, **kwargs):
         from azure.cli.core.commands.arm import _cli_generic_update_command, _cli_generic_wait_command
         self._check_stale()
-        merged_kwargs = _merge_kwargs(kwargs, self.group_kwargs)
+        merged_kwargs = _merge_kwargs(kwargs, self.group_kwargs, CLI_COMMAND_KWARGS)
         if getter_type:
-            merged_kwargs = _merge_kwargs(getter_type.settings, merged_kwargs)
+            merged_kwargs = _merge_kwargs(getter_type.settings, merged_kwargs, CLI_COMMAND_KWARGS)
         getter_op = self._resolve_operation(merged_kwargs, getter_name, getter_type)
         _cli_generic_wait_command(
             self.command_loader,
@@ -816,7 +824,7 @@ class AzArgumentContext(ArgumentsContext):
     def __init__(self, command_loader, scope, **kwargs):
         super(AzArgumentContext, self).__init__(command_loader, scope)
         self.scope = scope  # this is called "command" in knack, but that is not an accurate name
-        self.group_kwargs = _merge_kwargs(kwargs, command_loader.module_kwargs)
+        self.group_kwargs = _merge_kwargs(kwargs, command_loader.module_kwargs, CLI_PARAM_KWARGS)
         self.is_stale = False
 
     def __enter__(self):
@@ -849,7 +857,7 @@ class AzArgumentContext(ArgumentsContext):
 
     def _merge_kwargs(self, kwargs, base_kwargs=None):
         base = base_kwargs if base_kwargs is not None else getattr(self, 'group_kwargs')
-        return _merge_kwargs(kwargs, base)
+        return _merge_kwargs(kwargs, base, CLI_PARAM_KWARGS)
 
     # pylint: disable=arguments-differ
     def argument(self, dest, arg_type=None, **kwargs):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -29,6 +29,8 @@ logger = logging.getLogger('azure.cli.testsdk')
 class CheckerMixin(object):
 
     def _apply_kwargs(self, val):
+        #return val.format(**self.kwargs)
+        # TODO: detect when .format was used but brackets remain...
         try:
             return val.format(**self.kwargs)
         except Exception:  # pylint: disable=broad-except

--- a/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
+++ b/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
@@ -7,7 +7,7 @@ import json
 from datetime import datetime, timedelta
 import unittest
 
-from azure.cli.testsdk import ScenarioTest, JMESPathCheck, JMESPathCheckExists, ResourceGroupPreparer, \
+from azure.cli.testsdk import ScenarioTest, JMESPathCheckExists, ResourceGroupPreparer, \
     StorageAccountPreparer
 from azure.mgmt.recoveryservices.models import StorageModelType
 
@@ -27,95 +27,94 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @VMPreparer()
     @StorageAccountPreparer()
     def test_backup_scenario(self, resource_group, vault_name, vm_name, storage_account):
+
+        self.kwargs.update({
+            'vault': vault_name,
+            'vm': vm_name
+        })
+
         # Enable Protection
-        self.cmd('backup protection enable-for-vm -g {} -v {} --vm {} -p DefaultPolicy'
-                 .format(resource_group, vault_name, vm_name)).get_output_in_json()
+        self.cmd('backup protection enable-for-vm -g {rg} -v {vault} --vm {vm} -p DefaultPolicy').get_output_in_json()
 
         # Get Container
-        container = self.cmd('backup container show -n {} -v {} -g {} --query properties.friendlyName'
-                             .format(vm_name, vault_name, resource_group)).get_output_in_json()
+        self.kwargs['container'] = self.cmd('backup container show -n {vm} -v {vault} -g {rg} --query properties.friendlyName').get_output_in_json()
 
         # Get Item
-        item = self.cmd('backup item list -g {} -v {} -c {} --query [0].properties.friendlyName'
-                        .format(resource_group, vault_name, container)).get_output_in_json()
+        self.kwargs['item'] = self.cmd('backup item list -g {rg} -v {vault} -c {container} --query [0].properties.friendlyName').get_output_in_json()
 
         # Trigger Backup
-        retain_date = datetime.utcnow() + timedelta(days=30)
-        backup_cmd_string = 'backup protection backup-now'
-        backup_cmd_string += ' -g {} -v {}'.format(resource_group, vault_name)
-        backup_cmd_string += ' -c {} -i {}'.format(container, item)
-        backup_cmd_string += ' --retain-until {} --query name'.format(retain_date.strftime('%d-%m-%Y'))
-        trigger_backup_job_name = self.cmd(backup_cmd_string).get_output_in_json()
-        self.cmd('backup job wait -g {} -v {} -n {}'.format(resource_group, vault_name, trigger_backup_job_name))
+        self.kwargs['retain_date'] = (datetime.utcnow() + timedelta(days=30)).strftime('%d-%m-%Y')
+        self.kwargs['job'] = self.cmd('backup protection backup-now -g {rg} -v {vault} -c {container} -i {item} --retain-until {retain_date} --query name').get_output_in_json()
+        self.cmd('backup job wait -g {rg} -v {vault} -n {job}')
 
         # Get Recovery Point
-        recovery_point = self.cmd('backup recoverypoint list -g {} -v {} -c {} -i {} --query [0].name'
-                                  .format(resource_group, vault_name, container, item)).get_output_in_json()
+        self.kwargs['recovery_point'] = self.cmd('backup recoverypoint list -g {rg} -v {vault} -c {container} -i {item} --query [0].name').get_output_in_json()
 
         # Trigger Restore
-        restore_cmd_string = 'backup restore restore-disks'
-        restore_cmd_string += ' -g {} -v {}'.format(resource_group, vault_name)
-        restore_cmd_string += ' -c {} -i {} -r {}'.format(container, item, recovery_point)
-        restore_cmd_string += ' --storage-account {} --query name'.format(storage_account)
-        restore_cmd_string += ' --restore-to-staging-storage-account'
-        trigger_restore_job_name = self.cmd(restore_cmd_string).get_output_in_json()
-        self.cmd('backup job wait -g {} -v {} -n {}'.format(resource_group, vault_name, trigger_restore_job_name))
+        self.kwargs['job'] = self.cmd('backup restore restore-disks -g {rg} -v {vault} -c {container} -i {item} -r {recovery_point} --storage-account {sa} --query name --restore-to-staging-storage-account').get_output_in_json()
+        self.cmd('backup job wait -g {rg} -v {vault} -n {job}')
 
         # Disable Protection
-        self.cmd('backup protection disable -g {} -v {} -c {} -i {} --delete-backup-data true --yes'
-                 .format(resource_group, vault_name, container, item))
+        self.cmd('backup protection disable -g {rg} -v {vault} -c {container} -i {item} --delete-backup-data true --yes')
 
     @ResourceGroupPreparer()
     @VaultPreparer(parameter_name='vault1')
     @VaultPreparer(parameter_name='vault2')
     def test_backup_vault(self, resource_group, resource_group_location, vault1, vault2):
-        vault3 = self.create_random_name('clitest-vault', 50)
-        self.cmd('backup vault create -n {} -g {} -l {}'
-                 .format(vault3, resource_group, resource_group_location), checks=[
-                     JMESPathCheck('name', vault3),
-                     JMESPathCheck('resourceGroup', resource_group),
-                     JMESPathCheck('location', resource_group_location),
-                     JMESPathCheck('properties.provisioningState', 'Succeeded')])
+
+        self.kwargs.update({
+            'loc': resource_group_location,
+            'vault1': vault1,
+            'vault2': vault2
+        })
+
+        self.kwargs['vault3'] = self.create_random_name('clitest-vault', 50)
+        self.cmd('backup vault create -n {vault3} -g {rg} -l {loc}', checks=[
+            self.check('name', '{vault3}'),
+            self.check('resourceGroup', '{rg}'),
+            self.check('location', '{loc}'),
+            self.check('properties.provisioningState', 'Succeeded')
+        ])
 
         self.cmd('backup vault list', checks=[
-            JMESPathCheck("length([?resourceGroup == '{}'])".format(resource_group), 3),
-            JMESPathCheck("length([?name == '{}'])".format(vault1), 1),
-            JMESPathCheck("length([?name == '{}'])".format(vault2), 1),
-            JMESPathCheck("length([?name == '{}'])".format(vault3), 1)])
+            self.check("length([?resourceGroup == '{rg}'])", 3),
+            self.check("length([?name == '{vault1}'])", 1),
+            self.check("length([?name == '{vault2}'])", 1),
+            self.check("length([?name == '{vault3}'])", 1)
+        ])
 
-        self.cmd('backup vault list -g {}'.format(resource_group), checks=[
-            JMESPathCheck("length(@)", 3),
-            JMESPathCheck("length([?name == '{}'])".format(vault1), 1),
-            JMESPathCheck("length([?name == '{}'])".format(vault2), 1),
-            JMESPathCheck("length([?name == '{}'])".format(vault3), 1)
+        self.cmd('backup vault list -g {rg}', checks=[
+            self.check("length(@)", 3),
+            self.check("length([?name == '{vault1}'])", 1),
+            self.check("length([?name == '{vault2}'])", 1),
+            self.check("length([?name == '{vault3}'])", 1)
         ])
 
         storage_model_types = [e.value for e in StorageModelType]
-        vault_properties = self.cmd('backup vault backup-properties show -n {} -g {}'
-                                    .format(vault1, resource_group), checks=[
-                                        JMESPathCheckExists("contains({}, storageModelType)"
-                                                            .format(storage_model_types)),
-                                        JMESPathCheck('storageTypeState', 'Unlocked'),
-                                        JMESPathCheck('resourceGroup', resource_group)]).get_output_in_json()
+        vault_properties = self.cmd('backup vault backup-properties show -n {vault1} -g {rg}', checks=[
+            JMESPathCheckExists("contains({}, storageModelType)".format(storage_model_types)),
+            self.check('storageTypeState', 'Unlocked'),
+            self.check('resourceGroup', '{rg}')
+        ]).get_output_in_json()
 
         if vault_properties['storageModelType'] == StorageModelType.geo_redundant.value:
             new_storage_model = StorageModelType.locally_redundant.value
         else:
             new_storage_model = StorageModelType.geo_redundant.value
 
-        self.cmd('backup vault backup-properties set -n {} -g {} --backup-storage-redundancy {}'
-                 .format(vault1, resource_group, new_storage_model))
+        self.kwargs['model'] = new_storage_model
+        self.cmd('backup vault backup-properties set -n {vault1} -g {rg} --backup-storage-redundancy {model}')
 
-        self.cmd('backup vault backup-properties show -n {} -g {}'.format(vault1, resource_group), checks=[
-            JMESPathCheck('storageModelType', new_storage_model)
+        self.cmd('backup vault backup-properties show -n {vault1} -g {rg}', checks=[
+            self.check('storageModelType', new_storage_model)
         ])
 
-        self.cmd('backup vault delete -n {} -g {} -y'.format(vault3, resource_group))
+        self.cmd('backup vault delete -n {vault3} -g {rg} -y')
 
         self.cmd('backup vault list', checks=[
-            JMESPathCheck("length([?resourceGroup == '{}'])".format(resource_group), 2),
-            JMESPathCheck("length([?name == '{}'])".format(vault1), 1),
-            JMESPathCheck("length([?name == '{}'])".format(vault2), 1)
+            self.check("length([?resourceGroup == '{rg}'])", 2),
+            self.check("length([?name == '{vault1}'])", 1),
+            self.check("length([?name == '{vault2}'])", 1)
         ])
 
     @ResourceGroupPreparer()
@@ -125,25 +124,32 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @ItemPreparer(vm_parameter_name='vm1')
     @ItemPreparer(vm_parameter_name='vm2')
     def test_backup_container(self, resource_group, vault_name, vm1, vm2):
-        container_json = self.cmd('backup container show -n {} -v {} -g {}'
-                                  .format(vm1, vault_name, resource_group), checks=[
-                                      JMESPathCheck('properties.friendlyName', vm1),
-                                      JMESPathCheck('properties.healthStatus', 'Healthy'),
-                                      JMESPathCheck('properties.registrationStatus', 'Registered'),
-                                      JMESPathCheck('properties.resourceGroup', resource_group),
-                                      JMESPathCheck('resourceGroup', resource_group)]).get_output_in_json()
 
-        vm1_json = self.cmd('vm show -n {} -g {}'.format(vm1, resource_group)).get_output_in_json()
+        self.kwargs.update({
+            'vault': vault_name,
+            'vm1': vm1,
+            'vm2': vm2
+        })
+
+        container_json = self.cmd('backup container show -n {vm1} -v {vault} -g {rg}', checks=[
+            self.check('properties.friendlyName', '{vm1}'),
+            self.check('properties.healthStatus', 'Healthy'),
+            self.check('properties.registrationStatus', 'Registered'),
+            self.check('properties.resourceGroup', '{rg}'),
+            self.check('resourceGroup', '{rg}')
+        ]).get_output_in_json()
+
+        vm1_json = self.cmd('vm show -n {vm1} -g {rg}').get_output_in_json()
 
         self.assertIn(vault_name.lower(), container_json['id'].lower())
         self.assertIn(vm1.lower(), container_json['name'].lower())
         self.assertIn(vm1.lower(), container_json['properties']['virtualMachineId'].lower())
         self.assertEqual(container_json['properties']['virtualMachineVersion'], _get_vm_version(vm1_json['type']))
 
-        self.cmd('backup container list -v {} -g {}'.format(vault_name, resource_group), checks=[
-            JMESPathCheck("length(@)", 2),
-            JMESPathCheck("length([?properties.friendlyName == '{}'])".format(vm1), 1),
-            JMESPathCheck("length([?properties.friendlyName == '{}'])".format(vm2), 1)])
+        self.cmd('backup container list -v {vault} -g {rg}', checks=[
+            self.check("length(@)", 2),
+            self.check("length([?properties.friendlyName == '{vm1}'])", 1),
+            self.check("length([?properties.friendlyName == '{vm2}'])", 1)])
 
     @ResourceGroupPreparer()
     @VaultPreparer()
@@ -154,48 +160,59 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @ItemPreparer(vm_parameter_name='vm1')
     @ItemPreparer(vm_parameter_name='vm2')
     def test_backup_policy(self, resource_group, vault_name, policy1, policy2, vm1, vm2):
-        policy3 = self.create_random_name('clitest-policy', 24)
-        default_policy = 'DefaultPolicy'
 
-        policy1_json = self.cmd('backup policy show -g {} -v {} -n {}'
-                                .format(resource_group, vault_name, policy1), checks=[
-                                    JMESPathCheck('name', policy1),
-                                    JMESPathCheck('resourceGroup', resource_group)]).get_output_in_json()
+        self.kwargs.update({
+            'policy1': policy1,
+            'policy2': policy2,
+            'policy3': self.create_random_name('clitest-policy', 24),
+            'default': 'DefaultPolicy',
+            'vault': vault_name,
+            'vm1': vm1,
+            'vm2': vm2
+        })
 
-        self.cmd('backup policy list -g {} -v {}'.format(resource_group, vault_name), checks=[
-            JMESPathCheck("length(@)", 4),
-            JMESPathCheck("length([?name == '{}'])".format(default_policy), 1),
-            JMESPathCheck("length([?name == '{}'])".format(policy1), 1),
-            JMESPathCheck("length([?name == '{}'])".format(policy2), 1)])
+        self.kwargs['policy1_json'] = self.cmd('backup policy show -g {rg} -v {vault} -n {policy1}', checks=[
+            self.check('name', '{policy1}'),
+            self.check('resourceGroup', '{rg}')
+        ]).get_output_in_json()
 
-        self.cmd('backup policy list-associated-items -g {} -v {} -n {}'
-                 .format(resource_group, vault_name, default_policy), checks=[
-                     JMESPathCheck("length(@)", 2),
-                     JMESPathCheck("length([?properties.friendlyName == '{}'])".format(vm1), 1),
-                     JMESPathCheck("length([?properties.friendlyName == '{}'])".format(vm2), 1)])
+        self.cmd('backup policy list -g {rg} -v {vault}', checks=[
+            self.check("length(@)", 4),
+            self.check("length([?name == '{default}'])", 1),
+            self.check("length([?name == '{policy1}'])", 1),
+            self.check("length([?name == '{policy2}'])", 1)
+        ])
 
-        policy1_json['name'] = policy3
-        policy1_json = json.dumps(policy1_json)
+        self.cmd('backup policy list-associated-items -g {rg} -v {vault} -n {default}', checks=[
+            self.check("length(@)", 2),
+            self.check("length([?properties.friendlyName == '{}'])".format(vm1), 1),
+            self.check("length([?properties.friendlyName == '{}'])".format(vm2), 1)
+        ])
 
-        self.cmd('backup policy set -g {} -v {} --policy \'{}\''
-                 .format(resource_group, vault_name, policy1_json), checks=[
-                     JMESPathCheck('name', policy3),
-                     JMESPathCheck('resourceGroup', resource_group)])
+        self.kwargs['policy1_json']['name'] = self.kwargs['policy3']
+        self.kwargs['policy1_json'] = json.dumps(self.kwargs['policy1_json'])
 
-        self.cmd('backup policy list -g {} -v {}'.format(resource_group, vault_name), checks=[
-            JMESPathCheck("length(@)", 5),
-            JMESPathCheck("length([?name == '{}'])".format(default_policy), 1),
-            JMESPathCheck("length([?name == '{}'])".format(policy1), 1),
-            JMESPathCheck("length([?name == '{}'])".format(policy2), 1),
-            JMESPathCheck("length([?name == '{}'])".format(policy3), 1)])
+        self.cmd("backup policy set -g {rg} -v {vault} --policy '{policy1_json}'", checks=[
+            self.check('name', '{policy3}'),
+            self.check('resourceGroup', '{rg}')
+        ])
 
-        self.cmd('backup policy delete -g {} -v {} -n {}'.format(resource_group, vault_name, policy3))
+        self.cmd('backup policy list -g {rg} -v {vault}', checks=[
+            self.check("length(@)", 5),
+            self.check("length([?name == '{default}'])", 1),
+            self.check("length([?name == '{policy1}'])", 1),
+            self.check("length([?name == '{policy2}'])", 1),
+            self.check("length([?name == '{policy3}'])", 1)
+        ])
 
-        self.cmd('backup policy list -g {} -v {}'.format(resource_group, vault_name), checks=[
-            JMESPathCheck("length(@)", 4),
-            JMESPathCheck("length([?name == '{}'])".format(default_policy), 1),
-            JMESPathCheck("length([?name == '{}'])".format(policy1), 1),
-            JMESPathCheck("length([?name == '{}'])".format(policy2), 1)])
+        self.cmd('backup policy delete -g {rg} -v {vault} -n {policy3}')
+
+        self.cmd('backup policy list -g {rg} -v {vault}', checks=[
+            self.check("length(@)", 4),
+            self.check("length([?name == '{default}'])", 1),
+            self.check("length([?name == '{policy1}'])", 1),
+            self.check("length([?name == '{policy2}'])", 1)
+        ])
 
     @ResourceGroupPreparer()
     @VaultPreparer()
@@ -205,52 +222,55 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @ItemPreparer(vm_parameter_name='vm2')
     @PolicyPreparer()
     def test_backup_item(self, resource_group, vault_name, vm1, vm2, policy_name):
-        container1 = self.cmd('backup container show -n {} -v {} -g {} --query properties.friendlyName'
-                              .format(vm1, vault_name, resource_group)).get_output_in_json()
-        container2 = self.cmd('backup container show -n {} -v {} -g {} --query properties.friendlyName'
-                              .format(vm2, vault_name, resource_group)).get_output_in_json()
 
-        default_policy = 'DefaultPolicy'
+        self.kwargs.update({
+            'vault': vault_name,
+            'vm1': vm1,
+            'vm2': vm2,
+            'policy': policy_name,
+            'default': 'DefaultPolicy'
+        })
+        self.kwargs['container1'] = self.cmd('backup container show -n {vm1} -v {vault} -g {rg} --query properties.friendlyName').get_output_in_json()
+        self.kwargs['container2'] = self.cmd('backup container show -n {vm2} -v {vault} -g {rg} --query properties.friendlyName').get_output_in_json()
 
-        item1_json = self.cmd('backup item show -g {} -v {} -c {} -n {}'
-                              .format(resource_group, vault_name, container1, vm1), checks=[
-                                  JMESPathCheck('properties.friendlyName', vm1),
-                                  JMESPathCheck('properties.healthStatus', 'Passed'),
-                                  JMESPathCheck('properties.protectionState', 'IRPending'),
-                                  JMESPathCheck('properties.protectionStatus', 'Healthy'),
-                                  JMESPathCheck('resourceGroup', resource_group)]).get_output_in_json()
+        item1_json = self.cmd('backup item show -g {rg} -v {vault} -c {container1} -n {vm1}', checks=[
+            self.check('properties.friendlyName', '{vm1}'),
+            self.check('properties.healthStatus', 'Passed'),
+            self.check('properties.protectionState', 'IRPending'),
+            self.check('properties.protectionStatus', 'Healthy'),
+            self.check('resourceGroup', '{rg}')
+        ]).get_output_in_json()
 
         self.assertIn(vault_name.lower(), item1_json['id'].lower())
         self.assertIn(vm1.lower(), item1_json['name'].lower())
         self.assertIn(vm1.lower(), item1_json['properties']['sourceResourceId'].lower())
         self.assertIn(vm1.lower(), item1_json['properties']['virtualMachineId'].lower())
-        self.assertIn(default_policy.lower(), item1_json['properties']['policyId'].lower())
+        self.assertIn(self.kwargs['default'].lower(), item1_json['properties']['policyId'].lower())
 
-        self.cmd('backup item list -g {} -v {} -c {}'
-                 .format(resource_group, vault_name, container1), checks=[
-                     JMESPathCheck("length(@)", 1),
-                     JMESPathCheck("length([?properties.friendlyName == '{}'])".format(vm1), 1)])
+        self.cmd('backup item list -g {rg} -v {vault} -c {container1}', checks=[
+            self.check("length(@)", 1),
+            self.check("length([?properties.friendlyName == '{vm1}'])", 1)
+        ])
 
-        self.cmd('backup item list -g {} -v {} -c {}'
-                 .format(resource_group, vault_name, container2), checks=[
-                     JMESPathCheck("length(@)", 1),
-                     JMESPathCheck("length([?properties.friendlyName == '{}'])".format(vm2), 1)])
+        self.cmd('backup item list -g {rg} -v {vault} -c {container2}', checks=[
+            self.check("length(@)", 1),
+            self.check("length([?properties.friendlyName == '{vm2}'])", 1)
+        ])
 
-        self.cmd('backup item list -g {} -v {}'
-                 .format(resource_group, vault_name), checks=[
-                     JMESPathCheck("length(@)", 2),
-                     JMESPathCheck("length([?properties.friendlyName == '{}'])".format(vm1), 1),
-                     JMESPathCheck("length([?properties.friendlyName == '{}'])".format(vm2), 1)])
+        self.cmd('backup item list -g {rg} -v {vault}', checks=[
+            self.check("length(@)", 2),
+            self.check("length([?properties.friendlyName == '{vm1}'])", 1),
+            self.check("length([?properties.friendlyName == '{vm2}'])", 1)
+        ])
 
-        self.cmd('backup item set-policy -g {} -v {} -c {} -n {} -p {}'
-                 .format(resource_group, vault_name, container1, vm1, policy_name), checks=[
-                     JMESPathCheck("properties.entityFriendlyName", vm1),
-                     JMESPathCheck("properties.operation", "ConfigureBackup"),
-                     JMESPathCheck("properties.status", "Completed"),
-                     JMESPathCheck("resourceGroup", resource_group)])
+        self.cmd('backup item set-policy -g {rg} -v {vault} -c {container1} -n {vm1} -p {policy}', checks=[
+            self.check("properties.entityFriendlyName", '{vm1}'),
+            self.check("properties.operation", "ConfigureBackup"),
+            self.check("properties.status", "Completed"),
+            self.check("resourceGroup", '{rg}')
+        ])
 
-        item1_json = self.cmd('backup item show -g {} -v {} -c {} -n {}'
-                              .format(resource_group, vault_name, container1, vm1)).get_output_in_json()
+        item1_json = self.cmd('backup item show -g {rg} -v {vault} -c {container1} -n {vm1}').get_output_in_json()
         self.assertIn(policy_name.lower(), item1_json['properties']['policyId'].lower())
 
     @ResourceGroupPreparer()
@@ -260,23 +280,28 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @RPPreparer()
     @RPPreparer()
     def test_backup_rp(self, resource_group, vault_name, vm_name):
-        rp_names = self.cmd('backup recoverypoint list -g {} -v {} -c {} -i {} --query [].name'
-                            .format(resource_group, vault_name, vm_name, vm_name), checks=[
-                                JMESPathCheck("length(@)", 2)]).get_output_in_json()
 
-        rp1_name = rp_names[0]
-        rp1_json = self.cmd('backup recoverypoint show -g {} -v {} -c {} -i {} -n {}'
-                            .format(resource_group, vault_name, vm_name, vm_name, rp1_name), checks=[
-                                JMESPathCheck("name", rp1_name),
-                                JMESPathCheck("resourceGroup", resource_group)]).get_output_in_json()
+        self.kwargs.update({
+            'vault': vault_name,
+            'vm': vm_name
+        })
+        rp_names = self.cmd('backup recoverypoint list -g {rg} -v {vault} -c {vm} -i {vm} --query [].name', checks=[
+            self.check("length(@)", 2)
+        ]).get_output_in_json()
+
+        self.kwargs['rp1'] = rp_names[0]
+        rp1_json = self.cmd('backup recoverypoint show -g {rg} -v {vault} -c {vm} -i {vm} -n {rp1}', checks=[
+            self.check("name", '{rp1}'),
+            self.check("resourceGroup", '{rg}')
+        ]).get_output_in_json()
         self.assertIn(vault_name.lower(), rp1_json['id'].lower())
         self.assertIn(vm_name.lower(), rp1_json['id'].lower())
 
-        rp2_name = rp_names[1]
-        rp2_json = self.cmd('backup recoverypoint show -g {} -v {} -c {} -i {} -n {}'
-                            .format(resource_group, vault_name, vm_name, vm_name, rp2_name), checks=[
-                                JMESPathCheck("name", rp2_name),
-                                JMESPathCheck("resourceGroup", resource_group)]).get_output_in_json()
+        self.kwargs['rp2'] = rp_names[1]
+        rp2_json = self.cmd('backup recoverypoint show -g {rg} -v {vault} -c {vm} -i {vm} -n {rp2}', checks=[
+            self.check("name", '{rp2}'),
+            self.check("resourceGroup", '{rg}')
+        ]).get_output_in_json()
         self.assertIn(vault_name.lower(), rp2_json['id'].lower())
         self.assertIn(vm_name.lower(), rp2_json['id'].lower())
 
@@ -284,36 +309,40 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @VaultPreparer()
     @VMPreparer()
     def test_backup_protection(self, resource_group, vault_name, vm_name):
-        self.cmd('backup protection enable-for-vm -g {} -v {} --vm {} -p DefaultPolicy'
-                 .format(resource_group, vault_name, vm_name), checks=[
-                     JMESPathCheck("properties.entityFriendlyName", vm_name),
-                     JMESPathCheck("properties.operation", "ConfigureBackup"),
-                     JMESPathCheck("properties.status", "Completed"),
-                     JMESPathCheck("resourceGroup", resource_group)])
 
-        self.cmd('backup protection disable -g {} -v {} -c {} -i {} --yes'
-                 .format(resource_group, vault_name, vm_name, vm_name), checks=[
-                     JMESPathCheck("properties.entityFriendlyName", vm_name),
-                     JMESPathCheck("properties.operation", "DisableBackup"),
-                     JMESPathCheck("properties.status", "Completed"),
-                     JMESPathCheck("resourceGroup", resource_group)])
+        self.kwargs.update({
+            'vault': vault_name,
+            'vm': vm_name
+        })
+        self.cmd('backup protection enable-for-vm -g {rg} -v {vault} --vm {vm} -p DefaultPolicy', checks=[
+            self.check("properties.entityFriendlyName", '{vm}'),
+            self.check("properties.operation", "ConfigureBackup"),
+            self.check("properties.status", "Completed"),
+            self.check("resourceGroup", '{rg}')
+        ])
 
-        self.cmd('backup item show -g {} -v {} -c {} -n {}'
-                 .format(resource_group, vault_name, vm_name, vm_name), checks=[
-                     JMESPathCheck("properties.friendlyName", vm_name),
-                     JMESPathCheck("properties.protectionState", "ProtectionStopped"),
-                     JMESPathCheck("resourceGroup", resource_group)])
+        self.cmd('backup protection disable -g {rg} -v {vault} -c {vm} -i {vm} --yes', checks=[
+            self.check("properties.entityFriendlyName", '{vm}'),
+            self.check("properties.operation", "DisableBackup"),
+            self.check("properties.status", "Completed"),
+            self.check("resourceGroup", '{rg}')
+        ])
 
-        self.cmd('backup protection disable -g {} -v {} -c {} -i {} --delete-backup-data true --yes'
-                 .format(resource_group, vault_name, vm_name, vm_name), checks=[
-                     JMESPathCheck("properties.entityFriendlyName", vm_name),
-                     JMESPathCheck("properties.operation", "DeleteBackupData"),
-                     JMESPathCheck("properties.status", "Completed"),
-                     JMESPathCheck("resourceGroup", resource_group)])
+        self.cmd('backup item show -g {rg} -v {vault} -c {vm} -n {vm}', checks=[
+            self.check("properties.friendlyName", '{vm}'),
+            self.check("properties.protectionState", "ProtectionStopped"),
+            self.check("resourceGroup", '{rg}')
+        ])
 
-        self.cmd('backup container list -v {} -g {}'
-                 .format(vault_name, resource_group), checks=[
-                     JMESPathCheck("length(@)", 0)])
+        self.cmd('backup protection disable -g {rg} -v {vault} -c {vm} -i {vm} --delete-backup-data true --yes', checks=[
+            self.check("properties.entityFriendlyName", '{vm}'),
+            self.check("properties.operation", "DeleteBackupData"),
+            self.check("properties.status", "Completed"),
+            self.check("resourceGroup", '{rg}')
+        ])
+
+        self.cmd('backup container list -v {vault} -g {rg}',
+                 checks=self.check("length(@)", 0))
 
     @ResourceGroupPreparer()
     @VaultPreparer()
@@ -322,49 +351,41 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @RPPreparer()
     @StorageAccountPreparer()
     def test_backup_restore(self, resource_group, vault_name, vm_name, storage_account):
-        rp_name = self.cmd('backup recoverypoint list -g {} -v {} -c {} -i {} --query [0].name'
-                           .format(resource_group, vault_name, vm_name, vm_name)).get_output_in_json()
+
+        self.kwargs.update({
+            'vault': vault_name,
+            'vm': vm_name
+        })
+        self.kwargs['rp'] = self.cmd('backup recoverypoint list -g {rg} -v {vault} -c {vm} -i {vm} --query [0].name').get_output_in_json()
 
         # Original Storage Account Restore Fails
-        osa_restore_cmd_string = 'backup restore restore-disks'
-        osa_restore_cmd_string += ' -g {} -v {}'.format(resource_group, vault_name)
-        osa_restore_cmd_string += ' -c {} -i {} -r {}'.format(vm_name, vm_name, rp_name)
-        osa_restore_cmd_string += ' --storage-account {}'.format(storage_account)
-        osa_restore_cmd_string += ' --restore-to-staging-storage-account false'
-        self.cmd(osa_restore_cmd_string, expect_failure=True)
+        self.cmd('backup restore restore-disks -g {rg} -v {vault} -c {vm} -i {vm} -r {rp} --storage-account {sa} --restore-to-staging-storage-account false', expect_failure=True)
 
         # Trigger Restore
-        restore_cmd_string = 'backup restore restore-disks'
-        restore_cmd_string += ' -g {} -v {}'.format(resource_group, vault_name)
-        restore_cmd_string += ' -c {} -i {} -r {}'.format(vm_name, vm_name, rp_name)
-        restore_cmd_string += ' --storage-account {}'.format(storage_account)
-        restore_cmd_string += ' --restore-to-staging-storage-account'
-        trigger_restore_job_json = self.cmd(restore_cmd_string, checks=[
-            JMESPathCheck("properties.entityFriendlyName", vm_name),
-            JMESPathCheck("properties.operation", "Restore"),
-            JMESPathCheck("properties.status", "InProgress"),
-            JMESPathCheck("resourceGroup", resource_group)
+        trigger_restore_job_json = self.cmd('backup restore restore-disks -g {rg} -v {vault} -c {vm} -i {vm} -r {rp} --storage-account {sa} --restore-to-staging-storage-account', checks=[
+            self.check("properties.entityFriendlyName", '{vm}'),
+            self.check("properties.operation", "Restore"),
+            self.check("properties.status", "InProgress"),
+            self.check("resourceGroup", '{rg}')
         ]).get_output_in_json()
-        trigger_restore_job_name = trigger_restore_job_json['name']
-        self.cmd('backup job wait -g {} -v {} -n {}'.format(resource_group, vault_name, trigger_restore_job_name))
+        self.kwargs['job'] = trigger_restore_job_json['name']
+        self.cmd('backup job wait -g {rg} -v {vault} -n {job}')
 
-        trigger_restore_job_details = self.cmd('backup job show -g {} -v {} -n {}'
-                                               .format(resource_group, vault_name, trigger_restore_job_name), checks=[
-                                                   JMESPathCheck("properties.entityFriendlyName", vm_name),
-                                                   JMESPathCheck("properties.operation", "Restore"),
-                                                   JMESPathCheck("properties.status", "Completed"),
-                                                   JMESPathCheck("resourceGroup", resource_group)
-                                               ]).get_output_in_json()
+        trigger_restore_job_details = self.cmd('backup job show -g {rg} -v {vault} -n {job}', checks=[
+            self.check("properties.entityFriendlyName", '{vm}'),
+            self.check("properties.operation", "Restore"),
+            self.check("properties.status", "Completed"),
+            self.check("resourceGroup", '{rg}')
+        ]).get_output_in_json()
 
         property_bag = trigger_restore_job_details['properties']['extendedInfo']['propertyBag']
         self.assertEqual(property_bag['Target Storage Account Name'], storage_account)
 
-        restore_container = property_bag['Config Blob Container Name']
-        restore_blob = property_bag['Config Blob Name']
+        self.kwargs['container'] = property_bag['Config Blob Container Name']
+        self.kwargs['blob'] = property_bag['Config Blob Name']
 
-        self.cmd('storage blob exists --account-name {} -c {} -n {}'
-                 .format(storage_account, restore_container, restore_blob), checks=[
-                     JMESPathCheck("exists", True)])
+        self.cmd('storage blob exists --account-name {sa} -c {container} -n {blob}',
+                 checks=self.check("exists", True))
 
     @ResourceGroupPreparer()
     @VaultPreparer()
@@ -373,35 +394,32 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @RPPreparer()
     @StorageAccountPreparer()
     def test_backup_job(self, resource_group, vault_name, vm_name, storage_account):
-        rp_name = self.cmd('backup recoverypoint list -g {} -v {} -c {} -i {} --query [0].name'
-                           .format(resource_group, vault_name, vm_name, vm_name)).get_output_in_json()
 
-        restore_cmd_string = 'backup restore restore-disks'
-        restore_cmd_string += ' -g {} -v {}'.format(resource_group, vault_name)
-        restore_cmd_string += ' -c {} -i {} -r {}'.format(vm_name, vm_name, rp_name)
-        restore_cmd_string += ' --storage-account {} --query name'.format(storage_account)
-        restore_cmd_string += ' --restore-to-staging-storage-account'
-        trigger_restore_job_name = self.cmd(restore_cmd_string).get_output_in_json()
+        self.kwargs.update({
+            'vault': vault_name,
+            'vm': vm_name
+        })
+        self.kwargs['rp'] = self.cmd('backup recoverypoint list -g {rg} -v {vault} -c {vm} -i {vm} --query [0].name').get_output_in_json()
+        self.kwargs['job'] = self.cmd('backup restore restore-disks -g {rg} -v {vault} -c {vm} -i {vm} -r {rp} --storage-account {sa} --query name --restore-to-staging-storage-account').get_output_in_json()
 
-        self.cmd('backup job show -g {} -v {} -n {}'
-                 .format(resource_group, vault_name, trigger_restore_job_name), checks=[
-                     JMESPathCheck("name", trigger_restore_job_name),
-                     JMESPathCheck("properties.entityFriendlyName", vm_name),
-                     JMESPathCheck("properties.operation", "Restore"),
-                     JMESPathCheck("properties.status", "InProgress"),
-                     JMESPathCheck("resourceGroup", resource_group)])
+        self.cmd('backup job show -g {rg} -v {vault} -n {job}', checks=[
+            self.check("name", '{job}'),
+            self.check("properties.entityFriendlyName", '{vm}'),
+            self.check("properties.operation", "Restore"),
+            self.check("properties.status", "InProgress"),
+            self.check("resourceGroup", '{rg}')
+        ])
 
-        self.cmd('backup job list -g {} -v {}'.format(resource_group, vault_name), checks=[
-            JMESPathCheck("length([?name == '{}'])".format(trigger_restore_job_name), 1)])
+        self.cmd('backup job list -g {rg} -v {vault}',
+                 checks=self.check("length([?name == '{job}'])", 1))
 
-        self.cmd('backup job list -g {} -v {} --status InProgress'.format(resource_group, vault_name), checks=[
-            JMESPathCheck("length([?name == '{}'])".format(trigger_restore_job_name), 1)])
+        self.cmd('backup job list -g {rg} -v {vault} --status InProgress',
+                 checks=self.check("length([?name == '{job}'])", 1))
 
-        self.cmd('backup job list -g {} -v {} --operation Restore'.format(resource_group, vault_name), checks=[
-            JMESPathCheck("length([?name == '{}'])".format(trigger_restore_job_name), 1)])
+        self.cmd('backup job list -g {rg} -v {vault} --operation Restore',
+                 checks=self.check("length([?name == '{job}'])", 1))
 
-        self.cmd('backup job list -g {} -v {} --operation Restore --status InProgress'
-                 .format(resource_group, vault_name), checks=[
-                     JMESPathCheck("length([?name == '{}'])".format(trigger_restore_job_name), 1)])
+        self.cmd('backup job list -g {rg} -v {vault} --operation Restore --status InProgress',
+                 checks=self.check("length([?name == '{job}'])", 1))
 
-        self.cmd('backup job stop -g {} -v {} -n {}'.format(resource_group, vault_name, trigger_restore_job_name))
+        self.cmd('backup job stop -g {rg} -v {vault} -n {job}')

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/latest/test_monitor_diagnostic_settings.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/latest/test_monitor_diagnostic_settings.py
@@ -11,10 +11,13 @@ class TestMonitorDiagnosticSettings(ScenarioTest):
     @ResourceGroupPreparer(location='southcentralus')
     @StorageAccountPreparer(location='southcentralus')
     def test_monitor_diagnostic_settings_scenario(self, resource_group, storage_account):
-        nsg_name = self.create_random_name(prefix='nsg', length=16)
-        self.cmd('network nsg create -n {} -g {}'.format(nsg_name, resource_group))
 
-        log_config = json.dumps([
+        self.kwargs.update({
+            'nsg': self.create_random_name(prefix='nsg', length=16)
+        })
+        self.cmd('network nsg create -n {nsg} -g {rg}')
+
+        self.kwargs['log_config'] = json.dumps([
             {
                 "category": "NetworkSecurityGroupEvent",
                 "enabled": True,
@@ -27,42 +30,21 @@ class TestMonitorDiagnosticSettings(ScenarioTest):
             }
         ])
 
-        self.cmd('monitor diagnostic-settings create -n test01 '
-                 '--resource {} '
-                 '--resource-type Microsoft.Network/networkSecurityGroups '
-                 '--resource-group {} '
-                 '--storage-account {} '
-                 '--log \'{}\' -o json'
-                 ''.format(nsg_name, resource_group, storage_account, log_config)).assert_with_checks(
-            JMESPathCheck('name', 'test01')
-        )
+        self.cmd('monitor diagnostic-settings create -n test01 --resource {nsg} --resource-type Microsoft.Network/networkSecurityGroups --resource-group {rg} --storage-account {sa} --log \'{log_config}\' -o json',
+                 checks=self.check('name', 'test01'))
 
-        self.cmd('monitor diagnostic-settings list '
-                 '--resource {} '
-                 '--resource-type Microsoft.Network/networkSecurityGroups '
-                 '--resource-group {} -o json'.format(nsg_name, resource_group)).assert_with_checks(
-            JMESPathCheck('length(value)', 1),
-            JMESPathCheck('value[0].name', 'test01')
-        )
+        self.cmd('monitor diagnostic-settings list --resource {nsg} --resource-type Microsoft.Network/networkSecurityGroups --resource-group {rg} -o json', checks=[
+            self.check('length(value)', 1),
+            self.check('value[0].name', 'test01')
+        ])
 
-        self.cmd('monitor diagnostic-settings show -n test01 '
-                 '--resource {} '
-                 '--resource-type Microsoft.Network/networkSecurityGroups '
-                 '--resource-group {} -o json'.format(nsg_name, resource_group)).assert_with_checks(
-            JMESPathCheck('name', 'test01')
-        )
+        self.cmd('monitor diagnostic-settings show -n test01 --resource {nsg} --resource-type Microsoft.Network/networkSecurityGroups --resource-group {rg} -o json',
+                 checks=self.check('name', 'test01'))
 
-        self.cmd('monitor diagnostic-settings delete -n test01 '
-                 '--resource {} '
-                 '--resource-type Microsoft.Network/networkSecurityGroups '
-                 '--resource-group {} -o json'.format(nsg_name, resource_group))
+        self.cmd('monitor diagnostic-settings delete -n test01 --resource {nsg} --resource-type Microsoft.Network/networkSecurityGroups --resource-group {rg} -o json')
 
-        self.cmd('monitor diagnostic-settings list '
-                 '--resource {} '
-                 '--resource-type Microsoft.Network/networkSecurityGroups '
-                 '--resource-group {} -o json'.format(nsg_name, resource_group)).assert_with_checks(
-            JMESPathCheck('length(value)', 0)
-        )
+        self.cmd('monitor diagnostic-settings list --resource {nsg} --resource-type Microsoft.Network/networkSecurityGroups --resource-group {rg} -o json',
+                 checks=self.check('length(value)', 0))
 
 
 if __name__ == '__main__':

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -765,9 +765,9 @@ class InvokeActionTest(ScenarioTest):
         self.cmd('resource invoke-action --action generalize --ids {vm_id}')
         self.cmd('resource invoke-action --action deallocate --ids {vm_id}')
 
-        request_body = '{\\"vhdPrefix\\":\\"myPrefix\\",\\"destinationContainerName\\":\\"container\\",\\"overwriteVhds\\":\\"true\\"}'
+        self.kwargs['request_body'] = '{\\"vhdPrefix\\":\\"myPrefix\\",\\"destinationContainerName\\":\\"container\\",\\"overwriteVhds\\":\\"true\\"}'
 
-        self.cmd('resource invoke-action --action capture --ids {} --request-body {}'.format(self.kwargs['vm_id'], request_body))
+        self.cmd('resource invoke-action --action capture --ids {vm_id} --request-body {request_body}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR does two things:

1. Fixes #5055. Now, when any of the command authoring commands that accept kwargs are invoked, the supplied kwargs will be validated and any errors will be raised instead of silently ignored.

2. Similiarly, this fixes an issue in the test base when using the `self.kwargs` feature so that kwarg mis-spellings in commands raise an actionable error instead of manifesting in strange, hard-to-diagnose ways.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
