### PR TITLE
DevTestLabs: Require --artifacts param if formula artifacts has parameters

### DIFF
--- a/src/command_modules/azure-cli-lab/HISTORY.rst
+++ b/src/command_modules/azure-cli-lab/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.19
+++++++
+* Minor fixes.
+
 0.0.18
 ++++++
 * Minor fixes.

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
@@ -377,11 +377,20 @@ def _update_artifacts(artifacts, lab_resource_id):
 
     result_artifacts = []
     for artifact in artifacts:
-        artifact_id = artifact.get('artifact_id', None)
+        if artifact.__class__.__name__ == "ArtifactInstallProperties":
+            if artifact.parameters:
+                raise CLIError("Formulas with parameterized artifacts are not supported. Use --artifacts to supply"
+                               "artifacts to the virtual machine.")
+            artifact_id = _update_artifact_id(artifact.artifact_id, lab_resource_id)
+            parameters = []
+        else:
+            artifact_id = artifact.get('artifact_id', None)
+            parameters = artifact.get('parameters', [])
+
         if artifact_id:
             result_artifact = dict()
             result_artifact['artifact_id'] = _update_artifact_id(artifact_id, lab_resource_id)
-            result_artifact['parameters'] = artifact.get('parameters', [])
+            result_artifact['parameters'] = parameters
             result_artifacts.append(result_artifact)
         else:
             raise CLIError("Missing 'artifactId' for artifact: '{}'".format(artifact))

--- a/src/command_modules/azure-cli-lab/setup.py
+++ b/src/command_modules/azure-cli-lab/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.18"
+VERSION = "0.0.19"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
BUG: formulas with artifacts will fail with an implementation error message of "'ArtifactInstallProperties' object has no attribute 'get'"

If a formula artifact has parameters, output error message that the user need to use the --artifacts parameter

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
