### PR TITLE
[ACI] (docs only) remove PREVIEW branding

### DIFF
--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
@@ -8,7 +8,7 @@ from knack.help_files import helps  # pylint: disable=unused-import
 
 helps['container'] = """
     type: group
-    short-summary: (PREVIEW) Manage Azure Container Instances.
+    short-summary: Manage Azure Container Instances.
 """
 
 helps['container create'] = """


### PR DESCRIPTION
This is a help content-only change (`_help.py`) that removes the "(PREVIEW)" tag on the [az container command reference](https://docs.microsoft.com/cli/azure/container).
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

Cc: @jluk @yangl900 