### PR TITLE
Fixed up rules violations for command group help, `redis patch-schedule show`

### DIFF
--- a/src/command_modules/azure-cli-batch/HISTORY.rst
+++ b/src/command_modules/azure-cli-batch/HISTORY.rst
@@ -4,11 +4,11 @@ Release History
 ===============
 
 3.2.1
-++++++
-* Minor fixes
++++++
+* Minor fixes.
 
 3.2.0
-++++++
++++++
 * Updated to Batch SDK 4.1.1.
 * `sdist` is now compatible with wheel 0.31.0
 

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_help.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_help.py
@@ -155,6 +155,11 @@ helps['batch job-schedule'] = """
     short-summary: Manage Batch job schedules.
 """
 
+helps['batch node service-logs'] = """
+    type: group
+    short-summary: Manage the service log files of a Batch compute node.
+"""
+
 helps['batch node user'] = """
     type: group
     short-summary: Manage the user accounts of a Batch compute node.
@@ -219,6 +224,11 @@ helps['batch pool all-statistics show'] = """
 helps['batch pool usage-metrics'] = """
     type: group
     short-summary: View usage metrics of Batch pools.
+"""
+
+helps['batch pool node-counts'] = """
+    type: group
+    short-summary: Get node counts for Batch pools.
 """
 
 helps['batch pool node-agent-skus'] = """

--- a/src/command_modules/azure-cli-monitor/HISTORY.rst
+++ b/src/command_modules/azure-cli-monitor/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.6
++++++
+* Minor fixes.
+
 0.1.5
 +++++
 * Minor fixes.

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
@@ -236,6 +236,10 @@ helps['monitor diagnostic-settings'] = """
             type: group
             short-summary: Manage service diagnostic settings.
             """
+helps['monitor diagnostic-settings categories'] = """
+            type: group
+            short-summary: Retrieve service diagnostic settings categories.
+            """
 helps['monitor diagnostic-settings create'] = """
             type: command
             short-summary: Create diagnostic settings for the specified resource.

--- a/src/command_modules/azure-cli-monitor/setup.py
+++ b/src/command_modules/azure-cli-monitor/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.5"
+VERSION = "0.1.6"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-redis/HISTORY.rst
+++ b/src/command_modules/azure-cli-redis/HISTORY.rst
@@ -3,9 +3,13 @@
 Release History
 ===============
 
+
+0.2.13
+++++++
+* Deprecated `redis patch-schedule patch-schedule show` in favor of `redis patch-schedule show`.
+
 0.2.12
 ++++++
-
 * `sdist` is now compatible with wheel 0.31.0
 
 0.2.11

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
@@ -37,3 +37,9 @@ helps['redis patch-schedule'] = """
     type: group
     short-summary: Manage Redis patch schedules.
 """
+
+helps['redis patch-schedule patch-schedule'] = """
+    type: group
+    short-summary: This group will soon be deprecated. The command, `redis patch-schedule patch-schedule show`,
+     will be replaced with `redis patch-schedule show`'
+"""

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
@@ -40,6 +40,6 @@ helps['redis patch-schedule'] = """
 
 helps['redis patch-schedule patch-schedule'] = """
     type: group
-    short-summary: This group is deprecated and will be removed in CLI version 2.0.36. 
+    short-summary: This group is deprecated and will be removed in CLI version 2.0.36.
         The command, `redis patch-schedule patch-schedule show`, will be replaced with `redis patch-schedule show`'
 """

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
@@ -40,6 +40,6 @@ helps['redis patch-schedule'] = """
 
 helps['redis patch-schedule patch-schedule'] = """
     type: group
-    short-summary: This group will soon be deprecated. The command, `redis patch-schedule patch-schedule show`,
-     will be replaced with `redis patch-schedule show`'
+    short-summary: This group is deprecated and will be removed in CLI version 2.0.36. 
+        The command, `redis patch-schedule patch-schedule show`, will be replaced with `redis patch-schedule show`'
 """

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/commands.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/commands.py
@@ -38,4 +38,4 @@ def load_command_table(self, _):
     with self.command_group('redis patch-schedule', redis_patch) as g:
         g.command('set', 'create_or_update')
         g.command('delete', 'delete')
-        g.command('patch-schedule show', 'get')
+        g.command('show', 'get')

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/commands.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/commands.py
@@ -39,3 +39,4 @@ def load_command_table(self, _):
         g.command('set', 'create_or_update')
         g.command('delete', 'delete')
         g.command('show', 'get')
+        g.command('patch-schedule show', 'get', deprecate_info="az redis patch-schedule show")

--- a/src/command_modules/azure-cli-redis/setup.py
+++ b/src/command_modules/azure-cli-redis/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.2.12"
+VERSION = "0.2.13"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,13 +2,17 @@
 
 Release History
 ===============
+
 2.0.23
 ++++++
-* Minor changes
+* Minor fixes.
+
+2.0.23
+++++++
+* Minor fixes.
 
 2.0.22
 ++++++
-
 * `sdist` is now compatible with wheel 0.31.0
 
 2.0.21

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -7,10 +7,6 @@ Release History
 ++++++
 * Minor fixes.
 
-2.0.23
-++++++
-* Minor fixes.
-
 2.0.22
 ++++++
 * `sdist` is now compatible with wheel 0.31.0

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -117,6 +117,10 @@ helps['ad sp show'] = """
     type: command
     short-summary: Get the details of a service principal.
 """
+helps['ad app'] = """
+    type: group
+    short-summary: Manage applications with AAD Graph.
+"""
 helps['ad app delete'] = """
     type: command
     short-summary: Delete an application.

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -12,6 +12,11 @@ vm_ids_example = """        - name: {0}
             az {1} --ids $(az vm list -g MyResourceGroup --query "[].id" -o tsv)
 """
 
+helps['vm secret'] = """
+    type: group
+    short-summary: Manage VM secrets.
+"""
+
 helps['vm secret add'] = """
     type: command
     short-summary: Add a secret to a VM.

--- a/tools/automation/cli_linter/linter.py
+++ b/tools/automation/cli_linter/linter.py
@@ -70,9 +70,9 @@ class Linter(object):
 
 
 class LinterManager(object):
-    def __init__(self, command_table=None, help_file_entries=None, loaded_help=None, exclusions={}):
+    def __init__(self, command_table=None, help_file_entries=None, loaded_help=None, exclusions=None):
         self.linter = Linter(command_table=command_table, help_file_entries=help_file_entries, loaded_help=loaded_help)
-        self._exclusions = exclusions
+        self._exclusions = exclusions or {}
         self._rules = {
             'help_file_entries': [],
             'command_groups': [],

--- a/tools/automation/cli_linter/rules/command_group_rules.py
+++ b/tools/automation/cli_linter/rules/command_group_rules.py
@@ -7,7 +7,6 @@ from ..rule_decorators import command_group_rule, exclude_from_ci
 from ..linter import RuleError
 
 
-@exclude_from_ci
 @command_group_rule
 def missing_group_help_rule(linter, command_group_name):
     if not linter.get_command_group_help(command_group_name):

--- a/tools/automation/cli_linter/rules/command_rules.py
+++ b/tools/automation/cli_linter/rules/command_rules.py
@@ -7,6 +7,7 @@ from ..rule_decorators import command_rule, exclude_from_ci
 from ..linter import RuleError
 
 
+@exclude_from_ci
 @command_rule
 def missing_command_help_rule(linter, command_name):
     if not linter.get_command_help(command_name):

--- a/tools/automation/cli_linter/rules/command_rules.py
+++ b/tools/automation/cli_linter/rules/command_rules.py
@@ -7,7 +7,6 @@ from ..rule_decorators import command_rule, exclude_from_ci
 from ..linter import RuleError
 
 
-@exclude_from_ci
 @command_rule
 def missing_command_help_rule(linter, command_name):
     if not linter.get_command_help(command_name):


### PR DESCRIPTION
---
-Also deprecated `redis patch-schedule patch-schedule show`
-addresses command group help rule for https://github.com/Azure/azure-cli/issues/6021

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
