### PR TITLE
Fix: Extension metadata not being loaded

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -68,7 +68,7 @@ DEPENDENCIES = [
     'requests',
     'six',
     'tabulate>=0.7.7,<=0.8.2',
-    'wheel',
+    'wheel==0.30.0',
 ]
 
 if sys.version_info < (3, 4):

--- a/src/command_modules/azure-cli-extension/HISTORY.rst
+++ b/src/command_modules/azure-cli-extension/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.13
+++++++
+* Pin version of `wheel` so extensions can get metadata shown again.
+
 0.0.12
 ++++++
 * Linux distro check message should be output to debug instead of warning.

--- a/src/command_modules/azure-cli-extension/setup.py
+++ b/src/command_modules/azure-cli-extension/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.12"
+VERSION = "0.0.13"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
@@ -33,7 +33,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-cli-core',
     'pip',
-    'wheel',
+    'wheel==0.30.0',
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
Pin the version of wheel until a fix is available.

This is due to https://github.com/pypa/wheel/issues/235