### PR TITLE
Fixed broken interactive completers with positional arguments

### DIFF
--- a/src/command_modules/azure-cli-interactive/HISTORY.rst
+++ b/src/command_modules/azure-cli-interactive/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.3.20
+++++++
+* Allow interactive completers to function with positional arguments.
+
 0.3.19
 ++++++
 * Stops completions upon unrecognized commands.

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/_dump_commands.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/_dump_commands.py
@@ -103,7 +103,8 @@ class FreshTable(object):
                         'help': cmd.arguments[key].type.settings.get('help') or ''
                     }
                     # the key is the first alias option
-                    parameter_metadata[cmd.arguments[key].options_list[0]] = options
+                    if cmd.arguments[key].options_list:
+                        parameter_metadata[cmd.arguments[key].options_list[0]] = options
 
                 cmd_table_data[command_name] = {
                     'parameters': parameter_metadata,

--- a/src/command_modules/azure-cli-interactive/setup.py
+++ b/src/command_modules/azure-cli-interactive/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     cmdclass = {}
 
 # Version is also defined in azclishell.__init__.py.
-VERSION = "0.3.19"
+VERSION = "0.3.20"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
---
Fixes: https://github.com/Azure/azure-cli/issues/6109

-help dumping was broken with positional args, this fixes it.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
