### PR TITLE
Ref doc gen script supports sphinx==1.6.7

### DIFF
--- a/doc/generating_sphinx_docs.md
+++ b/doc/generating_sphinx_docs.md
@@ -2,7 +2,7 @@
 
 ## Set up environment ##
 
-1. Inside a Python virtual environment, run "pip install sphinx"
+1. Inside a Python virtual environment, run "pip install sphinx==1.6.7"
 2. If Az isn't set up in this virtual environment, run "python scripts\dev_setup.py" from azure-cli
 
 ## Run Sphinx ##


### PR DESCRIPTION
1.7 was released a few days ago and the script doesn't support that version as some imports were removed.

cc: @georgechenchao though I think in your appveyor scripts you've already pinned to a specific version of sphinx.
