### PR TITLE
ad app create/update: document update on permissions support

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.23
+++++++
+* `az ad app create/update`: document updates on using `--required-resource-accesses`
 
 2.0.22
 ++++++

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 2.0.23
 ++++++
-* `az ad app create/update`: document updates on using `--required-resource-accesses`
+* Minor changes
 
 2.0.22
 ++++++

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -121,10 +121,6 @@ helps['ad app delete'] = """
     type: command
     short-summary: Delete an application.
 """
-helps['ad app create'] = """
-    type: command
-    short-summary: Create an application.
-"""
 helps['ad app list'] = """
     type: command
     short-summary: List applications.
@@ -136,6 +132,20 @@ helps['ad app show'] = """
 helps['ad app update'] = """
     type: command
     short-summary: Update an application.
+    examples:
+        - name: update a native application with delegated permission of "access the AAD directory as the signed-in user"
+          text: |
+                az ad app update --id e042ec79-34cd-498f-9d9f-123456781234 --required-resource-accesses @manifest.json
+                ("manifest.json" contains the following content)
+                [{
+                    "resourceAppId": "00000002-0000-0000-c000-000000000000",
+                    "resourceAccess": [
+                        {
+                            "id": "a42657d6-7f20-40e3-b6f0-cee03008a62a",
+                            "type": "Scope"
+                        }
+                   ]
+                }]
 """
 helps['ad user list'] = """
     type: command
@@ -261,9 +271,9 @@ helps['ad app create'] = """
     type: command
     short-summary: Create a web application, web API or native application
     examples:
-        - name: Create a native application with delegated permission of "access the AAD directory as the signed-in user
+        - name: Create a native application with delegated permission of "access the AAD directory as the signed-in user"
           text: |
-                az ad app create --display-name my-native --native-app --requiredResourceAccess @manifest.json
+                az ad app create --display-name my-native --native-app --required-resource-accesses @manifest.json
                 ("manifest.json" contains the following content)
                 [{
                     "resourceAppId": "00000002-0000-0000-c000-000000000000",

--- a/src/command_modules/azure-cli-role/setup.py
+++ b/src/command_modules/azure-cli-role/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.22"
+VERSION = "2.0.23"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fix #6023 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
