### PR TITLE
msi: terminology update to identity

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.1.29
+++++++
+* webapp/functionapp: author managed identity commands `identity assign/show`, and deprecate `assign-identity`
+
 0.1.28
 ++++++
 * webapp: updating tests/code for sdk update

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -44,19 +44,43 @@ helps['webapp auth update'] = """
           --facebook-oauth-scopes public_profile email
 """
 
-helps['webapp assign-identity'] = """
+helps['webapp identity assign'] = """
     type: command
     short-summary: (PREVIEW) assign managed service identity to the webapp
     examples:
         - name: assign local identity and assign a reader role to the current resource group.
           text: >
-            az webapp assign-identity -g MyResourceGroup -n MyUniqueApp --role reader --scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/MyResourceGroup
+            az webapp identity assign -g MyResourceGroup -n MyUniqueApp --role reader --scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/MyResourceGroup
         - name: disable the identity when there is need.
           text: >
             az webapp config appsettings set -g MyResourceGroup -n MyUniqueApp --settings WEBSITE_DISABLE_MSI=true
 """
 
-helps['functionapp assign-identity'] = helps['webapp assign-identity'].replace('webapp', 'functionapp')
+helps['webapp identity'] = """
+    type: group
+    short-summary: (PREVIEW) manage webapp's managed service identity
+"""
+
+helps['webapp identity show'] = """
+    type: command
+    short-summary: (PREVIEW) display webapp's managed service identity
+"""
+
+helps['functionapp identity'] = helps['webapp identity'].replace('webapp', 'functionapp')
+
+helps['functionapp identity assign'] = helps['webapp identity assign'].replace('webapp', 'functionapp')
+
+helps['functionapp identity show'] = helps['webapp identity show'].replace('webapp', 'functionapp')
+
+helps['webapp assign-identity'] = """
+    type: command
+    short-summary: (Deprecated, please use 'az webapp identity assign')
+"""
+
+helps['functionapp assign-identity'] = """
+    type: command
+    short-summary: (Deprecated, please use 'az functionapp identity assign')
+"""
 
 helps['webapp config'] = """
 type: group

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -76,7 +76,9 @@ def load_command_table(self, _):
         g.custom_command('restart', 'restart_webapp')
         g.custom_command('browse', 'view_in_browser')
         g.custom_command('list-runtimes', 'list_runtimes')
-        g.custom_command('assign-identity', 'assign_identity')
+        g.custom_command('assign-identity', 'assign_identity', deprecate_info='az webapp identity assign')
+        g.custom_command('identity assign', 'assign_identity')
+        g.custom_command('identity show', 'show_identity')
         g.generic_update_command('update', custom_func_name='update_webapp', setter_arg_name='site_envelope')
 
     with self.command_group('webapp traffic-routing') as g:
@@ -178,7 +180,9 @@ def load_command_table(self, _):
         g.custom_command('start', 'start_webapp')
         g.custom_command('restart', 'restart_webapp')
         g.custom_command('list-consumption-locations', 'list_consumption_locations')
-        g.custom_command('assign-identity', 'assign_identity')
+        g.custom_command('assign-identity', 'assign_identity', deprecate_info='identity assign')
+        g.custom_command('identity assign', 'assign_identity')
+        g.custom_command('identity show', 'show_identity')
 
     with self.command_group('functionapp config appsettings') as g:
         g.custom_command('list', 'get_app_settings', exception_handler=empty_on_404)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -258,6 +258,10 @@ def assign_identity(cmd, resource_group_name, name, role='Contributor', scope=No
     return webapp.identity
 
 
+def show_identity(cmd, resource_group_name, name):
+    return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get').identity
+
+
 def get_auth_settings(cmd, resource_group_name, name, slot=None):
     return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get_auth_settings', slot)
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_assign_system_identity.yaml
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_assign_system_identity.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{"location": "westus", "tags": {"use": "az-test"}}'
+    body: '{"location": "westus", "tags": {"use": "az-test"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -8,22 +8,23 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 22 Dec 2017 18:26:50 GMT']
+      date: ['Tue, 06 Mar 2018 22:21:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -34,28 +35,28 @@ interactions:
       CommandName: [appservice plan create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 22 Dec 2017 18:26:57 GMT']
+      date: ['Tue, 06 Mar 2018 22:21:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"sku": {"tier": "BASIC", "capacity": 1, "name": "B1"},
-      "location": "westus", "properties": {"name": "web-msi-plan000002", "perSiteScaling":
-      false}}'
+    body: 'b''{"properties": {"name": "web-msi-plan000002", "perSiteScaling": false},
+      "location": "westus", "sku": {"capacity": 1, "tier": "BASIC", "name": "B1"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -63,21 +64,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['150']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 websitemanagementclient/0.34.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-web/0.35.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","name":"web-msi-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","name":"web-msi-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
         US","properties":{"serverFarmId":0,"name":"web-msi-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-091_896","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-093_4853","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1365']
+      content-length: ['1366']
       content-type: [application/json]
-      date: ['Fri, 22 Dec 2017 18:27:11 GMT']
+      date: ['Tue, 06 Mar 2018 22:21:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -85,6 +85,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
@@ -96,21 +97,20 @@ interactions:
       CommandName: [webapp create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 websitemanagementclient/0.34.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-web/0.35.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","name":"web-msi-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","name":"web-msi-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
         US","properties":{"serverFarmId":0,"name":"web-msi-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-091_896","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"mdmId":"waws-prod-bay-093_4853","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1365']
+      content-length: ['1366']
       content-type: [application/json]
-      date: ['Fri, 22 Dec 2017 18:27:19 GMT']
+      date: ['Tue, 06 Mar 2018 22:21:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -118,35 +118,35 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"reserved": false, "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002",
-      "scmSiteAlsoStopped": false, "siteConfig": {"appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION",
-      "value": "6.9.1"}], "netFrameworkVersion": "v4.6", "localMySqlEnabled": false}},
-      "location": "West US"}'
+    body: 'b''b\''{"properties": {"scmSiteAlsoStopped": false, "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002",
+      "reserved": false, "siteConfig": {"netFrameworkVersion": "v4.6", "appSettings":
+      [{"value": "6.9.1", "name": "WEBSITE_NODE_DEFAULT_VERSION"}], "http20Enabled":
+      true, "localMySqlEnabled": false}}, "location": "West US"}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [webapp create]
       Connection: [keep-alive]
-      Content-Length: ['458']
+      Content-Length: ['481']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 websitemanagementclient/0.34.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-web/0.35.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003?api-version=2016-08-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-091.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2017-12-22T18:27:25.9966667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.42.128.171,104.42.131.62,104.42.134.143,104.42.130.245,104.42.133.164","possibleOutboundIpAddresses":"104.42.128.171,104.42.131.62,104.42.134.143,104.42.130.245,104.42.133.164,104.42.129.68,104.42.130.49","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-091","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-093.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2018-03-06T22:21:22.11","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.112.191.159,138.91.252.122,40.86.180.238,138.91.248.136,138.91.253.41","possibleOutboundIpAddresses":"40.112.191.159,138.91.252.122,40.86.180.238,138.91.248.136,138.91.253.41,138.91.254.30,138.91.249.213","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-093","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3095']
+      content-length: ['3125']
       content-type: [application/json]
-      date: ['Fri, 22 Dec 2017 18:27:26 GMT']
-      etag: ['"1D37B52847A8635"']
+      date: ['Tue, 06 Mar 2018 22:21:48 GMT']
+      etag: ['"1D3B599756121C0"']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -154,11 +154,12 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -166,21 +167,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['2']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 websitemanagementclient/0.34.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-web/0.35.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/publishxml?api-version=2016-08-01
   response:
-    body: {string: !!python/unicode '<publishData><publishProfile profileName="web-msi000003
-        - Web Deploy" publishMethod="MSDeploy" publishUrl="web-msi000003.scm.azurewebsites.net:443"
-        msdeploySite="web-msi000003" userName="$web-msi000003" userPWD="8nM5dZdDn0FxtvdwmGebk5ecjQEfN41e0y8agZeMBaEwB8N19tt8ZvqnKooA"
+    body: {string: '<publishData><publishProfile profileName="web-msi000003 - Web
+        Deploy" publishMethod="MSDeploy" publishUrl="web-msi000003.scm.azurewebsites.net:443"
+        msdeploySite="web-msi000003" userName="$web-msi000003" userPWD="esx8Jw4DCjDpM74Xbfhd9iwJ9S2hi58eS4JgilJmczroMxtQZcNq1aWRKWrb"
         destinationAppUrl="http://web-msi000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-msi000003
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-091.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-msi000003\$web-msi000003" userPWD="8nM5dZdDn0FxtvdwmGebk5ecjQEfN41e0y8agZeMBaEwB8N19tt8ZvqnKooA"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-093.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-msi000003\$web-msi000003" userPWD="esx8Jw4DCjDpM74Xbfhd9iwJ9S2hi58eS4JgilJmczroMxtQZcNq1aWRKWrb"
         destinationAppUrl="http://web-msi000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>'}
@@ -188,12 +188,13 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1114']
       content-type: [application/xml]
-      date: ['Fri, 22 Dec 2017 18:27:32 GMT']
+      date: ['Tue, 06 Mar 2018 22:21:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
@@ -202,24 +203,23 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [webapp assign-identity]
+      CommandName: [webapp managed-identity assign]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 websitemanagementclient/0.34.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-web/0.35.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003?api-version=2016-08-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-091.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2017-12-22T18:27:26.4033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.42.128.171,104.42.131.62,104.42.134.143,104.42.130.245,104.42.133.164","possibleOutboundIpAddresses":"104.42.128.171,104.42.131.62,104.42.134.143,104.42.130.245,104.42.133.164,104.42.129.68,104.42.130.49","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-091","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-093.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2018-03-06T22:21:22.78","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.112.191.159,138.91.252.122,40.86.180.238,138.91.248.136,138.91.253.41","possibleOutboundIpAddresses":"40.112.191.159,138.91.252.122,40.86.180.238,138.91.248.136,138.91.253.41,138.91.254.30,138.91.249.213","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-093","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3095']
+      content-length: ['3125']
       content-type: [application/json]
-      date: ['Fri, 22 Dec 2017 18:27:35 GMT']
-      etag: ['"1D37B52847A8635"']
+      date: ['Tue, 06 Mar 2018 22:21:50 GMT']
+      etag: ['"1D3B599756121C0"']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -227,38 +227,39 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"kind": "app", "properties": {"hostNameSslStates": [{"sslState":
-      "Disabled", "name": "web-msi000003.azurewebsites.net", "hostType": "Standard"},
-      {"sslState": "Disabled", "name": "web-msi000003.scm.azurewebsites.net", "hostType":
-      "Repository"}], "reserved": false, "containerSize": 0, "httpsOnly": false, "clientAffinityEnabled":
-      true, "clientCertEnabled": false, "enabled": true, "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002",
-      "hostNamesDisabled": false, "scmSiteAlsoStopped": false, "dailyMemoryTimeQuota":
-      0}, "identity": {"type": "SystemAssigned"}, "location": "West US"}'
+    body: 'b''b\''b\\\''{"kind": "app", "properties": {"hostNamesDisabled": false,
+      "httpsOnly": false, "enabled": true, "hostNameSslStates": [{"hostType": "Standard",
+      "name": "web-msi000003.azurewebsites.net", "sslState": "Disabled"}, {"hostType":
+      "Repository", "name": "web-msi000003.scm.azurewebsites.net", "sslState": "Disabled"}],
+      "containerSize": 0, "clientCertEnabled": false, "reserved": false, "clientAffinityEnabled":
+      true, "dailyMemoryTimeQuota": 0, "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002",
+      "scmSiteAlsoStopped": false}, "identity": {"type": "SystemAssigned"}, "location":
+      "West US"}\\\''\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [webapp assign-identity]
+      CommandName: [webapp managed-identity assign]
       Connection: [keep-alive]
       Content-Length: ['761']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 websitemanagementclient/0.34.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-web/0.35.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003?api-version=2016-08-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-091.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2017-12-22T18:27:46.39","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.42.128.171,104.42.131.62,104.42.134.143,104.42.130.245,104.42.133.164","possibleOutboundIpAddresses":"104.42.128.171,104.42.131.62,104.42.134.143,104.42.130.245,104.42.133.164,104.42.129.68,104.42.130.49","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-091","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false},"identity":{"type":"SystemAssigned","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"834c993d-92da-4497-b91e-a59791a26038"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-093.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2018-03-06T22:21:53.2566667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.112.191.159,138.91.252.122,40.86.180.238,138.91.248.136,138.91.253.41","possibleOutboundIpAddresses":"40.112.191.159,138.91.252.122,40.86.180.238,138.91.248.136,138.91.253.41,138.91.254.30,138.91.249.213","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-093","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false},"identity":{"type":"SystemAssigned","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"9184a74c-35c1-4a9f-a86e-3872c0388fd7"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3230']
+      content-length: ['3270']
       content-type: [application/json]
-      date: ['Fri, 22 Dec 2017 18:27:50 GMT']
-      etag: ['"1D37B5290643F60"']
+      date: ['Tue, 06 Mar 2018 22:21:54 GMT']
+      etag: ['"1D3B599878B808B"']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -266,7 +267,8 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -274,26 +276,26 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [webapp assign-identity]
+      CommandName: [webapp managed-identity assign]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27Reader%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Reader%27&api-version=2015-07-01
   response:
-    body: {string: !!python/unicode '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
-        you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-08-19T00:03:56.0652623Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'}
+    body: {string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
+        you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2018-01-30T18:08:25.4031403Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'}
     headers:
       cache-control: [no-cache]
       content-length: ['578']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 22 Dec 2017 18:28:17 GMT']
+      date: ['Tue, 06 Mar 2018 22:21:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
+      server: [Microsoft-IIS/10.0]
       set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -303,31 +305,97 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
-      "principalId": "834c993d-92da-4497-b91e-a59791a26038"}}'
+    body: '{"properties": {"principalId": "9184a74c-35c1-4a9f-a86e-3872c0388fd7",
+      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [webapp assign-identity]
+      CommandName: [webapp managed-identity assign]
       Connection: [keep-alive]
       Content-Length: ['233']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46667?api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46668?api-version=2015-07-01
   response:
-    body: {string: !!python/unicode '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"834c993d-92da-4497-b91e-a59791a26038","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001","createdOn":"2017-12-22T18:28:37.6563573Z","updatedOn":"2017-12-22T18:28:37.6563573Z","createdBy":null,"updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46667","type":"Microsoft.Authorization/roleAssignments","name":"88daaf5a-ea86-4a68-9d45-477538d46667"}'}
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 9184a74c35c14a9fa86e3872c0388fd7
+        does not exist in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:21:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"properties": {"principalId": "9184a74c-35c1-4a9f-a86e-3872c0388fd7",
+      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp managed-identity assign]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46668?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 9184a74c35c14a9fa86e3872c0388fd7
+        does not exist in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:22:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"properties": {"principalId": "9184a74c-35c1-4a9f-a86e-3872c0388fd7",
+      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp managed-identity assign]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46668?api-version=2015-07-01
+  response:
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"9184a74c-35c1-4a9f-a86e-3872c0388fd7","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001","createdOn":"2018-03-06T22:22:09.8467547Z","updatedOn":"2018-03-06T22:22:09.8467547Z","createdBy":null,"updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46668","type":"Microsoft.Authorization/roleAssignments","name":"88daaf5a-ea86-4a68-9d45-477538d46668"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['868']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 22 Dec 2017 18:28:39 GMT']
+      date: ['Tue, 06 Mar 2018 22:22:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
+      server: [Microsoft-IIS/10.0]
       set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
@@ -340,24 +408,23 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [webapp assign-identity]
+      CommandName: [webapp managed-identity assign]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 websitemanagementclient/0.34.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-web/0.35.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings/list?api-version=2016-08-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
         US","properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['353']
       content-type: [application/json]
-      date: ['Fri, 22 Dec 2017 18:29:29 GMT']
+      date: ['Tue, 06 Mar 2018 22:22:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -365,34 +432,34 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"kind": "<type ''str''>", "properties": {"WEBSITE_NODE_DEFAULT_VERSION":
+    body: '{"kind": "<class ''str''>", "properties": {"WEBSITE_NODE_DEFAULT_VERSION":
       "6.9.1", "WEBSITE_DISABLE_MSI": "False"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [webapp assign-identity]
+      CommandName: [webapp managed-identity assign]
       Connection: [keep-alive]
-      Content-Length: ['113']
+      Content-Length: ['114']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 websitemanagementclient/0.34.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-web/0.35.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings?api-version=2016-08-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
         US","properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","WEBSITE_DISABLE_MSI":"False"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['383']
       content-type: [application/json]
-      date: ['Fri, 22 Dec 2017 18:29:55 GMT']
-      etag: ['"1D37B52DD544AE0"']
+      date: ['Tue, 06 Mar 2018 22:22:14 GMT']
+      etag: ['"1D3B59993EFCDEB"']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -400,7 +467,40 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [webapp managed-identity show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-web/0.35.0 Azure-SDK-For-Python AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003","name":"web-msi000003","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"web-msi000003","state":"Running","hostNames":["web-msi000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-093.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/web-msi000003","repositorySiteName":"web-msi000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-msi000003.azurewebsites.net","web-msi000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-msi000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-msi000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/web-msi-plan000002","reserved":false,"lastModifiedTimeUtc":"2018-03-06T22:22:14.0466667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-msi000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.112.191.159,138.91.252.122,40.86.180.238,138.91.248.136,138.91.253.41","possibleOutboundIpAddresses":"40.112.191.159,138.91.252.122,40.86.180.238,138.91.248.136,138.91.253.41,138.91.254.30,138.91.249.213","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-093","cloningInfo":null,"snapshotInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-msi000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false},"identity":{"type":"SystemAssigned","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"9184a74c-35c1-4a9f-a86e-3872c0388fd7"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3270']
+      content-type: [application/json]
+      date: ['Tue, 06 Mar 2018 22:22:15 GMT']
+      etag: ['"1D3B59993EFCDEB"']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -411,28 +511,28 @@ interactions:
       CommandName: [role assignment list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6&$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27834c993d-92da-4497-b91e-a59791a26038%27%29
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%279184a74c-35c1-4a9f-a86e-3872c0388fd7%27%29&api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['166']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 22 Dec 2017 18:29:59 GMT']
-      duration: ['696053']
+      date: ['Tue, 06 Mar 2018 22:22:16 GMT']
+      duration: ['1251341']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [i5T3PZb4nvO/Lx6r7PY0YF5cJT7txjPGyrTjk/cAezM=]
-      ocp-aad-session-key: [wEOF3x_mhoG966Ejs-PDuYflZ-fv1e5LiaPRBCVbgocsYy7djLj1Swaa0BE5-xWg_OnKPuqAkea_Cd2M4YUdhfgtEwxpr7G0FMJFxPQClXEaYDgahXrN1Km3JvyEJeSJ.P47Brxo2kLH4KGKdiI9EBbwHViYP_8NzyWvP6lOc-EM]
+      ocp-aad-diagnostics-server-name: [buf1B7dwYkgP82cSMQE6yXD5AMTHLO4QlaO3zB8DEWY=]
+      ocp-aad-session-key: [piPwJMCiF_IuotZmhQiI1-ZoeymCdKwYYCt-VnFIZiC9wTl2eSvf9VZmarBzJ8TZa7uAsKTwZKCNkDLuw1GBqjs0m1uss13H3mQvchRkdpIh1MGaIPCdQ7rgE48A3hWf.2vBsG6T4irPcIvhM6yaaiokUa6yx-ri9cPPj9f235uU]
       pragma: [no-cache]
-      request-id: [0ea9f6ae-e578-4dd8-a8ac-5895d9622efb]
-      server: [Microsoft-IIS/8.5]
+      request-id: [1e4fd01d-5bf9-42b4-847f-859d4a25d9aa]
+      server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
@@ -440,8 +540,7 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"objectIds": ["834c993d-92da-4497-b91e-a59791a26038"],
-      "includeDirectoryObjectReferences": true}'
+    body: '{"includeDirectoryObjectReferences": true, "objectIds": ["9184a74c-35c1-4a9f-a86e-3872c0388fd7"]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -449,28 +548,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['97']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"834c993d-92da-4497-b91e-a59791a26038","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":["isExplicit=False","/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003"],"appDisplayName":null,"appId":"a7a41914-b191-42ec-9abc-2a21adda16fe","appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"web-msi000003","errorUrl":null,"homepage":null,"keyCredentials":[{"customKeyIdentifier":null,"endDate":"2018-03-22T18:22:00Z","keyId":"f5d28957-b5cc-4158-84ff-4e15b5620541","startDate":"2017-12-22T18:22:00Z","type":"AsymmetricX509Cert","usage":"Verify","value":null}],"logoutUrl":null,"oauth2Permissions":[],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["a7a41914-b191-42ec-9abc-2a21adda16fe","https://identity.azure.net/N7OC7IfM206y7mdG+2uDverBqytIOGHjmLBOoV+PlYI="],"servicePrincipalType":"ServiceAccount","tags":[],"tokenEncryptionKeyId":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"9184a74c-35c1-4a9f-a86e-3872c0388fd7","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":["isExplicit=False","/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003"],"appDisplayName":null,"appId":"fe595003-fc12-4239-8a36-c684879d00ee","appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"web-msi000003","errorUrl":null,"homepage":null,"keyCredentials":[{"customKeyIdentifier":null,"endDate":"2018-06-04T22:16:00Z","keyId":"a4e78846-0a06-4fc8-abbb-3bdcd8cabba8","startDate":"2018-03-06T22:16:00Z","type":"AsymmetricX509Cert","usage":"Verify","value":null}],"logoutUrl":null,"oauth2Permissions":[],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["fe595003-fc12-4239-8a36-c684879d00ee","https://identity.azure.net/tIsIqEqJbwh5TBAnHmPR9gHWbL81ap5rsFyY1hLC75c="],"servicePrincipalType":"ServiceAccount","tags":[],"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1373']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 22 Dec 2017 18:30:15 GMT']
-      duration: ['1179097']
+      date: ['Tue, 06 Mar 2018 22:22:16 GMT']
+      duration: ['1412963']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [zYFOqxuM54Aw2TyX3bLhJZ/cB4A9F8cptTJtgCGrP+c=]
-      ocp-aad-session-key: [szQG3QAlZmJAA7psXk_E7ARv9u5QGy6l-5NOO1P5IGpIyQ2lwahM3MyyJxYiJPvYsZYFxWad9-GvFW_1R1U-zOXXEhw7ajplLMOz62L_G1Y1EV91dzN5o0AWrF4g4a1a.lKWqCaZFAVfvzm_fdjsDybGs0_a5YqVuPRejOHJFZII]
+      ocp-aad-diagnostics-server-name: [Sc2pAAOmY8aSv/aLCwU6TdePeGX0EkRiT7UCAVIcgX4=]
+      ocp-aad-session-key: [geKZsWXG1pLYXKJmtz499rz84drTg25KYMUIIHczBz2PTAogYO9PICrfb14K1APbJdQibq8DaecLmV6UhgIRxaqBy1n8k6xRpMxK1EwxLTtkWOxyWXiPbqjSXVVqFUZ_.FAlKBit4OM3LhaGFzkZp_kk2D_KGvW38teWkislw9KI]
       pragma: [no-cache]
-      request-id: [62c90cd3-ed9b-48d8-a7b5-17ac5a838b9f]
-      server: [Microsoft-IIS/8.5]
+      request-id: [2d7765dc-f71c-4262-b182-df88a9cfb29f]
+      server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
@@ -485,22 +584,22 @@ interactions:
       CommandName: [role assignment list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01&$filter=principalId%20eq%20%27834c993d-92da-4497-b91e-a59791a26038%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%279184a74c-35c1-4a9f-a86e-3872c0388fd7%27&api-version=2015-07-01
   response:
-    body: {string: !!python/unicode '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"834c993d-92da-4497-b91e-a59791a26038","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001","createdOn":"2017-12-22T18:28:39.3738199Z","updatedOn":"2017-12-22T18:28:39.3738199Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46667","type":"Microsoft.Authorization/roleAssignments","name":"88daaf5a-ea86-4a68-9d45-477538d46667"}]}'}
+    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"9184a74c-35c1-4a9f-a86e-3872c0388fd7","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001","createdOn":"2018-03-06T22:22:11.9629025Z","updatedOn":"2018-03-06T22:22:11.9629025Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d46668","type":"Microsoft.Authorization/roleAssignments","name":"88daaf5a-ea86-4a68-9d45-477538d46668"}]}'}
     headers:
       cache-control: [no-cache]
       content-length: ['914']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 22 Dec 2017 18:30:45 GMT']
+      date: ['Tue, 06 Mar 2018 22:22:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
+      server: [Microsoft-IIS/10.0]
       set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -517,22 +616,33 @@ interactions:
       CommandName: [role assignment list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01
   response:
-    body: {string: "{\"value\":[{\"properties\":{\"roleName\":\"API Management Service\
-        \ Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can manage service\
-        \ and the APIs\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\"\
-        :[\"Microsoft.ApiManagement/service/*\",\"Microsoft.Authorization/*/read\"\
-        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
-        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
-        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
-        ,\"updatedOn\":\"2017-01-23T23:12:00.5823195Z\",\"createdBy\":null,\"updatedBy\"\
-        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/312a565d-c81f-4fd8-895a-4e21e48d571c\"\
+    body: {string: "{\"value\":[{\"properties\":{\"roleName\":\"cli-test-rolebsppzo3\"\
+        ,\"type\":\"CustomRole\",\"description\":\"Can monitor compute, network and\
+        \ storage, and restart virtual machines\",\"assignableScopes\":[\"/subscriptions/00000000-0000-0000-0000-000000000000\"\
+        ],\"permissions\":[{\"actions\":[\"Microsoft.Compute/*/read\",\"Microsoft.Compute/virtualMachines/start/action\"\
+        ,\"Microsoft.Compute/virtualMachines/restart/action\",\"Microsoft.Network/*/read\"\
+        ,\"Microsoft.Storage/*/read\",\"Microsoft.Authorization/*/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/resources/read\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2018-02-09T08:32:47.4900478Z\"\
+        ,\"updatedOn\":\"2018-03-05T19:49:48.7613832Z\",\"createdBy\":\"93a01e49-673a-4e15-8230-51214a737962\"\
+        ,\"updatedBy\":\"93a01e49-673a-4e15-8230-51214a737962\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/88daaf5a-ea86-4a68-9d45-477538d41738\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"88daaf5a-ea86-4a68-9d45-477538d41738\"\
+        },{\"properties\":{\"roleName\":\"API Management Service Contributor\",\"\
+        type\":\"BuiltInRole\",\"description\":\"Can manage service and the APIs\"\
+        ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ApiManagement/service/*\"\
+        ,\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"\
+        Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\"\
+        :\"2017-01-23T23:12:00.5823195Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/312a565d-c81f-4fd8-895a-4e21e48d571c\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"312a565d-c81f-4fd8-895a-4e21e48d571c\"\
         },{\"properties\":{\"roleName\":\"API Management Service Operator Role\",\"\
         type\":\"BuiltInRole\",\"description\":\"Can manage service but not the APIs\"\
@@ -582,13 +692,13 @@ interactions:
         ,\"description\":\"Create and Manage Jobs using Automation Runbooks.\",\"\
         assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
         ,\"Microsoft.Automation/automationAccounts/jobs/read\",\"Microsoft.Automation/automationAccounts/jobs/resume/action\"\
-        ,\"Microsoft.Automation/automationAccounts/jobs/stop/action\",\"Microsoft.Automation/automationAccounts/jobs/streams/read\"\
-        ,\"Microsoft.Automation/automationAccounts/jobs/suspend/action\",\"Microsoft.Automation/automationAccounts/jobs/write\"\
-        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\"\
-        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
-        ],\"notActions\":[]}],\"createdOn\":\"2017-04-19T20:52:41.0020018Z\",\"updatedOn\"\
-        :\"2017-04-25T01:02:08.3049604Z\",\"createdBy\":null,\"updatedBy\":null},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4fe576fe-1146-4730-92eb-48519fa6bf9f\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/stop/action\",\"Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups/read\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/streams/read\",\"Microsoft.Automation/automationAccounts/jobs/suspend/action\"\
+        ,\"Microsoft.Automation/automationAccounts/jobs/write\",\"Microsoft.Insights/alertRules/*\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2017-04-19T20:52:41.0020018Z\"\
+        ,\"updatedOn\":\"2018-03-06T02:20:41.6886187Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4fe576fe-1146-4730-92eb-48519fa6bf9f\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4fe576fe-1146-4730-92eb-48519fa6bf9f\"\
         },{\"properties\":{\"roleName\":\"Automation Operator\",\"type\":\"BuiltInRole\"\
         ,\"description\":\"Automation Operators are able to start, stop, suspend,\
@@ -597,14 +707,15 @@ interactions:
         ,\"Microsoft.Automation/automationAccounts/jobs/resume/action\",\"Microsoft.Automation/automationAccounts/jobs/stop/action\"\
         ,\"Microsoft.Automation/automationAccounts/jobs/streams/read\",\"Microsoft.Automation/automationAccounts/jobs/suspend/action\"\
         ,\"Microsoft.Automation/automationAccounts/jobs/write\",\"Microsoft.Automation/automationAccounts/jobSchedules/read\"\
-        ,\"Microsoft.Automation/automationAccounts/jobSchedules/write\",\"Microsoft.Automation/automationAccounts/read\"\
-        ,\"Microsoft.Automation/automationAccounts/runbooks/read\",\"Microsoft.Automation/automationAccounts/schedules/read\"\
-        ,\"Microsoft.Automation/automationAccounts/schedules/write\",\"Microsoft.Insights/alertRules/*\"\
-        ,\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\"\
-        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
-        ],\"notActions\":[]}],\"createdOn\":\"2015-08-18T01:05:03.3916130Z\",\"updatedOn\"\
-        :\"2016-05-31T23:13:38.5728496Z\",\"createdBy\":null,\"updatedBy\":null},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/d3881f73-407a-4167-8283-e981cbba0404\"\
+        ,\"Microsoft.Automation/automationAccounts/jobSchedules/write\",\"Microsoft.Automation/automationAccounts/linkedWorkspace/read\"\
+        ,\"Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups/read\"\
+        ,\"Microsoft.Automation/automationAccounts/read\",\"Microsoft.Automation/automationAccounts/runbooks/read\"\
+        ,\"Microsoft.Automation/automationAccounts/schedules/read\",\"Microsoft.Automation/automationAccounts/schedules/write\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2015-08-18T01:05:03.3916130Z\"\
+        ,\"updatedOn\":\"2018-03-06T02:10:10.7101464Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/d3881f73-407a-4167-8283-e981cbba0404\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"d3881f73-407a-4167-8283-e981cbba0404\"\
         },{\"properties\":{\"roleName\":\"Automation Runbook Operator\",\"type\":\"\
         BuiltInRole\",\"description\":\"Read Runbook properties - to be able to create\
@@ -838,11 +949,12 @@ interactions:
         },{\"properties\":{\"roleName\":\"Cosmos DB Account Reader Role\",\"type\"\
         :\"BuiltInRole\",\"description\":\"Can read Azure Cosmos DB Accounts data\"\
         ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\"\
-        ,\"Microsoft.DocumentDB/databaseAccounts/*/read\",\"Microsoft.DocumentDB/databaseAccounts/readonlykeys/action\"\
-        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
-        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2017-10-30T17:53:54.6005577Z\"\
-        ,\"updatedOn\":\"2017-10-30T18:07:15.7673112Z\",\"createdBy\":null,\"updatedBy\"\
-        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8\"\
+        ,\"Microsoft.DocumentDB/*/read\",\"Microsoft.DocumentDB/databaseAccounts/readonlykeys/action\"\
+        ,\"Microsoft.Insights/MetricDefinitions/read\",\"Microsoft.Insights/Metrics/read\"\
+        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2017-10-30T17:53:54.6005577Z\",\"updatedOn\"\
+        :\"2018-02-21T01:36:59.6186231Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fbdf93bf-df7d-467e-a4d2-9458aa1360c8\"\
         },{\"properties\":{\"roleName\":\"Data Factory Contributor\",\"type\":\"BuiltInRole\"\
         ,\"description\":\"Create and manage data factories, as well as child resources\
@@ -934,6 +1046,15 @@ interactions:
         ,\"updatedOn\":\"2017-12-14T02:01:18.4641200Z\",\"createdBy\":null,\"updatedBy\"\
         :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/f25e0fa2-a7c8-4377-a976-54943a77a395\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"f25e0fa2-a7c8-4377-a976-54943a77a395\"\
+        },{\"properties\":{\"roleName\":\"Lab Creator\",\"type\":\"BuiltInRole\",\"\
+        description\":\"Lets you create, manage, delete your managed labs under your\
+        \ Azure Lab Accounts.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ManagedLab/labAccounts/createLab/action\"\
+        ,\"Microsoft.ManagedLab/labAccounts/*/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2018-01-18T23:38:58.1036141Z\"\
+        ,\"updatedOn\":\"2018-02-16T00:20:27.3498866Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b97fb8bc-a8b2-4522-a38b-dd33c7e65ead\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b97fb8bc-a8b2-4522-a38b-dd33c7e65ead\"\
         },{\"properties\":{\"roleName\":\"Log Analytics Contributor\",\"type\":\"\
         BuiltInRole\",\"description\":\"Log Analytics Contributor can read all monitoring\
         \ data and edit monitoring settings. Editing monitoring settings includes\
@@ -941,14 +1062,14 @@ interactions:
         \ to configure collection of logs from Azure Storage; creating and configuring\
         \ Automation accounts; adding solutions; and configuring Azure diagnostics\
         \ on all Azure resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
-        actions\":[\"Microsoft.Automation/automationAccounts/*\",\"*/read\",\"Microsoft.ClassicCompute/virtualMachines/extensions/*\"\
+        actions\":[\"*/read\",\"Microsoft.Automation/automationAccounts/*\",\"Microsoft.ClassicCompute/virtualMachines/extensions/*\"\
         ,\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.Compute/virtualMachines/extensions/*\"\
         ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/diagnosticSettings/*\"\
         ,\"Microsoft.OperationalInsights/*\",\"Microsoft.OperationsManagement/*\"\
         ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourcegroups/deployments/*\"\
         ,\"Microsoft.Storage/storageAccounts/listKeys/action\",\"Microsoft.Support/*\"\
         ],\"notActions\":[]}],\"createdOn\":\"2017-04-25T21:51:45.3174711Z\",\"updatedOn\"\
-        :\"2017-05-19T04:00:50.7280454Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        :\"2018-01-30T18:08:26.6376126Z\",\"createdBy\":null,\"updatedBy\":null},\"\
         id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\
         },{\"properties\":{\"roleName\":\"Log Analytics Reader\",\"type\":\"BuiltInRole\"\
@@ -958,7 +1079,7 @@ interactions:
         /\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.OperationalInsights/workspaces/analytics/query/action\"\
         ,\"Microsoft.OperationalInsights/workspaces/search/action\",\"Microsoft.Support/*\"\
         ],\"notActions\":[\"Microsoft.OperationalInsights/workspaces/sharedKeys/read\"\
-        ]}],\"createdOn\":\"2017-05-02T00:20:28.1449012Z\",\"updatedOn\":\"2017-05-02T22:36:45.2104697Z\"\
+        ]}],\"createdOn\":\"2017-05-02T00:20:28.1449012Z\",\"updatedOn\":\"2018-01-30T18:08:26.0438523Z\"\
         ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/73c42c96-874c-492b-b04d-ab87d138a893\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"73c42c96-874c-492b-b04d-ab87d138a893\"\
         },{\"properties\":{\"roleName\":\"Logic App Contributor\",\"type\":\"BuiltInRole\"\
@@ -969,11 +1090,11 @@ interactions:
         ,\"Microsoft.Insights/logdefinitions/*\",\"Microsoft.Insights/metricDefinitions/*\"\
         ,\"Microsoft.Logic/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/operationresults/read\"\
         ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/listkeys/action\"\
-        ,\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.Support/*\",\"Microsoft.Web/connections/*\"\
-        ,\"Microsoft.Web/connectionGateways/*\",\"Microsoft.Web/serverFarms/join/action\"\
+        ,\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.Support/*\",\"Microsoft.Web/connectionGateways/*\"\
+        ,\"Microsoft.Web/connections/*\",\"Microsoft.Web/customApis/*\",\"Microsoft.Web/serverFarms/join/action\"\
         ,\"Microsoft.Web/serverFarms/read\",\"Microsoft.Web/sites/functions/listSecrets/action\"\
         ],\"notActions\":[]}],\"createdOn\":\"2016-04-28T21:33:30.4656007Z\",\"updatedOn\"\
-        :\"2016-11-09T20:20:11.3665904Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        :\"2018-01-10T23:11:44.8580600Z\",\"createdBy\":null,\"updatedBy\":null},\"\
         id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/87a39d53-fc1b-424a-814c-f7e04687dc9e\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"87a39d53-fc1b-424a-814c-f7e04687dc9e\"\
         },{\"properties\":{\"roleName\":\"Logic App Operator\",\"type\":\"BuiltInRole\"\
@@ -984,10 +1105,11 @@ interactions:
         ,\"Microsoft.Logic/workflows/disable/action\",\"Microsoft.Logic/workflows/enable/action\"\
         ,\"Microsoft.Logic/workflows/validate/action\",\"Microsoft.Resources/deployments/operations/read\"\
         ,\"Microsoft.Resources/subscriptions/operationresults/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
-        ,\"Microsoft.Support/*\",\"Microsoft.Web/connections/*/read\",\"Microsoft.Web/connectionGateways/*/read\"\
-        ,\"Microsoft.Web/serverFarms/read\"],\"notActions\":[]}],\"createdOn\":\"\
-        2016-04-28T21:33:30.4656007Z\",\"updatedOn\":\"2016-11-09T20:26:07.8911630Z\"\
-        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/515c2055-d9d4-4321-b1b9-bd0c9a0f79fe\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.Web/connectionGateways/*/read\",\"Microsoft.Web/connections/*/read\"\
+        ,\"Microsoft.Web/customApis/*/read\",\"Microsoft.Web/serverFarms/read\"],\"\
+        notActions\":[]}],\"createdOn\":\"2016-04-28T21:33:30.4656007Z\",\"updatedOn\"\
+        :\"2018-01-10T23:14:26.9539724Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/515c2055-d9d4-4321-b1b9-bd0c9a0f79fe\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"515c2055-d9d4-4321-b1b9-bd0c9a0f79fe\"\
         },{\"properties\":{\"roleName\":\"Managed Identity Contributor\",\"type\"\
         :\"BuiltInRole\",\"description\":\"Create, Read, Update, and Delete User Assigned\
@@ -1019,15 +1141,15 @@ interactions:
         Microsoft.Insights/webtests/*\",\"Microsoft.OperationalInsights/workspaces/intelligencepacks/*\"\
         ,\"Microsoft.OperationalInsights/workspaces/savedSearches/*\",\"Microsoft.OperationalInsights/workspaces/search/action\"\
         ,\"Microsoft.OperationalInsights/workspaces/sharedKeys/action\",\"Microsoft.OperationalInsights/workspaces/storageinsightconfigs/*\"\
-        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-09-21T19:21:08.4345976Z\"\
-        ,\"updatedOn\":\"2017-12-20T18:41:58.1319162Z\",\"createdBy\":null,\"updatedBy\"\
-        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\"\
+        ,\"Microsoft.Support/*\",\"Microsoft.WorkloadMonitor/workloads/*\"],\"notActions\"\
+        :[]}],\"createdOn\":\"2016-09-21T19:21:08.4345976Z\",\"updatedOn\":\"2018-01-30T18:08:28.4990834Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"749f88d5-cbae-40b8-bcfc-e573ddc772fa\"\
         },{\"properties\":{\"roleName\":\"Monitoring Reader\",\"type\":\"BuiltInRole\"\
         ,\"description\":\"Can read all monitoring data.\",\"assignableScopes\":[\"\
         /\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.OperationalInsights/workspaces/search/action\"\
         ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2016-09-21T19:19:52.4939376Z\"\
-        ,\"updatedOn\":\"2017-07-07T20:00:57.2225683Z\",\"createdBy\":null,\"updatedBy\"\
+        ,\"updatedOn\":\"2018-01-30T18:08:27.2626250Z\",\"createdBy\":null,\"updatedBy\"\
         :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/43d0d8ad-25c7-4714-9337-8ba259a9fe05\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"43d0d8ad-25c7-4714-9337-8ba259a9fe05\"\
         },{\"properties\":{\"roleName\":\"Network Contributor\",\"type\":\"BuiltInRole\"\
@@ -1058,7 +1180,7 @@ interactions:
         },{\"properties\":{\"roleName\":\"Reader\",\"type\":\"BuiltInRole\",\"description\"\
         :\"Lets you view everything, but not make any changes.\",\"assignableScopes\"\
         :[\"/\"],\"permissions\":[{\"actions\":[\"*/read\"],\"notActions\":[]}],\"\
-        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-08-19T00:03:56.0652623Z\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2018-01-30T18:08:25.4031403Z\"\
         ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"acdd72a7-3385-48ef-bd42-f606fba81ae7\"\
         },{\"properties\":{\"roleName\":\"Redis Cache Contributor\",\"type\":\"BuiltInRole\"\
@@ -1075,11 +1197,10 @@ interactions:
         \ EA, with rights to create/modify resource policy, create support ticket\
         \ and read resources/hierarchy.\",\"assignableScopes\":[\"/\"],\"permissions\"\
         :[{\"actions\":[\"*/read\",\"Microsoft.Authorization/policyassignments/*\"\
-        ,\"Microsoft.Authorization/policydefinitions/*\",\"Microsoft.PolicyInsights/*\"\
-        ,\"Microsoft.Support/*\",\"Microsoft.Authorization/policysetdefinitions/*\"\
-        ],\"notActions\":[]}],\"createdOn\":\"2017-08-25T19:08:01.3861639Z\",\"updatedOn\"\
-        :\"2017-12-11T19:50:28.9095808Z\",\"createdBy\":null,\"updatedBy\":null},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/36243c78-bf99-498c-9df9-86d9f8d28608\"\
+        ,\"Microsoft.Authorization/policydefinitions/*\",\"Microsoft.Authorization/policysetdefinitions/*\"\
+        ,\"Microsoft.PolicyInsights/*\",\"Microsoft.Support/*\"],\"notActions\":[]}],\"\
+        createdOn\":\"2017-08-25T19:08:01.3861639Z\",\"updatedOn\":\"2018-01-30T18:08:27.8272264Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/36243c78-bf99-498c-9df9-86d9f8d28608\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"36243c78-bf99-498c-9df9-86d9f8d28608\"\
         },{\"properties\":{\"roleName\":\"Scheduler Job Collections Contributor\"\
         ,\"type\":\"BuiltInRole\",\"description\":\"Lets you manage Scheduler job\
@@ -1102,14 +1223,15 @@ interactions:
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"7ca78c08-252a-4471-8644-bb5ff32d4ba0\"\
         },{\"properties\":{\"roleName\":\"Security Admin\",\"type\":\"BuiltInRole\"\
         ,\"description\":\"Security Admin Role\",\"assignableScopes\":[\"/\"],\"permissions\"\
-        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
-        ,\"Microsoft.operationalInsights/workspaces/*/read\",\"Microsoft.Resources/deployments/*\"\
-        ,\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Security/*/read\"\
-        ,\"Microsoft.Support/*\",\"Microsoft.Authorization/policyAssignments/*\",\"\
-        Microsoft.Authorization/policySetDefinitions/*\",\"Microsoft.Authorization/policyDefinitions/*\"\
-        ],\"notActions\":[]}],\"createdOn\":\"2017-05-03T07:51:23.0917487Z\",\"updatedOn\"\
-        :\"2017-11-09T01:46:17.1597247Z\",\"createdBy\":null,\"updatedBy\":null},\"\
-        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fb1c8493-542b-48eb-b624-b4c8fea62acd\"\
+        :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Authorization/policyAssignments/*\"\
+        ,\"Microsoft.Authorization/policyDefinitions/*\",\"Microsoft.Authorization/policySetDefinitions/*\"\
+        ,\"Microsoft.Insights/alertRules/*\",\"Microsoft.operationalInsights/workspaces/*/read\"\
+        ,\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"\
+        ,\"Microsoft.Security/*/read\",\"Microsoft.Security/locations/alerts/dismiss/action\"\
+        ,\"Microsoft.Security/locations/tasks/dismiss/action\",\"Microsoft.Security/policies/write\"\
+        ,\"Microsoft.Support/*\"],\"notActions\":[]}],\"createdOn\":\"2017-05-03T07:51:23.0917487Z\"\
+        ,\"updatedOn\":\"2018-02-21T11:45:03.7750985Z\",\"createdBy\":null,\"updatedBy\"\
+        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fb1c8493-542b-48eb-b624-b4c8fea62acd\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fb1c8493-542b-48eb-b624-b4c8fea62acd\"\
         },{\"properties\":{\"roleName\":\"Security Manager\",\"type\":\"BuiltInRole\"\
         ,\"description\":\"Lets you manage security components, security policies\
@@ -1132,7 +1254,7 @@ interactions:
         :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"39bc4728-0917-49c7-9d2c-d95423bc2eb4\"\
         },{\"properties\":{\"roleName\":\"Site Recovery Contributor\",\"type\":\"\
-        BuiltInRole\",\"description\":\"Lets you manage Site Recovery sservice except\
+        BuiltInRole\",\"description\":\"Lets you manage Site Recovery service except\
         \ vault creation and role assignment\",\"assignableScopes\":[\"/\"],\"permissions\"\
         :[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\"\
         ,\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\"\
@@ -1239,10 +1361,12 @@ interactions:
         ,\"Microsoft.Sql/servers/read\",\"Microsoft.Support/*\"],\"notActions\":[\"\
         Microsoft.Sql/servers/databases/auditingPolicies/*\",\"Microsoft.Sql/servers/databases/auditingSettings/*\"\
         ,\"Microsoft.Sql/servers/databases/auditRecords/read\",\"Microsoft.Sql/servers/databases/connectionPolicies/*\"\
-        ,\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\"\
-        ,\"Microsoft.Sql/servers/databases/securityMetrics/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessment/*\"\
+        ,\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/extendedAuditingSettings/*\"\
+        ,\"Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels/*\"\
+        ,\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/securityMetrics/*\"\
+        ,\"Microsoft.Sql/servers/databases/sensitivityLabels/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessments/*\"\
         ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\"\
-        ]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2017-11-13T18:45:48.4626427Z\"\
+        ]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2018-02-15T19:48:41.1575716Z\"\
         ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9b7fa17d-e63e-47b0-bb0a-15c516ac86ec\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9b7fa17d-e63e-47b0-bb0a-15c516ac86ec\"\
         },{\"properties\":{\"roleName\":\"SQL Security Manager\",\"type\":\"BuiltInRole\"\
@@ -1256,14 +1380,15 @@ interactions:
         ,\"Microsoft.Sql/servers/databases/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditRecords/read\"\
         ,\"Microsoft.Sql/servers/databases/connectionPolicies/*\",\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\"\
         ,\"Microsoft.Sql/servers/databases/read\",\"Microsoft.Sql/servers/databases/schemas/read\"\
-        ,\"Microsoft.Sql/servers/databases/schemas/tables/columns/read\",\"Microsoft.Sql/servers/databases/schemas/tables/read\"\
-        ,\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/securityMetrics/*\"\
-        ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessment/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\"\
+        ,\"Microsoft.Sql/servers/databases/schemas/tables/columns/read\",\"Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels/*\"\
+        ,\"Microsoft.Sql/servers/databases/schemas/tables/read\",\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\"\
+        ,\"Microsoft.Sql/servers/databases/securityMetrics/*\",\"Microsoft.Sql/servers/databases/sensitivityLabels/*\"\
+        ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessments/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\"\
         ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\",\"\
         Microsoft.Sql/servers/firewallRules/*\",\"Microsoft.Sql/servers/read\",\"\
         Microsoft.Sql/servers/securityAlertPolicies/*\",\"Microsoft.Support/*\"],\"\
         notActions\":[]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\"\
-        :\"2017-11-13T18:42:25.1400282Z\",\"createdBy\":null,\"updatedBy\":\"yaiyun\"\
+        :\"2018-02-15T19:48:40.2200727Z\",\"createdBy\":null,\"updatedBy\":\"yaiyun\"\
         },\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"056cd41c-7e88-42e1-933e-88ba6a50c9c3\"\
         },{\"properties\":{\"roleName\":\"SQL Server Contributor\",\"type\":\"BuiltInRole\"\
@@ -1276,12 +1401,14 @@ interactions:
         ],\"notActions\":[\"Microsoft.Sql/servers/auditingPolicies/*\",\"Microsoft.Sql/servers/auditingSettings/*\"\
         ,\"Microsoft.Sql/servers/databases/auditingPolicies/*\",\"Microsoft.Sql/servers/databases/auditingSettings/*\"\
         ,\"Microsoft.Sql/servers/databases/auditRecords/read\",\"Microsoft.Sql/servers/databases/connectionPolicies/*\"\
-        ,\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\"\
-        ,\"Microsoft.Sql/servers/databases/securityMetrics/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessment/*\"\
+        ,\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/extendedAuditingSettings/*\"\
+        ,\"Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels/*\"\
+        ,\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/securityMetrics/*\"\
+        ,\"Microsoft.Sql/servers/databases/sensitivityLabels/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessments/*\"\
         ,\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\"\
-        ,\"Microsoft.Sql/servers/securityAlertPolicies/*\"]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\"\
-        ,\"updatedOn\":\"2017-11-13T18:48:48.9023666Z\",\"createdBy\":null,\"updatedBy\"\
-        :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437\"\
+        ,\"Microsoft.Sql/servers/extendedAuditingSettings/*\",\"Microsoft.Sql/servers/securityAlertPolicies/*\"\
+        ]}],\"createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2018-02-15T19:48:41.8450730Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437\"\
         },{\"properties\":{\"roleName\":\"Storage Account Contributor\",\"type\":\"\
         BuiltInRole\",\"description\":\"Lets you manage storage accounts, but not\
@@ -1304,7 +1431,7 @@ interactions:
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"81a9662b-bebf-436f-a333-f67b29880f12\"\
         },{\"properties\":{\"roleName\":\"Storage Blob Data Contributor (Preview)\"\
         ,\"type\":\"BuiltInRole\",\"description\":\"Allows for read, write and delete\
-        \ access to Azure Storage blob containers and data\",\"assignableScopes\"\
+        \ access to Azure Storage blob containers and data.\",\"assignableScopes\"\
         :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/read\"\
         ,\"Microsoft.Storage/storageAccounts/blobServices/containers/write\",\"Microsoft.Storage/storageAccounts/blobServices/containers/delete\"\
         ,\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\"\
@@ -1316,7 +1443,7 @@ interactions:
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ba92f5b4-2d11-453d-a403-e96b0029c9fe\"\
         },{\"properties\":{\"roleName\":\"Storage Blob Data Reader (Preview)\",\"\
         type\":\"BuiltInRole\",\"description\":\"Allows for read access to Azure Storage\
-        \ blob containers and data\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        \ blob containers and data.\",\"assignableScopes\":[\"/\"],\"permissions\"\
         :[{\"actions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/read\"\
         ,\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\"\
         ],\"notActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\"\
@@ -1325,7 +1452,7 @@ interactions:
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"2a2b9908-6ea1-4ae2-8e65-a410df84e7d1\"\
         },{\"properties\":{\"roleName\":\"Storage Queue Data Contributor (Preview)\"\
         ,\"type\":\"BuiltInRole\",\"description\":\"Allows for read, write, and delete\
-        \ access to Azure Storage queues and queue messages\",\"assignableScopes\"\
+        \ access to Azure Storage queues and queue messages.\",\"assignableScopes\"\
         :[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/read\"\
         ,\"Microsoft.Storage/storageAccounts/queueServices/queues/write\",\"Microsoft.Storage/storageAccounts/queueServices/queues/delete\"\
         ,\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/read\"\
@@ -1337,7 +1464,7 @@ interactions:
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"974c5e8b-45b9-4653-ba55-5f855dd0fb88\"\
         },{\"properties\":{\"roleName\":\"Storage Queue Data Reader (Preview)\",\"\
         type\":\"BuiltInRole\",\"description\":\"Allows for read access to Azure Storage\
-        \ queues and queue messages\",\"assignableScopes\":[\"/\"],\"permissions\"\
+        \ queues and queue messages.\",\"assignableScopes\":[\"/\"],\"permissions\"\
         :[{\"actions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/read\"\
         ,\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/read\"\
         ],\"notActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\"\
@@ -1367,9 +1494,19 @@ interactions:
         BuiltInRole\",\"description\":\"Lets you manage user access to Azure resources.\"\
         ,\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"\
         Microsoft.Authorization/*\",\"Microsoft.Support/*\"],\"notActions\":[]}],\"\
-        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2016-05-31T23:14:04.6964687Z\"\
+        createdOn\":\"0001-01-01T08:00:00.0000000Z\",\"updatedOn\":\"2018-01-30T18:08:24.4656640Z\"\
         ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"18d7d88d-d35e-4fb5-a5c3-7773c20a72d9\"\
+        },{\"properties\":{\"roleName\":\"Virtual Machine Administrator Login\",\"\
+        type\":\"BuiltInRole\",\"description\":\"-\\tUsers with this role have the\
+        \ ability to login to a virtual machine with Windows administrator or Linux\
+        \ root user privileges.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"\
+        actions\":[\"Microsoft.Compute/virtualMachines/loginAsAdmin/action\",\"Microsoft.Compute/virtualMachines/login/action\"\
+        ,\"Microsoft.Compute/virtualMachine/loginAsAdmin/action\",\"Microsoft.Compute/virtualMachine/logon/action\"\
+        ],\"notActions\":[]}],\"createdOn\":\"2018-02-09T18:36:13.3315744Z\",\"updatedOn\"\
+        :\"2018-02-09T18:36:13.3315744Z\",\"createdBy\":null,\"updatedBy\":null},\"\
+        id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/1c0163c0-47e6-4577-8991-ea5c82e286e4\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"1c0163c0-47e6-4577-8991-ea5c82e286e4\"\
         },{\"properties\":{\"roleName\":\"Virtual Machine Contributor\",\"type\":\"\
         BuiltInRole\",\"description\":\"Lets you manage virtual machines, but not\
         \ access to them, and not the virtual network or storage account they\uFFFD\
@@ -1398,6 +1535,14 @@ interactions:
         ,\"updatedOn\":\"2017-11-14T03:00:30.1736393Z\",\"createdBy\":null,\"updatedBy\"\
         :null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c\"\
         ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9980e02c-c2be-4d73-94e8-173b1dc7cf3c\"\
+        },{\"properties\":{\"roleName\":\"Virtual Machine User Login\",\"type\":\"\
+        BuiltInRole\",\"description\":\"Users with this role have the ability to login\
+        \ to a virtual machine as a regular user.\",\"assignableScopes\":[\"/\"],\"\
+        permissions\":[{\"actions\":[\"Microsoft.Compute/virtualMachines/login/action\"\
+        ,\"Microsoft.Compute/virtualMachine/logon/action\"],\"notActions\":[]}],\"\
+        createdOn\":\"2018-02-09T18:36:13.3315744Z\",\"updatedOn\":\"2018-02-09T18:36:13.3315744Z\"\
+        ,\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fb879df8-f326-4884-b1cf-06f3ad86be52\"\
+        ,\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fb879df8-f326-4884-b1cf-06f3ad86be52\"\
         },{\"properties\":{\"roleName\":\"Web Plan Contributor\",\"type\":\"BuiltInRole\"\
         ,\"description\":\"Lets you manage the web plans for websites, but not access\
         \ to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"\
@@ -1422,12 +1567,12 @@ interactions:
         }]}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['82228']
+      content-length: ['86757']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 22 Dec 2017 18:30:54 GMT']
+      date: ['Tue, 06 Mar 2018 22:22:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
+      server: [Microsoft-IIS/10.0]
       set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -1437,8 +1582,7 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"objectIds": ["834c993d-92da-4497-b91e-a59791a26038"],
-      "includeDirectoryObjectReferences": true}'
+    body: '{"includeDirectoryObjectReferences": true, "objectIds": ["9184a74c-35c1-4a9f-a86e-3872c0388fd7"]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1446,28 +1590,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['97']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"834c993d-92da-4497-b91e-a59791a26038","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":["isExplicit=False","/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003"],"appDisplayName":null,"appId":"a7a41914-b191-42ec-9abc-2a21adda16fe","appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"web-msi000003","errorUrl":null,"homepage":null,"keyCredentials":[{"customKeyIdentifier":null,"endDate":"2018-03-22T18:22:00Z","keyId":"f5d28957-b5cc-4158-84ff-4e15b5620541","startDate":"2017-12-22T18:22:00Z","type":"AsymmetricX509Cert","usage":"Verify","value":null}],"logoutUrl":null,"oauth2Permissions":[],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["a7a41914-b191-42ec-9abc-2a21adda16fe","https://identity.azure.net/N7OC7IfM206y7mdG+2uDverBqytIOGHjmLBOoV+PlYI="],"servicePrincipalType":"ServiceAccount","tags":[],"tokenEncryptionKeyId":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"9184a74c-35c1-4a9f-a86e-3872c0388fd7","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":["isExplicit=False","/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Web/sites/web-msi000003"],"appDisplayName":null,"appId":"fe595003-fc12-4239-8a36-c684879d00ee","appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"web-msi000003","errorUrl":null,"homepage":null,"keyCredentials":[{"customKeyIdentifier":null,"endDate":"2018-06-04T22:16:00Z","keyId":"a4e78846-0a06-4fc8-abbb-3bdcd8cabba8","startDate":"2018-03-06T22:16:00Z","type":"AsymmetricX509Cert","usage":"Verify","value":null}],"logoutUrl":null,"oauth2Permissions":[],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["fe595003-fc12-4239-8a36-c684879d00ee","https://identity.azure.net/tIsIqEqJbwh5TBAnHmPR9gHWbL81ap5rsFyY1hLC75c="],"servicePrincipalType":"ServiceAccount","tags":[],"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1373']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 22 Dec 2017 18:32:43 GMT']
-      duration: ['1424338']
+      date: ['Tue, 06 Mar 2018 22:22:17 GMT']
+      duration: ['1184189']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [tloBiTzV9KbgWyL0nGvOfolvuIjvoIkswnX3WD63Y1k=]
-      ocp-aad-session-key: [us2ucBCnEJBciTTi51OKjVhpGLJzrkCQn65qclvrcPFdNYFmWp8-uc1gRQ88kAjiIIRja1o9zSOb0HI6MJVSISVQqPszx_Q5oNyWkgokar_Rr9gZrKUABSZKXMxlljOy.DkjRx15yR5W1PWFHpIpNcP1VcOadY8QyeCMFQa2Xn4E]
+      ocp-aad-diagnostics-server-name: [D/Nmvm5J7gPvWHCUgVGONxymxBaqFgS9HDIqypgJ6Ac=]
+      ocp-aad-session-key: [SUAhD5_MgYZmXt6mxhMPemqfpirqoGaoZ8Eo_mbbpq_cyGfBVaSK9UsOLKrIolEfNoClxhdxzhqcTShDv1xNhBq0G7c92hMCpAz16QG4fsY2HBhX67j3RQQT7MM-wuXt._KR2qJ3upgGeQCM5iKgEue_NiIFR17joaLjkwTxW6So]
       pragma: [no-cache]
-      request-id: [3a05554d-a327-4e31-98a6-acd10086218e]
-      server: [Microsoft-IIS/8.5]
+      request-id: [2f68d4f8-cd25-43f5-bb29-3178d9baf6c7]
+      server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
@@ -1483,22 +1627,23 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.12 (Darwin-17.2.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.22 msrest_azure/0.4.19 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.24]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 22 Dec 2017 18:32:48 GMT']
+      date: ['Tue, 06 Mar 2018 22:22:18 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdQNUJVVFVLTkFWUlFDNEtTS0dGN01EQVBHRVFEVEFQQTIyQXxDOTlDQjMyNUM0RDkyMUYwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdNQTZTTUg2UjdYM1A3RlJJWFRBVkFQWEZSUVVORk9TUTVKRHwyQUJFRjgwQkM2RkM3MzExLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.28"
+VERSION = "0.1.29"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.0.20
 ++++++
+* az login: use `--identity` and deprecate `--msi`
 * enable login/logout commands in cloud shell
 
 2.0.19

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import argparse
+
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import CliCommandType
 
@@ -45,8 +47,10 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('username', options_list=('--username', '-u'), help='user name, service principal, or managed service identity ID')
             c.argument('tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
             c.argument('allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
-            c.argument('msi', action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
-            c.argument('msi_port', help="the port to retrieve tokens for login", arg_group='Managed Service Identity')
+            c.argument('msi', help=argparse.SUPPRESS)
+            c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
+            c.argument('msi_port', help=argparse.SUPPRESS)
+            c.argument('identity_port', help="the port to retrieve tokens for login. Default: 50342", arg_group='Managed Service Identity')
 
         with self.argument_context('logout') as c:
             c.argument('username', help='account user, if missing, logout the current active account')

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
@@ -24,10 +24,10 @@ helps['login'] = """
             az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
         - name: Log in using a VM's system assigned identity
           text: >
-            az login --msi
+            az login --identity
         - name: Log in using a VM's user assigned identity. Client or object ids of the service identity also work
           text: >
-            az login --msi -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
+            az login --identity -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
     """
 
 helps['account'] = """

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -12,12 +12,10 @@ from knack.util import CLIError
 from azure.cli.core._profile import Profile
 from azure.cli.core.util import in_cloud_console
 
-from azure.cli.core.commands.validators import DefaultStr
-
 logger = get_logger(__name__)
 
 _CLOUD_CONSOLE_LOGOUT_WARNING = ("Logout successful. Re-login to your initial Cloud Shell identity with"
-                                 " 'az login --msi'. Login with a new identity with 'az login'.")
+                                 " 'az login --identity'. Login with a new identity with 'az login'.")
 _CLOUD_CONSOLE_LOGIN_WARNING = ("Cloud Shell is automatically authenticated under the initial account signed-in with."
                                 " Run 'az login' only if you need to use a different account")
 
@@ -92,22 +90,23 @@ def account_clear(cmd):
 
 
 # pylint: disable=inconsistent-return-statements
-def login(cmd, username=None, password=None, service_principal=None, tenant=None,
-          allow_no_subscriptions=False, msi=False, msi_port=DefaultStr(50342)):
+def login(cmd, username=None, password=None, service_principal=None, tenant=None, allow_no_subscriptions=False,
+          identity=False, identity_port=None,
+          msi=False, msi_port=None):  # will remove msi_xxx in a future release
     """Log in to access Azure subscriptions"""
     from adal.adal_error import AdalError
     import requests
 
     # quick argument usage check
     if (any([password, service_principal, tenant, allow_no_subscriptions]) and
-            any([msi, not getattr(msi_port, 'is_default', None)])):
-        raise CLIError("usage error: '--msi/--msi-port' are not applicable with other arguments")
+            any([identity, msi])):
+        raise CLIError("usage error: '--identity/--identity-port' are not applicable with other arguments")
 
     interactive = False
 
     profile = Profile(cli_ctx=cmd.cli_ctx, async_persist=False)
 
-    if msi:
+    if identity or msi:
         if in_cloud_console():
             return profile.find_subscriptions_in_cloud_console()
         return profile.find_subscriptions_in_vm_with_msi(msi_port, username)

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -109,7 +109,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
     if identity or msi:
         if in_cloud_console():
             return profile.find_subscriptions_in_cloud_console()
-        return profile.find_subscriptions_in_vm_with_msi(msi_port, username)
+        return profile.find_subscriptions_in_vm_with_msi(identity_port or msi_port, username)
     elif in_cloud_console():  # tell users they might not need login
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)
 

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.0.28
 ++++++
+* vm/vmss: author managed identity commands `identity assign/remove/show`, and deprecate `assign-identity/remove-identity`
 * vmss create: default priority to None
 * Support Autorest 3.0 based SDKs
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -1182,21 +1182,41 @@ helps['vm wait'] = """
 {0}
 """.format(vm_ids_example.format('Wait until all VMs in a resource group are deleted.', 'vm wait --deleted'))
 
-helps['vm assign-identity'] = """
+helps['vm identity'] = """
+    type: group
+    short-summary: manage service identities of a VM
+"""
+
+helps['vm identity assign'] = """
     type: command
     short-summary: Enable managed service identity on a VM.
     long-summary: This is required to authenticate and interact with other Azure services using bearer tokens.
     examples:
         - name: Enable identity on a VM with the 'Reader' role.
-          text: az vm assign-identity -g MyResourceGroup -n MyVm --role Reader
+          text: az vm identity assign -g MyResourceGroup -n MyVm --role Reader
 """
 
-helps['vm remove-identity'] = """
+helps['vm identity remove'] = """
     type: command
     short-summary: (PREVIEW) Remove user assigned identities from a VM.
     examples:
         - name: Remove 2 identities which are in the same resource group with the VM
-          text: az vm remove-identity -g MyResourceGroup -n MyVm --identities readerId writerId
+          text: az vm identity remove -g MyResourceGroup -n MyVm --identities readerId writerId
+"""
+
+helps['vm identity show'] = """
+    type: command
+    short-summary: display VM's managed identity info.
+"""
+
+helps['vm assign-identity'] = """
+    type: command
+    short-summary: (Deprecated, please use 'az vm identity assign')
+"""
+
+helps['vm remove-identity'] = """
+    type: command
+    short-summary: (Deprecated, please use 'az vm identity remove')
 """
 
 helps['vm run-command'] = """
@@ -1214,21 +1234,41 @@ helps['vm run-command invoke'] = """
           text: az vm run-command invoke -g MyResourceGroup -n MyVm --command-id RunShellScript --scripts 'echo $0 $1' --parameters hello world
 """
 
-helps['vmss assign-identity'] = """
+helps['vmss identity'] = """
+    type: group
+    short-summary: manage service identities of a VM scaleset.
+"""
+
+helps['vmss identity assign'] = """
     type: command
     short-summary: Enable managed service identity on a VMSS.
     long-summary: This is required to authenticate and interact with other Azure services using bearer tokens.
     examples:
         - name: Enable identity on a VMSS with the 'Owner' role.
-          text: az vmss assign-identity -g MyResourceGroup -n MyVmss --role Owner
+          text: az vmss identity assign -g MyResourceGroup -n MyVmss --role Owner
 """
 
-helps['vmss remove-identity'] = """
+helps['vmss identity remove'] = """
     type: command
     short-summary: (PREVIEW) Remove user assigned identities from a VM scaleset.
     examples:
         - name: Remove 2 identities which are in the same resource group with the VM scaleset
-          text: az vmss remove-identity -g MyResourceGroup -n MyVm --identities readerId writerId
+          text: az vmss identity remove -g MyResourceGroup -n MyVm --identities readerId writerId
+"""
+
+helps['vmss identity show'] = """
+    type: command
+    short-summary: display VM scaleset's managed identity info.
+"""
+
+helps['vmss assign-identity'] = """
+    type: command
+    short-summary: (Deprecated, please use 'az vmss identity assign')
+"""
+
+helps['vmss remove-identity'] = """
+    type: command
+    short-summary: (Deprecated, please use 'az vmss identity remove')
 """
 
 helps['disk'] = """

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -22,7 +22,7 @@ from azure.cli.command_modules.vm._validators import (
     validate_vmss_disk, validate_asg_names_or_ids)
 
 
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-statements, too-many-branches
 def load_arguments(self, _):
     from azure.mgmt.compute.models import CachingTypes, UpgradeMode
     from azure.mgmt.storage.models import SkuName
@@ -323,16 +323,21 @@ def load_arguments(self, _):
         with self.argument_context(scope) as c:
             c.argument('no_auto_upgrade', action='store_true', help='by doing this, extension system will not pick the highest minor version for the specified version number, and will not auto update to the latest build/revision number on any scale set updates in future.')
 
-    for scope in ['vm assign-identity', 'vmss assign-identity']:
+    for scope in ['vm assign-identity', 'vmss assign-identity', 'vm identity assign', 'vmss identity assign']:
         with self.argument_context(scope) as c:
             c.argument('assign_identity', options_list=['--identities'], nargs='*', help="the identities to assign")
             c.argument('port', type=int, help="The port to fetch AAD token. Default: 50342")
             c.argument('vm_name', existing_vm_name)
             c.argument('vmss_name', vmss_name_type)
 
-    for scope in ['vm remove-identity', 'vmss remove-identity']:
+    for scope in ['vm remove-identity', 'vmss remove-identity', 'vm identity remove', 'vmss identity remove']:
         with self.argument_context(scope) as c:
             c.argument('identities', nargs='+', help="space-separated user assigned identities to remove")
+            c.argument('vm_name', existing_vm_name)
+            c.argument('vmss_name', vmss_name_type)
+
+    for scope in ['vm identity show', 'vmss identity show']:
+        with self.argument_context(scope) as c:
             c.argument('vm_name', existing_vm_name)
             c.argument('vmss_name', vmss_name_type)
 
@@ -387,7 +392,7 @@ def load_arguments(self, _):
             c.argument('plan_publisher', help='plan publisher')
             c.argument('plan_promotion_code', help='plan promotion code')
 
-    for scope in ['vm create', 'vmss create', 'vm assign-identity', 'vmss assign-identity']:
+    for scope in ['vm create', 'vmss create', 'vm assign-identity', 'vmss assign-identity', 'vm identity assign', 'vmss identity assign']:
         with self.argument_context(scope) as c:
             arg_group = 'Managed Service Identity' if scope.split()[-1] == 'create' else None
             c.argument('identity_scope', options_list=['--scope'], arg_group=arg_group, help="Scope that the system assigned identity can access")

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -159,8 +159,15 @@ def load_command_table(self, _):
         g.generic_update_command('update', custom_func_name='update_snapshot', setter_arg_name='snapshot')
 
     with self.command_group('vm', compute_vm_sdk) as g:
-        g.custom_command('assign-identity', 'assign_vm_identity', validator=process_assign_identity_namespace)
-        g.custom_command('remove-identity', 'remove_vm_identity', validator=process_remove_identity_namespace, min_api='2017-12-01')
+
+        g.custom_command('assign-identity', 'assign_vm_identity', validator=process_assign_identity_namespace,
+                         deprecate_info='az vm identity assign')
+        g.custom_command('remove-identity', 'remove_vm_identity', validator=process_remove_identity_namespace, min_api='2017-12-01',
+                         deprecate_info='az vm identity remove')
+        g.custom_command('identity assign', 'assign_vm_identity', validator=process_assign_identity_namespace)
+        g.custom_command('identity remove', 'remove_vm_identity', validator=process_remove_identity_namespace, min_api='2017-12-01')
+        g.custom_command('identity show', 'show_vm_identity')
+
         g.custom_command('capture', 'capture_vm')
         g.custom_command('create', 'create_vm', transform=transform_vm_create_output, supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_vm_create_namespace)
         g.command('convert', 'convert_to_managed_disks', min_api='2016-04-30-preview')
@@ -262,8 +269,12 @@ def load_command_table(self, _):
         g.custom_command('reset-ssh', 'reset_linux_ssh')
 
     with self.command_group('vmss', compute_vmss_sdk, operation_group='virtual_machine_scale_sets') as g:
-        g.custom_command('assign-identity', 'assign_vmss_identity', validator=process_assign_identity_namespace)
-        g.custom_command('remove-identity', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01')
+        g.custom_command('assign-identity', 'assign_vmss_identity', validator=process_assign_identity_namespace, deprecate_info='az vmss identity assign')
+        g.custom_command('remove-identity', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01',
+                         deprecate_info='az vmss identity remove')
+        g.custom_command('identity assign', 'assign_vmss_identity', validator=process_assign_identity_namespace)
+        g.custom_command('identity remove', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01')
+        g.custom_command('identity show', 'show_vmss_identity')
         g.custom_command('create', 'create_vmss', transform=DeploymentOutputLongRunningOperation(self.cli_ctx, 'Starting vmss create'), supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_vmss_create_namespace)
         g.custom_command('deallocate', 'deallocate_vmss', supports_no_wait=True)
         g.command('delete', 'delete', supports_no_wait=True)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -406,6 +406,16 @@ def update_snapshot(cmd, instance, sku=None):
 
 
 # region VirtualMachines Identity
+def show_vm_identity(cmd, resource_group_name, vm_name):
+    client = _compute_client_factory(cmd.cli_ctx)
+    return client.virtual_machines.get(resource_group_name, vm_name).identity
+
+
+def show_vmss_identity(cmd, resource_group_name, vm_name):
+    client = _compute_client_factory(cmd.cli_ctx)
+    return client.virtual_machine_scale_sets.get(resource_group_name, vm_name).identity
+
+
 def assign_vm_identity(cmd, resource_group_name, vm_name, assign_identity=None, identity_role='Contributor',
                        identity_role_id=None, identity_scope=None, port=None):
     VirtualMachineIdentity, ResourceIdentityType = cmd.get_models('VirtualMachineIdentity', 'ResourceIdentityType')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_explicit_msi.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_explicit_msi.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"location": "westcentralus", "tags": {"use": "az-test"}}'
+    body: '{"tags": {"use": "az-test"}, "location": "westcentralus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -10,7 +10,7 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -20,11 +20,12 @@ interactions:
       cache-control: [no-cache]
       content-length: ['225']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:54:57 GMT']
+      date: ['Tue, 06 Mar 2018 21:27:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -36,7 +37,7 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -46,11 +47,12 @@ interactions:
       cache-control: [no-cache]
       content-length: ['225']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:54:59 GMT']
+      date: ['Tue, 06 Mar 2018 21:27:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "westcentralus"}'
@@ -62,22 +64,23 @@ interactions:
       Content-Length: ['29']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 azure-mgmt-msi/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+          msrest_azure/0.4.20 azure-mgmt-msi/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1?api-version=2015-08-31-preview
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1","name":"id1","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"7cb420ac-3c14-4b1c-84ba-ffffd1885e25","clientId":"2d122efe-5ee1-4724-88c6-fd9081283ad0","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=7cb420ac-3c14-4b1c-84ba-ffffd1885e25&aid=2d122efe-5ee1-4724-88c6-fd9081283ad0"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1","name":"id1","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"6f0accc3-6982-4f57-913c-e8fda90e2473","clientId":"cfb8ea4c-96fa-4c9a-9a1b-f13ca44e2193","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=6f0accc3-6982-4f57-913c-e8fda90e2473&aid=cfb8ea4c-96fa-4c9a-9a1b-f13ca44e2193"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['789']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:55:01 GMT']
+      date: ['Tue, 06 Mar 2018 21:27:30 GMT']
       expires: ['-1']
       location: [/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1]
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -90,7 +93,7 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -100,11 +103,12 @@ interactions:
       cache-control: [no-cache]
       content-length: ['225']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:55:02 GMT']
+      date: ['Tue, 06 Mar 2018 21:27:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "westcentralus"}'
@@ -116,22 +120,23 @@ interactions:
       Content-Length: ['29']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 azure-mgmt-msi/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+          msrest_azure/0.4.20 azure-mgmt-msi/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2?api-version=2015-08-31-preview
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2","name":"id2","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"8a30f9fd-ceb3-4f9a-a0a3-b58e79f6ba18","clientId":"ac113f60-e8b2-475a-8022-576c1b2fb8dc","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=8a30f9fd-ceb3-4f9a-a0a3-b58e79f6ba18&aid=ac113f60-e8b2-475a-8022-576c1b2fb8dc"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2","name":"id2","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"87ecd36e-18a0-48d2-81e4-8c3b2f82af77","clientId":"1f5eb982-57e4-4d74-909b-8b21c5887a1b","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=87ecd36e-18a0-48d2-81e4-8c3b2f82af77&aid=1f5eb982-57e4-4d74-909b-8b21c5887a1b"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['789']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:55:05 GMT']
+      date: ['Tue, 06 Mar 2018 21:27:33 GMT']
       expires: ['-1']
       location: [/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2]
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -144,7 +149,7 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -154,11 +159,12 @@ interactions:
       cache-control: [no-cache]
       content-length: ['225']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:55:06 GMT']
+      date: ['Tue, 06 Mar 2018 21:27:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -213,9 +219,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:55:07 GMT']
+      date: ['Tue, 06 Mar 2018 21:27:33 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Thu, 25 Jan 2018 01:00:07 GMT']
+      expires: ['Tue, 06 Mar 2018 21:32:33 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -223,12 +229,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [e2999d2f669727b5deaa0ff9531737ebc717f980]
+      x-fastly-request-id: [bbf83c73ffbb8dfc27f2054181e7eadf7ba4b1ff]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['967E:2E76A:1C89E5:1D3736:5A692AEB']
-      x-served-by: [cache-mdw17336-MDW]
-      x-timer: ['S1516841708.701832,VS0,VE50']
+      x-github-request-id: ['A818:6109:4F5C41:547CE5:5A9F07C5']
+      x-served-by: [cache-sea1023-SEA]
+      x-timer: ['S1520371654.865079,VS0,VE104']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -240,7 +246,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-11-01
@@ -250,54 +256,52 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:55:08 GMT']
+      date: ['Tue, 06 Mar 2018 21:27:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"parameters": {}, "template": {"variables": {}, "contentVersion":
-      "1.0.0.0", "resources": [{"apiVersion": "2015-06-15", "name": "vm2VNET", "dependsOn":
-      [], "tags": {}, "location": "westcentralus", "properties": {"addressSpace":
-      {"addressPrefixes": ["10.0.0.0/16"]}, "subnets": [{"name": "vm2Subnet", "properties":
-      {"addressPrefix": "10.0.0.0/24"}}]}, "type": "Microsoft.Network/virtualNetworks"},
-      {"apiVersion": "2015-06-15", "name": "vm2NSG", "dependsOn": [], "tags": {},
-      "location": "westcentralus", "properties": {"securityRules": [{"name": "default-allow-ssh",
-      "properties": {"direction": "Inbound", "sourcePortRange": "*", "access": "Allow",
-      "destinationPortRange": "22", "priority": 1000, "destinationAddressPrefix":
-      "*", "protocol": "Tcp", "sourceAddressPrefix": "*"}}]}, "type": "Microsoft.Network/networkSecurityGroups"},
-      {"apiVersion": "2017-11-01", "name": "vm2PublicIP", "dependsOn": [], "tags":
-      {}, "location": "westcentralus", "properties": {"publicIPAllocationMethod":
-      "dynamic"}, "type": "Microsoft.Network/publicIPAddresses"}, {"apiVersion": "2015-06-15",
-      "name": "vm2VMNic", "dependsOn": ["Microsoft.Network/virtualNetworks/vm2VNET",
+    body: 'b''{"properties": {"template": {"contentVersion": "1.0.0.0", "outputs":
+      {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "variables": {}, "parameters": {}, "resources": [{"dependsOn": [], "type": "Microsoft.Network/virtualNetworks",
+      "name": "vm2VNET", "location": "westcentralus", "tags": {}, "apiVersion": "2015-06-15",
+      "properties": {"subnets": [{"name": "vm2Subnet", "properties": {"addressPrefix":
+      "10.0.0.0/24"}}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}}, {"dependsOn":
+      [], "type": "Microsoft.Network/networkSecurityGroups", "name": "vm2NSG", "location":
+      "westcentralus", "tags": {}, "apiVersion": "2015-06-15", "properties": {"securityRules":
+      [{"name": "default-allow-ssh", "properties": {"sourceAddressPrefix": "*", "direction":
+      "Inbound", "protocol": "Tcp", "priority": 1000, "sourcePortRange": "*", "access":
+      "Allow", "destinationAddressPrefix": "*", "destinationPortRange": "22"}}]}},
+      {"dependsOn": [], "type": "Microsoft.Network/publicIPAddresses", "name": "vm2PublicIP",
+      "location": "westcentralus", "tags": {}, "apiVersion": "2017-11-01", "properties":
+      {"publicIPAllocationMethod": "dynamic"}}, {"dependsOn": ["Microsoft.Network/virtualNetworks/vm2VNET",
       "Microsoft.Network/networkSecurityGroups/vm2NSG", "Microsoft.Network/publicIpAddresses/vm2PublicIP"],
-      "tags": {}, "location": "westcentralus", "properties": {"networkSecurityGroup":
+      "type": "Microsoft.Network/networkInterfaces", "name": "vm2VMNic", "location":
+      "westcentralus", "tags": {}, "apiVersion": "2015-06-15", "properties": {"networkSecurityGroup":
       {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},
-      "ipConfigurations": [{"name": "ipconfigvm2", "properties": {"publicIPAddress":
-      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"},
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet"},
-      "privateIPAllocationMethod": "Dynamic"}}]}, "type": "Microsoft.Network/networkInterfaces"},
-      {"apiVersion": "2017-12-01", "name": "vm2/ManagedIdentityExtensionForLinux",
-      "dependsOn": ["Microsoft.Compute/virtualMachines/vm2"], "location": "westcentralus",
-      "properties": {"autoUpgradeMinorVersion": true, "typeHandlerVersion": "1.0",
-      "publisher": "Microsoft.ManagedIdentity", "settings": {"port": 50342}, "type":
-      "ManagedIdentityExtensionForLinux"}, "type": "Microsoft.Compute/virtualMachines/extensions"},
-      {"apiVersion": "2017-12-01", "name": "vm2", "dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"],
-      "tags": {}, "identity": {"identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
-      "type": "UserAssigned"}, "location": "westcentralus", "properties": {"hardwareProfile":
-      {"vmSize": "Standard_DS1_v2"}, "osProfile": {"computerName": "vm2", "adminUsername":
-      "yugangw", "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh":
-      {"publicKeys": [{"path": "/home/yugangw/.ssh/authorized_keys", "keyData": "ssh-rsa
-      AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}}}, "storageProfile": {"imageReference": {"sku": "16.04-LTS",
-      "offer": "UbuntuServer", "publisher": "Canonical", "version": "latest"}, "osDisk":
-      {"createOption": "fromImage", "name": null, "caching": "ReadWrite", "managedDisk":
-      {"storageAccountType": null}}}, "networkProfile": {"networkInterfaces": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]}},
-      "type": "Microsoft.Compute/virtualMachines"}], "outputs": {}, "parameters":
-      {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
-      "mode": "Incremental"}}'''
+      "ipConfigurations": [{"name": "ipconfigvm2", "properties": {"subnet": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"},
+      "privateIPAllocationMethod": "Dynamic"}}]}}, {"dependsOn": ["Microsoft.Compute/virtualMachines/vm2"],
+      "type": "Microsoft.Compute/virtualMachines/extensions", "name": "vm2/ManagedIdentityExtensionForLinux",
+      "location": "westcentralus", "apiVersion": "2017-12-01", "properties": {"publisher":
+      "Microsoft.ManagedIdentity", "settings": {"port": 50342}, "autoUpgradeMinorVersion":
+      true, "type": "ManagedIdentityExtensionForLinux", "typeHandlerVersion": "1.0"}},
+      {"dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"], "type": "Microsoft.Compute/virtualMachines",
+      "name": "vm2", "location": "westcentralus", "identity": {"identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
+      "type": "UserAssigned"}, "tags": {}, "apiVersion": "2017-12-01", "properties":
+      {"storageProfile": {"osDisk": {"managedDisk": {"storageAccountType": null},
+      "caching": "ReadWrite", "createOption": "fromImage", "name": null}, "imageReference":
+      {"publisher": "Canonical", "offer": "UbuntuServer", "version": "latest", "sku":
+      "16.04-LTS"}}, "osProfile": {"computerName": "vm2", "adminUsername": "yugangw",
+      "linuxConfiguration": {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n", "path": "/home/yugangw/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
+      true}}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}}]}, "mode": "Incremental",
+      "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -307,21 +311,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_HiffyLMj8q2ruEqCgcXvhpmTjgLMw9PJ","name":"vm_deploy_HiffyLMj8q2ruEqCgcXvhpmTjgLMw9PJ","properties":{"templateHash":"13557104952159593253","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-01-25T00:55:10.5999615Z","duration":"PT0.5585714S","correlationId":"b8cb07c3-7822-4724-b173-63dd96eb9a38","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westcentralus"]},{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm2VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm2/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_qXN7f3eqWc98G2iHaJisMWbYlcOW5Sz6","name":"vm_deploy_qXN7f3eqWc98G2iHaJisMWbYlcOW5Sz6","properties":{"templateHash":"12360498380712578009","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-03-06T21:27:36.0252425Z","duration":"PT0.4639291S","correlationId":"72322207-f17f-445f-bb65-8bc3f85100ac","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westcentralus"]},{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm2VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm2/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_HiffyLMj8q2ruEqCgcXvhpmTjgLMw9PJ/operationStatuses/08586847651754362500?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_qXN7f3eqWc98G2iHaJisMWbYlcOW5Sz6/operationStatuses/08586812352299163220?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['2964']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:55:09 GMT']
+      date: ['Tue, 06 Mar 2018 21:27:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -334,21 +339,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812352299163220?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:55:40 GMT']
+      date: ['Tue, 06 Mar 2018 21:28:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -360,21 +366,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812352299163220?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:56:11 GMT']
+      date: ['Tue, 06 Mar 2018 21:28:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -386,21 +393,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812352299163220?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:56:41 GMT']
+      date: ['Tue, 06 Mar 2018 21:29:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -412,21 +420,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812352299163220?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:57:11 GMT']
+      date: ['Tue, 06 Mar 2018 21:29:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -438,255 +447,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:57:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:58:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:58:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:59:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 00:59:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:00:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:00:45 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:01:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:01:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847651754362500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812352299163220?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:16 GMT']
+      date: ['Tue, 06 Mar 2018 21:30:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -698,21 +474,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_HiffyLMj8q2ruEqCgcXvhpmTjgLMw9PJ","name":"vm_deploy_HiffyLMj8q2ruEqCgcXvhpmTjgLMw9PJ","properties":{"templateHash":"13557104952159593253","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-01-25T01:01:52.4714786Z","duration":"PT6M42.4300885S","correlationId":"b8cb07c3-7822-4724-b173-63dd96eb9a38","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westcentralus"]},{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm2VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm2/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForLinux"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_qXN7f3eqWc98G2iHaJisMWbYlcOW5Sz6","name":"vm_deploy_qXN7f3eqWc98G2iHaJisMWbYlcOW5Sz6","properties":{"templateHash":"12360498380712578009","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-03-06T21:29:49.1989524Z","duration":"PT2M13.637639S","correlationId":"72322207-f17f-445f-bb65-8bc3f85100ac","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westcentralus"]},{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm2VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm2/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForLinux"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3945']
+      content-length: ['3944']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:17 GMT']
+      date: ['Tue, 06 Mar 2018 21:30:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -724,21 +501,21 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2?$expand=instanceView&api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"5379f3dd-01ae-42de-a588-eccd03f9a4b3\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"1c7d6815-cc23-48a2-8157-f239732917a4\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm2_OsDisk_1_865641a8faa948a88e780ce3e41eafd6\",\r\n   \
+        \     \"name\": \"vm2_OsDisk_1_a12cd0f1e59b429ab6e0e7b6d418cbd5\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_865641a8faa948a88e780ce3e41eafd6\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_a12cd0f1e59b429ab6e0e7b6d418cbd5\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\"\
         ,\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
@@ -752,34 +529,34 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
         : {\r\n      \"computerName\": \"vm2\",\r\n      \"osName\": \"ubuntu\",\r\
         \n      \"osVersion\": \"16.04\",\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\"\
-        : \"2.2.20\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
+        : \"2.2.22\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
         code\": \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\"\
         ,\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\"\
-        : \"Guest Agent is running\",\r\n            \"time\": \"2018-01-25T01:02:18+00:00\"\
+        : \"Guest Agent is running\",\r\n            \"time\": \"2018-03-06T21:30:11+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
         \      {\r\n            \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux\"\
-        ,\r\n            \"typeHandlerVersion\": \"1.0.0.10\",\r\n            \"status\"\
+        ,\r\n            \"typeHandlerVersion\": \"1.0.0.11\",\r\n            \"status\"\
         : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
         \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
         ,\r\n              \"message\": \"Plugin enabled\"\r\n            }\r\n  \
         \        }\r\n        ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n\
-        \          \"name\": \"vm2_OsDisk_1_865641a8faa948a88e780ce3e41eafd6\",\r\n\
+        \          \"name\": \"vm2_OsDisk_1_a12cd0f1e59b429ab6e0e7b6d418cbd5\",\r\n\
         \          \"statuses\": [\r\n            {\r\n              \"code\": \"\
         ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\n \
         \             \"displayStatus\": \"Provisioning succeeded\",\r\n         \
-        \     \"time\": \"2018-01-25T00:55:45.9099338+00:00\"\r\n            }\r\n\
+        \     \"time\": \"2018-03-06T21:27:58.5559965+00:00\"\r\n            }\r\n\
         \          ]\r\n        }\r\n      ],\r\n      \"extensions\": [\r\n     \
         \   {\r\n          \"name\": \"ManagedIdentityExtensionForLinux\",\r\n   \
         \       \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux\"\
-        ,\r\n          \"typeHandlerVersion\": \"1.0.0.10\",\r\n          \"statuses\"\
+        ,\r\n          \"typeHandlerVersion\": \"1.0.0.11\",\r\n          \"statuses\"\
         : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
         : \"Provisioning succeeded\",\r\n              \"message\": \"Successfully\
-        \ started managed identity extension service. 2018-01-25 01:01:21.918725209\
+        \ started managed identity extension service. 2018-03-06 21:29:45.988906438\
         \ +0000 UTC.\"\r\n            }\r\n          ]\r\n        }\r\n      ],\r\n\
         \      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2018-01-25T01:01:33.7730452+00:00\"\
+        \ succeeded\",\r\n          \"time\": \"2018-03-06T21:29:47.9021485+00:00\"\
         \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\
@@ -799,14 +576,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['5282']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:18 GMT']
+      date: ['Tue, 06 Mar 2018 21:30:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4797,Microsoft.Compute/LowCostGet30Min;38393']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4792,Microsoft.Compute/LowCostGet30Min;38344']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -817,18 +595,18 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic?api-version=2017-11-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"e6135abf-e61e-4898-9569-621380b6fd5c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"30783115-508e-4e84-b939-b139a1e1417e\\\"\",\r\n \
         \ \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"0b000460-3e99-44b4-a901-d11d46533f82\",\r\n    \"ipConfigurations\": [\r\
+        \ \"3770b630-f144-47d1-87f2-02b06f9ddb97\",\r\n    \"ipConfigurations\": [\r\
         \n      {\r\n        \"name\": \"ipconfigvm2\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
-        ,\r\n        \"etag\": \"W/\\\"e6135abf-e61e-4898-9569-621380b6fd5c\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"30783115-508e-4e84-b939-b139a1e1417e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -837,8 +615,8 @@ interactions:
         \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
         : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
         \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"3odr1s2u3uauzixose402535ce.yx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-F8-22-77\",\r\n    \"enableAcceleratedNetworking\"\
+        internalDomainNameSuffix\": \"drhn5fjowmdujgb4nn5dp4orfa.yx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-F8-25-A3\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -849,14 +627,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2233']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:19 GMT']
-      etag: [W/"e6135abf-e61e-4898-9569-621380b6fd5c"]
+      date: ['Tue, 06 Mar 2018 21:30:14 GMT']
+      etag: [W/"30783115-508e-4e84-b939-b139a1e1417e"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -867,16 +646,16 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP?api-version=2017-11-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"2909f443-552e-46c5-866d-89ae0193aef7\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"265237bc-510e-4979-b69f-a43dd7b17dc1\\\"\",\r\n \
         \ \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"68eec11e-b681-4974-b866-4655e0fed807\",\r\n    \"ipAddress\": \"13.78.162.134\"\
+        \ \"95f05ccd-6a18-40f5-989b-0557dac8f7a2\",\r\n    \"ipAddress\": \"52.161.164.117\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\
         \n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
@@ -884,16 +663,17 @@ interactions:
         \n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['894']
+      content-length: ['895']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:19 GMT']
-      etag: [W/"2909f443-552e-46c5-866d-89ae0193aef7"]
+      date: ['Tue, 06 Mar 2018 21:30:14 GMT']
+      etag: [W/"265237bc-510e-4979-b69f-a43dd7b17dc1"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -905,7 +685,7 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -915,11 +695,12 @@ interactions:
       cache-control: [no-cache]
       content-length: ['225']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:20 GMT']
+      date: ['Tue, 06 Mar 2018 21:30:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -974,22 +755,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:20 GMT']
+      date: ['Tue, 06 Mar 2018 21:30:15 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Thu, 25 Jan 2018 01:07:20 GMT']
-      source-age: ['0']
+      expires: ['Tue, 06 Mar 2018 21:35:15 GMT']
+      source-age: ['131']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
+      x-cache: [HIT]
+      x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [1bf9efeee2010a2c5a983199ea4104a2d280b718]
+      x-fastly-request-id: [834542f7826a92a6324cd4dced9ea111871479f7]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['55F4:2A988:4C295:4EBE8:5A692C9C']
-      x-served-by: [cache-sea1026-SEA]
-      x-timer: ['S1516842140.361528,VS0,VE2']
+      x-github-request-id: ['4B6E:1E85:362C3:38C57:5A9F07E1']
+      x-served-by: [cache-dfw18626-DFW]
+      x-timer: ['S1520371816.587578,VS0,VE1']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -1001,22 +782,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-11-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm2VNET\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"1fbb531c-a329-4af3-959a-37b5a357c3d0\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"3daa64d2-a41f-484e-a797-477ff1fe514f\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westcentralus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n\
         \        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\"\
-        : \"cb1d87eb-ed94-4c01-a2ee-913dae7fbf14\",\r\n        \"addressSpace\": {\r\
+        : \"95df4e1c-b32e-4407-983e-6b7e37f9d128\",\r\n        \"addressSpace\": {\r\
         \n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n    \
         \      ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n      \
         \      \"name\": \"vm2Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"1fbb531c-a329-4af3-959a-37b5a357c3d0\\\"\
+        ,\r\n            \"etag\": \"W/\\\"3daa64d2-a41f-484e-a797-477ff1fe514f\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
@@ -1029,13 +810,14 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1526']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:20 GMT']
+      date: ['Tue, 06 Mar 2018 21:30:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1047,21 +829,21 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27reader%27
   response:
     body: {string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
-        you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-08-19T00:03:56.0652623Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'}
+        you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2018-01-30T18:08:25.4031403Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'}
     headers:
       cache-control: [no-cache]
       content-length: ['578']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:20 GMT']
+      date: ['Tue, 06 Mar 2018 21:30:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
+      server: [Microsoft-IIS/10.0]
       set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -1071,47 +853,45 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"parameters": {}, "template": {"variables": {}, "contentVersion":
-      "1.0.0.0", "resources": [{"apiVersion": "2015-06-15", "name": "vm1NSG", "dependsOn":
-      [], "tags": {}, "location": "westcentralus", "properties": {"securityRules":
-      [{"name": "default-allow-ssh", "properties": {"direction": "Inbound", "sourcePortRange":
-      "*", "access": "Allow", "destinationPortRange": "22", "priority": 1000, "destinationAddressPrefix":
-      "*", "protocol": "Tcp", "sourceAddressPrefix": "*"}}]}, "type": "Microsoft.Network/networkSecurityGroups"},
-      {"apiVersion": "2017-11-01", "name": "vm1PublicIP", "dependsOn": [], "tags":
-      {}, "location": "westcentralus", "properties": {"publicIPAllocationMethod":
-      "dynamic"}, "type": "Microsoft.Network/publicIPAddresses"}, {"apiVersion": "2015-06-15",
-      "name": "vm1VMNic", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm1NSG",
-      "Microsoft.Network/publicIpAddresses/vm1PublicIP"], "tags": {}, "location":
-      "westcentralus", "properties": {"networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
-      "ipConfigurations": [{"name": "ipconfigvm1", "properties": {"publicIPAddress":
-      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet"},
-      "privateIPAllocationMethod": "Dynamic"}}]}, "type": "Microsoft.Network/networkInterfaces"},
-      {"apiVersion": "2015-07-01", "name": "bc91468b-7f38-4fa4-934f-aee0fc919b07",
-      "dependsOn": ["Microsoft.Compute/virtualMachines/vm1"], "properties": {"principalId":
-      "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default\'',
+    body: 'b''{"properties": {"template": {"contentVersion": "1.0.0.0", "outputs":
+      {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "variables": {}, "parameters": {}, "resources": [{"dependsOn": [], "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "vm1NSG", "location": "westcentralus", "tags": {}, "apiVersion": "2015-06-15",
+      "properties": {"securityRules": [{"name": "default-allow-ssh", "properties":
+      {"sourceAddressPrefix": "*", "direction": "Inbound", "protocol": "Tcp", "priority":
+      1000, "sourcePortRange": "*", "access": "Allow", "destinationAddressPrefix":
+      "*", "destinationPortRange": "22"}}]}}, {"dependsOn": [], "type": "Microsoft.Network/publicIPAddresses",
+      "name": "vm1PublicIP", "location": "westcentralus", "tags": {}, "apiVersion":
+      "2017-11-01", "properties": {"publicIPAllocationMethod": "dynamic"}}, {"dependsOn":
+      ["Microsoft.Network/networkSecurityGroups/vm1NSG", "Microsoft.Network/publicIpAddresses/vm1PublicIP"],
+      "type": "Microsoft.Network/networkInterfaces", "name": "vm1VMNic", "location":
+      "westcentralus", "tags": {}, "apiVersion": "2015-06-15", "properties": {"networkSecurityGroup":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
+      "ipConfigurations": [{"name": "ipconfigvm1", "properties": {"subnet": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
+      "privateIPAllocationMethod": "Dynamic"}}]}}, {"dependsOn": ["Microsoft.Compute/virtualMachines/vm1"],
+      "type": "Microsoft.Authorization/roleAssignments", "apiVersion": "2015-07-01",
+      "properties": {"principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default\'',
       \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
       "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001"},
-      "type": "Microsoft.Authorization/roleAssignments"}, {"apiVersion": "2017-12-01",
-      "name": "vm1/ManagedIdentityExtensionForLinux", "dependsOn": ["bc91468b-7f38-4fa4-934f-aee0fc919b07"],
-      "location": "westcentralus", "properties": {"autoUpgradeMinorVersion": true,
-      "typeHandlerVersion": "1.0", "publisher": "Microsoft.ManagedIdentity", "settings":
-      {"port": 50342}, "type": "ManagedIdentityExtensionForLinux"}, "type": "Microsoft.Compute/virtualMachines/extensions"},
-      {"apiVersion": "2017-12-01", "name": "vm1", "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"],
-      "tags": {}, "identity": {"identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
-      "type": "SystemAssigned,UserAssigned"}, "location": "westcentralus", "properties":
-      {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "osProfile": {"computerName":
-      "vm1", "adminUsername": "ubuntuadmin", "linuxConfiguration": {"disablePasswordAuthentication":
-      true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}}}, "storageProfile": {"imageReference": {"sku": "16.04-LTS",
-      "offer": "UbuntuServer", "publisher": "Canonical", "version": "latest"}, "osDisk":
-      {"createOption": "fromImage", "name": null, "caching": "ReadWrite", "managedDisk":
-      {"storageAccountType": null}}}, "networkProfile": {"networkInterfaces": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]}},
-      "type": "Microsoft.Compute/virtualMachines"}], "outputs": {}, "parameters":
-      {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
-      "mode": "Incremental"}}'''
+      "name": "38353c75-1d8a-4a1c-a48d-da29e8727ba1"}, {"dependsOn": ["38353c75-1d8a-4a1c-a48d-da29e8727ba1"],
+      "type": "Microsoft.Compute/virtualMachines/extensions", "name": "vm1/ManagedIdentityExtensionForLinux",
+      "location": "westcentralus", "apiVersion": "2017-12-01", "properties": {"publisher":
+      "Microsoft.ManagedIdentity", "settings": {"port": 50342}, "autoUpgradeMinorVersion":
+      true, "type": "ManagedIdentityExtensionForLinux", "typeHandlerVersion": "1.0"}},
+      {"dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"], "type": "Microsoft.Compute/virtualMachines",
+      "name": "vm1", "location": "westcentralus", "identity": {"identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
+      "type": "SystemAssigned,UserAssigned"}, "tags": {}, "apiVersion": "2017-12-01",
+      "properties": {"storageProfile": {"osDisk": {"managedDisk": {"storageAccountType":
+      null}, "caching": "ReadWrite", "createOption": "fromImage", "name": null}, "imageReference":
+      {"publisher": "Canonical", "offer": "UbuntuServer", "version": "latest", "sku":
+      "16.04-LTS"}}, "osProfile": {"computerName": "vm1", "adminUsername": "ubuntuadmin",
+      "linuxConfiguration": {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n", "path": "/home/ubuntuadmin/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
+      true}}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}}]}, "mode": "Incremental",
+      "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1121,21 +901,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_qnj0CCX63DAqn4lxMI85usvObCUFRzbL","name":"vm_deploy_qnj0CCX63DAqn4lxMI85usvObCUFRzbL","properties":{"templateHash":"8959998009787007993","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-01-25T01:02:23.6062688Z","duration":"PT0.4658616S","correlationId":"9bd90745-1a17-4ccd-8bd0-6becfab3f9a2","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westcentralus"]},{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/bc91468b-7f38-4fa4-934f-aee0fc919b07","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"bc91468b-7f38-4fa4-934f-aee0fc919b07"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/bc91468b-7f38-4fa4-934f-aee0fc919b07","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"bc91468b-7f38-4fa4-934f-aee0fc919b07"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm1/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_BK1Xbtn5GLvqJHhMQQCHBILbVR9UyfAB","name":"vm_deploy_BK1Xbtn5GLvqJHhMQQCHBILbVR9UyfAB","properties":{"templateHash":"8474434747265286544","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-03-06T21:30:18.1947335Z","duration":"PT0.4880427S","correlationId":"3301ceaa-64b2-4088-aaf8-ad599f973415","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westcentralus"]},{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/38353c75-1d8a-4a1c-a48d-da29e8727ba1","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"38353c75-1d8a-4a1c-a48d-da29e8727ba1"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/38353c75-1d8a-4a1c-a48d-da29e8727ba1","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"38353c75-1d8a-4a1c-a48d-da29e8727ba1"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm1/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_qnj0CCX63DAqn4lxMI85usvObCUFRzbL/operationStatuses/08586847647423372319?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_BK1Xbtn5GLvqJHhMQQCHBILbVR9UyfAB/operationStatuses/08586812350677709439?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['3750']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:23 GMT']
+      date: ['Tue, 06 Mar 2018 21:30:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -1148,21 +929,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847647423372319?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812350677709439?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:02:53 GMT']
+      date: ['Tue, 06 Mar 2018 21:30:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1174,21 +956,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847647423372319?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812350677709439?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:03:24 GMT']
+      date: ['Tue, 06 Mar 2018 21:31:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1200,21 +983,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847647423372319?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812350677709439?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:03:54 GMT']
+      date: ['Tue, 06 Mar 2018 21:31:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1226,21 +1010,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847647423372319?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812350677709439?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:04:24 GMT']
+      date: ['Tue, 06 Mar 2018 21:32:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1252,21 +1037,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847647423372319?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812350677709439?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:04:55 GMT']
+      date: ['Tue, 06 Mar 2018 21:32:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1278,21 +1064,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586847647423372319?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812350677709439?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:05:25 GMT']
+      date: ['Tue, 06 Mar 2018 21:33:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1304,21 +1091,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_qnj0CCX63DAqn4lxMI85usvObCUFRzbL","name":"vm_deploy_qnj0CCX63DAqn4lxMI85usvObCUFRzbL","properties":{"templateHash":"8959998009787007993","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-01-25T01:05:03.1643618Z","duration":"PT2M40.0239546S","correlationId":"9bd90745-1a17-4ccd-8bd0-6becfab3f9a2","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westcentralus"]},{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/bc91468b-7f38-4fa4-934f-aee0fc919b07","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"bc91468b-7f38-4fa4-934f-aee0fc919b07"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/bc91468b-7f38-4fa4-934f-aee0fc919b07","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"bc91468b-7f38-4fa4-934f-aee0fc919b07"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm1/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/bc91468b-7f38-4fa4-934f-aee0fc919b07"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_BK1Xbtn5GLvqJHhMQQCHBILbVR9UyfAB","name":"vm_deploy_BK1Xbtn5GLvqJHhMQQCHBILbVR9UyfAB","properties":{"templateHash":"8474434747265286544","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-03-06T21:33:10.8075908Z","duration":"PT2M53.1009S","correlationId":"3301ceaa-64b2-4088-aaf8-ad599f973415","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westcentralus"]},{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/38353c75-1d8a-4a1c-a48d-da29e8727ba1","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"38353c75-1d8a-4a1c-a48d-da29e8727ba1"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/38353c75-1d8a-4a1c-a48d-da29e8727ba1","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"38353c75-1d8a-4a1c-a48d-da29e8727ba1"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm1/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/38353c75-1d8a-4a1c-a48d-da29e8727ba1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['4766']
+      content-length: ['4763']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:05:26 GMT']
+      date: ['Tue, 06 Mar 2018 21:33:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1330,21 +1118,21 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1358,34 +1146,34 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
         : {\r\n      \"computerName\": \"vm1\",\r\n      \"osName\": \"ubuntu\",\r\
         \n      \"osVersion\": \"16.04\",\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\"\
-        : \"2.2.20\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
+        : \"2.2.22\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
         code\": \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\"\
         ,\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\"\
-        : \"Guest Agent is running\",\r\n            \"time\": \"2018-01-25T01:05:26+00:00\"\
+        : \"Guest Agent is running\",\r\n            \"time\": \"2018-03-06T21:33:19+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
         \      {\r\n            \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux\"\
-        ,\r\n            \"typeHandlerVersion\": \"1.0.0.10\",\r\n            \"status\"\
+        ,\r\n            \"typeHandlerVersion\": \"1.0.0.11\",\r\n            \"status\"\
         : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
         \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
         ,\r\n              \"message\": \"Plugin enabled\"\r\n            }\r\n  \
         \        }\r\n        ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n\
-        \          \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n\
+        \          \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n\
         \          \"statuses\": [\r\n            {\r\n              \"code\": \"\
         ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\n \
         \             \"displayStatus\": \"Provisioning succeeded\",\r\n         \
-        \     \"time\": \"2018-01-25T01:02:47.6948913+00:00\"\r\n            }\r\n\
+        \     \"time\": \"2018-03-06T21:30:51.0723355+00:00\"\r\n            }\r\n\
         \          ]\r\n        }\r\n      ],\r\n      \"extensions\": [\r\n     \
         \   {\r\n          \"name\": \"ManagedIdentityExtensionForLinux\",\r\n   \
         \       \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux\"\
-        ,\r\n          \"typeHandlerVersion\": \"1.0.0.10\",\r\n          \"statuses\"\
+        ,\r\n          \"typeHandlerVersion\": \"1.0.0.11\",\r\n          \"statuses\"\
         : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
         : \"Provisioning succeeded\",\r\n              \"message\": \"Successfully\
-        \ started managed identity extension service. 2018-01-25 01:04:48.841744298\
+        \ started managed identity extension service. 2018-03-06 21:33:06.543607662\
         \ +0000 UTC.\"\r\n            }\r\n          ]\r\n        }\r\n      ],\r\n\
         \      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2018-01-25T01:04:55.4605426+00:00\"\
+        \ succeeded\",\r\n          \"time\": \"2018-03-06T21:33:09.5916036+00:00\"\
         \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\
@@ -1398,7 +1186,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -1407,14 +1195,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['5423']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:05:27 GMT']
+      date: ['Tue, 06 Mar 2018 21:33:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4793,Microsoft.Compute/LowCostGet30Min;38386']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4792,Microsoft.Compute/LowCostGet30Min;38336']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1425,18 +1214,18 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2017-11-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"b7f6ca74-d7c0-49a9-a357-9b2ebf00c377\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"a7cf7e3f-1e9b-4213-a34b-a2d0815c667b\\\"\",\r\n \
         \ \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"d7ffe2e1-95af-44d2-b74e-b2c23f478149\",\r\n    \"ipConfigurations\": [\r\
+        \ \"5fa519bd-7d2b-472e-a6bb-abcb10e473ca\",\r\n    \"ipConfigurations\": [\r\
         \n      {\r\n        \"name\": \"ipconfigvm1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"b7f6ca74-d7c0-49a9-a357-9b2ebf00c377\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"a7cf7e3f-1e9b-4213-a34b-a2d0815c667b\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -1445,8 +1234,8 @@ interactions:
         \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
         : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
         \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"3odr1s2u3uauzixose402535ce.yx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-F8-E1-70\",\r\n    \"enableAcceleratedNetworking\"\
+        internalDomainNameSuffix\": \"drhn5fjowmdujgb4nn5dp4orfa.yx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-F8-52-CD\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -1457,14 +1246,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2233']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:05:27 GMT']
-      etag: [W/"b7f6ca74-d7c0-49a9-a357-9b2ebf00c377"]
+      date: ['Tue, 06 Mar 2018 21:33:21 GMT']
+      etag: [W/"a7cf7e3f-1e9b-4213-a34b-a2d0815c667b"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1475,16 +1265,16 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
-          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.26]
+          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP?api-version=2017-11-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"996e5bd3-c652-4dd0-af9b-cb4192774785\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"8325ba0f-ca09-46f2-a413-f548ce578fb8\\\"\",\r\n \
         \ \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"13ae8272-71d4-4f87-9506-da601b261438\",\r\n    \"ipAddress\": \"13.78.166.49\"\
+        \ \"71365c6d-92eb-46b1-b914-a01177fd6253\",\r\n    \"ipAddress\": \"52.161.158.140\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\
         \n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
@@ -1492,42 +1282,43 @@ interactions:
         \n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['893']
+      content-length: ['895']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:05:28 GMT']
-      etag: [W/"996e5bd3-c652-4dd0-af9b-cb4192774785"]
+      date: ['Tue, 06 Mar 2018 21:33:22 GMT']
+      etag: [W/"8325ba0f-ca09-46f2-a413-f548ce578fb8"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm show]
+      CommandName: [vm managed-identity show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1548,7 +1339,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -1557,40 +1348,41 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3214']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:05:39 GMT']
+      date: ['Tue, 06 Mar 2018 21:33:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4792,Microsoft.Compute/LowCostGet30Min;38385']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4791,Microsoft.Compute/LowCostGet30Min;38335']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm assign-identity]
+      CommandName: [vm managed-identity assign]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1611,7 +1403,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -1620,54 +1412,54 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3214']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:05:51 GMT']
+      date: ['Tue, 06 Mar 2018 21:33:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4788,Microsoft.Compute/LowCostGet30Min;38381']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4790,Microsoft.Compute/LowCostGet30Min;38334']
     status: {code: 200, message: OK}
 - request:
     body: 'b''{"identity": {"identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2",
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
-      "type": "SystemAssigned, UserAssigned"}, "location": "westcentralus", "properties":
-      {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "osProfile": {"secrets":
-      [], "computerName": "vm1", "adminUsername": "ubuntuadmin", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}}}, "storageProfile": {"dataDisks": [], "imageReference":
-      {"sku": "16.04-LTS", "offer": "UbuntuServer", "publisher": "Canonical", "version":
-      "latest"}, "osDisk": {"diskSizeGB": 30, "name": "vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244",
-      "createOption": "FromImage", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244",
-      "storageAccountType": "Premium_LRS"}, "osType": "Linux", "caching": "ReadWrite"}},
-      "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]}},
-      "tags": {}}'''
+      "type": "SystemAssigned, UserAssigned"}, "tags": {}, "properties": {"osProfile":
+      {"secrets": [], "computerName": "vm1", "adminUsername": "ubuntuadmin", "linuxConfiguration":
+      {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n", "path": "/home/ubuntuadmin/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
+      true}}, "storageProfile": {"imageReference": {"publisher": "Canonical", "offer":
+      "UbuntuServer", "version": "latest", "sku": "16.04-LTS"}, "osDisk": {"managedDisk":
+      {"storageAccountType": "Premium_LRS", "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b"},
+      "caching": "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "osType":
+      "Linux", "name": "vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b"}, "dataDisks":
+      []}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}, "location": "westcentralus"}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm assign-identity]
+      CommandName: [vm managed-identity assign]
       Connection: [keep-alive]
       Content-Length: ['1861']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1688,79 +1480,81 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/fc6606ff-3031-42d1-a6c9-9ca9a48eefb9?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/08722136-63ec-438f-b0b7-6970cb6059e2?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['3374']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:05:52 GMT']
+      date: ['Tue, 06 Mar 2018 21:33:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;239,Microsoft.Compute/PutVM30Min;1197']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;239,Microsoft.Compute/PutVM30Min;1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm assign-identity]
+      CommandName: [vm managed-identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/fc6606ff-3031-42d1-a6c9-9ca9a48eefb9?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/08722136-63ec-438f-b0b7-6970cb6059e2?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-01-25T01:05:54.9917747+00:00\",\r\
-        \n  \"endTime\": \"2018-01-25T01:06:06.2573932+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"fc6606ff-3031-42d1-a6c9-9ca9a48eefb9\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T21:33:46.9824815+00:00\",\r\
+        \n  \"endTime\": \"2018-03-06T21:33:53.6075222+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"08722136-63ec-438f-b0b7-6970cb6059e2\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:06:23 GMT']
+      date: ['Tue, 06 Mar 2018 21:34:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11987,Microsoft.Compute/GetOperation30Min;23940']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11986,Microsoft.Compute/GetOperation30Min;23884']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm assign-identity]
+      CommandName: [vm managed-identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1781,7 +1575,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
@@ -1791,40 +1585,41 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3375']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:06:33 GMT']
+      date: ['Tue, 06 Mar 2018 21:34:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4785,Microsoft.Compute/LowCostGet30Min;38378']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4785,Microsoft.Compute/LowCostGet30Min;38329']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm assign-identity]
+      CommandName: [vm managed-identity assign]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1838,34 +1633,34 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
         : {\r\n      \"computerName\": \"vm1\",\r\n      \"osName\": \"ubuntu\",\r\
         \n      \"osVersion\": \"16.04\",\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\"\
-        : \"2.2.20\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
+        : \"2.2.22\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
         code\": \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\"\
         ,\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\"\
-        : \"Guest Agent is running\",\r\n            \"time\": \"2018-01-25T01:06:05+00:00\"\
+        : \"Guest Agent is running\",\r\n            \"time\": \"2018-03-06T21:34:15+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
         \      {\r\n            \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux\"\
-        ,\r\n            \"typeHandlerVersion\": \"1.0.0.10\",\r\n            \"status\"\
+        ,\r\n            \"typeHandlerVersion\": \"1.0.0.11\",\r\n            \"status\"\
         : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
         \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
         ,\r\n              \"message\": \"Plugin enabled\"\r\n            }\r\n  \
         \        }\r\n        ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n\
-        \          \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n\
+        \          \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n\
         \          \"statuses\": [\r\n            {\r\n              \"code\": \"\
         ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\n \
         \             \"displayStatus\": \"Provisioning succeeded\",\r\n         \
-        \     \"time\": \"2018-01-25T01:05:56.4292984+00:00\"\r\n            }\r\n\
+        \     \"time\": \"2018-03-06T21:33:48.1856191+00:00\"\r\n            }\r\n\
         \          ]\r\n        }\r\n      ],\r\n      \"extensions\": [\r\n     \
         \   {\r\n          \"name\": \"ManagedIdentityExtensionForLinux\",\r\n   \
         \       \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux\"\
-        ,\r\n          \"typeHandlerVersion\": \"1.0.0.10\",\r\n          \"statuses\"\
+        ,\r\n          \"typeHandlerVersion\": \"1.0.0.11\",\r\n          \"statuses\"\
         : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
         : \"Provisioning succeeded\",\r\n              \"message\": \"Successfully\
-        \ started managed identity extension service. 2018-01-25 01:06:00.972926798\
+        \ started managed identity extension service. 2018-03-06 21:33:53.411032781\
         \ +0000 UTC.\"\r\n            }\r\n          ]\r\n        }\r\n      ],\r\n\
         \      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2018-01-25T01:06:06.2417459+00:00\"\
+        \ succeeded\",\r\n          \"time\": \"2018-03-06T21:33:53.6075222+00:00\"\
         \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\
@@ -1878,7 +1673,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
@@ -1888,29 +1683,30 @@ interactions:
       cache-control: [no-cache]
       content-length: ['5584']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:06:44 GMT']
+      date: ['Tue, 06 Mar 2018 21:34:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4784,Microsoft.Compute/LowCostGet30Min;38377']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4784,Microsoft.Compute/LowCostGet30Min;38328']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westcentralus", "properties": {"settings": {"port": 50342},
-      "publisher": "Microsoft.ManagedIdentity", "typeHandlerVersion": "1.0", "autoUpgradeMinorVersion":
-      true, "type": "ManagedIdentityExtensionForLinux"}}'
+    body: '{"properties": {"publisher": "Microsoft.ManagedIdentity", "settings": {"port":
+      50342}, "autoUpgradeMinorVersion": true, "type": "ManagedIdentityExtensionForLinux",
+      "typeHandlerVersion": "1.0"}, "location": "westcentralus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm assign-identity]
+      CommandName: [vm managed-identity assign]
       Connection: [keep-alive]
       Content-Length: ['222']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux?api-version=2017-12-01
@@ -1923,18 +1719,19 @@ interactions:
         : \"westcentralus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux\"\
         ,\r\n  \"name\": \"ManagedIdentityExtensionForLinux\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/d0962859-92bb-4e69-8b05-358e6e0ad81d?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/0bb63764-c8bd-4edf-bb83-e3693fc4890e?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['596']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:06:45 GMT']
+      date: ['Tue, 06 Mar 2018 21:34:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/UpdateVM3Min;238,Microsoft.Compute/UpdateVM30Min;1197']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/UpdateVM3Min;238,Microsoft.Compute/UpdateVM30Min;1193']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -1942,40 +1739,41 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm assign-identity]
+      CommandName: [vm managed-identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/d0962859-92bb-4e69-8b05-358e6e0ad81d?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/0bb63764-c8bd-4edf-bb83-e3693fc4890e?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-01-25T01:06:47.8981303+00:00\",\r\
-        \n  \"endTime\": \"2018-01-25T01:06:47.9918505+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"d0962859-92bb-4e69-8b05-358e6e0ad81d\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T21:34:30.2952593+00:00\",\r\
+        \n  \"endTime\": \"2018-03-06T21:34:30.3733698+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"0bb63764-c8bd-4edf-bb83-e3693fc4890e\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:07:16 GMT']
+      date: ['Tue, 06 Mar 2018 21:35:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11994,Microsoft.Compute/GetOperation30Min;23939']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11992,Microsoft.Compute/GetOperation30Min;23912']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm assign-identity]
+      CommandName: [vm managed-identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux?api-version=2017-12-01
   response:
@@ -1990,40 +1788,41 @@ interactions:
       cache-control: [no-cache]
       content-length: ['597']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:07:16 GMT']
+      date: ['Tue, 06 Mar 2018 21:34:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4786,Microsoft.Compute/LowCostGet30Min;38376']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4784,Microsoft.Compute/LowCostGet30Min;38343']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm show]
+      CommandName: [vm managed-identity show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2044,7 +1843,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
@@ -2054,14 +1853,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3375']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:07:17 GMT']
+      date: ['Tue, 06 Mar 2018 21:35:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4785,Microsoft.Compute/LowCostGet30Min;38375']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4783,Microsoft.Compute/LowCostGet30Min;38342']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2073,21 +1873,21 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2108,7 +1908,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
@@ -2118,29 +1918,29 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3375']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:07:29 GMT']
+      date: ['Tue, 06 Mar 2018 21:35:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4784,Microsoft.Compute/LowCostGet30Min;38374']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4782,Microsoft.Compute/LowCostGet30Min;38341']
     status: {code: 200, message: OK}
 - request:
     body: 'b''{"identity": {"identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2"],
-      "type": "SystemAssigned, UserAssigned"}, "location": "westcentralus", "properties":
-      {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "osProfile": {"secrets":
-      [], "computerName": "vm1", "adminUsername": "ubuntuadmin", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}}}, "storageProfile": {"dataDisks": [], "imageReference":
-      {"sku": "16.04-LTS", "offer": "UbuntuServer", "publisher": "Canonical", "version":
-      "latest"}, "osDisk": {"diskSizeGB": 30, "name": "vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244",
-      "createOption": "FromImage", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244",
-      "storageAccountType": "Premium_LRS"}, "osType": "Linux", "caching": "ReadWrite"}},
-      "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]}},
-      "tags": {}}'''
+      "type": "SystemAssigned, UserAssigned"}, "tags": {}, "properties": {"osProfile":
+      {"secrets": [], "computerName": "vm1", "adminUsername": "ubuntuadmin", "linuxConfiguration":
+      {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n", "path": "/home/ubuntuadmin/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
+      true}}, "storageProfile": {"imageReference": {"publisher": "Canonical", "offer":
+      "UbuntuServer", "version": "latest", "sku": "16.04-LTS"}, "osDisk": {"managedDisk":
+      {"storageAccountType": "Premium_LRS", "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b"},
+      "caching": "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "osType":
+      "Linux", "name": "vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b"}, "dataDisks":
+      []}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}, "location": "westcentralus"}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -2150,21 +1950,21 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2185,24 +1985,25 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/a4e35871-3538-44ec-ba48-17f2884afb33?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/1ac49d16-8b64-4f1b-8069-9303cf3cb0b7?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['3213']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:07:31 GMT']
+      date: ['Tue, 06 Mar 2018 21:35:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;238,Microsoft.Compute/PutVM30Min;1196']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;238,Microsoft.Compute/PutVM30Min;1194']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -2214,25 +2015,26 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/a4e35871-3538-44ec-ba48-17f2884afb33?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/1ac49d16-8b64-4f1b-8069-9303cf3cb0b7?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-01-25T01:07:33.1951033+00:00\",\r\
-        \n  \"endTime\": \"2018-01-25T01:07:42.7107224+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"a4e35871-3538-44ec-ba48-17f2884afb33\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T21:35:14.5297732+00:00\",\r\
+        \n  \"endTime\": \"2018-03-06T21:35:19.4203907+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"1ac49d16-8b64-4f1b-8069-9303cf3cb0b7\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:08:01 GMT']
+      date: ['Tue, 06 Mar 2018 21:35:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11995,Microsoft.Compute/GetOperation30Min;23937']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11992,Microsoft.Compute/GetOperation30Min;23910']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2243,20 +2045,20 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2277,7 +2079,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -2286,14 +2088,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3214']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:08:11 GMT']
+      date: ['Tue, 06 Mar 2018 21:35:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4783,Microsoft.Compute/LowCostGet30Min;38369']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4782,Microsoft.Compute/LowCostGet30Min;38337']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2305,21 +2108,21 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2340,7 +2143,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -2349,14 +2152,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3214']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:08:22 GMT']
+      date: ['Tue, 06 Mar 2018 21:35:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4782,Microsoft.Compute/LowCostGet30Min;38368']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4781,Microsoft.Compute/LowCostGet30Min;38336']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2368,21 +2172,21 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2403,7 +2207,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned, UserAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -2412,28 +2216,28 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3214']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:08:35 GMT']
+      date: ['Tue, 06 Mar 2018 21:36:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4781,Microsoft.Compute/LowCostGet30Min;38367']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4780,Microsoft.Compute/LowCostGet30Min;38335']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"identity": {"type": "SystemAssigned"}, "location": "westcentralus",
-      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "osProfile":
+    body: 'b''{"identity": {"type": "SystemAssigned"}, "tags": {}, "properties": {"osProfile":
       {"secrets": [], "computerName": "vm1", "adminUsername": "ubuntuadmin", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}}}, "storageProfile": {"dataDisks": [], "imageReference":
-      {"sku": "16.04-LTS", "offer": "UbuntuServer", "publisher": "Canonical", "version":
-      "latest"}, "osDisk": {"diskSizeGB": 30, "name": "vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244",
-      "createOption": "FromImage", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244",
-      "storageAccountType": "Premium_LRS"}, "osType": "Linux", "caching": "ReadWrite"}},
-      "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]}},
-      "tags": {}}'''
+      {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n", "path": "/home/ubuntuadmin/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
+      true}}, "storageProfile": {"imageReference": {"publisher": "Canonical", "offer":
+      "UbuntuServer", "version": "latest", "sku": "16.04-LTS"}, "osDisk": {"managedDisk":
+      {"storageAccountType": "Premium_LRS", "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b"},
+      "caching": "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "osType":
+      "Linux", "name": "vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b"}, "dataDisks":
+      []}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}, "location": "westcentralus"}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -2443,21 +2247,21 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2478,23 +2282,24 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/7a958292-ec26-4e6f-a31a-377b020b56be?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/f3b2841f-ee18-4e87-b753-116bf86fa56a?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['3009']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:08:37 GMT']
+      date: ['Tue, 06 Mar 2018 21:36:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;238,Microsoft.Compute/PutVM30Min;1195']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;237,Microsoft.Compute/PutVM30Min;1193']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -2506,25 +2311,26 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/7a958292-ec26-4e6f-a31a-377b020b56be?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/f3b2841f-ee18-4e87-b753-116bf86fa56a?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-01-25T01:08:39.08573+00:00\",\r\n\
-        \  \"endTime\": \"2018-01-25T01:08:48.6013632+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"7a958292-ec26-4e6f-a31a-377b020b56be\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T21:36:10.5309373+00:00\",\r\
+        \n  \"endTime\": \"2018-03-06T21:36:21.3747051+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"f3b2841f-ee18-4e87-b753-116bf86fa56a\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['182']
+      content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:09:07 GMT']
+      date: ['Tue, 06 Mar 2018 21:36:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11995,Microsoft.Compute/GetOperation30Min;23935']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11993,Microsoft.Compute/GetOperation30Min;23908']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2535,20 +2341,20 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2569,7 +2375,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
@@ -2577,40 +2383,41 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3010']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:09:16 GMT']
+      date: ['Tue, 06 Mar 2018 21:36:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4785,Microsoft.Compute/LowCostGet30Min;38363']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4781,Microsoft.Compute/LowCostGet30Min;38331']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm show]
+      CommandName: [vm managed-identity show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8c14fa41-b1c0-4136-bcec-500904a2e822\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3e2c87a4-b898-497f-bc08-1f595eb666a5\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_07c616c9e2024cc7a3fe9ab195ec2244\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_c0f07af976d8485d8b05572447b7273b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2631,7 +2438,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\":\
-        \ \"SystemAssigned\",\r\n    \"principalId\": \"15d5da8a-4d3e-4ac4-8836-34ee4185c1a8\"\
+        \ \"SystemAssigned\",\r\n    \"principalId\": \"40506b2c-924c-4f3d-9cf8-2a5b8b02c996\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
@@ -2639,14 +2446,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3010']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 25 Jan 2018 01:09:28 GMT']
+      date: ['Tue, 06 Mar 2018 21:36:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4783,Microsoft.Compute/LowCostGet30Min;38361']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4780,Microsoft.Compute/LowCostGet30Min;38330']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2659,7 +2467,7 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
           msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.26]
+          AZURECLI/2.0.29]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -2668,11 +2476,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 25 Jan 2018 01:09:29 GMT']
+      date: ['Tue, 06 Mar 2018 21:36:53 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdaR1lUVFRQTVA0LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdFUUNXM1AyWlg3LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_explicit_msi.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_explicit_msi.yaml
@@ -8,8 +8,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['57']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
@@ -20,7 +20,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['225']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:23 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -35,8 +35,8 @@ interactions:
       CommandName: [identity create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -47,7 +47,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['225']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:24 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -63,18 +63,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['29']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 azure-mgmt-msi/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.29]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-msi/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1?api-version=2015-08-31-preview
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1","name":"id1","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"440ba7b5-1cdc-40dc-ad13-9223eee6bb05","clientId":"a192e35a-ad78-4331-ae27-0329dbdb95e6","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=440ba7b5-1cdc-40dc-ad13-9223eee6bb05&aid=a192e35a-ad78-4331-ae27-0329dbdb95e6"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1","name":"id1","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"aa2500a9-64b3-4871-8439-da48360d5cb1","clientId":"706a1fd2-90df-4482-9310-eec7e1915762","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=aa2500a9-64b3-4871-8439-da48360d5cb1&aid=706a1fd2-90df-4482-9310-eec7e1915762"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['789']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:28 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:38 GMT']
       expires: ['-1']
       location: [/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1]
       pragma: [no-cache]
@@ -91,8 +91,8 @@ interactions:
       CommandName: [identity create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -103,7 +103,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['225']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:28 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -119,18 +119,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['29']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 azure-mgmt-msi/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.29]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 azure-mgmt-msi/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2?api-version=2015-08-31-preview
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2","name":"id2","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"2a221818-7a95-4312-9656-bca566fcc943","clientId":"a08a6c07-5983-459f-aefd-78d7009bec3a","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=2a221818-7a95-4312-9656-bca566fcc943&aid=a08a6c07-5983-459f-aefd-78d7009bec3a"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2","name":"id2","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"b47150e7-2516-45c6-a325-5b4470c7a394","clientId":"5912cd65-e2a5-49b1-bfe5-37a200791ff3","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=b47150e7-2516-45c6-a325-5b4470c7a394&aid=5912cd65-e2a5-49b1-bfe5-37a200791ff3"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['789']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:31 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:40 GMT']
       expires: ['-1']
       location: [/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2]
       pragma: [no-cache]
@@ -147,8 +147,8 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -159,7 +159,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['225']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:31 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -219,9 +219,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:32 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:41 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Thu, 01 Mar 2018 00:35:32 GMT']
+      expires: ['Tue, 06 Mar 2018 22:10:41 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -229,12 +229,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [023fec8ad25f39a9a3303f77b3148c87a0ebb401]
+      x-fastly-request-id: [fbd2c169fe1596b6bd2575fa11747984aac74ff1]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['84F2:6113:15CF92C:16A62E0:5A9749A7']
-      x-served-by: [cache-sea1042-SEA]
-      x-timer: ['S1519864232.992997,VS0,VE91']
+      x-github-request-id: ['0E64:610E:12BE7C6:13BACEF:5A9F10B5']
+      x-served-by: [cache-sea1050-SEA]
+      x-timer: ['S1520373942.511320,VS0,VE104']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -245,8 +245,8 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.29]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 networkmanagementclient/1.7.0 Azure-SDK-For-Python AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-11-01
@@ -256,7 +256,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:32 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -271,12 +271,12 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27reader%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27reader%27&api-version=2015-07-01
   response:
     body: {string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
         you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2018-01-30T18:08:25.4031403Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'}
@@ -284,7 +284,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['578']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:32 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -297,72 +297,73 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"parameters": {}, "mode": "Incremental", "template":
-      {"parameters": {}, "outputs": {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
-      \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
-      "type": "object"}}, "variables": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "resources": [{"location": "westcentralus", "tags": {}, "dependsOn": [], "name":
-      "vmss1VNET", "properties": {"subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"},
-      "name": "vmss1Subnet"}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}},
-      "apiVersion": "2015-06-15", "type": "Microsoft.Network/virtualNetworks"}, {"sku":
-      {"name": "Basic"}, "location": "westcentralus", "dependsOn": [], "tags": {},
-      "name": "vmss1LBPublicIP", "properties": {"publicIPAllocationMethod": "Dynamic"},
-      "apiVersion": "2017-11-01", "type": "Microsoft.Network/publicIPAddresses"},
-      {"sku": {"name": "Basic"}, "location": "westcentralus", "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
-      "Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"], "tags": {}, "name":
-      "vmss1LB", "properties": {"backendAddressPools": [{"name": "vmss1LBBEPool"}],
-      "inboundNatPools": [{"properties": {"frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
-      \''vmss1LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"},
-      "backendPort": 22, "protocol": "tcp", "frontendPortRangeEnd": "50119", "frontendPortRangeStart":
-      "50000"}, "name": "vmss1LBNatPool"}], "frontendIPConfigurations": [{"properties":
-      {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}},
-      "name": "loadBalancerFrontEnd"}]}, "apiVersion": "2017-11-01", "type": "Microsoft.Network/loadBalancers"},
-      {"properties": {"principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default\'',
+    body: 'b''{"properties": {"mode": "Incremental", "template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "variables": {}, "outputs": {"VMSS": {"type": "object", "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]"}},
+      "parameters": {}, "resources": [{"dependsOn": [], "properties": {"addressSpace":
+      {"addressPrefixes": ["10.0.0.0/16"]}, "subnets": [{"name": "vmss1Subnet", "properties":
+      {"addressPrefix": "10.0.0.0/24"}}]}, "apiVersion": "2015-06-15", "name": "vmss1VNET",
+      "type": "Microsoft.Network/virtualNetworks", "tags": {}, "location": "westcentralus"},
+      {"dependsOn": [], "sku": {"name": "Basic"}, "apiVersion": "2017-11-01", "properties":
+      {"publicIPAllocationMethod": "Dynamic"}, "tags": {}, "name": "vmss1LBPublicIP",
+      "type": "Microsoft.Network/publicIPAddresses", "location": "westcentralus"},
+      {"dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"],
+      "sku": {"name": "Basic"}, "properties": {"frontendIPConfigurations": [{"name":
+      "loadBalancerFrontEnd", "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}}}],
+      "backendAddressPools": [{"name": "vmss1LBBEPool"}], "inboundNatPools": [{"name":
+      "vmss1LBNatPool", "properties": {"frontendPortRangeStart": "50000", "frontendIPConfiguration":
+      {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'', \''vmss1LB\''),
+      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}, "protocol":
+      "tcp", "frontendPortRangeEnd": "50119", "backendPort": 22}}]}, "apiVersion":
+      "2017-11-01", "name": "vmss1LB", "type": "Microsoft.Network/loadBalancers",
+      "tags": {}, "location": "westcentralus"}, {"dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss1"],
+      "name": "6e8e16d4-ad84-4ba1-b0fa-00ba688d5670", "type": "Microsoft.Authorization/roleAssignments",
+      "properties": {"principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default\'',
       \''2015-08-31-PREVIEW\'').principalId]", "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001",
       "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"},
-      "type": "Microsoft.Authorization/roleAssignments", "apiVersion": "2015-07-01",
-      "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss1"], "name": "5dc679b3-2c9c-47d0-8088-a4d5f60708ed"},
-      {"apiVersion": "2017-12-01", "location": "westcentralus", "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
-      "Microsoft.Network/loadBalancers/vmss1LB"], "tags": {}, "type": "Microsoft.Compute/virtualMachineScaleSets",
-      "name": "vmss1", "properties": {"singlePlacementGroup": true, "upgradePolicy":
-      {"mode": "manual"}, "overprovision": true, "virtualMachineProfile": {"networkProfile":
-      {"networkInterfaceConfigurations": [{"properties": {"primary": "true", "ipConfigurations":
-      [{"properties": {"loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+      "apiVersion": "2015-07-01"}, {"dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
+      "Microsoft.Network/loadBalancers/vmss1LB"], "sku": {"capacity": 1, "name": "Standard_D1_v2"},
+      "apiVersion": "2017-12-01", "properties": {"upgradePolicy": {"mode": "manual"},
+      "virtualMachineProfile": {"extensionProfile": {"extensions": [{"name": "ManagedIdentityExtensionForLinux",
+      "properties": {"publisher": "Microsoft.ManagedIdentity", "autoUpgradeMinorVersion":
+      true, "typeHandlerVersion": "1.0", "type": "ManagedIdentityExtensionForLinux",
+      "settings": {"port": 50342}}}]}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss1726fNic", "properties": {"ipConfigurations": [{"name": "vmss1726fIPConfig",
+      "properties": {"loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}},
-      "name": "vmss10290IPConfig"}]}, "name": "vmss10290Nic"}]}, "extensionProfile":
-      {"extensions": [{"properties": {"typeHandlerVersion": "1.0", "publisher": "Microsoft.ManagedIdentity",
-      "autoUpgradeMinorVersion": true, "settings": {"port": 50342}, "type": "ManagedIdentityExtensionForLinux"},
-      "name": "ManagedIdentityExtensionForLinux"}]}, "osProfile": {"adminUsername":
-      "ubuntuadmin", "computerNamePrefix": "vmss10290", "linuxConfiguration": {"disablePasswordAuthentication":
-      true, "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==
-      yugangw2@YUGANGLP2\\n", "path": "/home/ubuntuadmin/.ssh/authorized_keys"}]}}},
-      "storageProfile": {"osDisk": {"caching": "ReadWrite", "managedDisk": {"storageAccountType":
-      null}, "createOption": "FromImage"}, "imageReference": {"version": "latest",
-      "offer": "UbuntuServer", "publisher": "Canonical", "sku": "16.04-LTS"}}}}, "sku":
-      {"capacity": 1, "name": "Standard_D1_v2"}, "identity": {"identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
-      "type": "SystemAssigned,UserAssigned"}}], "contentVersion": "1.0.0.0"}}}'''
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}}}],
+      "primary": "true"}}]}, "osProfile": {"computerNamePrefix": "vmss1726f", "linuxConfiguration":
+      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n"}]}}, "adminUsername": "ubuntuadmin"}, "storageProfile":
+      {"imageReference": {"publisher": "Canonical", "sku": "16.04-LTS", "offer": "UbuntuServer",
+      "version": "latest"}, "osDisk": {"caching": "ReadWrite", "createOption": "FromImage",
+      "managedDisk": {"storageAccountType": null}}}}, "singlePlacementGroup": true,
+      "overprovision": true}, "location": "westcentralus", "name": "vmss1", "type":
+      "Microsoft.Compute/virtualMachineScaleSets", "tags": {}, "identity": {"type":
+      "SystemAssigned,UserAssigned", "identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]}}],
+      "contentVersion": "1.0.0.0"}, "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss create]
       Connection: [keep-alive]
-      Content-Length: ['5288']
+      Content-Length: ['5286']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_1kEOcdhbRvMVLOoY3skaFhQwRyikY1sn","name":"vmss_deploy_1kEOcdhbRvMVLOoY3skaFhQwRyikY1sn","properties":{"templateHash":"3281289539408506465","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-03-01T00:30:35.3246929Z","duration":"PT0.9106086S","correlationId":"f3f94618-7cb0-4034-a4a3-c3b851edce25","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"loadBalancers","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/5dc679b3-2c9c-47d0-8088-a4d5f60708ed","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"5dc679b3-2c9c-47d0-8088-a4d5f60708ed"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_4BFXcgYzDmYeU4NZsndlWGqrZvqSRnrs","name":"vmss_deploy_4BFXcgYzDmYeU4NZsndlWGqrZvqSRnrs","properties":{"templateHash":"2258258667834943491","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-03-06T22:05:44.2750244Z","duration":"PT0.590736S","correlationId":"0b368815-17a1-4d6b-bada-fe520c24c273","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"loadBalancers","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/6e8e16d4-ad84-4ba1-b0fa-00ba688d5670","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"6e8e16d4-ad84-4ba1-b0fa-00ba688d5670"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_1kEOcdhbRvMVLOoY3skaFhQwRyikY1sn/operationStatuses/08586817426510736721?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_4BFXcgYzDmYeU4NZsndlWGqrZvqSRnrs/operationStatuses/08586812329417933414?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['3333']
+      content-length: ['3332']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:30:35 GMT']
+      date: ['Tue, 06 Mar 2018 22:05:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -377,19 +378,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586817426510736721?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:31:06 GMT']
+      date: ['Tue, 06 Mar 2018 22:06:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -404,19 +405,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586817426510736721?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:31:36 GMT']
+      date: ['Tue, 06 Mar 2018 22:06:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -431,19 +432,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586817426510736721?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:32:06 GMT']
+      date: ['Tue, 06 Mar 2018 22:07:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -458,19 +459,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586817426510736721?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:32:37 GMT']
+      date: ['Tue, 06 Mar 2018 22:07:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -485,19 +486,208 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586817426510736721?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:08:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:08:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:09:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:09:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:10:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:10:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:11:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586812329417933414?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:07 GMT']
+      date: ['Tue, 06 Mar 2018 22:11:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -512,21 +702,21 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_1kEOcdhbRvMVLOoY3skaFhQwRyikY1sn","name":"vmss_deploy_1kEOcdhbRvMVLOoY3skaFhQwRyikY1sn","properties":{"templateHash":"3281289539408506465","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-03-01T00:32:53.5460314Z","duration":"PT2M19.1319471S","correlationId":"f3f94618-7cb0-4034-a4a3-c3b851edce25","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"loadBalancers","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/5dc679b3-2c9c-47d0-8088-a4d5f60708ed","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"5dc679b3-2c9c-47d0-8088-a4d5f60708ed"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss10290","adminUsername":"ubuntuadmin","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/ubuntuadmin/.ssh/authorized_keys","keyData":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==
-        yugangw2@YUGANGLP2\n"}]}},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"16.04-LTS","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss10290Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss10290IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]},"extensionProfile":{"extensions":[{"properties":{"publisher":"Microsoft.ManagedIdentity","type":"ManagedIdentityExtensionForLinux","typeHandlerVersion":"1.0","autoUpgradeMinorVersion":true,"settings":{"port":50342}},"name":"ManagedIdentityExtensionForLinux"}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"f59608f4-82b4-4319-af59-80d6bebf1382"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/5dc679b3-2c9c-47d0-8088-a4d5f60708ed"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_4BFXcgYzDmYeU4NZsndlWGqrZvqSRnrs","name":"vmss_deploy_4BFXcgYzDmYeU4NZsndlWGqrZvqSRnrs","properties":{"templateHash":"2258258667834943491","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-03-06T22:11:20.4965215Z","duration":"PT5M36.8122331S","correlationId":"0b368815-17a1-4d6b-bada-fe520c24c273","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"loadBalancers","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/6e8e16d4-ad84-4ba1-b0fa-00ba688d5670","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"6e8e16d4-ad84-4ba1-b0fa-00ba688d5670"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss1726f","adminUsername":"ubuntuadmin","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/ubuntuadmin/.ssh/authorized_keys","keyData":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+        yugangw@YUGANGW1\n"}]}},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"16.04-LTS","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss1726fNic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss1726fIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]},"extensionProfile":{"extensions":[{"properties":{"publisher":"Microsoft.ManagedIdentity","type":"ManagedIdentityExtensionForLinux","typeHandlerVersion":"1.0","autoUpgradeMinorVersion":true,"settings":{"port":50342}},"name":"ManagedIdentityExtensionForLinux"}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"dfa17cb9-1840-49d0-8086-2a16403a3592"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/6e8e16d4-ad84-4ba1-b0fa-00ba688d5670"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['6458']
+      content-length: ['6456']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:07 GMT']
+      date: ['Tue, 06 Mar 2018 22:11:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -541,8 +731,8 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -553,13 +743,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -567,9 +757,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -581,19 +771,19 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3690']
+      content-length: ['3688']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:08 GMT']
+      date: ['Tue, 06 Mar 2018 22:11:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -601,18 +791,18 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;192,Microsoft.Compute/GetVMScaleSet30Min;992']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;192,Microsoft.Compute/GetVMScaleSet30Min;989']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss show]
+      CommandName: [vmss managed-identity show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -623,13 +813,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -637,9 +827,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -651,19 +841,19 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3690']
+      content-length: ['3688']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:08 GMT']
+      date: ['Tue, 06 Mar 2018 22:11:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -671,18 +861,18 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;191,Microsoft.Compute/GetVMScaleSet30Min;991']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;191,Microsoft.Compute/GetVMScaleSet30Min;988']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss assign-identity]
+      CommandName: [vmss managed-identity assign]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -693,13 +883,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -707,9 +897,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -721,19 +911,19 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3690']
+      content-length: ['3688']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:09 GMT']
+      date: ['Tue, 06 Mar 2018 22:11:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -741,42 +931,41 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;190,Microsoft.Compute/GetVMScaleSet30Min;990']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;190,Microsoft.Compute/GetVMScaleSet30Min;987']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"singlePlacementGroup": true, "upgradePolicy": {"mode":
-      "Manual", "automaticOSUpgrade": false}, "overprovision": true, "virtualMachineProfile":
-      {"networkProfile": {"networkInterfaceConfigurations": [{"properties": {"enableAcceleratedNetworking":
-      false, "dnsSettings": {"dnsServers": []}, "enableIPForwarding": false, "primary":
-      true, "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+    body: 'b''{"location": "westcentralus", "sku": {"tier": "Standard", "name": "Standard_D1_v2",
+      "capacity": 1}, "properties": {"upgradePolicy": {"mode": "Manual", "automaticOSUpgrade":
+      false}, "virtualMachineProfile": {"extensionProfile": {"extensions": [{"name":
+      "ManagedIdentityExtensionForLinux", "properties": {"publisher": "Microsoft.ManagedIdentity",
+      "autoUpgradeMinorVersion": true, "typeHandlerVersion": "1.0", "type": "ManagedIdentityExtensionForLinux",
+      "settings": {"port": 50342}}}]}, "osProfile": {"adminUsername": "ubuntuadmin",
+      "computerNamePrefix": "vmss1726f", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n"}]}}}, "storageProfile": {"imageReference": {"publisher":
+      "Canonical", "sku": "16.04-LTS", "offer": "UbuntuServer", "version": "latest"},
+      "osDisk": {"caching": "ReadWrite", "createOption": "FromImage", "managedDisk":
+      {"storageAccountType": "Standard_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss1726fNic", "properties": {"dnsSettings": {"dnsServers": []},
+      "primary": true, "enableAcceleratedNetworking": false, "ipConfigurations": [{"name":
+      "vmss1726fIPConfig", "properties": {"loadBalancerBackendAddressPools": [{"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAddressVersion": "IPv4"}, "name": "vmss10290IPConfig"}]}, "name":
-      "vmss10290Nic"}]}, "extensionProfile": {"extensions": [{"properties": {"typeHandlerVersion":
-      "1.0", "type": "ManagedIdentityExtensionForLinux", "autoUpgradeMinorVersion":
-      true, "settings": {"port": 50342}, "publisher": "Microsoft.ManagedIdentity"},
-      "name": "ManagedIdentityExtensionForLinux"}]}, "osProfile": {"secrets": [],
-      "adminUsername": "ubuntuadmin", "computerNamePrefix": "vmss10290", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==
-      yugangw2@YUGANGLP2\\n"}]}}}, "storageProfile": {"osDisk": {"caching": "ReadWrite",
-      "managedDisk": {"storageAccountType": "Standard_LRS"}, "createOption": "FromImage"},
-      "imageReference": {"version": "latest", "offer": "UbuntuServer", "publisher":
-      "Canonical", "sku": "16.04-LTS"}}}}, "sku": {"tier": "Standard", "capacity":
-      1, "name": "Standard_D1_v2"}, "location": "westcentralus", "identity": {"identityIds":
-      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2",
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
-      "type": "SystemAssigned, UserAssigned"}, "tags": {}}'''
+      "privateIPAddressVersion": "IPv4", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}}}],
+      "enableIPForwarding": false}}]}}, "singlePlacementGroup": true, "overprovision":
+      true}, "identity": {"type": "SystemAssigned, UserAssigned", "identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]},
+      "tags": {}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss assign-identity]
+      CommandName: [vmss managed-identity assign]
       Connection: [keep-alive]
-      Content-Length: ['2771']
+      Content-Length: ['2769']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
@@ -787,13 +976,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -801,9 +990,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -815,21 +1004,21 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/3add661a-2fa8-495a-80c0-a15a3899aa47?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5260d19f-b4ad-49c9-9600-91018f0a7b34?api-version=2017-12-01']
       cache-control: [no-cache]
-      content-length: ['3850']
+      content-length: ['3848']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:11 GMT']
+      date: ['Tue, 06 Mar 2018 22:11:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -837,7 +1026,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;38,Microsoft.Compute/CreateVMScaleSet30Min;198,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;39,Microsoft.Compute/CreateVMScaleSet30Min;198,Microsoft.Compute/VmssQueuedVMOperations;4800']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
@@ -846,22 +1035,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss assign-identity]
+      CommandName: [vmss managed-identity assign]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/3add661a-2fa8-495a-80c0-a15a3899aa47?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5260d19f-b4ad-49c9-9600-91018f0a7b34?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-01T00:33:11.2601316+00:00\",\r\
-        \n  \"endTime\": \"2018-03-01T00:33:39.7758465+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"3add661a-2fa8-495a-80c0-a15a3899aa47\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T22:11:52.7012336+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"5260d19f-b4ad-49c9-9600-91018f0a7b34\"\
+        \r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['184']
+      content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:41 GMT']
+      date: ['Tue, 06 Mar 2018 22:12:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -869,17 +1058,107 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11983,Microsoft.Compute/GetOperation30Min;23983']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11984,Microsoft.Compute/GetOperation30Min;23955']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss assign-identity]
+      CommandName: [vmss managed-identity assign]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5260d19f-b4ad-49c9-9600-91018f0a7b34?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T22:11:52.7012336+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"5260d19f-b4ad-49c9-9600-91018f0a7b34\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:12:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11984,Microsoft.Compute/GetOperation30Min;23952']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss managed-identity assign]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5260d19f-b4ad-49c9-9600-91018f0a7b34?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T22:11:52.7012336+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"5260d19f-b4ad-49c9-9600-91018f0a7b34\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:13:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11985,Microsoft.Compute/GetOperation30Min;23949']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss managed-identity assign]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.29]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5260d19f-b4ad-49c9-9600-91018f0a7b34?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T22:11:52.7012336+00:00\",\r\
+        \n  \"endTime\": \"2018-03-06T22:13:48.9207107+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"5260d19f-b4ad-49c9-9600-91018f0a7b34\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['184']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Mar 2018 22:13:54 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11986,Microsoft.Compute/GetOperation30Min;23946']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss managed-identity assign]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -889,13 +1168,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -903,9 +1182,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -917,20 +1196,20 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3851']
+      content-length: ['3849']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:41 GMT']
+      date: ['Tue, 06 Mar 2018 22:13:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -938,18 +1217,18 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;189,Microsoft.Compute/GetVMScaleSet30Min;989']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;189,Microsoft.Compute/GetVMScaleSet30Min;986']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss assign-identity]
+      CommandName: [vmss managed-identity assign]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -960,13 +1239,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -974,9 +1253,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -988,20 +1267,20 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3851']
+      content-length: ['3849']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:42 GMT']
+      date: ['Tue, 06 Mar 2018 22:13:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1009,42 +1288,41 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;188,Microsoft.Compute/GetVMScaleSet30Min;988']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;188,Microsoft.Compute/GetVMScaleSet30Min;985']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"singlePlacementGroup": true, "upgradePolicy": {"mode":
-      "Manual", "automaticOSUpgrade": false}, "overprovision": true, "virtualMachineProfile":
-      {"networkProfile": {"networkInterfaceConfigurations": [{"properties": {"enableAcceleratedNetworking":
-      false, "dnsSettings": {"dnsServers": []}, "enableIPForwarding": false, "primary":
-      true, "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+    body: 'b''{"location": "westcentralus", "sku": {"tier": "Standard", "name": "Standard_D1_v2",
+      "capacity": 1}, "properties": {"upgradePolicy": {"mode": "Manual", "automaticOSUpgrade":
+      false}, "virtualMachineProfile": {"extensionProfile": {"extensions": [{"name":
+      "ManagedIdentityExtensionForLinux", "properties": {"publisher": "Microsoft.ManagedIdentity",
+      "autoUpgradeMinorVersion": true, "typeHandlerVersion": "1.0", "type": "ManagedIdentityExtensionForLinux",
+      "settings": {"port": 50342}}}]}, "osProfile": {"adminUsername": "ubuntuadmin",
+      "computerNamePrefix": "vmss1726f", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n"}]}}}, "storageProfile": {"imageReference": {"publisher":
+      "Canonical", "sku": "16.04-LTS", "offer": "UbuntuServer", "version": "latest"},
+      "osDisk": {"caching": "ReadWrite", "createOption": "FromImage", "managedDisk":
+      {"storageAccountType": "Standard_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss1726fNic", "properties": {"dnsSettings": {"dnsServers": []},
+      "primary": true, "enableAcceleratedNetworking": false, "ipConfigurations": [{"name":
+      "vmss1726fIPConfig", "properties": {"loadBalancerBackendAddressPools": [{"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAddressVersion": "IPv4"}, "name": "vmss10290IPConfig"}]}, "name":
-      "vmss10290Nic"}]}, "extensionProfile": {"extensions": [{"properties": {"typeHandlerVersion":
-      "1.0", "type": "ManagedIdentityExtensionForLinux", "autoUpgradeMinorVersion":
-      true, "settings": {"port": 50342}, "publisher": "Microsoft.ManagedIdentity"},
-      "name": "ManagedIdentityExtensionForLinux"}]}, "osProfile": {"secrets": [],
-      "adminUsername": "ubuntuadmin", "computerNamePrefix": "vmss10290", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==
-      yugangw2@YUGANGLP2\\n"}]}}}, "storageProfile": {"osDisk": {"caching": "ReadWrite",
-      "managedDisk": {"storageAccountType": "Standard_LRS"}, "createOption": "FromImage"},
-      "imageReference": {"version": "latest", "offer": "UbuntuServer", "publisher":
-      "Canonical", "sku": "16.04-LTS"}}}}, "sku": {"tier": "Standard", "capacity":
-      1, "name": "Standard_D1_v2"}, "location": "westcentralus", "identity": {"identityIds":
-      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2",
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
-      "type": "SystemAssigned, UserAssigned"}, "tags": {}}'''
+      "privateIPAddressVersion": "IPv4", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}}}],
+      "enableIPForwarding": false}}]}}, "singlePlacementGroup": true, "overprovision":
+      true}, "identity": {"type": "SystemAssigned, UserAssigned", "identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]},
+      "tags": {}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss assign-identity]
+      CommandName: [vmss managed-identity assign]
       Connection: [keep-alive]
-      Content-Length: ['2771']
+      Content-Length: ['2769']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
@@ -1055,13 +1333,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1069,9 +1347,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1083,21 +1361,21 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/a74dc9b2-368f-43a4-9202-1ba28bbfdb7f?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/3fe11cd2-934f-46d3-814a-75732fd5bd99?api-version=2017-12-01']
       cache-control: [no-cache]
-      content-length: ['3850']
+      content-length: ['3848']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:33:43 GMT']
+      date: ['Tue, 06 Mar 2018 22:14:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1106,7 +1384,7 @@ interactions:
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;38,Microsoft.Compute/CreateVMScaleSet30Min;197,Microsoft.Compute/VmssQueuedVMOperations;4800']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
 - request:
@@ -1114,22 +1392,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss assign-identity]
+      CommandName: [vmss managed-identity assign]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/a74dc9b2-368f-43a4-9202-1ba28bbfdb7f?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/3fe11cd2-934f-46d3-814a-75732fd5bd99?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-01T00:33:44.1196114+00:00\",\r\
-        \n  \"endTime\": \"2018-03-01T00:33:44.3071239+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"a74dc9b2-368f-43a4-9202-1ba28bbfdb7f\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T22:14:05.3739165+00:00\",\r\
+        \n  \"endTime\": \"2018-03-06T22:14:05.6708226+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"3fe11cd2-934f-46d3-814a-75732fd5bd99\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:34:14 GMT']
+      date: ['Tue, 06 Mar 2018 22:14:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1137,17 +1415,17 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11984,Microsoft.Compute/GetOperation30Min;23980']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11986,Microsoft.Compute/GetOperation30Min;23943']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss assign-identity]
+      CommandName: [vmss managed-identity assign]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -1157,13 +1435,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1171,9 +1449,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1185,20 +1463,20 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3851']
+      content-length: ['3849']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:34:15 GMT']
+      date: ['Tue, 06 Mar 2018 22:14:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1206,18 +1484,18 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;177,Microsoft.Compute/GetVMScaleSet30Min;977']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;187,Microsoft.Compute/GetVMScaleSet30Min;974']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss show]
+      CommandName: [vmss managed-identity show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -1228,13 +1506,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1242,9 +1520,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1256,20 +1534,20 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3851']
+      content-length: ['3849']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:34:15 GMT']
+      date: ['Tue, 06 Mar 2018 22:14:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1277,7 +1555,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;176,Microsoft.Compute/GetVMScaleSet30Min;976']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;186,Microsoft.Compute/GetVMScaleSet30Min;973']
     status: {code: 200, message: OK}
 - request:
     body: '{"instanceIds": ["*"]}'
@@ -1288,8 +1566,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: POST
@@ -1297,18 +1575,18 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/0fd99343-5295-41e9-8269-768e3682d828?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/05e643ae-b58e-4bf0-9f81-8fde4a4fba0c?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 01 Mar 2018 00:34:16 GMT']
+      date: ['Tue, 06 Mar 2018 22:14:37 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/0fd99343-5295-41e9-8269-768e3682d828?monitor=true&api-version=2017-12-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/05e643ae-b58e-4bf0-9f81-8fde4a4fba0c?monitor=true&api-version=2017-12-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1199,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;1197,Microsoft.Compute/VmssQueuedVMOperations;4799']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1199,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;1199,Microsoft.Compute/VmssQueuedVMOperations;4799']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['1']
     status: {code: 202, message: Accepted}
 - request:
@@ -1318,20 +1596,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/0fd99343-5295-41e9-8269-768e3682d828?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/05e643ae-b58e-4bf0-9f81-8fde4a4fba0c?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-01T00:34:16.5885373+00:00\",\r\
-        \n  \"endTime\": \"2018-03-01T00:34:22.8698634+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"0fd99343-5295-41e9-8269-768e3682d828\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T22:14:37.8271882+00:00\",\r\
+        \n  \"endTime\": \"2018-03-06T22:14:43.5928015+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"05e643ae-b58e-4bf0-9f81-8fde4a4fba0c\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:34:46 GMT']
+      date: ['Tue, 06 Mar 2018 22:15:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1339,7 +1617,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11986,Microsoft.Compute/GetOperation30Min;23978']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11987,Microsoft.Compute/GetOperation30Min;23945']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1349,8 +1627,8 @@ interactions:
       CommandName: [vmss remove-identity]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -1361,13 +1639,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1375,9 +1653,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1389,20 +1667,20 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3851']
+      content-length: ['3849']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:34:47 GMT']
+      date: ['Tue, 06 Mar 2018 22:15:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1410,41 +1688,40 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;175,Microsoft.Compute/GetVMScaleSet30Min;975']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;185,Microsoft.Compute/GetVMScaleSet30Min;974']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"singlePlacementGroup": true, "upgradePolicy": {"mode":
-      "Manual", "automaticOSUpgrade": false}, "overprovision": true, "virtualMachineProfile":
-      {"networkProfile": {"networkInterfaceConfigurations": [{"properties": {"enableAcceleratedNetworking":
-      false, "dnsSettings": {"dnsServers": []}, "enableIPForwarding": false, "primary":
-      true, "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+    body: 'b''{"location": "westcentralus", "sku": {"tier": "Standard", "name": "Standard_D1_v2",
+      "capacity": 1}, "properties": {"upgradePolicy": {"mode": "Manual", "automaticOSUpgrade":
+      false}, "virtualMachineProfile": {"extensionProfile": {"extensions": [{"name":
+      "ManagedIdentityExtensionForLinux", "properties": {"publisher": "Microsoft.ManagedIdentity",
+      "autoUpgradeMinorVersion": true, "typeHandlerVersion": "1.0", "type": "ManagedIdentityExtensionForLinux",
+      "settings": {"port": 50342}}}]}, "osProfile": {"adminUsername": "ubuntuadmin",
+      "computerNamePrefix": "vmss1726f", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n"}]}}}, "storageProfile": {"imageReference": {"publisher":
+      "Canonical", "sku": "16.04-LTS", "offer": "UbuntuServer", "version": "latest"},
+      "osDisk": {"caching": "ReadWrite", "createOption": "FromImage", "managedDisk":
+      {"storageAccountType": "Standard_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss1726fNic", "properties": {"dnsSettings": {"dnsServers": []},
+      "primary": true, "enableAcceleratedNetworking": false, "ipConfigurations": [{"name":
+      "vmss1726fIPConfig", "properties": {"loadBalancerBackendAddressPools": [{"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAddressVersion": "IPv4"}, "name": "vmss10290IPConfig"}]}, "name":
-      "vmss10290Nic"}]}, "extensionProfile": {"extensions": [{"properties": {"typeHandlerVersion":
-      "1.0", "type": "ManagedIdentityExtensionForLinux", "autoUpgradeMinorVersion":
-      true, "settings": {"port": 50342}, "publisher": "Microsoft.ManagedIdentity"},
-      "name": "ManagedIdentityExtensionForLinux"}]}, "osProfile": {"secrets": [],
-      "adminUsername": "ubuntuadmin", "computerNamePrefix": "vmss10290", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==
-      yugangw2@YUGANGLP2\\n"}]}}}, "storageProfile": {"osDisk": {"caching": "ReadWrite",
-      "managedDisk": {"storageAccountType": "Standard_LRS"}, "createOption": "FromImage"},
-      "imageReference": {"version": "latest", "offer": "UbuntuServer", "publisher":
-      "Canonical", "sku": "16.04-LTS"}}}}, "sku": {"tier": "Standard", "capacity":
-      1, "name": "Standard_D1_v2"}, "location": "westcentralus", "identity": {"identityIds":
-      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2"],
-      "type": "SystemAssigned, UserAssigned"}, "tags": {}}'''
+      "privateIPAddressVersion": "IPv4", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}}}],
+      "enableIPForwarding": false}}]}}, "singlePlacementGroup": true, "overprovision":
+      true}, "identity": {"type": "SystemAssigned, UserAssigned", "identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2"]},
+      "tags": {}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss remove-identity]
       Connection: [keep-alive]
-      Content-Length: ['2617']
+      Content-Length: ['2615']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
@@ -1455,13 +1732,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1469,9 +1746,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1483,20 +1760,20 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/ed81b23c-02a9-42a9-b9b9-06a299b7fe4e?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/06016896-c530-4f7e-bfad-e4b6793a734f?api-version=2017-12-01']
       cache-control: [no-cache]
-      content-length: ['3689']
+      content-length: ['3687']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:34:49 GMT']
+      date: ['Tue, 06 Mar 2018 22:15:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1504,7 +1781,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;37,Microsoft.Compute/CreateVMScaleSet30Min;196,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;38,Microsoft.Compute/CreateVMScaleSet30Min;196,Microsoft.Compute/VmssQueuedVMOperations;4800']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
@@ -1515,20 +1792,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss remove-identity]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/ed81b23c-02a9-42a9-b9b9-06a299b7fe4e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/06016896-c530-4f7e-bfad-e4b6793a734f?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-01T00:34:49.2136933+00:00\",\r\
-        \n  \"endTime\": \"2018-03-01T00:34:50.5261983+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"ed81b23c-02a9-42a9-b9b9-06a299b7fe4e\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T22:15:10.5459439+00:00\",\r\
+        \n  \"endTime\": \"2018-03-06T22:15:11.9521869+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"06016896-c530-4f7e-bfad-e4b6793a734f\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:35:19 GMT']
+      date: ['Tue, 06 Mar 2018 22:15:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1536,7 +1813,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11988,Microsoft.Compute/GetOperation30Min;23976']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11987,Microsoft.Compute/GetOperation30Min;23943']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1545,8 +1822,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss remove-identity]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -1556,13 +1833,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1570,9 +1847,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1584,19 +1861,19 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3690']
+      content-length: ['3688']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:35:19 GMT']
+      date: ['Tue, 06 Mar 2018 22:15:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1604,7 +1881,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;169,Microsoft.Compute/GetVMScaleSet30Min;969']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;179,Microsoft.Compute/GetVMScaleSet30Min;968']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1614,8 +1891,8 @@ interactions:
       CommandName: [vmss show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -1626,13 +1903,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1640,9 +1917,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1654,19 +1931,19 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3690']
+      content-length: ['3688']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:35:20 GMT']
+      date: ['Tue, 06 Mar 2018 22:15:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1674,7 +1951,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;168,Microsoft.Compute/GetVMScaleSet30Min;968']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;178,Microsoft.Compute/GetVMScaleSet30Min;967']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1684,8 +1961,8 @@ interactions:
       CommandName: [vmss remove-identity]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -1696,13 +1973,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1710,9 +1987,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1724,19 +2001,19 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"85beaf82-69e1-4d29-8c82-875b5de5668e\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3690']
+      content-length: ['3688']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:35:21 GMT']
+      date: ['Tue, 06 Mar 2018 22:15:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1744,40 +2021,39 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;167,Microsoft.Compute/GetVMScaleSet30Min;967']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;177,Microsoft.Compute/GetVMScaleSet30Min;966']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"singlePlacementGroup": true, "upgradePolicy": {"mode":
-      "Manual", "automaticOSUpgrade": false}, "overprovision": true, "virtualMachineProfile":
-      {"networkProfile": {"networkInterfaceConfigurations": [{"properties": {"enableAcceleratedNetworking":
-      false, "dnsSettings": {"dnsServers": []}, "enableIPForwarding": false, "primary":
-      true, "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+    body: 'b''{"location": "westcentralus", "sku": {"tier": "Standard", "name": "Standard_D1_v2",
+      "capacity": 1}, "properties": {"upgradePolicy": {"mode": "Manual", "automaticOSUpgrade":
+      false}, "virtualMachineProfile": {"extensionProfile": {"extensions": [{"name":
+      "ManagedIdentityExtensionForLinux", "properties": {"publisher": "Microsoft.ManagedIdentity",
+      "autoUpgradeMinorVersion": true, "typeHandlerVersion": "1.0", "type": "ManagedIdentityExtensionForLinux",
+      "settings": {"port": 50342}}}]}, "osProfile": {"adminUsername": "ubuntuadmin",
+      "computerNamePrefix": "vmss1726f", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n"}]}}}, "storageProfile": {"imageReference": {"publisher":
+      "Canonical", "sku": "16.04-LTS", "offer": "UbuntuServer", "version": "latest"},
+      "osDisk": {"caching": "ReadWrite", "createOption": "FromImage", "managedDisk":
+      {"storageAccountType": "Standard_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss1726fNic", "properties": {"dnsSettings": {"dnsServers": []},
+      "primary": true, "enableAcceleratedNetworking": false, "ipConfigurations": [{"name":
+      "vmss1726fIPConfig", "properties": {"loadBalancerBackendAddressPools": [{"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAddressVersion": "IPv4"}, "name": "vmss10290IPConfig"}]}, "name":
-      "vmss10290Nic"}]}, "extensionProfile": {"extensions": [{"properties": {"typeHandlerVersion":
-      "1.0", "type": "ManagedIdentityExtensionForLinux", "autoUpgradeMinorVersion":
-      true, "settings": {"port": 50342}, "publisher": "Microsoft.ManagedIdentity"},
-      "name": "ManagedIdentityExtensionForLinux"}]}, "osProfile": {"secrets": [],
-      "adminUsername": "ubuntuadmin", "computerNamePrefix": "vmss10290", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==
-      yugangw2@YUGANGLP2\\n"}]}}}, "storageProfile": {"osDisk": {"caching": "ReadWrite",
-      "managedDisk": {"storageAccountType": "Standard_LRS"}, "createOption": "FromImage"},
-      "imageReference": {"version": "latest", "offer": "UbuntuServer", "publisher":
-      "Canonical", "sku": "16.04-LTS"}}}}, "sku": {"tier": "Standard", "capacity":
-      1, "name": "Standard_D1_v2"}, "location": "westcentralus", "identity": {"type":
-      "SystemAssigned"}, "tags": {}}'''
+      "privateIPAddressVersion": "IPv4", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}}}],
+      "enableIPForwarding": false}}]}}, "singlePlacementGroup": true, "overprovision":
+      true}, "identity": {"type": "SystemAssigned"}, "tags": {}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss remove-identity]
       Connection: [keep-alive]
-      Content-Length: ['2432']
+      Content-Length: ['2430']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: PUT
@@ -1788,13 +2064,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1802,9 +2078,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1816,19 +2092,19 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
-        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"85beaf82-69e1-4d29-8c82-875b5de5668e\"\
+        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/b6cc7cee-56e3-425a-989a-54ad67b38e2b?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/1c2f03d6-0f26-4aca-bee0-0224fc39705d?api-version=2017-12-01']
       cache-control: [no-cache]
-      content-length: ['3485']
+      content-length: ['3483']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:35:22 GMT']
+      date: ['Tue, 06 Mar 2018 22:15:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1836,7 +2112,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;36,Microsoft.Compute/CreateVMScaleSet30Min;195,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;37,Microsoft.Compute/CreateVMScaleSet30Min;195,Microsoft.Compute/VmssQueuedVMOperations;4800']
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
@@ -1847,20 +2123,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss remove-identity]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/b6cc7cee-56e3-425a-989a-54ad67b38e2b?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/1c2f03d6-0f26-4aca-bee0-0224fc39705d?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-01T00:35:21.9636819+00:00\",\r\
-        \n  \"endTime\": \"2018-03-01T00:35:22.7761525+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"b6cc7cee-56e3-425a-989a-54ad67b38e2b\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-03-06T22:15:43.3274072+00:00\",\r\
+        \n  \"endTime\": \"2018-03-06T22:15:44.2336448+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"1c2f03d6-0f26-4aca-bee0-0224fc39705d\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:35:51 GMT']
+      date: ['Tue, 06 Mar 2018 22:16:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1868,7 +2144,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11989,Microsoft.Compute/GetOperation30Min;23974']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;11988,Microsoft.Compute/GetOperation30Min;23941']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1877,8 +2153,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss remove-identity]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -1888,13 +2164,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1902,9 +2178,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1916,18 +2192,18 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
-        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"85beaf82-69e1-4d29-8c82-875b5de5668e\"\
+        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3486']
+      content-length: ['3484']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:35:52 GMT']
+      date: ['Tue, 06 Mar 2018 22:16:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1935,18 +2211,18 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;168,Microsoft.Compute/GetVMScaleSet30Min;961']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;171,Microsoft.Compute/GetVMScaleSet30Min;960']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss show]
+      CommandName: [vmss managed-identity show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: GET
@@ -1957,13 +2233,13 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10290\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1726f\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
-        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6ynxWeY589bvuJVjtobA+qIlWQwycoeRTYNyEUssLQdCWq7YRUxBhXZzf8O8qe8vz8JsxIgX2ynyn9mxNGAi16gDpkjM9jZ7ATfS4fnuugtx3khjbCOBUJ2A/5GcAwErCZwJ8aaRmuLaG26h9JJaP+amPCty6qXo3i6wnoE3PGy6UyDMr4mdPMT3K1IeWr71GiZ7lTEaBCDclFA628QE4VT0fuGcG/qnm6Q0cLZsyARtYCnTRZGyA+4aWTn/jDBlQY0cgH67nTtimUjkiS67Gd64xA/lri0ybb+ZzwGOxU3QysoYGvDl2TatYHjacS8h1la8qHVTe00Nj7K/NC/z3Q==\
-        \ yugangw2@YUGANGLP2\\n\"\r\n              }\r\n            ]\r\n        \
-        \  }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
+        ,\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \ yugangw@YUGANGW1\\n\"\r\n              }\r\n            ]\r\n          }\r\
+        \n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
         ,\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\
         \n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n\
@@ -1971,9 +2247,9 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss10290Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1726fNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss10290IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1726fIPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
@@ -1985,18 +2261,18 @@ interactions:
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
         \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
         \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f59608f4-82b4-4319-af59-80d6bebf1382\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"dfa17cb9-1840-49d0-8086-2a16403a3592\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
-        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"85beaf82-69e1-4d29-8c82-875b5de5668e\"\
+        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"085b7239-c4d8-4dab-b90b-d1e4d54e33d8\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3486']
+      content-length: ['3484']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 01 Mar 2018 00:35:53 GMT']
+      date: ['Tue, 06 Mar 2018 22:16:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2004,7 +2280,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;167,Microsoft.Compute/GetVMScaleSet30Min;960']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;170,Microsoft.Compute/GetVMScaleSet30Min;959']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2015,8 +2291,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.26
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.25
+          msrest_azure/0.4.20 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.29]
       accept-language: [en-US]
     method: DELETE
@@ -2026,12 +2302,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 01 Mar 2018 00:35:54 GMT']
+      date: ['Tue, 06 Mar 2018 22:16:14 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdZMkNRVzZCVTdJLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkc0VVZMTkNQQk0yLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 version: 1


### PR DESCRIPTION
Main change
1. `az vm/vmss/webapp/functionapp assign-identity/remove-identity` gets moved to under `az vm/vmss/webnapp/functionapp identity assign/remove`
2. author `az vm/vmss/webapp/functionapp identity show`
3. `az login --msi --msi-port 1234` get changed to `az login --identity --identity-port`
4. Old commands/argument still work (for 2 releases). Deprecation information is emitted on old commands

//cc: @skwan, @arluca @mayurid @twitchax 

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
