### PR TITLE
Makes dev_setup.py script more portable

### DIFF
--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -14,14 +14,17 @@ from subprocess import check_call, CalledProcessError
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), '..', '..'))
 
 
-def exec_command(command):
+def py_command(command):
     try:
-        print('Executing: ' + command)
-        check_call(command.split(), cwd=root_dir)
+        print('Executing: python ' + command)
+        check_call([sys.executable] + command.split(), cwd=root_dir)
         print()
     except CalledProcessError as err:
         print(err, file=sys.stderr)
         sys.exit(1)
+
+def pip_command(command):
+    py_command('-m pip ' + command)
 
 print('Running dev setup...')
 print('Root directory \'{}\'\n'.format(root_dir))
@@ -30,25 +33,25 @@ print('Root directory \'{}\'\n'.format(root_dir))
 privates_dir = os.path.join(root_dir, 'privates')
 if os.path.isdir(privates_dir) and os.listdir(privates_dir):
     whl_list = ' '.join([os.path.join(privates_dir, f) for f in os.listdir(privates_dir)])
-    exec_command('pip install {}'.format(whl_list))
+    pip_command('install {}'.format(whl_list))
 
 # install general requirements
-exec_command('pip install -r requirements.txt')
+pip_command('install -r requirements.txt')
 
 # install automation package
-exec_command('pip install -e ./tools')
+pip_command('install -e ./tools')
 
 # command modules have dependency on azure-cli-core so install this first
-exec_command('pip install -e src/azure-cli-nspkg')
-exec_command('pip install -e src/azure-cli-core')
-exec_command('python -m automation.setup.install_modules')
+pip_command('install -e src/azure-cli-nspkg')
+pip_command('install -e src/azure-cli-core')
+py_command('-m automation.setup.install_modules')
 
 # azure cli has dependencies on the above packages so install this one last
-exec_command('pip install -e src/azure-cli')
-exec_command('pip install -e src/azure-cli-testsdk')
+pip_command('install -e src/azure-cli')
+pip_command('install -e src/azure-cli-testsdk')
 
 # Ensure that the site package's azure/__init__.py has the old style namespace
 # package declaration by installing the old namespace package
-exec_command('pip install --force-reinstall azure-nspkg==1.0.0')
-exec_command('pip install --force-reinstall azure-mgmt-nspkg==1.0.0')
+pip_command('install --force-reinstall azure-nspkg==1.0.0')
+pip_command('install --force-reinstall azure-mgmt-nspkg==1.0.0')
 print('Finished dev setup.')


### PR DESCRIPTION
This will avoid problems where `python` and `pip` on PATH do not map to the version of Python that the script was started with.

I already contributed a similar change to the https://github.com/Azure/azure-sdk-for-python/pull/2062