### PR TITLE
Fix yaml format

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * Support Autorest 3.0 based SDKs
 * warn the user that `az aks browse` won't work in Azure Cloud Shell
 * add `aks upgrade-connector` command to upgrade an existing connector
+* `kubectl` config files are more readable block-style YAML
 
 2.0.27
 ++++++

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -989,7 +989,7 @@ def merge_kubernetes_configurations(existing_file, addition_file):
         existing['current-context'] = addition['current-context']
 
     with open(existing_file, 'w+') as stream:
-        yaml.dump(existing, stream, default_flow_style=True)
+        yaml.dump(existing, stream, default_flow_style=False)
 
     current_context = addition.get('current-context', 'UNKNOWN')
     msg = 'Merged "{}" as current context in {}'.format(current_context, existing_file)


### PR DESCRIPTION
[PyYAML](https://pyyaml.org/wiki/PyYAMLDocumentation)'s default is to choose YAML flow style for non-nested collections, but this is less human-readable and isn't the expected default for Kubernetes config files (although the `kubectl` tool is fine with both flavors). Let's use YAML block style consistently with `az aks get-credentials`.

Closes #5638

---

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
