### PR TITLE
vmss: expose 'az vmss perform-maintenance'

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.0.31
 ++++++
+* vmss: expose `az vmss perform-maintenance`
 * `vm diagnostics set`: detect VM's OS type reliably
 * `vm resize`: check if the requested size is different than currently set and update only on change
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -277,6 +277,7 @@ def load_command_table(self, _):
         g.custom_command('list-instance-public-ips', 'list_vmss_instance_public_ips')
         g.command('list-skus', 'list_skus')
         g.custom_command('reimage', 'reimage_vmss', supports_no_wait=True, min_api='2017-03-30')
+        g.command('perform-maintenance', 'perform_maintenance', min_api='2017-12-01')
         g.custom_command('restart', 'restart_vmss', supports_no_wait=True)
         g.custom_command('scale', 'scale_vmss', supports_no_wait=True)
         g.custom_command('show', 'show_vmss', exception_handler=empty_on_404, table_transformer=get_vmss_table_output_transformer(self, False))


### PR DESCRIPTION
Fix #6045
//CC: @gatneil 
I don't know whether it is possible to force trigger a maintenance so to write an end to end test, but i did run the command and see the request got rejected for a relevant error: `Operation 'performMaintenance' is not allowed on VM 'yg-ss_0' since the Subscription of this VM is not eligible.` 
Let me know other verification I can do.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
