### PR TITLE
webapp: remove '--runtime-version' from 'az webapp auth update'

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 0.1.32
 ++++++
+* webapp: remove `--runtime-version` from `az webapp auth update` as it's not very public ready
 * webapp: az webapp config set support for min_tls_version & https2.0
 
 0.1.31

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -272,7 +272,7 @@ def get_auth_settings(cmd, resource_group_name, name, slot=None):
 
 def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=None,  # pylint: disable=unused-argument
                          client_id=None, token_store_enabled=None,  # pylint: disable=unused-argument
-                         runtime_version=None, token_refresh_extension_hours=None,  # pylint: disable=unused-argument
+                         token_refresh_extension_hours=None,  # pylint: disable=unused-argument
                          allowed_external_redirect_urls=None, client_secret=None,  # pylint: disable=unused-argument
                          allowed_audiences=None, issuer=None, facebook_app_id=None,  # pylint: disable=unused-argument
                          facebook_app_secret=None, facebook_oauth_scopes=None,  # pylint: disable=unused-argument

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -770,7 +770,6 @@ class WebappAuthenticationTest(ScenarioTest):
             JMESPathCheck('defaultProvider', None),
             JMESPathCheck('enabled', False),
             JMESPathCheck('tokenStoreEnabled', None),
-            JMESPathCheck('runtimeVersion', None),
             JMESPathCheck('allowedExternalRedirectUrls', None),
             JMESPathCheck('tokenRefreshExtensionHours', None),
             JMESPathCheck('clientId', None),
@@ -784,7 +783,7 @@ class WebappAuthenticationTest(ScenarioTest):
 
         # update and verify
         result = self.cmd('webapp auth update -g {} -n {} --enabled true --action LoginWithFacebook '
-                          '--token-store false --runtime-version v5.0 --token-refresh-extension-hours 7.2 '
+                          '--token-store false --token-refresh-extension-hours 7.2 '
                           '--aad-client-id aad_client_id --aad-client-secret aad_secret '
                           '--aad-allowed-token-audiences https://audience1 --aad-token-issuer-url https://issuer_url '
                           '--facebook-app-id facebook_id --facebook-app-secret facebook_secret '
@@ -794,7 +793,6 @@ class WebappAuthenticationTest(ScenarioTest):
                               JMESPathCheck('defaultProvider', 'Facebook'),
                               JMESPathCheck('enabled', True),
                               JMESPathCheck('tokenStoreEnabled', False),
-                              JMESPathCheck('runtimeVersion', 'v5.0'),
                               JMESPathCheck('tokenRefreshExtensionHours', 7.2),
                               JMESPathCheck('clientId', 'aad_client_id'),
                               JMESPathCheck('clientSecret', 'aad_secret'),


### PR DESCRIPTION
Per suggestion from @cgillum, this configuration is not expected to be used by lots of people and will be revisited in future; also the telemetry data shows no usage in the last 6 months. So let us make it no-so discoverable by pulling it out.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
