### PR TITLE
Completions ignore unrecognized command args

### DIFF
--- a/src/command_modules/azure-cli-interactive/HISTORY.rst
+++ b/src/command_modules/azure-cli-interactive/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.3.19
+++++++
+* Stops completions upon unrecognized commands.
+
 0.3.18
 ++++++
 * Completions kick in as soon as command table loading is done.

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/az_completer.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/az_completer.py
@@ -240,7 +240,7 @@ class AzCompleter(Completer):
             for param in self.command_param_info.get(self.current_command, []):
                 if self.validate_param_completion(param, self.leftover_args):
                     yield self.yield_param_completion(param, self.unfinished_word)
-        else:
+        elif not self.leftover_args:
             for child_command in self.subtree.children:
                 if self.validate_completion(child_command):
                     yield Completion(child_command, -len(self.unfinished_word))

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_completion.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_completion.py
@@ -36,10 +36,8 @@ class CompletionTest(unittest.TestCase):
     def init_completer(self):
         with mock.patch.object(Configuration, 'get_help_files', lambda _: 'help_dump_test.json'):
             with mock.patch.object(Configuration, 'get_config_dir', lambda _: TEST_DIR):
-                print(TEST_DIR)
                 shell_ctx = AzInteractiveShell(TestCli(), None)
                 self.completer = shell_ctx.completer
-                print(self.completer.command_tree.children)
 
     def test_command_completion(self):
         # tests some azure commands
@@ -74,6 +72,12 @@ class CompletionTest(unittest.TestCase):
         gen = self.completer.get_completions(doc, None)
         completions = set(['vm', 'vmss'])
         self.verify_completions(gen, completions, -2)
+
+        # test unrecognized command does not complete
+        doc = Document(u'vm group ')
+        gen = self.completer.get_completions(doc, None)
+        completions = set()
+        self.verify_completions(gen, completions, 0)
 
     def test_param_completion(self):
         # tests some azure params

--- a/src/command_modules/azure-cli-interactive/setup.py
+++ b/src/command_modules/azure-cli-interactive/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     cmdclass = {}
 
 # Version is also defined in azclishell.__init__.py.
-VERSION = "0.3.18"
+VERSION = "0.3.19"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
---
completions were ignoring unrecognized command args
ex: 'vm group ' would show 'vm' completions: 'create, show, etc...'

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
