### PR TITLE
Switch ldash to dash for better cut/paste

### DIFF
--- a/doc/configuring_your_machine.md
+++ b/doc/configuring_your_machine.md
@@ -16,7 +16,7 @@ The Azure Python CLI projects sources are located on GitHub (https://github.com/
   ```
   #### OSX/Ubuntu (bash)
   ```Shell
-  python –m venv <clone root>/env
+  python -m venv <clone root>/env
   ```
 4.  Activate the env virtual environment by running:
 


### PR DESCRIPTION
The current invocation results in an error when pasted into a terminal:

```
python3: can't open file '–m': [Errno 2] No such file or directory
```