### PR TITLE
Make `resource_type`  a required parameter for `supported_api_version`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -286,13 +286,13 @@ class AzCommandsLoader(CLICommandsLoader):
                 raise APIVersionException(operation_group, self.cli_ctx.cloud.profile)
 
     def supported_api_version(self, resource_type=None, min_api=None, max_api=None, operation_group=None):
-        from azure.cli.core.profiles import supported_api_version, PROFILE_TYPE
+        from azure.cli.core.profiles import supported_api_version
         if not min_api and not max_api:
             # optimistically assume that fully supported if no api restriction listed
             return True
         api_support = supported_api_version(
             cli_ctx=self.cli_ctx,
-            resource_type=resource_type or self._get_resource_type() or PROFILE_TYPE,
+            resource_type=resource_type or self._get_resource_type(),
             min_api=min_api or self.min_profile,
             max_api=max_api or self.max_profile,
             operation_group=operation_group)

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -224,7 +224,7 @@ def supported_api_version(api_profile, resource_type, min_api=None, max_api=None
     or YYYY-MM-DD-profile-preview  formatted strings.
     """
     if not isinstance(resource_type, ResourceType) and resource_type != PROFILE_TYPE:
-        raise TypeError()
+        raise ValueError("'resource_type' is required.")
     if min_api is None and max_api is None:
         raise ValueError('At least a min or max version must be specified')
     api_version_obj = get_api_version(api_profile, resource_type, as_sdk_profile=True) \

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -106,7 +106,7 @@ def load_arguments(self, _):
         c.argument('display_name', help='display name of the assignment')
         c.argument('policy', help='name or id of the policy definition.', completer=get_policy_completion_list)
 
-    with self.argument_context('policy assignment create') as c:
+    with self.argument_context('policy assignment create', resource_type=ResourceType.MGMT_RESOURCE_POLICY) as c:
         c.argument('name', options_list=('--name', '-n'), help='name of the new assignment')
         c.argument('params', options_list=('--params', '-p'), help='JSON formatted string or path to file with parameter values of policy rule', min_api='2016-12-01')
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -170,7 +170,7 @@ def load_command_table(self, _):
         g.custom_command('operation show', 'show_provider_operations')
 
     # Resource feature commands
-    with self.command_group('feature', resource_feature_sdk, client_factory=cf_features) as g:
+    with self.command_group('feature', resource_feature_sdk, client_factory=cf_features, resource_type=ResourceType.MGMT_RESOURCE_FEATURES) as g:
         feature_table_transform = '{Name:name, RegistrationState:properties.state}'
         g.custom_command('list', 'list_features', table_transformer='[].' + feature_table_transform)
         g.command('show', 'get', exception_handler=empty_on_404, table_transformer=feature_table_transform)
@@ -232,13 +232,13 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_resource_links')
         g.custom_command('update', 'update_resource_link')
 
-    with self.command_group('managedapp', resource_managedapp_sdk, min_api='2017-05-10') as g:
+    with self.command_group('managedapp', resource_managedapp_sdk, min_api='2017-05-10', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES) as g:
         g.custom_command('create', 'create_application')
         g.command('delete', 'delete')
         g.custom_command('show', 'show_application', exception_handler=empty_on_404)
         g.custom_command('list', 'list_applications')
 
-    with self.command_group('managedapp definition', resource_managedapp_def_sdk, min_api='2017-05-10') as g:
+    with self.command_group('managedapp definition', resource_managedapp_def_sdk, min_api='2017-05-10', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES) as g:
         g.custom_command('create', 'create_applicationdefinition')
         g.command('delete', 'delete')
         g.custom_command('show', 'show_applicationdefinition')


### PR DESCRIPTION
Fix #5484.

Previously, if the `resource_type` kwarg was not supplied to `azure.cli.core.profiles._shared.supported_api_version` then it would assume the PROFILE_TYPE. This led to subtle bugs as observed in #5484. Making this required would prevent this subtle bug by forcing commands to specify PROFILE_TYPE for resource type (I don't know of anywhere that actually has to do that).

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
