### PR TITLE
rbac: remove deprecated 'az ad sp reset-credentials'

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 2.0.23
 ++++++
+* Breaking Change: remove deprecated `az ad sp reset-credentials`
 * Minor fixes.
 
 2.0.22

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.0.23
 ++++++
-* Breaking Change: remove deprecated `az ad sp reset-credentials`
+* BREAKING CHANGE: remove deprecated `az ad sp reset-credentials`
 * Minor fixes.
 
 2.0.22

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -72,11 +72,6 @@ helps['ad sp credential delete'] = """
     short-summary: delete a service principal's credential.
 """
 
-helps['ad sp reset-credentials'] = """
-    type: command
-    short-summary: (Deprecated, use "az ad sp credential reset")
-"""
-
 helps['ad sp credential reset'] = """
     type: command
     short-summary: Reset a service principal credential.

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -66,7 +66,7 @@ def load_arguments(self, _):
 
     for item in ['delete', 'list']:
         with self.argument_context('ad sp credential {}'.format(item)) as c:
-            c.argument('key_id', help='credential id')
+            c.argument('key_id', help='credential key id')
             c.argument('cert', action='store_true', help='a certificate based credential')
 
     with self.argument_context('ad') as c:

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -54,7 +54,7 @@ def load_arguments(self, _):
         c.argument('skip_assignment', arg_type=get_three_state_flag(), help='do not create default assignment')
         c.argument('show_auth_for_sdk', options_list='--sdk-auth', help='output result in compatible with Azure SDK auth file', arg_type=get_three_state_flag())
 
-    for item in ['create-for-rbac', 'reset-credentials', 'ad sp']:
+    for item in ['create-for-rbac', 'credential reset']:
         with self.argument_context('ad sp {}'.format(item)) as c:
             c.argument('name', name_arg_type)
             c.argument('cert', arg_group='Credential', validator=validate_cert)
@@ -63,6 +63,11 @@ def load_arguments(self, _):
             c.argument('create_cert', action='store_true', arg_group='Credential')
             c.argument('keyvault', arg_group='Credential')
             c.argument('append', action='store_true', help='Append the new credential instead of overwriting.')
+
+    for item in ['delete', 'list']:
+        with self.argument_context('ad sp credential {}'.format(item)) as c:
+            c.argument('key_id', help='credential id')
+            c.argument('cert', action='store_true', help='a certificate based credential')
 
     with self.argument_context('ad') as c:
         c.argument('display_name', help='object\'s display name or its prefix')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
@@ -91,7 +91,6 @@ def load_command_table(self, _):
     # RBAC related
     with self.command_group('ad sp') as g:
         g.custom_command('create-for-rbac', 'create_service_principal_for_rbac')
-        g.custom_command('reset-credentials', 'reset_service_principal_credential', deprecate_info='ad sp credential reset')
         g.custom_command('credential reset', 'reset_service_principal_credential')
         g.custom_command('credential list', 'list_service_principal_credentials')
         g.custom_command('credential delete', 'delete_service_principal_credential')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -32,7 +32,7 @@ class ServicePrincipalExpressCreateScenarioTest(ScenarioTest):
             self.check('[0].servicePrincipalNames[0]', '{app_id_uri}'),
             self.check('length([*])', 1),
         ])
-        self.cmd('ad sp reset-credentials -n {app_id_uri}',
+        self.cmd('ad sp credential reset -n {app_id_uri}',
                  checks=self.check('name', '{app_id_uri}'))
         # cleanup
         self.cmd('ad sp delete --id {app_id_uri}')  # this whould auto-delete the app as well

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -77,7 +77,7 @@ class RbacSPCertScenarioTest(RoleScenarioTest):
                                   checks=self.check('name', '{sp}')).get_output_in_json()
                 self.assertTrue(result['fileWithCertAndPrivateKey'].endswith('.pem'))
                 os.remove(result['fileWithCertAndPrivateKey'])
-                result = self.cmd('ad sp reset-credentials -n {sp} --create-cert',
+                result = self.cmd('ad sp credential reset -n {sp} --create-cert',
                                   checks=self.check('name', '{sp}')).get_output_in_json()
                 self.assertTrue(result['fileWithCertAndPrivateKey'].endswith('.pem'))
                 os.remove(result['fileWithCertAndPrivateKey'])
@@ -107,7 +107,7 @@ class RbacSPKeyVaultScenarioTest(LiveScenarioTest):
             with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
                 self.cmd('ad sp create-for-rbac --scopes {scope}/resourceGroups/{rg} --create-cert --keyvault {kv} --cert {cert} -n {sp}')
                 cer1 = self.cmd('keyvault certificate show --vault-name {kv} -n {cert}').get_output_in_json()['cer']
-                self.cmd('ad sp reset-credentials -n {sp} --create-cert --keyvault {kv} --cert {cert}')
+                self.cmd('ad sp credential reset -n {sp} --create-cert --keyvault {kv} --cert {cert}')
                 cer2 = self.cmd('keyvault certificate show --vault-name {kv} -n {cert}').get_output_in_json()['cer']
                 self.assertTrue(cer1 != cer2)
         finally:
@@ -135,7 +135,7 @@ class RbacSPKeyVaultScenarioTest(LiveScenarioTest):
             self.cmd('keyvault certificate create --vault-name {kv} -n {cert} -p "{policy}" --validity 24')
             with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
                 self.cmd('ad sp create-for-rbac -n {sp} --keyvault {kv} --cert {cert} --scopes {scope}/resourceGroups/{rg}')
-            self.cmd('ad sp reset-credentials -n {sp} --keyvault {kv} --cert {cert}')
+            self.cmd('ad sp credential reset -n {sp} --keyvault {kv} --cert {cert}')
         finally:
             self.cmd('ad app delete --id {sp}')
 
@@ -145,7 +145,7 @@ class RbacSPKeyVaultScenarioTest(LiveScenarioTest):
             self.cmd('keyvault certificate create --vault-name {kv} -n {cert} -p "{policy}" --validity 6')
             with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
                 self.cmd('ad sp create-for-rbac --scopes {scope}/resourceGroups/{rg} --keyvault {kv} --cert {cert} -n {sp}')
-            self.cmd('ad sp reset-credentials -n {sp} --keyvault {kv} --cert {cert}')
+            self.cmd('ad sp credential reset -n {sp} --keyvault {kv} --cert {cert}')
         finally:
             self.cmd('ad app delete --id {sp}')
 


### PR DESCRIPTION
Fix #6013 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
