### PR TITLE
Support custom resource types being added to API_PROFILES

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -13,6 +13,7 @@ Release History
   without specifying a query.
 * Display command suggestions on error if users have typo in their commands
 * More friendly error when users type `az ''`
+* Support custom resource types for command modules and extensions
 
 2.0.31
 ++++++

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -452,8 +452,7 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         from azure.cli.core.profiles import AZURE_API_PROFILES
         from azure.cli.core.profiles._shared import get_versioned_sdk_path
 
-        resource_types_in_profile = AZURE_API_PROFILES[self.cli_ctx.cloud.profile].keys()
-        for rt in resource_types_in_profile:
+        for rt in AZURE_API_PROFILES[self.cli_ctx.cloud.profile]:
             if operation.startswith(rt.import_prefix + ".operations."):
                 subs = operation[len(rt.import_prefix + ".operations."):]
                 operation_group = subs[:subs.index('_operations')]

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -449,10 +449,11 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         from importlib import import_module
         import types
 
-        from azure.cli.core.profiles import ResourceType
+        from azure.cli.core.profiles import AZURE_API_PROFILES
         from azure.cli.core.profiles._shared import get_versioned_sdk_path
 
-        for rt in ResourceType:
+        resource_types_in_profile = AZURE_API_PROFILES[self.cli_ctx.cloud.profile].keys()
+        for rt in resource_types_in_profile:
             if operation.startswith(rt.import_prefix + ".operations."):
                 subs = operation[len(rt.import_prefix + ".operations."):]
                 operation_group = subs[:subs.index('_operations')]

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -12,7 +12,7 @@ from azure.cli.core import __version__ as core_version
 import azure.cli.core._debug as _debug
 from azure.cli.core.extension import EXTENSIONS_MOD_PREFIX
 from azure.cli.core.profiles._shared import get_client_class, SDKProfile
-from azure.cli.core.profiles import ResourceType, get_api_version, get_sdk
+from azure.cli.core.profiles import ResourceType, CustomResourceType, get_api_version, get_sdk
 
 logger = get_logger(__name__)
 UA_AGENT = "AZURECLI/{}".format(core_version)
@@ -46,7 +46,7 @@ def resolve_client_arg_name(operation, kwargs):
 def get_mgmt_service_client(cli_ctx, client_or_resource_type, subscription_id=None, api_version=None,
                             **kwargs):
     sdk_profile = None
-    if isinstance(client_or_resource_type, ResourceType):
+    if isinstance(client_or_resource_type, (ResourceType, CustomResourceType)):
         # Get the versioned client
         client_type = get_client_class(client_or_resource_type)
         api_version = api_version or get_api_version(cli_ctx, client_or_resource_type, as_sdk_profile=True)

--- a/src/azure-cli-core/azure/cli/core/profiles/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/__init__.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 #  pylint: disable=unused-import
-from azure.cli.core.profiles._shared import AZURE_API_PROFILES, ResourceType, PROFILE_TYPE
+from azure.cli.core.profiles._shared import AZURE_API_PROFILES, ResourceType, CustomResourceType, PROFILE_TYPE
 
 
 def get_api_version(cli_ctx, resource_type, as_sdk_profile=False):
@@ -89,3 +89,15 @@ API_PROFILES = {
     'latest': AZURE_API_PROFILES['latest'],
     '2017-03-09-profile': AZURE_API_PROFILES['2017-03-09-profile']
 }
+
+
+def register_resource_type(profile_name, resource_type, api_version):
+    err_msg = "Failed to add resource type to profile '{p}': "
+    if not isinstance(resource_type, CustomResourceType):
+        raise TypeError((err_msg + "resource_type should be of type {c}, got {r}.").format(p=profile_name,
+                                                                                           c=CustomResourceType,
+                                                                                           r=type(resource_type)))
+    try:
+        API_PROFILES[profile_name].update({resource_type: api_version})
+    except KeyError:
+        raise ValueError((err_msg + "Profile '{p}' not found.").format(p=profile_name))

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -24,6 +24,12 @@ class APIVersionException(Exception):
 PROFILE_TYPE = object()
 
 
+class CustomResourceType(object):  # pylint: disable=too-few-public-methods
+    def __init__(self, import_prefix, client_name):
+        self.import_prefix = import_prefix
+        self.client_name = client_name
+
+
 class ResourceType(Enum):  # pylint: disable=too-few-public-methods
 
     MGMT_STORAGE = ('azure.mgmt.storage', 'StorageManagementClient')
@@ -227,12 +233,12 @@ def supported_api_version(api_profile, resource_type, min_api=None, max_api=None
     note: Currently supports YYYY-MM-DD, YYYY-MM-DD-preview, YYYY-MM-DD-profile
     or YYYY-MM-DD-profile-preview  formatted strings.
     """
-    if not isinstance(resource_type, ResourceType) and resource_type != PROFILE_TYPE:
+    if not isinstance(resource_type, (ResourceType, CustomResourceType)) and resource_type != PROFILE_TYPE:
         raise ValueError("'resource_type' is required.")
     if min_api is None and max_api is None:
         raise ValueError('At least a min or max version must be specified')
     api_version_obj = get_api_version(api_profile, resource_type, as_sdk_profile=True) \
-        if isinstance(resource_type, ResourceType) else api_profile
+        if isinstance(resource_type, (ResourceType, CustomResourceType)) else api_profile
     if isinstance(api_version_obj, SDKProfile):
         api_version_obj = api_version_obj.profile.get(operation_group or '', api_version_obj.default_api_version)
     return _validate_api_version(api_version_obj, min_api, max_api)


### PR DESCRIPTION
- Only list through RTs in the current profile instead of all (no need to go through all)

Marked as DNM for now to get feedback and also, it includes a change to storage that we wouldn't want to actually merge.