### PR TITLE
Improve ID parsing

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -206,7 +206,7 @@ def add_id_parameters(_, **kwargs):  # pylint: disable=unused-argument
                 existing_values = getattr(namespace, arg.name, None)
                 if existing_values is None:
                     existing_values = IterateValue()
-                    existing_values.append(parts[arg.type.settings['id_part']])
+                    existing_values.append(parts.get(arg.type.settings['id_part'], None))
                 else:
                     if isinstance(existing_values, str):
                         if not getattr(arg.type, 'configured_default_applied', None):
@@ -215,7 +215,7 @@ def add_id_parameters(_, **kwargs):  # pylint: disable=unused-argument
                                 arg.name, existing_values, parts[arg.type.settings['id_part']]
                             )
                         existing_values = IterateValue()
-                    existing_values.append(parts[arg.type.settings['id_part']])
+                    existing_values.append(parts.get(arg.type.settings['id_part']))
                 setattr(namespace, arg.name, existing_values)
 
         return SplitAction

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -186,6 +186,8 @@ def add_id_parameters(_, **kwargs):  # pylint: disable=unused-argument
                     try:
                         # support piping values from JSON. Does not require use of --query
                         json_vals = json.loads(val)
+                        if not isinstance(json_vals, list):
+                            json_vals = [json_vals]
                         for json_val in json_vals:
                             if 'id' in json_val:
                                 expanded_values += [json_val['id']]


### PR DESCRIPTION
Fixes 2 issues:

1. Previously, if you submitted an ID that was too short (for example, feed a VNET ID to a `subnet show` command) you would receive a stack trace. 

2. Updates the logic from the previous PR so that the JSON simplification will work for commands that return a JSON object. The old version only works for JSON Arrays.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
