### PR TITLE
Expand Tabulate package versions in core

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -67,7 +67,7 @@ DEPENDENCIES = [
     'pyyaml',
     'requests',
     'six',
-    'tabulate==0.7.7',
+    'tabulate>=0.7.7,<=0.8.2',
     'wheel',
 ]
 


### PR DESCRIPTION
In #3313 Tabulate was pinned to 0.7.7.  Pinning to this older version creates installation challenges and general irritation for users.

I understand the way the tests are written it is currently helpful to minimize change in this package, but I have verified that `TestCoreCLIOutput` tests work with all versions between `0.7.7` and `0.8.2` (latest) - so we can at least expand dependencies to that range.