### PR TITLE
Expose Azure CLI core telemetry to extension

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 2.0.28
 ++++++
 * Minor fixes
+* Expose telemetry to Azure CLI Extension
 
 2.0.27
 ++++++

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,6 @@ Release History
 
 2.0.28
 ++++++
-* Minor fixes
 * Expose telemetry to Azure CLI Extension
 
 2.0.27

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.0.28
 ++++++
-* Expose telemetry to Azure CLI Extension
+* Allow extensions to send telemetry with custom instrumentation key
 
 2.0.27
 ++++++

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -303,8 +303,7 @@ def set_raw_command_name(command):
 
 
 def add_extension_events(extension_events):
-    for extension_event in extension_events:
-        _session.extension_events.append(extension_event)
+    _session.extension_events.extend(extension_events)
 
 
 # definitions

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -43,6 +43,7 @@ class TelemetrySession(object):  # pylint: disable=too-many-instance-attributes
     feedback = None
     extension_management_detail = None
     raw_command = None
+    extension_events = []
 
     def add_exception(self, exception, fault_type, description=None, message=''):
         fault_type = _remove_symbols(fault_type).replace('"', '').replace("'", '').replace(' ', '-')
@@ -72,6 +73,13 @@ class TelemetrySession(object):  # pylint: disable=too-many-instance-attributes
         user_task.update(cli)
 
         events.append({'name': '{}/command'.format(PRODUCT_NAME), 'properties': user_task})
+
+        for extension_event in self.extension_events:
+            if 'name' in extension_event and 'properties' in extension_event:
+                properties = extension_event['properties']
+                # Inject correlation ID into every extension event
+                properties.update({'Reserved.DataModel.CorrelationId': self.correlation_id})
+                events.append({'name': extension_event['name'], 'properties': properties})
 
         for name, props in self.exceptions:
             props.update(base)
@@ -292,6 +300,11 @@ def set_module_correlation_data(correlation_data):
 def set_raw_command_name(command):
     # the raw command name user inputs
     _session.raw_command = command
+
+
+def add_extension_events(extension_events):
+    for extension_event in extension_events:
+        _session.extension_events.append(extension_event)
 
 
 # definitions

--- a/src/azure-cli-core/azure/cli/core/telemetry_upload.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry_upload.py
@@ -24,7 +24,6 @@ from applicationinsights.channel import SynchronousSender, SynchronousQueue, Tel
 import azure.cli.core.decorators as decorators
 
 DIAGNOSTICS_TELEMETRY_ENV_NAME = 'AZURE_CLI_DIAGNOSTICS_TELEMETRY'
-INSTRUMENTATION_KEY = 'c4395b75-49cc-422c-bc95-c7d51aef5d46'
 
 
 class LimitedRetrySender(SynchronousSender):
@@ -67,10 +66,6 @@ def in_diagnostic_mode():
 
 @decorators.suppress_all_exceptions(raise_in_diagnostics=True)
 def upload(data_to_save):
-    client = TelemetryClient(instrumentation_key=INSTRUMENTATION_KEY,
-                             telemetry_channel=TelemetryChannel(queue=SynchronousQueue(LimitedRetrySender())))
-    enable(INSTRUMENTATION_KEY)
-
     if in_diagnostic_mode():
         sys.stdout.write('Telemetry upload begins\n')
         sys.stdout.write('Got data {}\n'.format(json.dumps(json.loads(data_to_save), indent=2)))
@@ -82,25 +77,30 @@ def upload(data_to_save):
             sys.stdout.write('ERROR: {}/n'.format(str(err)))
             sys.stdout.write('Raw [{}]/n'.format(data_to_save))
 
-    for record in data_to_save:
-        name = record['name']
-        raw_properties = record['properties']
-        properties = {}
-        measurements = {}
-        for k in raw_properties:
-            v = raw_properties[k]
-            if isinstance(v, six.string_types):
-                properties[k] = v
-            else:
-                measurements[k] = v
-        client.track_event(record['name'], properties, measurements)
+    for instrumentation_key in data_to_save:
+        client = TelemetryClient(instrumentation_key=instrumentation_key,
+                                 telemetry_channel=TelemetryChannel(queue=SynchronousQueue(LimitedRetrySender())))
+        enable(instrumentation_key)
 
-        if in_diagnostic_mode():
-            sys.stdout.write(
-                '\nTrack Event: {}\nProperties: {}\nMeasurements: {}'.format(name, json.dumps(properties, indent=2),
-                                                                             json.dumps(measurements, indent=2)))
+        for record in data_to_save[instrumentation_key]:
+            name = record['name']
+            raw_properties = record['properties']
+            properties = {}
+            measurements = {}
+            for k in raw_properties:
+                v = raw_properties[k]
+                if isinstance(v, six.string_types):
+                    properties[k] = v
+                else:
+                    measurements[k] = v
+            client.track_event(record['name'], properties, measurements)
 
-    client.flush()
+            if in_diagnostic_mode():
+                sys.stdout.write(
+                    '\nTrack Event: {}\nProperties: {}\nMeasurements: {}'.format(name, json.dumps(properties, indent=2),
+                                                                                 json.dumps(measurements, indent=2)))
+
+        client.flush()
 
     if in_diagnostic_mode():
         sys.stdout.write('\nTelemetry upload completes\n')

--- a/src/azure-cli-core/azure/cli/core/telemetry_upload.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry_upload.py
@@ -87,8 +87,7 @@ def upload(data_to_save):
             raw_properties = record['properties']
             properties = {}
             measurements = {}
-            for k in raw_properties:
-                v = raw_properties[k]
+            for k, v in raw_properties.items():
                 if isinstance(v, six.string_types):
                     properties[k] = v
                 else:


### PR DESCRIPTION
Azure CLI extensions can now use `add_extension_event` from `azure.cli.core.telemetry` to add telemetry events to Azure CLI application insight.

In addition, extensions can specify their own application insight instrumentation key when calling `add_extension_event`. If no instrumentation key is specified, the telemetry will be sent to Azure CLI application insight.


### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
