### PR TITLE
Preview extension notation & Simple default view for extension list-a…

### DIFF
--- a/doc/extensions/metadata.md
+++ b/doc/extensions/metadata.md
@@ -50,4 +50,9 @@ Type: `string`
 
 Example: `"azext.maxCliCoreVersion": "2.0.15"`
 
+### azext.isPreview
+Description: Indicate that the extension is in preview.
 
+Type: `boolean`
+
+Example: `"azext.isPreview": true`

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -6,7 +6,7 @@ Release History
 
 2.0.30
 ++++++
-* Minor fixes
+* Show message for extensions marked as preview on -h.
 
 2.0.29
 ++++++

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -163,7 +163,8 @@ class MainCommandsLoader(CLICommandsLoader):
             if extensions:
                 logger.debug("Found %s extensions: %s", len(extensions), [e.name for e in extensions])
                 allowed_extensions = _handle_extension_suppressions(extensions)
-                for ext_name in [e.name for e in allowed_extensions]:
+                for ext in allowed_extensions:
+                    ext_name = ext.name
                     ext_dir = get_extension_path(ext_name)
                     sys.path.append(ext_dir)
                     try:
@@ -177,7 +178,8 @@ class MainCommandsLoader(CLICommandsLoader):
                         for cmd_name, cmd in extension_command_table.items():
                             cmd.command_source = ExtensionCommandSource(
                                 extension_name=ext_name,
-                                overrides_command=cmd_name in cmd_to_mod_map)
+                                overrides_command=cmd_name in cmd_to_mod_map,
+                                preview=ext.preview)
 
                         self.command_table.update(extension_command_table)
                         elapsed_time = timeit.default_timer() - start_time

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -56,6 +56,8 @@ class AzCliHelp(CLIHelp):
             return
         if help_file.command_source and isinstance(help_file.command_source, ExtensionCommandSource):
             logger.warning(help_file.command_source.get_command_warn_msg())
+            if help_file.command_source.preview:
+                logger.warning(help_file.command_source.get_preview_warn_msg())
 
     @classmethod
     def print_detailed_help(cls, cli_name, help_file):

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -568,11 +568,12 @@ def _load_module_command_loader(loader, args, mod):
 class ExtensionCommandSource(object):
     """ Class for commands contributed by an extension """
 
-    def __init__(self, overrides_command=False, extension_name=None):
+    def __init__(self, overrides_command=False, extension_name=None, preview=False):
         super(ExtensionCommandSource, self).__init__()
         # True if the command overrides a CLI command
         self.overrides_command = overrides_command
         self.extension_name = extension_name
+        self.preview = preview
 
     def get_command_warn_msg(self):
         if self.overrides_command:
@@ -584,6 +585,11 @@ class ExtensionCommandSource(object):
             if self.extension_name:
                 return "This command is from the following extension: {}".format(self.extension_name)
             return "This command is from an extension."
+
+    def get_preview_warn_msg(self):
+        if self.preview:
+            return "The extension is in preview"
+        return None
 
 
 def _load_client_exception_class():

--- a/src/azure-cli-core/azure/cli/core/extension.py
+++ b/src/azure-cli-core/azure/cli/core/extension.py
@@ -22,6 +22,7 @@ AZEXT_METADATA_FILENAME = 'azext_metadata.json'
 
 EXT_METADATA_MINCLICOREVERSION = 'azext.minCliCoreVersion'
 EXT_METADATA_MAXCLICOREVERSION = 'azext.maxCliCoreVersion'
+EXT_METADATA_ISPREVIEW = 'azext.isPreview'
 
 logger = get_logger(__name__)
 
@@ -42,6 +43,7 @@ class Extension(object):
         self.ext_type = ext_type
         self._version = None
         self._metadata = None
+        self._preview = None
 
     @property
     def version(self):
@@ -66,6 +68,19 @@ class Extension(object):
         except Exception:  # pylint: disable=broad-except
             logger.debug("Unable to get extension metadata: %s", traceback.format_exc())
         return self._metadata
+
+    @property
+    def preview(self):
+        """
+        Lazy load preview status.
+        Returns the preview status of the extension.
+        """
+        try:
+            if not isinstance(self._preview, bool):
+                self._preview = bool(self.metadata.get(EXT_METADATA_ISPREVIEW))
+        except Exception:  # pylint: disable=broad-except
+            logger.debug("Unable to get extension preview status: %s", traceback.format_exc())
+        return self._preview
 
     def get_version(self):
         raise NotImplementedError()

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -152,9 +152,9 @@ class TestCommandRegistration(unittest.TestCase):
         return ext_name
 
     def _mock_get_extensions():
-        MockExtension = namedtuple('Extension', ['name'])
-        return [MockExtension(name=__name__ + '.ExtCommandsLoader'),
-                MockExtension(name=__name__ + '.Ext2CommandsLoader')]
+        MockExtension = namedtuple('Extension', ['name', 'preview'])
+        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False),
+                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False)]
 
     def _mock_load_command_loader(loader, args, name, prefix):
 

--- a/src/command_modules/azure-cli-extension/HISTORY.rst
+++ b/src/command_modules/azure-cli-extension/HISTORY.rst
@@ -5,7 +5,9 @@ Release History
 
 0.0.11
 ++++++
-* Minor fixes
+* Preview extensions: Show message on `az extension add` if extension is in preview
+* BC: `az extension list-available` - The full extension data is now available with `--show-details`
+* `az extension list-available` - A simplified view of the extensions available is now shown by default
 
 0.0.10
 +++++++

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/__init__.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/__init__.py
@@ -27,7 +27,10 @@ class ExtensionCommandsLoader(AzCommandsLoader):
             return bool(not command_args.get('source') or prompt_y_n('Are you sure you want to install this extension?'))
 
         def transform_extension_list_available(results):
-            return [OrderedDict([('Name', r)]) for r in results]
+            if isinstance(results, dict):
+                # For --show-details, transform the table
+                return [OrderedDict([('Name', r)]) for r in results]
+            return results
 
         def validate_extension_add(namespace):
             if (namespace.extension_name and namespace.source) or (not namespace.extension_name and not namespace.source):
@@ -66,6 +69,9 @@ class ExtensionCommandsLoader(AzCommandsLoader):
             c.argument('extension_name', completer=extension_name_from_index_completion_list)
             c.argument('source', options_list=['--source', '-s'], help='Filepath or URL to an extension', completer=FilesCompleter())
             c.argument('yes', options_list=['--yes', '-y'], action='store_true', help='Do not prompt for confirmation.')
+
+        with self.argument_context('extension list-available') as c:
+            c.argument('show_details', options_list=['--show-details', '-d'], action='store_true', help='Show the raw data from the extension index.')
 
 
 COMMAND_LOADER_CLS = ExtensionCommandsLoader

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
@@ -251,6 +251,30 @@ class TestExtensionCommands(unittest.TestCase):
             list_available_extensions(index_url=index_url)
             c.assert_called_once_with(index_url)
 
+    def test_list_available_extensions_show_details(self):
+        with mock.patch('azure.cli.command_modules.extension.custom.get_index_extensions', autospec=True) as c:
+            list_available_extensions(show_details=True)
+            c.assert_called_once_with(None)
+
+    def test_list_available_extensions_no_show_details(self):
+        sample_index_extensions = {
+            'test_sample_extension1': [{
+                'metadata': {
+                    'name': 'test_sample_extension1',
+                    'summary': 'my summary',
+                    'version': '0.1.0',
+                    'name': 'extension1',
+            }}]
+        }
+        with mock.patch('azure.cli.command_modules.extension.custom.get_index_extensions', return_value=sample_index_extensions):
+            res = list_available_extensions()
+            self.assertIsInstance(res, list)
+            self.assertEqual(len(res), len(sample_index_extensions))
+            self.assertEqual(res[0]['name'], 'test_sample_extension1')
+            self.assertEqual(res[0]['summary'], 'my summary')
+            self.assertEqual(res[0]['version'], '0.1.0')
+            self.assertEqual(res[0]['preview'], False)
+
     def test_add_list_show_remove_extension_extra_index_url(self):
         """
         Tests extension addition while specifying --extra-index-url parameter.

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
@@ -262,9 +262,8 @@ class TestExtensionCommands(unittest.TestCase):
                 'metadata': {
                     'name': 'test_sample_extension1',
                     'summary': 'my summary',
-                    'version': '0.1.0',
-                    'name': 'extension1',
-            }}]
+                    'version': '0.1.0'
+                }}]
         }
         with mock.patch('azure.cli.command_modules.extension.custom.get_index_extensions', return_value=sample_index_extensions):
             res = list_available_extensions()


### PR DESCRIPTION
Preview extension notation & Simple default view for extension list-available

- Closes https://github.com/Azure/azure-cli-extensions/issues/33
- Add column for Installed
- Add column for Preview
- Add warning message on —help of preview extension commands
- Add warning on installation of a preview extension

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
