### PR TITLE
[Monitor] Fix erroneous usage strings

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -12,10 +12,11 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>{78c1ee79-34bd-41e9-beb0-9ecf0336c9a2}</InterpreterId>
-    <InterpreterVersion>2.7</InterpreterVersion>
+    <InterpreterId>{2151c13d-4041-4c88-bb0b-54ce1a741de6}</InterpreterId>
+    <InterpreterVersion>3.5</InterpreterVersion>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <CommandLineArguments>interactive</CommandLineArguments>
+    <CommandLineArguments>
+    </CommandLineArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
@@ -1202,16 +1203,26 @@
     <Content Include="command_modules\azure-cli-vm\HISTORY.rst" />
   </ItemGroup>
   <ItemGroup>
-    <Interpreter Include="..\env36b\">
-      <Id>{78c1ee79-34bd-41e9-beb0-9ecf0336c9a2}</Id>
-      <BaseInterpreter>{d09116de-bd02-4de4-8a41-0d9752df0ac8}</BaseInterpreter>
+    <Interpreter Include="..\..\env2\">
+      <Id>{f0ce7f81-ab4f-4088-b037-81002e6ddc44}</Id>
+      <BaseInterpreter>{2af0f10d-7135-4994-9156-5d01c9c11b7e}</BaseInterpreter>
       <Version>2.7</Version>
-      <Description>env36b (env36)</Description>
+      <Description>env2 (Python 2.7)</Description>
       <InterpreterPath>Scripts\python.exe</InterpreterPath>
-      <WindowsInterpreterPath>Scripts\python.exe</WindowsInterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
       <LibraryPath>Lib\</LibraryPath>
-      <PathEnvironmentVariable>
-      </PathEnvironmentVariable>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+      <Architecture>X86</Architecture>
+    </Interpreter>
+    <Interpreter Include="..\..\env3\">
+      <Id>{2151c13d-4041-4c88-bb0b-54ce1a741de6}</Id>
+      <BaseInterpreter>{6121b83b-bf4d-4953-9b9d-9360b34efe09}</BaseInterpreter>
+      <Version>3.5</Version>
+      <Description>env3 (Python 3.6)</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <LibraryPath>Lib\</LibraryPath>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
       <Architecture>Amd64</Architecture>
     </Interpreter>
   </ItemGroup>

--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -70,8 +70,14 @@ def generate_deployment_name(namespace):
 def get_default_location_from_resource_group(cmd, namespace):
     if not namespace.location:
         from azure.cli.core.commands.client_factory import get_mgmt_service_client
+        from msrestazure.azure_exceptions import CloudError
+        from knack.util import CLIError
+
         resource_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
-        rg = resource_client.resource_groups.get(namespace.resource_group_name)
+        try:
+            rg = resource_client.resource_groups.get(namespace.resource_group_name)
+        except CloudError as ex:
+            raise CLIError('error retrieving default location: {}'.format(ex.message))
         namespace.location = rg.location  # pylint: disable=no-member
         logger.debug("using location '%s' from resource group '%s'", namespace.location, rg.name)
 

--- a/src/command_modules/azure-cli-monitor/HISTORY.rst
+++ b/src/command_modules/azure-cli-monitor/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.5
++++++
+* Minor fixes.
+
 0.1.4
 +++++
 * `metrics list`: Added support for `--top`, `--orderby` and `--namespace`. [Closes #5785](https://github.com/Azure/azure-cli/issues/5785)

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/__init__.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/__init__.py
@@ -12,33 +12,21 @@ from azure.cli.command_modules.monitor._help import helps  # pylint: disable=unu
 # pylint: disable=line-too-long
 class MonitorArgumentContext(AzArgumentContext):
 
-    def resource_parameter_context(self, dest, arg_group=None, required=True, skip_validator=False):
+    def resource_parameter(self, dest, arg_group=None, required=True, skip_validator=False, alias='resource',
+                           preserve_resource_group_parameter=False):
         from azure.cli.command_modules.monitor.validators import get_target_resource_validator
-        self.argument(dest, options_list='--resource', arg_group=arg_group, required=required,
-                      validator=get_target_resource_validator(dest, required) if not skip_validator else None,
+        self.argument(dest, options_list='--{}'.format(alias), arg_group=arg_group, required=required,
+                      validator=get_target_resource_validator(
+                          dest, required, alias=alias,
+                          preserve_resource_group_parameter=preserve_resource_group_parameter) if not skip_validator else None,
                       help="Name or ID of the target resource.")
-        self.extra('namespace', options_list='--resource-namespace', arg_group=arg_group,
+        self.extra('namespace', options_list='--{}-namespace'.format(alias), arg_group=arg_group,
                    help="Target resource provider namespace.")
-        self.extra('parent', options_list='--resource-parent', arg_group=arg_group,
+        self.extra('parent', options_list='--{}-parent'.format(alias), arg_group=arg_group,
                    help="Target resource parent path, if applicable.")
-        self.extra('resource_type', options_list='--resource-type', arg_group=arg_group,
-                   help="Target resource type. Can also accept namespace/type format "
-                        "(Ex: 'Microsoft.Compute/virtualMachines)')")
+        self.extra('resource_type', options_list='--{}-type'.format(alias), arg_group=arg_group,
+                   help="Target resource type. Can also accept namespace/type format (Ex: 'Microsoft.Compute/virtualMachines)')")
         self.extra('resource_group_name', options_list=['--resource-group', '-g'], arg_group=arg_group)
-
-    def resource_parameter(self, dest, arg_group=None, required=True):
-        """ Helper method to add the extra parameters needed to support specifying name or ID for target resources. """
-        from azure.cli.command_modules.monitor.validators import get_target_resource_validator
-        self.argument(dest, options_list=['--{}'.format(dest)], arg_group=arg_group, required=required,
-                      validator=get_target_resource_validator(dest, required, preserve_resource_group_parameter=True),
-                      help="Name or ID of the target resource.")
-        self.extra('namespace', options_list=['--{}-namespace'.format(dest)], arg_group=arg_group,
-                   help="Target resource provider namespace.")
-        self.extra('parent', options_list=['--{}-parent'.format(dest)], arg_group=arg_group,
-                   help="Target resource parent path, if applicable.")
-        self.extra('resource_type', options_list=['--{}-type'.format(dest)], arg_group=arg_group,
-                   help="Target resource type. Can also accept namespace/type format "
-                        "(Ex: 'Microsoft.Compute/virtualMachines)')")
 
 
 class MonitorCommandsLoader(AzCommandsLoader):

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
@@ -40,7 +40,7 @@ def load_arguments(self, _):
         c.argument('rule_name', name_arg_type, id_part='name', help='Name of the alert rule.')
 
     with self.argument_context('monitor alert create') as c:
-        c.resource_parameter('target', arg_group='Target Resource')
+        c.resource_parameter('target', arg_group='Target Resource', alias='target', preserve_resource_group_parameter=True)
         c.argument('rule_name', name_arg_type, id_part='name', help='Name of the alert rule.')
         c.argument('disabled', arg_type=get_three_state_flag())
         c.argument('condition', action=ConditionAction, nargs='+')
@@ -59,7 +59,7 @@ def load_arguments(self, _):
 
     with self.argument_context('monitor alert update') as c:
         c.argument('rule_name', name_arg_type, id_part='name', help='Name of the alert rule.')
-        c.resource_parameter('target', arg_group='Target Resource', required=False)
+        c.resource_parameter('target', arg_group='Target Resource', required=False, preserve_resource_group_parameter=True)
 
     with self.argument_context('monitor alert update', arg_group='Action') as c:
         c.argument('email_service_owners', arg_type=get_three_state_flag())
@@ -88,13 +88,13 @@ def load_arguments(self, _):
         c.argument('metricnamespace', options_list=['--namespace'], help='Namespace to query metric definitions for.')
 
     with self.argument_context('monitor metrics list-definitions') as c:
-        c.resource_parameter_context('resource_uri', arg_group='Target Resource')
+        c.resource_parameter('resource_uri', arg_group='Target Resource')
 
     with self.argument_context('monitor metrics list') as c:
         from .validators import (process_metric_timespan, process_metric_aggregation, process_metric_result_type,
                                  process_metric_dimension, validate_metric_names)
         from azure.mgmt.monitor.models.monitor_management_client_enums import AggregationType
-        c.resource_parameter_context('resource_uri', arg_group='Target Resource')
+        c.resource_parameter('resource_uri', arg_group='Target Resource')
         c.extra('start_time', options_list=['--start-time'], validator=process_metric_timespan, arg_group='Time')
         c.extra('end_time', options_list=['--end-time'], arg_group='Time')
         c.extra('metadata', options_list=['--metadata'], action='store_true', validator=process_metric_result_type)
@@ -161,7 +161,7 @@ def load_arguments(self, _):
         c.argument('dest_profile', options_list=['--dest-schedule'], help='Name of the profile to copy rules to.')
 
     with self.argument_context('monitor autoscale rule create') as c:
-        c.resource_parameter('source', arg_group='Source', required=False)
+        c.resource_parameter('source', arg_group='Source', required=False, preserve_resource_group_parameter=True)
     # endregion
 
     # region Autoscale (OLD)
@@ -186,27 +186,27 @@ def load_arguments(self, _):
         c.argument('name', options_list=('--name', '-n'))
 
     with self.argument_context('monitor diagnostic-settings show') as c:
-        c.resource_parameter_context('resource_uri', required=True, arg_group='Target Resource')
+        c.resource_parameter('resource_uri', required=True, arg_group='Target Resource')
 
     with self.argument_context('monitor diagnostic-settings list') as c:
-        c.resource_parameter_context('resource_uri', required=True)
+        c.resource_parameter('resource_uri', required=True)
 
     with self.argument_context('monitor diagnostic-settings delete') as c:
-        c.resource_parameter_context('resource_uri', required=True, arg_group='Target Resource')
+        c.resource_parameter('resource_uri', required=True, arg_group='Target Resource')
 
     with self.argument_context('monitor diagnostic-settings update') as c:
-        c.resource_parameter_context('resource_uri', required=True, arg_group='Target Resource')
+        c.resource_parameter('resource_uri', required=True, arg_group='Target Resource')
 
     with self.argument_context('monitor diagnostic-settings create') as c:
-        c.resource_parameter_context('resource_uri', required=True, arg_group='Target Resource', skip_validator=True)
+        c.resource_parameter('resource_uri', required=True, arg_group='Target Resource', skip_validator=True)
         c.argument('logs', type=get_json_object)
         c.argument('metrics', type=get_json_object)
 
     with self.argument_context('monitor diagnostic-settings categories list') as c:
-        c.resource_parameter_context('resource_uri', required=True)
+        c.resource_parameter('resource_uri', required=True)
 
     with self.argument_context('monitor diagnostic-settings categories show') as c:
-        c.resource_parameter_context('resource_uri', required=True)
+        c.resource_parameter('resource_uri', required=True)
     # endregion
 
     # region LogProfiles

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
@@ -10,7 +10,7 @@ def process_autoscale_create_namespace(cmd, namespace):
     from msrestazure.tools import parse_resource_id
 
     validate_tags(namespace)
-    get_target_resource_validator('resource', True, True)(cmd, namespace)
+    get_target_resource_validator('resource', required=True, preserve_resource_group_parameter=True)(cmd, namespace)
     if not namespace.resource_group_name:
         namespace.resource_group_name = parse_resource_id(namespace.resource).get('resource_group', None)
     get_default_location_from_resource_group(cmd, namespace)
@@ -99,7 +99,7 @@ def validate_autoscale_timegrain(namespace):
     namespace.timegrain = timegrain
 
 
-def get_target_resource_validator(dest, required, preserve_resource_group_parameter=False):
+def get_target_resource_validator(dest, required, preserve_resource_group_parameter=False, alias='resource'):
     def _validator(cmd, namespace):
         from msrestazure.tools import is_valid_resource_id
         from knack.util import CLIError
@@ -111,7 +111,7 @@ def get_target_resource_validator(dest, required, preserve_resource_group_parame
 
         usage_error = CLIError('usage error: --{0} ID | --{0} NAME --resource-group NAME '
                                '--{0}-type TYPE [--{0}-parent PARENT] '
-                               '[--{0}-namespace NAMESPACE]'.format(dest))
+                               '[--{0}-namespace NAMESPACE]'.format(alias))
         if not name_or_id and required:
             raise usage_error
         elif name_or_id:

--- a/src/command_modules/azure-cli-monitor/setup.py
+++ b/src/command_modules/azure-cli-monitor/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.4"
+VERSION = "0.1.5"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes #5802.

Also fixes an issue in the `get_default_location_from_resource_group` validator when the resource group isn't found.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
