### PR TITLE
account: handle RDFE based accounts

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -351,7 +351,7 @@ class Profile(object):
     @staticmethod
     def _pick_working_subscription(subscriptions):
         from azure.mgmt.resource.subscriptions.models import SubscriptionState
-        s = next((x for x in subscriptions if x['state'] == SubscriptionState.enabled.value), None)
+        s = next((x for x in subscriptions if x.get(_STATE) == SubscriptionState.enabled.value), None)
         return s or subscriptions[0]
 
     def set_active_subscription(self, subscription):  # take id or name
@@ -658,6 +658,8 @@ class SubscriptionFinder(object):
         else:  # when refresh account, we will leverage local cached tokens
             token_entry = context.acquire_token(resource, username, _CLIENT_ID)
 
+        if not token_entry:
+            return []
         self.user_id = token_entry[_TOKEN_ENTRY_USER_ID]
 
         if tenant is None:

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -755,6 +755,17 @@ class TestProfile(unittest.TestCase):
         mock_auth_context.acquire_token.assert_called_once_with(
             mgmt_resource, self.user1, mock.ANY)
 
+    @mock.patch('adal.AuthenticationContext', autospec=True)
+    def test_find_subscriptions_thru_username_non_password(self, mock_auth_context):
+        cli = TestCli()
+        mock_auth_context.acquire_token_with_username_password.return_value = None
+        finder = SubscriptionFinder(cli, lambda _, _1, _2: mock_auth_context, None, lambda _: None)
+        # action
+        subs = finder.find_from_user_account(self.user1, 'bar', None, 'http://goo-resource')
+
+        # assert
+        self.assertEqual([], subs)
+
     @mock.patch('msrestazure.azure_active_directory.MSIAuthentication', autospec=True)
     @mock.patch('azure.cli.core.profiles._shared.get_client_class', autospec=True)
     @mock.patch('azure.cli.core._profile._get_cloud_console_token_endpoint', autospec=True)

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.0.22
 ++++++
+* account list: handle accounts which come from CLI 1.0/ASM mode
 * (Breaking change): remove `--msi` & `--msi-port` which were tagged `deprecating` 2 releases ago
 
 2.0.21

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_format.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_format.py
@@ -12,7 +12,7 @@ def transform_account_list(result):
         res = OrderedDict([('Name', r['name']),
                            ('CloudName', r['cloudName']),
                            ('SubscriptionId', r['id']),
-                           ('State', r['state']),
+                           ('State', r.get('state')),
                            ('IsDefault', r['isDefault'])])
         transformed.append(res)
     return transformed

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -37,7 +37,7 @@ def list_subscriptions(cmd, all=False, refresh=False):  # pylint: disable=redefi
     for sub in subscriptions:
         sub['cloudName'] = sub.pop('environmentName', None)
     if not all:
-        enabled_ones = [s for s in subscriptions if s['state'] == 'Enabled']
+        enabled_ones = [s for s in subscriptions if s.get('state') == 'Enabled']
         if len(enabled_ones) != len(subscriptions):
             logger.warning("A few accounts are skipped as they don't have 'Enabled' state. "
                            "Use '--all' to display them.")


### PR DESCRIPTION
Those accounts come from CLI 1.0/ASM mode, because they have no "state" inforamtion, that causes CLI to throw unhandled exceptions
Fix #5846 Fix #5911

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
