### PR TITLE
vmss create: warn on upcoming breaking changes on default balancer type

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 2.0.29
 ++++++
+* `vmss create`: warn on upcoming breaking changes on default balancer for scaleset with 100+ instances
 * vm snapshot/image: support zone resilient
 * vmss: report better encryption status through disk instance view
 * BC: `az vm extension delete` no longer returns output as expected for a `delete` command.

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -928,6 +928,10 @@ def _validate_vmss_create_load_balancer_or_app_gateway(cmd, namespace):
         balancer_type = 'loadBalancer' if namespace.instance_count <= INSTANCE_THRESHOLD \
             else 'applicationGateway'
         logger.debug("defaulting to '%s' because instance count <= %s", balancer_type, INSTANCE_THRESHOLD)
+        if balancer_type == 'applicationGateway':
+            logger.warning("In a future release of CLI, for scalesets with 100+ instances, the default balancer "
+                           "will be Standard Load Balancer instead of Application Gateway. Use '--app-gateway' to "
+                           "continue using applicaiton gateways")
     elif namespace.load_balancer:
         balancer_type = 'loadBalancer'
     elif namespace.application_gateway:


### PR DESCRIPTION
For scaelset with 100+ instances, the default balancer will become SLB, not app-gateway anymore. For the release next week, users will see a warning, then in the next release, I will commit the change.

//CC @gatneil  @christiankuhtz   

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
