### PR TITLE
Fix CLI @{file} syntax

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 2.0.32
 ++++++
 * Added limited support for positional arguments.
+* Fix issue where reading in from STDIN with @- didn't work. [#1398](https://github.com/Azure/azure-cli/issues/1398)
 
 2.0.31
 ++++++

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -65,7 +65,7 @@ def _expand_file_prefixed_files(args):
             import os
             content = read_file_content(os.path.expanduser(path), allow_binary=True)
 
-        return content[0:-1] if content and content[-1] == '\n' else content
+        return content.rstrip()
 
     def _maybe_load_file(arg):
         ix = arg.find('@')

--- a/src/azure-cli-core/azure/cli/core/tests/test_application.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_application.py
@@ -90,7 +90,7 @@ class TestApplication(unittest.TestCase):
         f_with_bom.close()
 
         with open(f.name, 'w+') as stream:
-            stream.write('foo')
+            stream.write('foo \r\n')
 
         from codecs import open as codecs_open
         with codecs_open(f_with_bom.name, encoding='utf-8-sig', mode='w+') as stream:


### PR DESCRIPTION
Fix #1398.  Fix #2597.

The issue was the infrastructure was reading in the value correctly from file/STDIN, but needed to chomp the trailing whitespace, newlines, etc.

Updated existing tests to protect this from regression.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [N/A] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
