### PR TITLE
Prevent make.bat returning exit code of 1 on success

### DIFF
--- a/doc/sphinx/make.bat
+++ b/doc/sphinx/make.bat
@@ -281,27 +281,38 @@ if "%1" == "dummy" (
 if "%1" == "xmlwithlatest" (
 	az cloud update --profile latest
 	%SPHINXBUILD% -E -b xml %ALLSPHINXOPTS% %BUILDDIR%/xml/latest
-	if errorlevel 1 exit /b 1
+	if errorlevel 1 (
+		echo.Build failed.
+		exit /b 1
+	)
 	echo.
 	echo.Build finished. The XML files are in %BUILDDIR%/xml/latest.
-	goto :eof
+	exit /b 0
 )
 
 if "%1" == "xmlwithversion" (
 	call :genxmlwithversion
-	if errorlevel 1 exit /b 1
+	if errorlevel 1 (
+		echo.Build failed.
+		exit /b 1
+	)
 	echo.
 	echo.Build finished. The XML files are in %BUILDDIR%/xml.
-	goto :eof
+	echo.
+	exit /b 0
 )
 
 :genxmlwithversion
 for /f %%i in ('az cloud list-profiles -o tsv') do (
 	az cloud update --profile %%i
 	%SPHINXBUILD% -E -b xml %ALLSPHINXOPTS% %BUILDDIR%/xml/%%i
-	if errorlevel 1 exit /b 1
-	echo.Build of profile %%i finished. The XML files are in %BUILDDIR%/xml/%%i.
+	if errorlevel 1 (
+		echo.Build of profile %%i reported error
+		exit /b 1
+	) else (
+		echo.Build of profile %%i finished. The XML files are in %BUILDDIR%/xml/%%i.
+	)
 )
-goto :eof
+exit /b 0
 
 :end


### PR DESCRIPTION
Under some circumstances the doc/sphinx/make.bat produces an exit code of 1 despite success (apparently due to arcane .BAT rules about error propagation). While this is fine in the AppVeyor build, it is blocking the migration to a VSTS-based build. (In a VSTS Build Definition, the Task for running .bat files cannot be instructed to ignore the exit code.)

This change explicitly sets the exit code to 0 on success for the cases that need to be run as part of the documentation CI build being ported to VSTS.