### PR TITLE
Resolve batch download of blobs with names starting with forward slash

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -7,6 +7,7 @@ Release History
 ++++++
 * Allow destination sas-token to apply to source for blob copy if source sas and account key are unspecified.
 * Expose --socket-timeout for blob uploads and downloads.
+* Treat blob names that start with path separators as relative paths.
 
 2.0.31
 ++++++

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
@@ -113,9 +113,9 @@ def storage_blob_copy_batch(cmd, client, source_client, destination_container=No
 def storage_blob_download_batch(client, source, destination, source_container_name, pattern=None, dryrun=False,
                                 progress_callback=None, max_connections=2):
 
-    def _download_blob(blob_service, container, destination_folder, blob_name):
+    def _download_blob(blob_service, container, destination_folder, normalized_blob_name, blob_name):
         # TODO: try catch IO exception
-        destination_path = os.path.join(destination_folder, blob_name)
+        destination_path = os.path.join(destination_folder, normalized_blob_name)
         destination_folder = os.path.dirname(destination_path)
         if not os.path.exists(destination_folder):
             mkdir_p(destination_folder)
@@ -124,7 +124,15 @@ def storage_blob_download_batch(client, source, destination, source_container_na
                                              progress_callback=progress_callback)
         return blob.name
 
-    source_blobs = list(collect_blobs(client, source_container_name, pattern))
+    source_blobs = collect_blobs(client, source_container_name, pattern)
+    blobs_to_download = {}
+    for blob_name in source_blobs:
+        # remove starting path seperator and normalize
+        normalized_blob_name = normalize_blob_file_path(None, blob_name)
+        if normalized_blob_name in blobs_to_download:
+            from knack.util import CLIError
+            raise CLIError('Multiple blobs with download path: `{}`'.format(normalized_blob_name))
+        blobs_to_download[normalized_blob_name] = blob_name
 
     if dryrun:
         logger = get_logger(__name__)
@@ -137,7 +145,8 @@ def storage_blob_download_batch(client, source, destination, source_container_na
             logger.warning('  - %s', b)
         return []
 
-    return list(_download_blob(client, source_container_name, destination, blob) for blob in source_blobs)
+    return list(_download_blob(client, source_container_name, destination, blob_normed, blobs_to_download[blob_normed])
+                for blob_normed in blobs_to_download)
 
 
 def storage_blob_upload_batch(cmd, client, source, destination, pattern=None,  # pylint: disable=too-many-locals

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
@@ -131,7 +131,9 @@ def storage_blob_download_batch(client, source, destination, source_container_na
         normalized_blob_name = normalize_blob_file_path(None, blob_name)
         if normalized_blob_name in blobs_to_download:
             from knack.util import CLIError
-            raise CLIError('Multiple blobs with download path: `{}`'.format(normalized_blob_name))
+            raise CLIError('Multiple blobs with download path: `{}`. As a solution, use the `--pattern` parameter '
+                           'to select for a subset of blobs to download OR utilize the `storage blob download` '
+                           'command instead to download individual blobs.'.format(normalized_blob_name))
         blobs_to_download[normalized_blob_name] = blob_name
 
     if dryrun:

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
@@ -56,8 +56,8 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
 
         for name in blob_names:
             self.storage_cmd('storage blob upload -c {} -f "{}" -n {} --type block', storage_account_info,
-                            src_container, local_file, name)
-        
+                             src_container, local_file, name)
+
         # download blobs that start with forward slash into local folder
         local_folder = self.create_temp_dir()
         self.storage_cmd('storage blob download-batch -s {} -d "{}" --pattern {}', storage_account_info, src_container,

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
@@ -49,6 +49,26 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
                          local_folder, '*/file_0')
         self.assertEqual(4, sum(len(f) for r, d, f in os.walk(local_folder)))
 
+        # upload blobs with names that start with path separator
+        local_file = self.create_temp_file(1)
+        src_container = self.create_container(storage_account_info)
+        blob_names = ['/dir1/file', 'dir1/file', '/dir2//file', 'dir2/file']
+
+        for name in blob_names:
+            self.storage_cmd('storage blob upload -c {} -f "{}" -n {} --type block', storage_account_info,
+                            src_container, local_file, name)
+        
+        # download blobs that start with forward slash into local folder
+        local_folder = self.create_temp_dir()
+        self.storage_cmd('storage blob download-batch -s {} -d "{}" --pattern {}', storage_account_info, src_container,
+                         local_folder, '/*')
+        self.assertEqual(2, sum(len(f) for r, d, f in os.walk(local_folder)))
+
+        # download blobs that start with forward slash into local folder with conflicts
+        local_folder = self.create_temp_dir()
+        self.storage_cmd_negative('storage blob download-batch -s {} -d "{}"', storage_account_info, src_container,
+                                  local_folder)
+
     @ResourceGroupPreparer()
     @StorageAccountPreparer()
     @StorageTestFilesPreparer()


### PR DESCRIPTION
---
Closes: https://github.com/Azure/azure-cli/issues/5837

-blob names starting with forward slashes are treated as relative paths.
-if multiple blob names would resolve to the same local file path, a CLIerror is thrown

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

