### PR TITLE
remove deprecated identity related commands

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 0.1.31
 ++++++
+* (Breaking change): remove `assign-identity` which was tagged `deprecating` 2 releases ago
 * webapp: capture the unhandled exception if the appservice plan doesn't exist
 
 0.1.30

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -72,16 +72,6 @@ helps['functionapp identity assign'] = helps['webapp identity assign'].replace('
 
 helps['functionapp identity show'] = helps['webapp identity show'].replace('webapp', 'functionapp')
 
-helps['webapp assign-identity'] = """
-    type: command
-    short-summary: (Deprecated, please use 'az webapp identity assign')
-"""
-
-helps['functionapp assign-identity'] = """
-    type: command
-    short-summary: (Deprecated, please use 'az functionapp identity assign')
-"""
-
 helps['webapp config'] = """
 type: group
 short-summary: Configure a web app.

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -136,7 +136,7 @@ def load_arguments(self, _):
             c.argument('slot_swap', arg_group='VSTS CD Provider', help='Name of the slot to be used for deployment and later promote to production. If slot is not available, it will be created. Default: Not configured')
             c.argument('repository_type', help='repository type', arg_type=get_enum_type(['git', 'mercurial', 'vsts', 'github', 'externalgit', 'localgit']))
             c.argument('git_token', help='Git access token required for auto sync')
-        with self.argument_context(scope + ' assign-identity') as c:
+        with self.argument_context(scope + ' identity') as c:
             c.argument('disable_msi', action='store_true', help='disable the identity')
             c.argument('scope', help="The scope the managed identity has access to")
             c.argument('role', help="Role name or id the managed identity will be assigned")

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -76,7 +76,6 @@ def load_command_table(self, _):
         g.custom_command('restart', 'restart_webapp')
         g.custom_command('browse', 'view_in_browser')
         g.custom_command('list-runtimes', 'list_runtimes')
-        g.custom_command('assign-identity', 'assign_identity', deprecate_info='az webapp identity assign')
         g.custom_command('identity assign', 'assign_identity')
         g.custom_command('identity show', 'show_identity')
         g.generic_update_command('update', custom_func_name='update_webapp', setter_arg_name='site_envelope')

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+2.0.22
+++++++
+* (Breaking change): remove `--msi` & `--msi-port` which were tagged `deprecating` 2 releases ago
+
 2.0.21
 ++++++
 * az login: warn on using --identity-port/--msi-port as they become useless with imds support

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import argparse
-
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import CliCommandType
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
@@ -47,9 +47,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('username', options_list=('--username', '-u'), help='user name, service principal, or managed service identity ID')
             c.argument('tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
             c.argument('allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
-            c.argument('msi', help=argparse.SUPPRESS)
             c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
-            c.argument('msi_port', type=int, help=argparse.SUPPRESS)
             c.argument('identity_port', type=int, help="the port to retrieve tokens for login. Default: 50342", arg_group='Managed Service Identity')
 
         with self.argument_context('logout') as c:

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -92,26 +92,24 @@ def account_clear(cmd):
 
 # pylint: disable=inconsistent-return-statements
 def login(cmd, username=None, password=None, service_principal=None, tenant=None, allow_no_subscriptions=False,
-          identity=False, identity_port=None,
-          msi=False, msi_port=None):  # will remove msi_xxx in a future release
+          identity=False, identity_port=None):
     """Log in to access Azure subscriptions"""
     from adal.adal_error import AdalError
     import requests
 
     # quick argument usage check
-    if (any([password, service_principal, tenant, allow_no_subscriptions]) and
-            any([identity, msi])):
+    if (any([password, service_principal, tenant, allow_no_subscriptions]) and identity):
         raise CLIError("usage error: '--identity' is not applicable with other arguments")
 
-    if msi_port or identity_port:
-        logger.warning("'--msi-port/--identity-port' is no longer required to login using managed identity."
+    if identity_port:
+        logger.warning("'--identity-port' is no longer required to login using managed identity."
                        " This flag will be removed in a future release of CLI.")
 
     interactive = False
 
     profile = Profile(cli_ctx=cmd.cli_ctx, async_persist=False)
 
-    if identity or msi:
+    if identity:
         if in_cloud_console():
             return profile.find_subscriptions_in_cloud_console()
         return profile.find_subscriptions_in_vm_with_msi(username)

--- a/src/command_modules/azure-cli-profile/setup.py
+++ b/src/command_modules/azure-cli-profile/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.21"
+VERSION = "2.0.22"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.0.30
 ++++++
+* (Breaking change): remove `assign-identity` & `remove-identity` which were tagged `deprecating` 2 releases ago
 * `vm create`: support configure Public-IP sku
 
 2.0.29

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -1203,16 +1203,6 @@ helps['vm identity show'] = """
     short-summary: display VM's managed identity info.
 """
 
-helps['vm assign-identity'] = """
-    type: command
-    short-summary: (Deprecated, please use 'az vm identity assign')
-"""
-
-helps['vm remove-identity'] = """
-    type: command
-    short-summary: (Deprecated, please use 'az vm identity remove')
-"""
-
 helps['vm run-command'] = """
     type: group
     short-summary: Manage run commands on a Virtual Machine
@@ -1253,16 +1243,6 @@ helps['vmss identity remove'] = """
 helps['vmss identity show'] = """
     type: command
     short-summary: display VM scaleset's managed identity info.
-"""
-
-helps['vmss assign-identity'] = """
-    type: command
-    short-summary: (Deprecated, please use 'az vmss identity assign')
-"""
-
-helps['vmss remove-identity'] = """
-    type: command
-    short-summary: (Deprecated, please use 'az vmss identity remove')
 """
 
 helps['disk'] = """

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -328,14 +328,14 @@ def load_arguments(self, _):
         with self.argument_context(scope) as c:
             c.argument('no_auto_upgrade', action='store_true', help='by doing this, extension system will not pick the highest minor version for the specified version number, and will not auto update to the latest build/revision number on any scale set updates in future.')
 
-    for scope in ['vm assign-identity', 'vmss assign-identity', 'vm identity assign', 'vmss identity assign']:
+    for scope in ['vm identity assign', 'vmss identity assign']:
         with self.argument_context(scope) as c:
             c.argument('assign_identity', options_list=['--identities'], nargs='*', help="the identities to assign")
             c.argument('port', type=int, help="The port to fetch AAD token. Default: 50342")
             c.argument('vm_name', existing_vm_name)
             c.argument('vmss_name', vmss_name_type)
 
-    for scope in ['vm remove-identity', 'vmss remove-identity', 'vm identity remove', 'vmss identity remove']:
+    for scope in ['vm identity remove', 'vmss identity remove']:
         with self.argument_context(scope) as c:
             c.argument('identities', nargs='+', help="space-separated user assigned identities to remove")
             c.argument('vm_name', existing_vm_name)
@@ -401,7 +401,7 @@ def load_arguments(self, _):
             c.argument('plan_publisher', help='plan publisher')
             c.argument('plan_promotion_code', help='plan promotion code')
 
-    for scope in ['vm create', 'vmss create', 'vm assign-identity', 'vmss assign-identity', 'vm identity assign', 'vmss identity assign']:
+    for scope in ['vm create', 'vmss create', 'vm identity assign', 'vmss identity assign']:
         with self.argument_context(scope) as c:
             arg_group = 'Managed Service Identity' if scope.split()[-1] == 'create' else None
             c.argument('identity_scope', options_list=['--scope'], arg_group=arg_group, help="Scope that the system assigned identity can access")

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -159,11 +159,6 @@ def load_command_table(self, _):
         g.generic_update_command('update', custom_func_name='update_snapshot', setter_arg_name='snapshot')
 
     with self.command_group('vm', compute_vm_sdk) as g:
-
-        g.custom_command('assign-identity', 'assign_vm_identity', validator=process_assign_identity_namespace,
-                         deprecate_info='az vm identity assign')
-        g.custom_command('remove-identity', 'remove_vm_identity', validator=process_remove_identity_namespace, min_api='2017-12-01',
-                         deprecate_info='az vm identity remove')
         g.custom_command('identity assign', 'assign_vm_identity', validator=process_assign_identity_namespace)
         g.custom_command('identity remove', 'remove_vm_identity', validator=process_remove_identity_namespace, min_api='2017-12-01')
         g.custom_command('identity show', 'show_vm_identity')
@@ -269,9 +264,6 @@ def load_command_table(self, _):
         g.custom_command('reset-ssh', 'reset_linux_ssh')
 
     with self.command_group('vmss', compute_vmss_sdk, operation_group='virtual_machine_scale_sets') as g:
-        g.custom_command('assign-identity', 'assign_vmss_identity', validator=process_assign_identity_namespace, deprecate_info='az vmss identity assign')
-        g.custom_command('remove-identity', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01',
-                         deprecate_info='az vmss identity remove')
         g.custom_command('identity assign', 'assign_vmss_identity', validator=process_assign_identity_namespace)
         g.custom_command('identity remove', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01')
         g.custom_command('identity show', 'show_vmss_identity')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -2099,13 +2099,13 @@ class MSIScenarioTest(ScenarioTest):
         self.cmd('vm identity show -g {rg} -n {vm}',
                  checks=self.check('length(identityIds)', 2))
         # remove the 1st user assigned identity
-        self.cmd('vm remove-identity -g {rg} -n {vm} --identities {emsi}')
+        self.cmd('vm identity remove -g {rg} -n {vm} --identities {emsi}')
         result = self.cmd('vm show -g {rg} -n {vm}',
                           checks=self.check('length(identity.identityIds)', 1)).get_output_in_json()
         self.assertEqual(result['identity']['identityIds'][0].lower(), emsi2_result['id'].lower())
 
         # remove the 2nd
-        self.cmd('vm remove-identity -g {rg} -n {vm} --identities {emsi2}')
+        self.cmd('vm identity remove -g {rg} -n {vm} --identities {emsi2}')
         # verify the VM still has the system assigned identity
         result = self.cmd('vm identity show -g {rg} -n {vm}', checks=[
             # blocked by https://github.com/Azure/azure-cli/issues/5103
@@ -2147,13 +2147,13 @@ class MSIScenarioTest(ScenarioTest):
         self.cmd('vmss update-instances -g {rg} -n {vmss} --instance-ids *')
 
         # remove the 1st user assigned identity
-        self.cmd('vmss remove-identity -g {rg} -n {vmss} --identities {emsi}')
+        self.cmd('vmss identity remove -g {rg} -n {vmss} --identities {emsi}')
         result = self.cmd('vmss show -g {rg} -n {vmss}',
                           checks=self.check('length(identity.identityIds)', 1)).get_output_in_json()
         self.assertEqual(result['identity']['identityIds'][0].lower(), emsi2_result['id'].lower())
 
         # remove the 2nd
-        self.cmd('vmss remove-identity -g {rg} -n {vmss} --identities {emsi2}')
+        self.cmd('vmss identity remove -g {rg} -n {vmss} --identities {emsi2}')
         # verify the vmss still has the system assigned identity
         self.cmd('vmss identity show -g {rg} -n {vmss}', checks=[
             # blocked by https://github.com/Azure/azure-cli/issues/5103


### PR DESCRIPTION


- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
