### PR TITLE
Fix issue of upload file with size between 195GB and 200GB

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ===============
 
+2.0.30
+++++++
+* Fix issue of upload file with size between 195GB and 200GB
+
+2.0.29
+++++++
+* Minor fixes.
+
 2.0.28
 ++++++
 * Fix problems with append blob uploads ignoring condition parameters.

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
@@ -235,8 +235,8 @@ def upload_blob(cmd, client, container_name, blob_name, file_path, blob_type=Non
         return client.append_blob_from_path(**append_blob_args)
 
     def upload_block_blob():
-        # increase the block size to 100MB when the file is larger than 200GB
-        if os.path.isfile(file_path) and os.stat(file_path).st_size > 200 * 1024 * 1024 * 1024:
+        # increase the block size to 100MB when the block list will contain more than 50,000 blocks
+        if os.path.isfile(file_path) and os.stat(file_path).st_size > 50000 * 4 * 1024 * 1024:
             client.MAX_BLOCK_SIZE = 100 * 1024 * 1024
             client.MAX_SINGLE_PUT_SIZE = 256 * 1024 * 1024
 

--- a/src/command_modules/azure-cli-storage/setup.py
+++ b/src/command_modules/azure-cli-storage/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.28"
+VERSION = "2.0.30"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
For the moment we get a error when we try to upload a blob file with size between 195GB and 200GB with CLI.

`The block list may not contain more than 50,000 blocks.`

A fix was apply during https://github.com/Azure/azure-cli/pull/4820 in order to manage file with size up to 200GB. But with block size set to 4MB, the real limit is not 200GB but 195,31GB (50000 * 4 * 1024 * 1024).

So I have updated the calcul to increase the block size to 100MB when the real limit is reached.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
