### PR TITLE
Allow for unusual location of bash in az script

### DIFF
--- a/src/azure-cli/az
+++ b/src/azure-cli/az
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink


### PR DESCRIPTION
On at least FreeBSD, bash does not live at `/bin/bash`. This may be the case on some other operating systems as well (likely the other *BSDs). Using `/usr/bin/env bash` solves this since `env` should live at this absolute path on any Unix-like system.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
