### PR TITLE
Support TXT record escape sequences in Azure DNS CLI

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+2.0.27
+++++++
+* `network dns zone import`: Support for importing of TXT records with RFC 1035 escape sequences.
+* `network dns zone export`: Support for exporting of TXT records with RFC 1035 escape sequences.
+* `network dns record-set txt add-record`: Support for TXT records with RFC 1035 escape sequences.
+
 2.0.26
 ++++++
 * `network dns zone create/update`: Adding support for Private DNS zones.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1172,7 +1172,6 @@ def add_dns_txt_record(cmd, resource_group_name, zone_name, record_set_name, val
     record = TxtRecord(value=value)
     record_type = 'txt'
     long_text = ''.join(x for x in record.value)
-    long_text = long_text.replace('\\', '')
     original_len = len(long_text)
     record.value = []
     while len(long_text) > 255:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
@@ -422,9 +422,9 @@ class DnsParseZoneFiles(unittest.TestCase):
         self._check_txt(zone, 't2.' + zn, [(3600, None, 'foobar')])
         self._check_txt(zone, 't3.' + zn, [(3600, None, 'foobar')])
         self._check_txt(zone, 't4.' + zn, [(3600, None, 'foo;bar')])
-        self._check_txt(zone, 't5.' + zn, [(3600, None, 'foo;bar')])
-        self._check_txt(zone, 't6.' + zn, [(3600, None, 'foo;bar')])
-        self._check_txt(zone, 't7.' + zn, [(3600, None, '"quoted string"')])
+        self._check_txt(zone, 't5.' + zn, [(3600, None, 'foo\\;bar')])
+        self._check_txt(zone, 't6.' + zn, [(3600, None, 'foo\\;bar')])
+        self._check_txt(zone, 't7.' + zn, [(3600, None, '\\"quoted string\\"')])
         self._check_txt(zone, 't8.' + zn, [(3600, None, 'foobar')])
         self._check_txt(zone, 't9.' + zn, [(3600, None, 'foobarr')])
         self._check_txt(zone, 't10.' + zn, [(3600, None, 'foo bar')])
@@ -539,6 +539,20 @@ class DnsParseZoneFiles(unittest.TestCase):
         self._check_soa(zone, zn, 3600, 1, 3600, 300, 2419200, 300)
         self._check_a(zone, 'www.' + zn, [(3600, '1.1.1.1')])
         self._check_a(zone, zn, [(3600, '1.1.1.1')])
+        self._check_ns(zone, zn, [
+            (172800, 'ns1-03.azure-dns.com.'),
+            (172800, 'ns2-03.azure-dns.net.'),
+            (172800, 'ns3-03.azure-dns.org.'),
+            (172800, 'ns4-03.azure-dns.info.'),
+        ])
+
+    def test_zone_file_7(self):
+        zn = 'zone7.com.'
+        zone = self._get_zone_object('zone7.txt', zn)
+        self._check_soa(zone, zn, 3600, 1, 3600, 300, 2419200, 300)
+        self._check_txt(zone, zn, [(60, None, 'a\\\\b\\255\\000\\;\\"\\"\\"testtesttest\\"\\"\\"')])
+        self._check_txt(zone, 'txt1.' + zn, [(3600, None, 'ab\\ cd')])
+        self._check_cname(zone, 'cn1.' + zn, 3600, 'contoso.com.')
         self._check_ns(zone, zn, [
             (172800, 'ns1-03.azure-dns.com.'),
             (172800, 'ns2-03.azure-dns.net.'),

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/zone_files/zone2.txt
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/zone_files/zone2.txt
@@ -26,12 +26,12 @@ a2                      A	1.2.3.4
                         A	2.3.4.5
 aaaa2                   AAAA 2001:cafe:130::100
                         AAAA 2001:cafe:130::101
-doozie                  TXT	( "abcdefghijklmnopqrstuvwxyz"
+doozie                  TXT	( "abcdefghijklmnopqrstuvwxyz" ; test comment
                               "1234567890"
                         	  "abcdefghijklmnopqrstuvwxyz"
-							  "1234567890"
+							  "1234567890" ; another comment
                         	  "abcdefghijklmnopqrstuvwxyz"
-							  "1234567890" )
+							  "1234567890" ) ; comments
 fee2                    CNAME	bar.com.
                         CNAME	bar. ; This should be ignored and a warning given
 mail                    MX	10	mail1.mymail.com.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/zone_files/zone7.txt
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/zone_files/zone7.txt
@@ -1,0 +1,25 @@
+; Exported zone file from Azure DNS
+; Resource Group Name: TheOne
+; Zone name: zone7.com
+; Date and time (UTC): Mon Jan 22 2018 09:09:43 GMT+0000
+
+$TTL 3600
+$ORIGIN zone7.com.
+
+@ 3600 IN SOA ns1-03.azure-dns.com. azuredns-hostmaster.microsoft.com. (
+                                1
+                                3600
+                                300
+                                2419200
+                                300
+                                )
+
+@ 172800 IN NS ns1-03.azure-dns.com.
+  172800 IN NS ns2-03.azure-dns.net.
+  172800 IN NS ns3-03.azure-dns.org.
+  172800 IN NS ns4-03.azure-dns.info.
+
+  60 IN TXT "a\\b\255\000\;" "\"\"\"testtesttest\"\"\"" ; "some test record
+
+txt1 TXT ab\ cd
+cn1 CNAME contoso.com.;comment1;comment2;comment3

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/parse_zone_file.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/parse_zone_file.py
@@ -157,19 +157,26 @@ def _tokenize_line(line, quote_strings=False, infer_name=True):
                 # end of token
                 if len(tokbuf) > 0:
                     ret.append(tokbuf)
-
                 tokbuf = ''
+
+            elif escape:
+                # escaped space (can be inside or outside of quote)
+                tokbuf += '\\' + c
+                escape = False
+
             elif quote:
                 # in quotes
                 tokbuf += c
-            elif escape:
-                # escaped space
-                tokbuf += c
-                escape = False
+            
             else:
                 tokbuf = ''
         elif c == '\\':
-            escape = True
+            if escape:
+                # escape of an escape is valid part of the line sequence
+                tokbuf += '\\\\'
+                escape = False
+            else:
+                escape = True
         elif c == '"':
             if not escape:
                 if quote:
@@ -190,6 +197,10 @@ def _tokenize_line(line, quote_strings=False, infer_name=True):
                 escape = False
         else:
             # normal character
+            if escape:
+                # append escape character
+                tokbuf += '\\'
+
             tokbuf += c
             escape = False
         firstchar = False
@@ -222,6 +233,7 @@ def _find_comment_index(line):
                 quote = not quote
         elif char == ';':
             if quote:
+                escape = False
                 continue
             elif escape:
                 escape = False
@@ -240,15 +252,11 @@ def _serialize(tokens):
     """
     Serialize tokens:
     * quote whitespace-containing tokens
-    * escape semicolons
     """
     ret = []
     for tok in tokens:
         if " " in tok:
             tok = '"%s"' % tok
-
-        if ";" in tok:
-            tok = tok.replace(";", "\;")
 
         ret.append(tok)
 
@@ -481,7 +489,6 @@ def _post_process_txt_record(record, current_ttl):
         record['txt'] = [record['txt']]
     record['ttl'] = _convert_to_seconds(record['ttl']) if 'ttl' in record else current_ttl
     long_text = ''.join(x for x in record['txt']) if isinstance(record['txt'], list) else record['txt']
-    long_text = long_text.replace('\\', '')
     original_len = len(long_text)
     record['txt'] = []
     while len(long_text) > 255:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/parse_zone_file.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/parse_zone_file.py
@@ -167,7 +167,7 @@ def _tokenize_line(line, quote_strings=False, infer_name=True):
             elif quote:
                 # in quotes
                 tokbuf += c
-            
+
             else:
                 tokbuf = ''
         elif c == '\\':

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/record_processors.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/record_processors.py
@@ -49,9 +49,28 @@ def _quote_field(data, field):
     if data is None:
         return None
 
-    data[field] = data[field].replace(";", "\;")
-    data[field] = data[field].replace('"', '\\"')
-    data[field] = '"%s"' % data[field]
+    # embedded quotes require escaping - but only if not escaped already
+    # note that semi-colons do not need escaping here since we are putting it
+    # inside of a quoted string
+    fieldBuf = ""
+    escape = False
+    for c in data[field]:
+        if c == '"':
+            fieldBuf += '\\"'
+            escape = False
+        elif c == '\\':
+            if escape:
+                fieldBuf += '\\\\'
+                escape = False
+            else:
+                escape = True
+        else:
+            if escape:
+                fieldBuf += '\\'
+            fieldBuf += c
+            escape = False
+
+    data[field] = '"%s"' % fieldBuf
 
     return data
 

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.26"
+VERSION = "2.0.27"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
We now support RFC 1035 DNS TXT record escape sequences in the Azure DNS service in order to support non-printable ASCII characters. The service will take care of all the escape sequences inside of TXT records.

Adding support in the CLI to forward these escape sequences to the Azure DNS service.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
