### PR TITLE
Fix for az interactive's display of IoT warning on first run

### DIFF
--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/__init__.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/__init__.py
@@ -14,7 +14,7 @@ from azure.cli.core.extension import extension_exists
 def handler(ctx, **kwargs):
     cmd = kwargs.get('command', None)
     if cmd and cmd.startswith('iot'):
-        if not extension_exists('azure_cli_iot_ext'):
+        if not extension_exists('azure-cli-iot-ext'):
             ran_before = ctx.config.getboolean('iot', 'first_run', fallback=False)
             if not ran_before:
                 extension_text = """

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
@@ -7,9 +7,7 @@
 from __future__ import print_function
 from os.path import exists
 from enum import Enum
-from knack.config import CLIConfig
 from knack.util import CLIError
-from knack.log import get_logger
 from azure.cli.core.commands import LongRunningOperation
 
 from azure.mgmt.iothub.models import (IotHubSku,
@@ -32,14 +30,10 @@ from azure.cli.command_modules.iot.mgmt_iot_hub_device.lib.models.authentication
 from azure.cli.command_modules.iot.mgmt_iot_hub_device.lib.models.device_description import DeviceDescription
 from azure.cli.command_modules.iot.mgmt_iot_hub_device.lib.models.x509_thumbprint import X509Thumbprint
 from azure.cli.command_modules.iot.sas_token_auth import SasTokenAuthentication
-from azure.cli.core.extension import extension_exists
-from azure.cli.core._environment import get_config_dir
 from azure.cli.core.util import sdk_no_wait
 
 from ._client_factory import resource_service_factory
 from ._utils import create_self_signed_certificate, open_certificate
-
-logger = get_logger(__name__)
 
 
 # CUSTOM TYPE

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
@@ -42,20 +42,6 @@ from ._utils import create_self_signed_certificate, open_certificate
 logger = get_logger(__name__)
 
 
-# IoT Extension run once awareness
-if not extension_exists('azure_cli_iot_ext'):
-    config = CLIConfig(get_config_dir())
-    ran_before = config.getboolean('iot', 'first_run', fallback=False)
-    if not ran_before:
-        extension_text = """
-                         Comprehensive IoT data-plane functionality is available
-                         in the Azure IoT CLI Extension. For more info and install guide
-                         go to https://github.com/Azure/azure-iot-cli-extension
-                         """
-        logger.warning(extension_text)
-        config.set_value('iot', 'first_run', 'yes')
-
-
 # CUSTOM TYPE
 class KeyType(Enum):
     primary = 'primary'


### PR DESCRIPTION
Fix for az interactive's display of IoT warning on first run as referenced in issue #5730

Extension warning/notification is implemented via knack event handler instead.

No command behavior changes.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
