### PR TITLE
remove the logics of wiring up REQUESTS_CA_BUNDLE as requests already handles it

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_debug.py
+++ b/src/azure-cli-core/azure/cli/core/_debug.py
@@ -6,12 +6,10 @@
 import os
 
 from knack.log import get_logger
-from knack.util import CLIError
 from .util import should_disable_connection_verify, DISABLE_VERIFY_VARIABLE_NAME
 logger = get_logger(__name__)
 
 ADAL_PYTHON_SSL_NO_VERIFY = "ADAL_PYTHON_SSL_NO_VERIFY"
-REQUESTS_CA_BUNDLE = "REQUESTS_CA_BUNDLE"
 
 
 def change_ssl_cert_verification(client):
@@ -20,12 +18,6 @@ def change_ssl_cert_verification(client):
                        DISABLE_VERIFY_VARIABLE_NAME)
         os.environ[ADAL_PYTHON_SSL_NO_VERIFY] = '1'
         client.config.connection.verify = False
-    elif REQUESTS_CA_BUNDLE in os.environ:
-        ca_bundle_file = os.environ[REQUESTS_CA_BUNDLE]
-        if not os.path.isfile(ca_bundle_file):
-            raise CLIError('REQUESTS_CA_BUNDLE environment variable is specified with an invalid file path')
-        logger.debug("Using CA bundle file at '%s'.", ca_bundle_file)
-        client.config.connection.verify = ca_bundle_file
     return client
 
 


### PR DESCRIPTION
@derekbekoe, it is possible I might have missed some context here, so feel free to close this PR if we do need it.

The `REQUESTS_CA_BUNDLE` is recognized by the [requests package](https://github.com/requests/requests/blob/master/requests/sessions.py#L684) already. Also on an invalid file path, it emits out a good error, hence I don't think CLI needs to do anything here. I have also verified things do work after pulling out the code.

- [na] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [na] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
