### PR TITLE
`az group export` fix output on failure

### DIFF
--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -2,10 +2,13 @@
 
 Release History
 ===============
+2.0.24
+++++++
+* `group deployment export`: On failure, command will now output a partial template and any failures.
+
 2.0.23
 ++++++
 * feature: bring back 'feature show' command
-* Minor fixes.
 
 2.0.22
 ++++++

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -476,8 +476,11 @@ def export_group_as_template(
     # On error, server still returns 200, with details in the error attribute
     if result.error:
         error = result.error
-        logger.warning(result.error.message)
-        for detail in error.details or []:
+        try:
+            logger.warning(error.message)
+        except AttributeError:
+            logger.warning(str(error))
+        for detail in getattr(error, 'details', None) or []:
             logger.error(detail.message)
 
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -470,16 +470,15 @@ def export_group_as_template(
     options = ','.join(export_options) if export_options else None
 
     result = rcf.resource_groups.export_template(resource_group_name, ['*'], options=options)
+
+    print(json.dumps(result.template, indent=2))
     # pylint: disable=no-member
     # On error, server still returns 200, with details in the error attribute
     if result.error:
         error = result.error
-        if (hasattr(error, 'details') and error.details and
-                hasattr(error.details[0], 'message')):
-            error = error.details[0].message
-        raise CLIError(error)
-
-    print(json.dumps(result.template, indent=2))
+        logger.warning(result.error.message)
+        for detail in error.details or []:
+            logger.error(detail.message)
 
 
 def create_application(cmd, resource_group_name,

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.23"
+VERSION = "2.0.24"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes #3889.

The command will now output the template object. If there are failures, it will output a warning about the failures, following by an error message for each failure.  Example:

```
{
  <partial ARM template>
}

Export template operation completed with errors. Some resources were not exported. Please see details for more information.
Could not get resources of the type 'Microsoft.Sql/servers/connectionPolicies'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/disasterRecoveryConfiguration'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/advisors'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/auditingPolicies'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/dataMaskingPolicies'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/extensions'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/geoBackupPolicies'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/securityAlertPolicies'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/transparentDataEncryption'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/auditingSettings'. Resources of this type will not be exported.
Could not get resources of the type 'Microsoft.Sql/servers/databases/syncGroups'. Resources of this type will not be exported.
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
