### PR TITLE
Reduce test re-recording impact for Network API bumps

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -10,6 +10,8 @@ from azure.cli.core.util import b64encode
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands.arm import ArmTemplateBuilder
 
+from azure.cli.command_modules.vm._vm_utils import get_target_network_api
+
 
 # pylint: disable=too-few-public-methods
 class StorageProfile(Enum):
@@ -80,7 +82,7 @@ def build_public_ip_resource(cmd, name, location, tags, address_allocation, dns_
         public_ip_properties['dnsSettings'] = {'domainNameLabel': dns_name}
 
     public_ip = {
-        'apiVersion': cmd.get_api_version(ResourceType.MGMT_NETWORK),
+        'apiVersion': get_target_network_api(cmd.cli_ctx),
         'type': 'Microsoft.Network/publicIPAddresses',
         'name': name,
         'location': location,
@@ -618,7 +620,7 @@ def build_load_balancer_resource(cmd, name, location, tags, backend_pool_name, n
         'name': name,
         'location': location,
         'tags': tags,
-        'apiVersion': cmd.get_api_version(ResourceType.MGMT_NETWORK),
+        'apiVersion': get_target_network_api(cmd.cli_ctx),
         'dependsOn': [],
         'properties': lb_properties
     }

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -13,7 +13,7 @@ from knack.util import CLIError
 from azure.cli.core.commands.validators import (
     get_default_location_from_resource_group, validate_file_or_dict, validate_parameter_set, validate_tags)
 from azure.cli.core.util import hash_string
-from azure.cli.command_modules.vm._vm_utils import check_existence
+from azure.cli.command_modules.vm._vm_utils import check_existence, get_target_network_api
 from azure.cli.command_modules.vm._template_builder import StorageProfile
 import azure.cli.core.keys as keys
 
@@ -1003,7 +1003,7 @@ def _validate_vmss_create_load_balancer_or_app_gateway(cmd, namespace):
 def get_network_client(cli_ctx):
     from azure.cli.core.profiles import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_NETWORK)
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_NETWORK, api_version=get_target_network_api(cli_ctx))
 
 
 def get_network_lb(cli_ctx, resource_group_name, lb_name):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -15,6 +15,18 @@ logger = get_logger(__name__)
 MSI_LOCAL_ID = '[system]'
 
 
+def get_target_network_api(cli_ctx):
+    """ Since most compute calls don't need advanced network functionality, we can target a supported, but not
+        necessarily latest, network API version is order to avoid having to re-record every test that uses VM create
+        (which there are a lot) whenever NRP bumps their API version (which is often)!
+    """
+    from azure.cli.core.profiles import get_api_version, ResourceType
+    version = get_api_version(cli_ctx, ResourceType.MGMT_NETWORK)
+    if cli_ctx.cloud.profile == 'latest':
+        version = '2018-01-01'
+    return version
+
+
 def read_content_if_is_file(string_or_file):
     content = string_or_file
     if os.path.exists(string_or_file):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -680,8 +680,10 @@ def get_vm(cmd, resource_group_name, vm_name, expand=None):
 
 def get_vm_details(cmd, resource_group_name, vm_name):
     from msrestazure.tools import parse_resource_id
+    from azure.cli.command_modules.vm._vm_utils import get_target_network_api
     result = get_instance_view(cmd, resource_group_name, vm_name)
-    network_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_NETWORK)
+    network_client = get_mgmt_service_client(
+        cmd.cli_ctx, ResourceType.MGMT_NETWORK, api_version=get_target_network_api(cmd.cli_ctx))
     public_ips = []
     fqdns = []
     private_ips = []

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_defaults.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_defaults.py
@@ -33,7 +33,7 @@ def _get_test_cmd():
     return cmd
 
 
-def _mock_resource_client(cli_ctx, client_type):
+def _mock_resource_client(cli_ctx, client_type, **kwargs):
     client = mock.MagicMock()
     if client_type is ResourceType.MGMT_NETWORK:
         def _mock_list(rg):
@@ -88,7 +88,7 @@ def _mock_resource_client(cli_ctx, client_type):
     return client
 
 
-def _mock_network_client_with_existing_subnet(*_):
+def _mock_network_client_with_existing_subnet(*_, **kwargs):
     client = mock.MagicMock()
 
     def _mock_list(rg):


### PR DESCRIPTION
Closes #5107.

This change primarily pins the API version used in many VM module network calls to a specific value when using profile "latest" so that network API bumps do not require re-recording.  Many tests still create network resources and thus would need to be re-recorded. To fix that would require quite a bit more work.

This change reduces the impact of a Network API change to re-recording 90 tests, down from 125. 
Best news: it eliminates the need to re-record the incredibly time consuming Backup tests!! 🙌

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
