### PR TITLE
vm: single pass encryption support

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.0.31
 ++++++
+* vm: support disk encryption w/o user provided service principals 
 * BREAKING CHANGE: do not use VM 'ManagedIdentityExtension' for MSI support
 * vmss: support eviction policy
 * BREAKING CHANGE: remove erroneous argument of `ids` from `vm extension list`,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -113,12 +113,18 @@ def encrypt_vm(cmd, resource_group_name, vm_name,  # pylint: disable=too-many-lo
         'KeyEncryptionAlgorithm': key_encryption_algorithm,
         'SequenceVersion': sequence_version,
     }
-    if not use_new_ade:
+    if use_new_ade:
+        public_config.update({
+            "KeyVaultResourceId": disk_encryption_keyvault,
+            "KekVaultResourceId": key_encryption_keyvault if key_encryption_key else '',
+        })
+    else:
         public_config.update({
             'AADClientID': aad_client_id,
             'AADClientCertThumbprint': aad_client_cert_thumbprint,
         })
-    private_config = {
+
+    ade_legacy_private_config = {
         'AADClientSecret': aad_client_secret if is_linux else (aad_client_secret or '')
     }
 
@@ -129,7 +135,7 @@ def encrypt_vm(cmd, resource_group_name, vm_name,  # pylint: disable=too-many-lo
     ext = VirtualMachineExtension(location=vm.location,  # pylint: disable=no-member
                                   publisher=extension['publisher'],
                                   virtual_machine_extension_type=extension['name'],
-                                  protected_settings=None if use_new_ade else private_config,
+                                  protected_settings=None if use_new_ade else ade_legacy_private_config,
                                   type_handler_version=extension['version'],
                                   settings=public_config,
                                   auto_upgrade_minor_version=True)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -222,16 +222,9 @@ def decrypt_vm(cmd, resource_group_name, vm_name, volume_type=None, force=False)
     # 1. be nice, figure out the default volume type and also verify VM will not be busted
     if is_linux:
         if volume_type:
-            if not force:
-                if volume_type == _DATA_VOLUME_TYPE:
-                    status = show_vm_encryption_status(cmd, resource_group_name, vm_name)
-                    if status['osDisk'] == _STATUS_ENCRYPTED:
-                        raise CLIError("Linux VM's OS disk is encrypted. Disabling encryption on data "
-                                       "disk can render the VM unbootable. Use '--force' "
-                                       "to ingore the warning")
-                else:
-                    raise CLIError("Only Data disks can have encryption disabled in a Linux VM. "
-                                   "Use '--force' to ingore the warning")
+            if not force and volume_type != _DATA_VOLUME_TYPE:
+                raise CLIError("Only Data disks can have encryption disabled in a Linux VM. "
+                               "Use '--force' to ingore the warning")
         else:
             volume_type = _DATA_VOLUME_TYPE
     elif volume_type is None:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -224,7 +224,7 @@ def decrypt_vm(cmd, resource_group_name, vm_name, volume_type=None, force=False)
         if volume_type:
             if not force and volume_type != _DATA_VOLUME_TYPE:
                 raise CLIError("Only Data disks can have encryption disabled in a Linux VM. "
-                               "Use '--force' to ingore the warning")
+                               "Use '--force' to ignore the warning")
         else:
             volume_type = _DATA_VOLUME_TYPE
     elif volume_type is None:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -48,7 +48,6 @@ def _find_existing_ade(vm, use_instance_view=False, ade_ext_info=None):
     return r
 
 
-# return (has_new_ade, has_old_ade)
 def _detect_ade_status(vm):
     if vm.storage_profile.os_disk.encryption_settings:
         return False, True
@@ -173,7 +172,7 @@ def encrypt_vm(cmd, resource_group_name, vm_name,  # pylint: disable=too-many-lo
     if not use_new_ade:
         if not (extension_result.instance_view.statuses and
                 extension_result.instance_view.statuses[0].message):
-            raise CLIError('Could not found url pointing to the secret for disk encryption')
+            raise CLIError('Could not find url pointing to the secret for disk encryption')
 
         # 3. update VM's storage profile with the secrets
         status_url = extension_result.instance_view.statuses[0].message

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_disk_encryption_e2e.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_disk_encryption_e2e.yaml
@@ -1,0 +1,1916 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"date": "2018-04-22T03:56:25Z", "product":
+      "azurecli", "cause": "automation"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001","name":"cli_test_vm_encryption000001","location":"westus","tags":{"date":"2018-04-22T03:56:25Z","product":"azurecli","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:56:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001","name":"cli_test_vm_encryption000001","location":"westus","tags":{"date":"2018-04-22T03:56:25Z","product":"azurecli","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:56:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 azure-graphrbac/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"a30db067-cde1-49be-95bb-9619a8cc8617","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"},{"disabledPlans":[],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"f82a60b8-1ee3-4cfb-a4fe-1c6a53c2656c"},{"disabledPlans":[],"skuId":"d3b4fe1f-9992-4930-8acb-ca6ec609365e"},{"disabledPlans":[],"skuId":"c52ea49f-fe5d-4e95-93ba-1de91d380f89"}],"assignedPlans":[{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"acffdce6-c30f-4dc2-81c0-372e33c515ec"},{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2018-03-17T03:06:21Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-03-17T03:06:21Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-03-17T00:53:26Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-01-09T10:35:29Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2017-12-31T21:14:52Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2017-12-31T21:14:52Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2017-12-31T03:27:36Z","capabilityStatus":"Deleted","service":"Adallom","servicePlanId":"932ad362-64a8-4783-9106-97849a1a30b9"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2017-10-06T23:11:11Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2017-10-06T23:11:11Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2017-10-06T23:11:11Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2017-10-06T23:11:11Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"},{"assignedTimestamp":"2017-07-06T19:19:59Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"4828c8ec-dc2e-4779-b502-87ac9ce28ab7"},{"assignedTimestamp":"2017-07-06T19:19:59Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Deleted","service":"ProcessSimple","servicePlanId":"76846ad7-7776-4c40-a281-a386362dd1b9"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Deleted","service":"PowerAppsService","servicePlanId":"c68f8d98-5534-41c8-bf36-22fa496fa792"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"9e700747-8b1d-45e5-ab8d-ef187ceec156"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Deleted","service":"OfficeForms","servicePlanId":"2789c901-c14e-48ab-a76a-be334d9d793a"},{"assignedTimestamp":"2017-07-06T19:19:57Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2017-07-06T19:19:57Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"159f4cd6-e380-449f-a816-af1a9ef76344"},{"assignedTimestamp":"2017-06-12T08:23:48Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2017-06-12T08:23:48Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2017-06-12T08:23:48Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2017-05-12T23:33:35Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"8e0c0a52-6a6c-4d40-8370-dd62790dcd70"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"c4048e79-4474-4c74-ba9b-c31ff225e511"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Deleted","service":"AzureAnalysis","servicePlanId":"2049e525-b859-401b-b2a0-e0a31c4b1fe4"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2016-12-19T03:16:33Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"2125cfd7-2110-4567-83c4-c1cd5275163d"},{"assignedTimestamp":"2016-12-19T03:16:33Z","capabilityStatus":"Deleted","service":"PowerBI","servicePlanId":"fc0a60aa-feee-4746-a0e3-aecfe81a38dd"},{"assignedTimestamp":"2016-11-18T18:51:08Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2016-11-18T18:51:08Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2012-10-10T07:21:11Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2015-07-30T06:17:13Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"5a10155d-f5c1-411a-a8ec-e99aae125390"},{"assignedTimestamp":"2015-07-30T06:17:13Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"27216c54-caf8-4d0d-97e2-517afb5c08f6"}],"city":"REDMOND","companyName":"MICROSOFT","consentProvidedForMinor":null,"country":null,"creationType":null,"department":"Azure
+        and Web COGS 1010 US","dirSyncEnabled":true,"displayName":"Yugang Wang","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Yugang","immutableId":"138058","isCompromised":null,"jobTitle":"SENIOR
+        SOFTWARE ENGINEER","lastDirSyncTime":"2018-04-14T15:08:08Z","legalAgeGroupClassification":null,"mail":"yugangw@microsoft.com","mailNickname":"yugangw","mobile":null,"onPremisesDistinguishedName":"CN=Yugang
+        Wang,OU=UserAccounts,DC=redmond,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-2127521184-1604012920-1887927527-415191","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"18/2250FL","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"}],"provisioningErrors":[],"proxyAddresses":["X500:/O=Nokia/OU=HUB/cn=Recipients/cn=yugangw","X500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=sdflabs.com-51490-Yugang
+        Wang (Volt)e3d6fb0c","X500:/o=microsoft/ou=northamerica/cn=Recipients/cn=572513","X500:/o=microsoft/ou=First
+        Administrative Group/cn=Recipients/cn=yugangw","X500:/o=microsoft/ou=External
+        (FYDIBOHF25SPDLT)/cn=Recipients/cn=0e00e165bf5842568a693fea3aa4faad","X500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=yugangw_microsoft.com","X500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=sdflabs.com-51490-Yugang
+        Wang","X500:/o=SDF/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=51490-yugangw_c50b13e019","X500:/o=MSNBC/ou=Servers/cn=Recipients/cn=yugangw","X500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=yugangw17d63dbbde","X500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=microsoft.onmicrosoft.com-55760-Yugang
+        Wang (Volt)","X500:/O=Microsoft/OU=APPS-WGA/cn=Recipients/cn=yugangw","X500:/o=MMS/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=Yugang Wang5ec8094e-2aed-488b-a327-9baed3c38367","SMTP:yugangw@microsoft.com","smtp:a-ywang2@microsoft.com","smtp:yugangw@msg.microsoft.com","x500:/o=microsoft/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=Yugang Wang (Volt)","smtp:YUGANGW@service.microsoft.com"],"refreshTokensValidFromDateTime":"2018-04-04T16:38:21Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":"yugangw@microsoft.com","state":null,"streetAddress":null,"surname":"Wang","telephoneNumber":"+1
+        (425) 7069936","thumbnailPhoto@odata.mediaContentType":"image/Jpeg","usageLocation":"US","userIdentities":[],"userPrincipalName":"yugangw@microsoft.com","userType":null,"extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10130001","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10130001","extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"90092430","extension_18e31482d3fb4a8ea958aa96b662f508_AddressLine1":"1
+        Microsoft Way","extension_18e31482d3fb4a8ea958aa96b662f508_CityName":"REDMOND","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1010","extension_18e31482d3fb4a8ea958aa96b662f508_CountryShortCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"138058","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"MAYURID","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Diwan,
+        Mayuri","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"186027","extension_18e31482d3fb4a8ea958aa96b662f508_StateProvinceCode":"WA","extension_18e31482d3fb4a8ea958aa96b662f508_ZipCode":"98052","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"17","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"18"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['15481']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Sun, 22 Apr 2018 03:56:29 GMT']
+      duration: ['587956']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [YPCVOwAR3XOdfRvDdWZX3yHf1fnOOll9dsEetoCYv9Y=]
+      ocp-aad-session-key: [q3f-hF12WIO-qsQaYBX-sTaEk41U6SNgMTFvlMqmMHLTWsZSHdU_vdr1Woy4Q3WF74GQNCqaGQmvkSqNQlInGjch13quBFckkD6zQq9K-GTQuurQIzi95qZPc-Tmvf-1.7egq9qi_dL3cEqsdql1vCT5jehJtCk4gATEj4-VtrWM]
+      pragma: [no-cache]
+      request-id: [9896b9f1-5e4d-4dc1-af1f-865075a4050c]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "properties": {"accessPolicies": [{"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "objectId": "a30db067-cde1-49be-95bb-9619a8cc8617", "permissions": {"certificates":
+      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
+      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover"], "secrets":
+      ["get", "list", "set", "delete", "backup", "restore", "recover"], "storage":
+      ["get", "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas",
+      "getsas", "deletesas"], "keys": ["get", "create", "delete", "list", "update",
+      "import", "backup", "restore", "recover"]}}], "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "enabledForDiskEncryption": true, "sku": {"name": "standard", "family": "A"}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
+      Connection: [keep-alive]
+      Content-Length: ['780']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002","name":"vault000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"a30db067-cde1-49be-95bb-9619a8cc8617","permissions":{"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":true,"vaultUri":"https://vault000002.vault.azure.net","provisioningState":"RegisteringDns"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1096']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:56:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.214]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001","name":"cli_test_vm_encryption000001","location":"westus","tags":{"date":"2018-04-22T03:56:25Z","product":"azurecli","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:56:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
+        ,\n  \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\"\
+        :{},\n  \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"\
+        type\":\"object\",\n      \"value\":{\n\n        \"Linux\":{\n          \"\
+        CentOS\":{\n            \"publisher\":\"OpenLogic\",\n            \"offer\"\
+        :\"CentOS\",\n            \"sku\":\"7.3\",\n            \"version\":\"latest\"\
+        \n          },\n          \"CoreOS\":{\n            \"publisher\":\"CoreOS\"\
+        ,\n            \"offer\":\"CoreOS\",\n            \"sku\":\"Stable\",\n  \
+        \          \"version\":\"latest\"\n          },\n          \"Debian\":{\n\
+        \            \"publisher\":\"credativ\",\n            \"offer\":\"Debian\"\
+        ,\n            \"sku\":\"8\",\n            \"version\":\"latest\"\n      \
+        \    },\n          \"openSUSE-Leap\": {\n            \"publisher\":\"SUSE\"\
+        ,\n            \"offer\":\"openSUSE-Leap\",\n            \"sku\":\"42.3\"\
+        ,\n            \"version\": \"latest\"\n          },\n          \"RHEL\":{\n\
+        \            \"publisher\":\"RedHat\",\n            \"offer\":\"RHEL\",\n\
+        \            \"sku\":\"7.3\",\n            \"version\":\"latest\"\n      \
+        \    },\n          \"SLES\":{\n            \"publisher\":\"SUSE\",\n     \
+        \       \"offer\":\"SLES\",\n            \"sku\":\"12-SP2\",\n           \
+        \ \"version\":\"latest\"\n          },\n          \"UbuntuLTS\":{\n      \
+        \      \"publisher\":\"Canonical\",\n            \"offer\":\"UbuntuServer\"\
+        ,\n            \"sku\":\"16.04-LTS\",\n            \"version\":\"latest\"\n\
+        \          }\n        },\n\n        \"Windows\":{\n          \"Win2016Datacenter\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2016-Datacenter\",\n   \
+        \         \"version\":\"latest\"\n          },\n          \"Win2012R2Datacenter\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2012-R2-Datacenter\",\n\
+        \            \"version\":\"latest\"\n          },\n          \"Win2012Datacenter\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2012-Datacenter\",\n   \
+        \         \"version\":\"latest\"\n          },\n          \"Win2008R2SP1\"\
+        :{\n            \"publisher\":\"MicrosoftWindowsServer\",\n            \"\
+        offer\":\"WindowsServer\",\n            \"sku\":\"2008-R2-SP1\",\n       \
+        \     \"version\":\"latest\"\n          }\n        }\n      }\n    }\n  }\n\
+        }\n"}
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['*']
+      cache-control: [max-age=300]
+      connection: [keep-alive]
+      content-length: ['2235']
+      content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
+      content-type: [text/plain; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:56:33 GMT']
+      etag: ['"60d07919b4224266adafb81340896eea100dc887"']
+      expires: ['Sun, 22 Apr 2018 04:01:33 GMT']
+      source-age: ['0']
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization,Accept-Encoding']
+      via: [1.1 varnish]
+      x-cache: [MISS]
+      x-cache-hits: ['0']
+      x-content-type-options: [nosniff]
+      x-fastly-request-id: [bc4936260c2e21371676187b0766e049c5e84d62]
+      x-frame-options: [deny]
+      x-geo-block-list: ['']
+      x-github-request-id: ['6A1A:087B:10AED71:11ACA64:5ADC07F1']
+      x-served-by: [cache-sea1040-SEA]
+      x-timer: ['S1524369393.150298,VS0,VE94']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-01-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:56:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"properties": {"parameters": {"adminPassword": {"value": "Test123456789!"}},
+      "mode": "Incremental", "template": {"variables": {}, "resources": [{"location":
+      "westus", "tags": {}, "type": "Microsoft.Network/virtualNetworks", "properties":
+      {"subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"}, "name": "vm1Subnet"}],
+      "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}, "name": "vm1VNET", "apiVersion":
+      "2015-06-15", "dependsOn": []}, {"location": "westus", "tags": {}, "type": "Microsoft.Network/networkSecurityGroups",
+      "properties": {"securityRules": [{"properties": {"protocol": "Tcp", "sourceAddressPrefix":
+      "*", "priority": 1000, "access": "Allow", "destinationAddressPrefix": "*", "destinationPortRange":
+      "3389", "sourcePortRange": "*", "direction": "Inbound"}, "name": "rdp"}]}, "name":
+      "vm1NSG", "apiVersion": "2015-06-15", "dependsOn": []}, {"location": "westus",
+      "tags": {}, "apiVersion": "2018-01-01", "properties": {"publicIPAllocationMethod":
+      null}, "name": "vm1PublicIP", "type": "Microsoft.Network/publicIPAddresses",
+      "dependsOn": []}, {"location": "westus", "tags": {}, "apiVersion": "2015-06-15",
+      "properties": {"ipConfigurations": [{"properties": {"privateIPAllocationMethod":
+      "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"}},
+      "name": "ipconfigvm1"}], "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"}},
+      "name": "vm1VMNic", "type": "Microsoft.Network/networkInterfaces", "dependsOn":
+      ["Microsoft.Network/virtualNetworks/vm1VNET", "Microsoft.Network/networkSecurityGroups/vm1NSG",
+      "Microsoft.Network/publicIpAddresses/vm1PublicIP"]}, {"location": "westus",
+      "tags": {}, "apiVersion": "2017-12-01", "properties": {"networkProfile": {"networkInterfaces":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "storageProfile": {"osDisk": {"name": null, "createOption": "fromImage", "managedDisk":
+      {"storageAccountType": null}, "caching": "ReadWrite"}, "imageReference": {"publisher":
+      "MicrosoftWindowsServer", "version": "latest", "offer": "WindowsServer", "sku":
+      "2012-Datacenter"}}, "osProfile": {"adminPassword": "[parameters(\''adminPassword\'')]",
+      "computerName": "vm1", "adminUsername": "clitester1"}, "hardwareProfile": {"vmSize":
+      "Standard_DS1_v2"}}, "name": "vm1", "type": "Microsoft.Compute/virtualMachines",
+      "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"]}], "contentVersion":
+      "1.0.0.0", "parameters": {"adminPassword": {"metadata": {"description": "Secure
+      adminPassword"}, "type": "securestring"}}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "outputs": {}}}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Length: ['3323']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/vm_deploy_6FKbvG5D21XmRXcnirAoQEuZn1kv2kG6","name":"vm_deploy_6FKbvG5D21XmRXcnirAoQEuZn1kv2kG6","properties":{"templateHash":"12739928157800941260","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-22T03:56:36.0022532Z","duration":"PT0.8123616S","correlationId":"a316712a-9072-4da2-b857-369ed474b5b4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/vm_deploy_6FKbvG5D21XmRXcnirAoQEuZn1kv2kG6/operationStatuses/08586772374902877398?api-version=2017-05-10']
+      cache-control: [no-cache]
+      content-length: ['2741']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:56:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:57:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:57:37 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:58:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:58:37 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:59:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 03:59:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:00:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:00:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:01:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:01:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:02:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:02:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:03:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:03:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:04:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:04:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:05:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772374902877398?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:05:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Resources/deployments/vm_deploy_6FKbvG5D21XmRXcnirAoQEuZn1kv2kG6","name":"vm_deploy_6FKbvG5D21XmRXcnirAoQEuZn1kv2kG6","properties":{"templateHash":"12739928157800941260","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-22T04:05:41.3630729Z","duration":"PT9M6.1731813S","correlationId":"a316712a-9072-4da2-b857-369ed474b5b4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3807']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:05:45 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"64249057-14c2-432e-a40e-095bc953fc6b\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"\
+        WindowsServer\",\r\n        \"sku\": \"2012-Datacenter\",\r\n        \"version\"\
+        : \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"\
+        Windows\",\r\n        \"name\": \"vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
+        ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        \r\n        },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\"\
+        : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
+        ,\r\n      \"adminUsername\": \"clitester1\",\r\n      \"windowsConfiguration\"\
+        : {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\"\
+        : true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
+        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n\
+        \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/Unavailable\"\
+        ,\r\n            \"level\": \"Warning\",\r\n            \"displayStatus\"\
+        : \"Not Ready\",\r\n            \"message\": \"VM status blob is found but\
+        \ not yet populated.\",\r\n            \"time\": \"2018-04-22T04:05:45+00:00\"\
+        \r\n          }\r\n        ]\r\n      },\r\n      \"disks\": [\r\n       \
+        \ {\r\n          \"name\": \"vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
+        : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
+        \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
+        \       \"time\": \"2018-04-22T03:57:17.5470353+00:00\"\r\n            }\r\
+        \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
+        \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
+        \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
+        ,\r\n          \"time\": \"2018-04-22T04:05:30.064763+00:00\"\r\n        },\r\
+        \n        {\r\n          \"code\": \"PowerState/running\",\r\n          \"\
+        level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n    \
+        \    }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
+        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
+        ,\r\n  \"name\": \"vm1\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['2950']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:05:45 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4171,Microsoft.Compute/LowCostGet30Min;33451']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2018-01-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
+        ,\r\n  \"etag\": \"W/\\\"cda09e60-1c45-4d98-a15c-a42736760984\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"0bfa5bec-79b8-4210-a9bd-d9b23eaacad9\"\
+        ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
+        ,\r\n        \"etag\": \"W/\\\"cda09e60-1c45-4d98-a15c-a42736760984\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
+        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
+        \r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
+        \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
+        : \"IPv4\",\r\n          \"isInUseWithService\": false\r\n        }\r\n  \
+        \    }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n\
+        \      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"\
+        s5ppklxafblurhitxc5raxulcd.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
+        macAddress\": \"00-0D-3A-36-58-B9\",\r\n    \"enableAcceleratedNetworking\"\
+        : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
+        : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
+        \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
+        \r\n    },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\
+        \r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['2596']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:05:45 GMT']
+      etag: [W/"cda09e60-1c45-4d98-a15c-a42736760984"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP?api-version=2018-01-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
+        ,\r\n  \"etag\": \"W/\\\"7c0159d0-4991-4f10-8655-34002940f98d\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"369326a3-fb34-4788-a83b-deb8cece02b5\"\
+        ,\r\n    \"ipAddress\": \"13.93.195.119\",\r\n    \"publicIPAddressVersion\"\
+        : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
+        : 4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
+        \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\
+        \n  \"sku\": {\r\n    \"name\": \"Basic\",\r\n    \"tier\": \"Regional\"\r\
+        \n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1022']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:05:46 GMT']
+      etag: [W/"7c0159d0-4991-4f10-8655-34002940f98d"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"64249057-14c2-432e-a40e-095bc953fc6b\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"\
+        WindowsServer\",\r\n        \"sku\": \"2012-Datacenter\",\r\n        \"version\"\
+        : \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"\
+        Windows\",\r\n        \"name\": \"vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
+        ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        \r\n        },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\"\
+        : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
+        ,\r\n      \"adminUsername\": \"clitester1\",\r\n      \"windowsConfiguration\"\
+        : {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\"\
+        : true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
+        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
+        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
+        tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
+        ,\r\n  \"name\": \"vm1\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1778']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:05:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4170,Microsoft.Compute/LowCostGet30Min;33450']
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''b\''{"properties": {"publisher": "Microsoft.Azure.Security", "autoUpgradeMinorVersion":
+      true, "settings": {"KeyEncryptionKeyURL": null, "KeyEncryptionAlgorithm": "RSA-OAEP",
+      "VolumeType": "OS", "EncryptionOperation": "EnableEncryption", "KeyVaultResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002",
+      "KekVaultResourceId": "", "SequenceVersion": "39ddc19c-90cc-40c6-ad3d-042dfdd79536",
+      "KeyVaultURL": "https://vault000002.vault.azure.net"}, "typeHandlerVersion":
+      "2.2", "type": "AzureDiskEncryption"}, "location": "westus"}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      Content-Length: ['669']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Security\"\
+        ,\r\n    \"type\": \"AzureDiskEncryption\",\r\n    \"typeHandlerVersion\"\
+        : \"2.2\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\":\
+        \ {\"KeyEncryptionKeyURL\":null,\"KeyEncryptionAlgorithm\":\"RSA-OAEP\",\"\
+        VolumeType\":\"OS\",\"EncryptionOperation\":\"EnableEncryption\",\"KeyVaultResourceId\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        ,\"KekVaultResourceId\":\"\",\"SequenceVersion\":\"39ddc19c-90cc-40c6-ad3d-042dfdd79536\"\
+        ,\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"},\r\n    \"provisioningState\"\
+        : \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption\"\
+        ,\r\n  \"name\": \"AzureDiskEncryption\"\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01']
+      cache-control: [no-cache]
+      content-length: ['1058']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:05:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/UpdateVM3Min;238,Microsoft.Compute/UpdateVM30Min;1186']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:06:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14924,Microsoft.Compute/GetOperation30Min;29575']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:06:59 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14938,Microsoft.Compute/GetOperation30Min;29571']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:07:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14957,Microsoft.Compute/GetOperation30Min;29565']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:08:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14964,Microsoft.Compute/GetOperation30Min;29559']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:08:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14972,Microsoft.Compute/GetOperation30Min;29556']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:09:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29553']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:09:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29550']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:10:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14981,Microsoft.Compute/GetOperation30Min;29547']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:10:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29544']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:05:58.9564777+00:00\",\r\
+        \n  \"endTime\": \"2018-04-22T04:11:02.5438476+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"1ebfd8dc-eaae-48a1-a7c1-74b9e613e36d\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['184']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:11:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29541']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Security\"\
+        ,\r\n    \"type\": \"AzureDiskEncryption\",\r\n    \"typeHandlerVersion\"\
+        : \"2.2\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\":\
+        \ {\"KeyEncryptionKeyURL\":null,\"KeyEncryptionAlgorithm\":\"RSA-OAEP\",\"\
+        VolumeType\":\"OS\",\"EncryptionOperation\":\"EnableEncryption\",\"KeyVaultResourceId\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        ,\"KekVaultResourceId\":\"\",\"SequenceVersion\":\"39ddc19c-90cc-40c6-ad3d-042dfdd79536\"\
+        ,\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"},\r\n    \"provisioningState\"\
+        : \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption\"\
+        ,\r\n  \"name\": \"AzureDiskEncryption\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1059']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:11:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33428']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption enable]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption?$expand=instanceView&api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Security\"\
+        ,\r\n    \"type\": \"AzureDiskEncryption\",\r\n    \"typeHandlerVersion\"\
+        : \"2.2\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\":\
+        \ {\"KeyEncryptionKeyURL\":null,\"KeyEncryptionAlgorithm\":\"RSA-OAEP\",\"\
+        VolumeType\":\"OS\",\"EncryptionOperation\":\"EnableEncryption\",\"KeyVaultResourceId\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        ,\"KekVaultResourceId\":\"\",\"SequenceVersion\":\"39ddc19c-90cc-40c6-ad3d-042dfdd79536\"\
+        ,\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"},\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"name\": \"AzureDiskEncryption\"\
+        ,\r\n      \"type\": \"Microsoft.Azure.Security.AzureDiskEncryption\",\r\n\
+        \      \"typeHandlerVersion\": \"2.2.0.1\",\r\n      \"statuses\": [\r\n \
+        \       {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n    \
+        \      \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
+        \ succeeded\",\r\n          \"message\": \"\"\r\n        }\r\n      ]\r\n\
+        \    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption\"\
+        ,\r\n  \"name\": \"AzureDiskEncryption\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1440']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:11:16 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4194,Microsoft.Compute/LowCostGet30Min;33427']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"64249057-14c2-432e-a40e-095bc953fc6b\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"\
+        WindowsServer\",\r\n        \"sku\": \"2012-Datacenter\",\r\n        \"version\"\
+        : \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"\
+        Windows\",\r\n        \"name\": \"vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
+        ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        \r\n        },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\"\
+        : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
+        ,\r\n      \"adminUsername\": \"clitester1\",\r\n      \"windowsConfiguration\"\
+        : {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\"\
+        : true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
+        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
+        : {\r\n      \"computerName\": \"VM1\",\r\n      \"osName\": \"Windows Server\
+        \ 2012 Datacenter\",\r\n      \"osVersion\": \"Microsoft Windows NT 6.2.9200.0\"\
+        ,\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.7.41491.872\"\
+        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
+        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
+        \ new configurations.\",\r\n            \"time\": \"2018-04-22T04:11:16+00:00\"\
+        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
+        \      {\r\n            \"type\": \"Microsoft.Azure.Security.AzureDiskEncryption\"\
+        ,\r\n            \"typeHandlerVersion\": \"2.2.0.1\",\r\n            \"status\"\
+        : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
+        \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
+        \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
+        : [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        ,\r\n          \"encryptionSettings\": [\r\n            {\r\n            \
+        \  \"enabled\": true,\r\n              \"diskEncryptionKey\": {\r\n      \
+        \          \"sourceVault\": {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        \r\n                },\r\n                \"secretUrl\": \"https://vault000002.vault.azure.net/secrets/02EB85F5-5D7F-4BDC-8221-B6B3E42DEAF4/11249677cafa49cbb5edbd66643d518d\"\
+        \r\n              }\r\n            }\r\n          ],\r\n          \"statuses\"\
+        : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
+        : \"Provisioning succeeded\",\r\n              \"time\": \"2018-04-22T04:11:02.5282257+00:00\"\
+        \r\n            },\r\n            {\r\n              \"code\": \"EncryptionState/encrypted\"\
+        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
+        : \"Encryption is enabled on disk\"\r\n            }\r\n          ]\r\n  \
+        \      }\r\n      ],\r\n      \"extensions\": [\r\n        {\r\n         \
+        \ \"name\": \"AzureDiskEncryption\",\r\n          \"type\": \"Microsoft.Azure.Security.AzureDiskEncryption\"\
+        ,\r\n          \"typeHandlerVersion\": \"2.2.0.1\",\r\n          \"statuses\"\
+        : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
+        : \"Provisioning succeeded\",\r\n              \"message\": \"\"\r\n     \
+        \       }\r\n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\
+        \n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n  \
+        \        \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
+        \ succeeded\",\r\n          \"time\": \"2018-04-22T04:11:02.5438476+00:00\"\
+        \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
+        ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
+        \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\
+        \n      \"properties\": {\r\n        \"publisher\": \"Microsoft.Azure.Security\"\
+        ,\r\n        \"type\": \"AzureDiskEncryption\",\r\n        \"typeHandlerVersion\"\
+        : \"2.2\",\r\n        \"autoUpgradeMinorVersion\": true,\r\n        \"settings\"\
+        : {\"KeyEncryptionKeyURL\":null,\"KeyEncryptionAlgorithm\":\"RSA-OAEP\",\"\
+        VolumeType\":\"OS\",\"EncryptionOperation\":\"EnableEncryption\",\"KeyVaultResourceId\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        ,\"KekVaultResourceId\":\"\",\"SequenceVersion\":\"39ddc19c-90cc-40c6-ad3d-042dfdd79536\"\
+        ,\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"},\r\n        \"provisioningState\"\
+        : \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption\"\
+        ,\r\n      \"name\": \"AzureDiskEncryption\"\r\n    }\r\n  ],\r\n  \"type\"\
+        : \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n\
+        \  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
+        ,\r\n  \"name\": \"vm1\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['5795']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:11:16 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4193,Microsoft.Compute/LowCostGet30Min;33426']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption disable]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"64249057-14c2-432e-a40e-095bc953fc6b\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"\
+        WindowsServer\",\r\n        \"sku\": \"2012-Datacenter\",\r\n        \"version\"\
+        : \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"\
+        Windows\",\r\n        \"name\": \"vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
+        ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_cefd3210ccd54592bb8a1f17363d9aae\"\
+        \r\n        },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\"\
+        : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
+        ,\r\n      \"adminUsername\": \"clitester1\",\r\n      \"windowsConfiguration\"\
+        : {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\"\
+        : true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
+        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"resources\"\
+        : [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\": \"Microsoft.Azure.Security\"\
+        ,\r\n        \"type\": \"AzureDiskEncryption\",\r\n        \"typeHandlerVersion\"\
+        : \"2.2\",\r\n        \"autoUpgradeMinorVersion\": true,\r\n        \"settings\"\
+        : {\"KeyEncryptionKeyURL\":null,\"KeyEncryptionAlgorithm\":\"RSA-OAEP\",\"\
+        VolumeType\":\"OS\",\"EncryptionOperation\":\"EnableEncryption\",\"KeyVaultResourceId\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        ,\"KekVaultResourceId\":\"\",\"SequenceVersion\":\"39ddc19c-90cc-40c6-ad3d-042dfdd79536\"\
+        ,\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"},\r\n        \"provisioningState\"\
+        : \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption\"\
+        ,\r\n      \"name\": \"AzureDiskEncryption\"\r\n    }\r\n  ],\r\n  \"type\"\
+        : \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n\
+        \  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
+        ,\r\n  \"name\": \"vm1\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['2919']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:11:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4192,Microsoft.Compute/LowCostGet30Min;33425']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"publisher": "Microsoft.Azure.Security", "autoUpgradeMinorVersion":
+      true, "settings": {"EncryptionOperation": "DisableEncryption", "SequenceVersion":
+      "4deba6dd-eaa3-4bdd-a7fc-75f3c9d0e4bb", "VolumeType": null}, "typeHandlerVersion":
+      "2.2", "type": "AzureDiskEncryption"}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption disable]
+      Connection: [keep-alive]
+      Content-Length: ['309']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Security\"\
+        ,\r\n    \"type\": \"AzureDiskEncryption\",\r\n    \"typeHandlerVersion\"\
+        : \"2.2\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\":\
+        \ {\"EncryptionOperation\":\"DisableEncryption\",\"SequenceVersion\":\"4deba6dd-eaa3-4bdd-a7fc-75f3c9d0e4bb\"\
+        ,\"VolumeType\":null},\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\
+        \n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption\"\
+        ,\r\n  \"name\": \"AzureDiskEncryption\"\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/daa7aec7-0017-461f-852b-a2c22085fdf6?api-version=2017-12-01']
+      cache-control: [no-cache]
+      content-length: ['708']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:11:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/UpdateVM3Min;239,Microsoft.Compute/UpdateVM30Min;1185']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption disable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/daa7aec7-0017-461f-852b-a2c22085fdf6?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:11:18.6382599+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"daa7aec7-0017-461f-852b-a2c22085fdf6\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:11:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29540']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption disable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/daa7aec7-0017-461f-852b-a2c22085fdf6?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:11:18.6382599+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"daa7aec7-0017-461f-852b-a2c22085fdf6\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:12:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29539']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption disable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/daa7aec7-0017-461f-852b-a2c22085fdf6?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:11:18.6382599+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"daa7aec7-0017-461f-852b-a2c22085fdf6\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:12:49 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29538']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption disable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/daa7aec7-0017-461f-852b-a2c22085fdf6?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T04:11:18.6382599+00:00\",\r\
+        \n  \"endTime\": \"2018-04-22T04:13:13.7832946+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"daa7aec7-0017-461f-852b-a2c22085fdf6\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['184']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:13:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14991,Microsoft.Compute/GetOperation30Min;29537']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption disable]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Security\"\
+        ,\r\n    \"type\": \"AzureDiskEncryption\",\r\n    \"typeHandlerVersion\"\
+        : \"2.2\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\":\
+        \ {\"EncryptionOperation\":\"DisableEncryption\",\"SequenceVersion\":\"4deba6dd-eaa3-4bdd-a7fc-75f3c9d0e4bb\"\
+        ,\"VolumeType\":null},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\
+        \n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption\"\
+        ,\r\n  \"name\": \"AzureDiskEncryption\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['709']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:13:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4193,Microsoft.Compute/LowCostGet30Min;33423']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm encryption disable]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption?$expand=instanceView&api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.Security\"\
+        ,\r\n    \"type\": \"AzureDiskEncryption\",\r\n    \"typeHandlerVersion\"\
+        : \"2.2\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\":\
+        \ {\"EncryptionOperation\":\"DisableEncryption\",\"SequenceVersion\":\"4deba6dd-eaa3-4bdd-a7fc-75f3c9d0e4bb\"\
+        ,\"VolumeType\":null},\r\n    \"provisioningState\": \"Succeeded\",\r\n  \
+        \  \"instanceView\": {\r\n      \"name\": \"AzureDiskEncryption\",\r\n   \
+        \   \"type\": \"Microsoft.Azure.Security.AzureDiskEncryption\",\r\n      \"\
+        typeHandlerVersion\": \"2.2.0.1\",\r\n      \"statuses\": [\r\n        {\r\
+        \n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\"\
+        : \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n\
+        \          \"message\": \"Disable Encryption completed successfully\"\r\n\
+        \        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_encryption000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/AzureDiskEncryption\"\
+        ,\r\n  \"name\": \"AzureDiskEncryption\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1131']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sun, 22 Apr 2018 04:13:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4192,Microsoft.Compute/LowCostGet30Min;33422']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_encryption000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Sun, 22 Apr 2018 04:13:21 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGVk06NUZFTkNSWVBUSU9ONTRIUUtJQVZWU1VONEdNMzVZNXwyNDgzMkJERjQ2MUYzNjc3LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_disk_encryption_e2e.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_disk_encryption_e2e.yaml
@@ -1,32 +1,32 @@
 interactions:
 - request:
-    body: '{"location": "eastus2euap", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-03-30T21:12:33Z"}}'
+    body: '{"tags": {"cause": "automation", "product": "azurecli", "date": "2018-04-22T05:32:42Z"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [group create]
       Connection: [keep-alive]
-      Content-Length: ['115']
+      Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001","name":"cli_test_vmss_encryption000001","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2018-03-30T21:12:33Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001","name":"cli_test_vmss_encryption000001","location":"westus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-22T05:32:42Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['389']
+      content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:12:34 GMT']
+      date: ['Sun, 22 Apr 2018 05:32:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -36,19 +36,19 @@ interactions:
       CommandName: [keyvault create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001","name":"cli_test_vmss_encryption000001","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2018-03-30T21:12:33Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001","name":"cli_test_vmss_encryption000001","location":"westus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-22T05:32:42Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['389']
+      content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:12:35 GMT']
+      date: ['Sun, 22 Apr 2018 05:32:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -62,74 +62,92 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 azure-graphrbac/0.40.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":[],"skuId":"a403ebcc-fae0-4ca2-8c8c-7a907fd6c235"}],"assignedPlans":[{"assignedTimestamp":"2017-12-07T23:01:21Z","capabilityStatus":"Enabled","service":"AzureAnalysis","servicePlanId":"2049e525-b859-401b-b2a0-e0a31c4b1fe4"}],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2018-03-06T16:42:32Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":"US","userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"a30db067-cde1-49be-95bb-9619a8cc8617","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"},{"disabledPlans":[],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"f82a60b8-1ee3-4cfb-a4fe-1c6a53c2656c"},{"disabledPlans":[],"skuId":"d3b4fe1f-9992-4930-8acb-ca6ec609365e"},{"disabledPlans":[],"skuId":"c52ea49f-fe5d-4e95-93ba-1de91d380f89"}],"assignedPlans":[{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"acffdce6-c30f-4dc2-81c0-372e33c515ec"},{"assignedTimestamp":"2018-03-20T02:14:40Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2018-03-17T03:06:21Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-03-17T03:06:21Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-03-17T00:53:26Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-01-09T10:35:29Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2017-12-31T21:14:52Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2017-12-31T21:14:52Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2017-12-31T03:27:36Z","capabilityStatus":"Deleted","service":"Adallom","servicePlanId":"932ad362-64a8-4783-9106-97849a1a30b9"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2017-12-17T18:29:20Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2017-10-06T23:11:11Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2017-10-06T23:11:11Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2017-10-06T23:11:11Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2017-10-06T23:11:11Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"},{"assignedTimestamp":"2017-07-06T19:19:59Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"4828c8ec-dc2e-4779-b502-87ac9ce28ab7"},{"assignedTimestamp":"2017-07-06T19:19:59Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Deleted","service":"ProcessSimple","servicePlanId":"76846ad7-7776-4c40-a281-a386362dd1b9"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Deleted","service":"PowerAppsService","servicePlanId":"c68f8d98-5534-41c8-bf36-22fa496fa792"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"9e700747-8b1d-45e5-ab8d-ef187ceec156"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2017-07-06T19:19:58Z","capabilityStatus":"Deleted","service":"OfficeForms","servicePlanId":"2789c901-c14e-48ab-a76a-be334d9d793a"},{"assignedTimestamp":"2017-07-06T19:19:57Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2017-07-06T19:19:57Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"159f4cd6-e380-449f-a816-af1a9ef76344"},{"assignedTimestamp":"2017-06-12T08:23:48Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2017-06-12T08:23:48Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2017-06-12T08:23:48Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2017-05-12T23:33:35Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"8e0c0a52-6a6c-4d40-8370-dd62790dcd70"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"c4048e79-4474-4c74-ba9b-c31ff225e511"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Deleted","service":"AzureAnalysis","servicePlanId":"2049e525-b859-401b-b2a0-e0a31c4b1fe4"},{"assignedTimestamp":"2017-01-26T08:02:47Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2016-12-19T03:16:33Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"2125cfd7-2110-4567-83c4-c1cd5275163d"},{"assignedTimestamp":"2016-12-19T03:16:33Z","capabilityStatus":"Deleted","service":"PowerBI","servicePlanId":"fc0a60aa-feee-4746-a0e3-aecfe81a38dd"},{"assignedTimestamp":"2016-11-18T18:51:08Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2016-11-18T18:51:08Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2012-10-10T07:21:11Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2015-07-30T06:17:13Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"5a10155d-f5c1-411a-a8ec-e99aae125390"},{"assignedTimestamp":"2015-07-30T06:17:13Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"27216c54-caf8-4d0d-97e2-517afb5c08f6"}],"city":"REDMOND","companyName":"MICROSOFT","consentProvidedForMinor":null,"country":null,"creationType":null,"department":"Azure
+        and Web COGS 1010 US","dirSyncEnabled":true,"displayName":"Yugang Wang","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Yugang","immutableId":"138058","isCompromised":null,"jobTitle":"SENIOR
+        SOFTWARE ENGINEER","lastDirSyncTime":"2018-04-14T15:08:08Z","legalAgeGroupClassification":null,"mail":"yugangw@microsoft.com","mailNickname":"yugangw","mobile":null,"onPremisesDistinguishedName":"CN=Yugang
+        Wang,OU=UserAccounts,DC=redmond,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-2127521184-1604012920-1887927527-415191","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"18/2250FL","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"}],"provisioningErrors":[],"proxyAddresses":["X500:/O=Nokia/OU=HUB/cn=Recipients/cn=yugangw","X500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=sdflabs.com-51490-Yugang
+        Wang (Volt)e3d6fb0c","X500:/o=microsoft/ou=northamerica/cn=Recipients/cn=572513","X500:/o=microsoft/ou=First
+        Administrative Group/cn=Recipients/cn=yugangw","X500:/o=microsoft/ou=External
+        (FYDIBOHF25SPDLT)/cn=Recipients/cn=0e00e165bf5842568a693fea3aa4faad","X500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=yugangw_microsoft.com","X500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=sdflabs.com-51490-Yugang
+        Wang","X500:/o=SDF/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=51490-yugangw_c50b13e019","X500:/o=MSNBC/ou=Servers/cn=Recipients/cn=yugangw","X500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=yugangw17d63dbbde","X500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=microsoft.onmicrosoft.com-55760-Yugang
+        Wang (Volt)","X500:/O=Microsoft/OU=APPS-WGA/cn=Recipients/cn=yugangw","X500:/o=MMS/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=Yugang Wang5ec8094e-2aed-488b-a327-9baed3c38367","SMTP:yugangw@microsoft.com","smtp:a-ywang2@microsoft.com","smtp:yugangw@msg.microsoft.com","x500:/o=microsoft/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=Yugang Wang (Volt)","smtp:YUGANGW@service.microsoft.com"],"refreshTokensValidFromDateTime":"2018-04-04T16:38:21Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":"yugangw@microsoft.com","state":null,"streetAddress":null,"surname":"Wang","telephoneNumber":"+1
+        (425) 7069936","thumbnailPhoto@odata.mediaContentType":"image/Jpeg","usageLocation":"US","userIdentities":[],"userPrincipalName":"yugangw@microsoft.com","userType":null,"extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10130001","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10130001","extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"90092430","extension_18e31482d3fb4a8ea958aa96b662f508_AddressLine1":"1
+        Microsoft Way","extension_18e31482d3fb4a8ea958aa96b662f508_CityName":"REDMOND","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1010","extension_18e31482d3fb4a8ea958aa96b662f508_CountryShortCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"138058","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"MAYURID","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Diwan,
+        Mayuri","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"186027","extension_18e31482d3fb4a8ea958aa96b662f508_StateProvinceCode":"WA","extension_18e31482d3fb4a8ea958aa96b662f508_ZipCode":"98052","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"17","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"18"}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1612']
+      content-length: ['15481']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 30 Mar 2018 21:12:35 GMT']
-      duration: ['845371']
+      date: ['Sun, 22 Apr 2018 05:32:49 GMT']
+      duration: ['922729']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [PsQ9Z9cw9lW/SAFMwFi8L+ljoU1+bKSpefQx7+tAUAQ=]
-      ocp-aad-session-key: [H1eo7Bh3m5eQKYHg7f186-di7Banye2FL-HYqCnEo5wUgP0n9UjiklH46_C5n-nhFRGV-V9PEWz1q-cKlL3FTU97HSdp26f3_nwqnWw5LxN3Sqw8fczvh9p0-tI2SGR9.8_LnxF3Z2jmUlJzCYMnqke9owV7h-APROcvr-oTfRCo]
+      ocp-aad-diagnostics-server-name: [oNrsfdz3Fhte7wfqy+uUhdb2Yij4mN6MnViek/b/vco=]
+      ocp-aad-session-key: [8S5KPR-2i234s3wJu_E8z7klokPECX_LF0WQiIe7CzZH9tpxpan5u45_aP1rXmr3pySViPe7txD_vCagFjF-TmGhSNMldPzWTYfQ9YmPXOlKDQviQ1a75nUXnUh_7hUY.E-ENl2yc1MzzXvfTv1hePelO_u8rEKBUGEkVLf8f3To]
       pragma: [no-cache]
-      request-id: [b28c5601-49be-4df3-ae1d-a8502e838427]
+      request-id: [c7080f26-d189-417d-a329-c0cf65ad239e]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "eastus2euap", "properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
+    body: '{"properties": {"enabledForDiskEncryption": true, "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "sku": {"name": "standard", "family": "A"}, "accessPolicies": [{"objectId":
+      "a30db067-cde1-49be-95bb-9619a8cc8617", "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "permissions": {"secrets": ["get", "list", "set", "delete", "backup", "restore",
+      "recover"], "keys": ["get", "create", "delete", "list", "update", "import",
       "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
       "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
       "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
-      "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}}],
-      "enabledForDiskEncryption": true}}'
+      "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}}]},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [keyvault create]
       Connection: [keep-alive]
-      Content-Length: ['785']
+      Content-Length: ['780']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002","name":"vault000002","type":"Microsoft.KeyVault/vaults","location":"eastus2euap","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":true,"vaultUri":"https://vault000002.vault.azure.net","provisioningState":"RegisteringDns"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002","name":"vault000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"a30db067-cde1-49be-95bb-9619a8cc8617","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"keys":["get","create","delete","list","update","import","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":true,"vaultUri":"https://vault000002.vault.azure.net","provisioningState":"RegisteringDns"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1101']
+      content-length: ['1096']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:12:39 GMT']
+      date: ['Sun, 22 Apr 2018 05:32:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
+      server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
-      x-ms-keyvault-service-version: [1.0.0.213]
-      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      x-ms-keyvault-service-version: [1.0.0.214]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -140,19 +158,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001","name":"cli_test_vmss_encryption000001","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2018-03-30T21:12:33Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001","name":"cli_test_vmss_encryption000001","location":"westus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-22T05:32:42Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['389']
+      content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:12:40 GMT']
+      date: ['Sun, 22 Apr 2018 05:32:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -212,22 +230,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:12:41 GMT']
+      date: ['Sun, 22 Apr 2018 05:32:54 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 30 Mar 2018 21:17:41 GMT']
-      source-age: ['149']
+      expires: ['Sun, 22 Apr 2018 05:37:54 GMT']
+      source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [HIT]
-      x-cache-hits: ['1']
+      x-cache: [MISS]
+      x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [f99c302c4dcf56860474b15f957e7ec27db0663d]
+      x-fastly-request-id: [155b8b76c4c111ea7fc9291a03326f6a22806697]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['8228:21621:5ED88:65FF7:5ABEA7B4']
-      x-served-by: [cache-dfw18625-DFW]
-      x-timer: ['S1522444362.737840,VS0,VE1']
+      x-github-request-id: ['162E:0874:6A4A50:70F6DB:5ADC1E71']
+      x-served-by: [cache-sea1038-SEA]
+      x-timer: ['S1524375174.476602,VS0,VE96']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -238,9 +256,9 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-01-01
@@ -250,7 +268,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:12:41 GMT']
+      date: ['Sun, 22 Apr 2018 05:32:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -258,68 +276,70 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {"adminPassword": {"type": "securestring",
-      "metadata": {"description": "Secure adminPassword"}}}, "variables": {}, "resources":
-      [{"name": "vmss1VNET", "type": "Microsoft.Network/virtualNetworks", "location":
-      "eastus2euap", "apiVersion": "2015-06-15", "dependsOn": [], "tags": {}, "properties":
-      {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}, "subnets": [{"name":
-      "vmss1Subnet", "properties": {"addressPrefix": "10.0.0.0/24"}}]}}, {"apiVersion":
-      "2018-01-01", "type": "Microsoft.Network/publicIPAddresses", "name": "vmss1LBPublicIP",
-      "location": "eastus2euap", "tags": {}, "dependsOn": [], "properties": {"publicIPAllocationMethod":
-      "Dynamic"}, "sku": {"name": "Basic"}}, {"type": "Microsoft.Network/loadBalancers",
-      "name": "vmss1LB", "location": "eastus2euap", "tags": {}, "apiVersion": "2018-01-01",
-      "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"],
-      "properties": {"backendAddressPools": [{"name": "vmss1LBBEPool"}], "inboundNatPools":
-      [{"name": "vmss1LBNatPool", "properties": {"frontendIPConfiguration": {"id":
-      "[concat(resourceId(\''Microsoft.Network/loadBalancers\'', \''vmss1LB\''), \''/frontendIPConfigurations/\'',
-      \''loadBalancerFrontEnd\'')]"}, "protocol": "tcp", "frontendPortRangeStart":
-      "50000", "frontendPortRangeEnd": "50119", "backendPort": 3389}}], "frontendIPConfigurations":
-      [{"name": "loadBalancerFrontEnd", "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}}}]},
-      "sku": {"name": "Basic"}}, {"type": "Microsoft.Compute/virtualMachineScaleSets",
-      "name": "vmss1", "location": "eastus2euap", "tags": {}, "apiVersion": "2017-12-01",
-      "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/loadBalancers/vmss1LB"],
-      "sku": {"name": "Standard_D1_v2", "capacity": 1}, "properties": {"overprovision":
-      true, "upgradePolicy": {"mode": "manual"}, "virtualMachineProfile": {"storageProfile":
-      {"osDisk": {"createOption": "FromImage", "caching": "ReadWrite", "managedDisk":
-      {"storageAccountType": null}}, "imageReference": {"publisher": "MicrosoftWindowsServer",
-      "offer": "WindowsServer", "sku": "2016-Datacenter", "version": "latest"}}, "osProfile":
-      {"computerNamePrefix": "vmss109b0", "adminUsername": "clitester1", "adminPassword":
-      "[parameters(\''adminPassword\'')]"}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"name": "vmss109b0Nic", "properties": {"primary": "true", "ipConfigurations":
-      [{"name": "vmss109b0IPConfig", "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
-      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},
-      "singlePlacementGroup": true}}], "outputs": {"VMSS": {"type": "object", "value":
-      "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'', \''vmss1\''),providers(\''Microsoft.Compute\'',
-      \''virtualMachineScaleSets\'').apiVersions[0])]"}}}, "parameters": {"adminPassword":
-      {"value": "Test123456789!"}}, "mode": "Incremental"}}'''
+    body: 'b''{"properties": {"mode": "Incremental", "parameters": {"adminPassword":
+      {"value": "Test123456789!"}}, "template": {"variables": {}, "outputs": {"VMSS":
+      {"type": "object", "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]"}},
+      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "resources": [{"name": "vmss1VNET", "properties":
+      {"subnets": [{"name": "vmss1Subnet", "properties": {"addressPrefix": "10.0.0.0/24"}}],
+      "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}, "location": "westus",
+      "dependsOn": [], "tags": {}, "type": "Microsoft.Network/virtualNetworks", "apiVersion":
+      "2015-06-15"}, {"name": "vmss1LBPublicIP", "properties": {"publicIPAllocationMethod":
+      "Dynamic"}, "location": "westus", "dependsOn": [], "tags": {}, "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2018-01-01"}, {"name": "vmss1LB", "properties": {"backendAddressPools":
+      [{"name": "vmss1LBBEPool"}], "inboundNatPools": [{"name": "vmss1LBNatPool",
+      "properties": {"frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
+      \''vmss1LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"},
+      "protocol": "tcp", "frontendPortRangeEnd": "50119", "frontendPortRangeStart":
+      "50000", "backendPort": 3389}}], "frontendIPConfigurations": [{"name": "loadBalancerFrontEnd",
+      "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}}}]},
+      "location": "westus", "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
+      "Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"], "tags": {}, "type":
+      "Microsoft.Network/loadBalancers", "apiVersion": "2018-01-01"}, {"name": "vmss1",
+      "properties": {"overprovision": true, "upgradePolicy": {"mode": "manual"}, "singlePlacementGroup":
+      null, "virtualMachineProfile": {"networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss1c833Nic", "properties": {"primary": "true", "ipConfigurations":
+      [{"name": "vmss1c833IPConfig", "properties": {"loadBalancerBackendAddressPools":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]},
+      "osProfile": {"computerNamePrefix": "vmss1c833", "adminUsername": "clitester1",
+      "adminPassword": "[parameters(\''adminPassword\'')]"}, "storageProfile": {"osDisk":
+      {"managedDisk": {"storageAccountType": null}, "createOption": "FromImage", "caching":
+      "ReadWrite"}, "imageReference": {"sku": "2016-Datacenter", "publisher": "MicrosoftWindowsServer",
+      "version": "latest", "offer": "WindowsServer"}}}}, "location": "westus", "dependsOn":
+      ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/loadBalancers/vmss1LB"],
+      "tags": {}, "type": "Microsoft.Compute/virtualMachineScaleSets", "apiVersion":
+      "2017-12-01", "sku": {"capacity": 1, "name": "Standard_D1_v2"}}], "parameters":
+      {"adminPassword": {"type": "securestring", "metadata": {"description": "Secure
+      adminPassword"}}}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss create]
       Connection: [keep-alive]
-      Content-Length: ['3911']
+      Content-Length: ['3839']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/vmss_deploy_bK23sylUMvNyuum0JJHlhgzjUj4ZeYUh","name":"vmss_deploy_bK23sylUMvNyuum0JJHlhgzjUj4ZeYUh","properties":{"templateHash":"4491498272878269058","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-03-30T21:12:45.7157866Z","duration":"PT1.432648S","correlationId":"0ca49d7b-d653-4d5b-aa11-158b295fa13f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus2euap"]},{"resourceType":"publicIPAddresses","locations":["eastus2euap"]},{"resourceType":"loadBalancers","locations":["eastus2euap"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["eastus2euap"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/vmss_deploy_XtFCfVtM5nIhTF9lJg1znZXH1QIrzXbh","name":"vmss_deploy_XtFCfVtM5nIhTF9lJg1znZXH1QIrzXbh","properties":{"templateHash":"11626768805484738706","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-22T05:32:57.9390481Z","duration":"PT0.9111427S","correlationId":"8b5712c1-d6a1-4dac-ad01-6afc8a7f4850","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/vmss_deploy_bK23sylUMvNyuum0JJHlhgzjUj4ZeYUh/operationStatuses/08586791625211944850?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/vmss_deploy_XtFCfVtM5nIhTF9lJg1znZXH1QIrzXbh/operationStatuses/08586772317084497170?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['2709']
+      content-length: ['2691']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:12:46 GMT']
+      date: ['Sun, 22 Apr 2018 05:32:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1189']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -329,19 +349,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:13:17 GMT']
+      date: ['Sun, 22 Apr 2018 05:33:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -356,19 +376,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:13:47 GMT']
+      date: ['Sun, 22 Apr 2018 05:33:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -383,19 +403,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:14:18 GMT']
+      date: ['Sun, 22 Apr 2018 05:34:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -410,19 +430,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:14:50 GMT']
+      date: ['Sun, 22 Apr 2018 05:34:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -437,19 +457,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:15:20 GMT']
+      date: ['Sun, 22 Apr 2018 05:35:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -464,19 +484,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:15:51 GMT']
+      date: ['Sun, 22 Apr 2018 05:36:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -491,19 +511,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:16:22 GMT']
+      date: ['Sun, 22 Apr 2018 05:36:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -518,19 +538,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:16:53 GMT']
+      date: ['Sun, 22 Apr 2018 05:37:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -545,19 +565,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:17:23 GMT']
+      date: ['Sun, 22 Apr 2018 05:37:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -572,19 +592,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:17:54 GMT']
+      date: ['Sun, 22 Apr 2018 05:38:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -599,100 +619,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:18:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:18:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:19:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586791625211944850?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586772317084497170?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:19:58 GMT']
+      date: ['Sun, 22 Apr 2018 05:38:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -707,19 +646,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/vmss_deploy_bK23sylUMvNyuum0JJHlhgzjUj4ZeYUh","name":"vmss_deploy_bK23sylUMvNyuum0JJHlhgzjUj4ZeYUh","properties":{"templateHash":"4491498272878269058","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-03-30T21:19:43.6795082Z","duration":"PT6M59.3963696S","correlationId":"0ca49d7b-d653-4d5b-aa11-158b295fa13f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus2euap"]},{"resourceType":"publicIPAddresses","locations":["eastus2euap"]},{"resourceType":"loadBalancers","locations":["eastus2euap"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["eastus2euap"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss109b0","adminUsername":"clitester1","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2016-Datacenter","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss109b0Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss109b0IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"fa8eae86-670e-4d21-9940-85263738f253"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Resources/deployments/vmss_deploy_XtFCfVtM5nIhTF9lJg1znZXH1QIrzXbh","name":"vmss_deploy_XtFCfVtM5nIhTF9lJg1znZXH1QIrzXbh","properties":{"templateHash":"11626768805484738706","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-22T05:38:16.8083965Z","duration":"PT5M19.7804911S","correlationId":"8b5712c1-d6a1-4dac-ad01-6afc8a7f4850","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss1c833","adminUsername":"clitester1","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2016-Datacenter","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss1c833Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss1c833IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"a45f020e-6c88-4c81-a03c-5a910b381d9e"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['5326']
+      content-length: ['5307']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:19:59 GMT']
+      date: ['Sun, 22 Apr 2018 05:38:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -734,9 +673,9 @@ interactions:
       CommandName: [vmss encryption enable]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -746,7 +685,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss109b0\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1c833\",\r\n        \"adminUsername\"\
         : \"clitester1\",\r\n        \"windowsConfiguration\": {\r\n          \"provisionVMAgent\"\
         : true,\r\n          \"enableAutomaticUpdates\": true\r\n        },\r\n  \
         \      \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n    \
@@ -756,23 +695,23 @@ interactions:
         \   },\r\n        \"imageReference\": {\r\n          \"publisher\": \"MicrosoftWindowsServer\"\
         ,\r\n          \"offer\": \"WindowsServer\",\r\n          \"sku\": \"2016-Datacenter\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss109b0Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1c833Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss109b0IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss1c833IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"fa8eae86-670e-4d21-9940-85263738f253\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"a45f020e-6c88-4c81-a03c-5a910b381d9e\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"EastUS2EUAP\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2522']
+      content-length: ['2517']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:20:01 GMT']
+      date: ['Sun, 22 Apr 2018 05:38:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -780,7 +719,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;192,Microsoft.Compute/GetVMScaleSet30Min;1492']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;184,Microsoft.Compute/GetVMScaleSet30Min;1467']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -790,64 +729,62 @@ interactions:
       CommandName: [vmss encryption enable]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002","name":"vault000002","type":"Microsoft.KeyVault/vaults","location":"eastus2euap","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":true,"vaultUri":"https://vault000002.vault.azure.net/","provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002","name":"vault000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"a30db067-cde1-49be-95bb-9619a8cc8617","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"keys":["get","create","delete","list","update","import","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":true,"vaultUri":"https://vault000002.vault.azure.net/","provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1097']
+      content-length: ['1092']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:20:02 GMT']
+      date: ['Sun, 22 Apr 2018 05:38:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
+      server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
-      x-ms-keyvault-service-version: [1.0.0.213]
+      x-ms-keyvault-service-version: [1.0.0.214]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''b\''{"location": "EastUS2EUAP", "tags": {}, "sku": {"name": "Standard_D1_v2",
-      "tier": "Standard", "capacity": 1}, "properties": {"upgradePolicy": {"mode":
-      "Manual", "automaticOSUpgrade": false}, "virtualMachineProfile": {"osProfile":
-      {"computerNamePrefix": "vmss109b0", "adminUsername": "clitester1", "windowsConfiguration":
-      {"provisionVMAgent": true, "enableAutomaticUpdates": true}, "secrets": []},
-      "storageProfile": {"imageReference": {"publisher": "MicrosoftWindowsServer",
-      "offer": "WindowsServer", "sku": "2016-Datacenter", "version": "latest"}, "osDisk":
-      {"caching": "ReadWrite", "createOption": "FromImage", "managedDisk": {"storageAccountType":
-      "Standard_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations": [{"name":
-      "vmss109b0Nic", "properties": {"primary": true, "enableAcceleratedNetworking":
-      false, "dnsSettings": {"dnsServers": []}, "ipConfigurations": [{"name": "vmss109b0IPConfig",
-      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAddressVersion": "IPv4", "loadBalancerBackendAddressPools": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+    body: 'b''b\''{"tags": {}, "properties": {"overprovision": true, "upgradePolicy":
+      {"mode": "Manual", "automaticOSUpgrade": false}, "singlePlacementGroup": true,
+      "virtualMachineProfile": {"extensionProfile": {"extensions": [{"name": "AzureDiskEncryption",
+      "properties": {"typeHandlerVersion": "2.2", "forceUpdateTag": "d989f460-fd2e-44b3-95a4-98f2ed80b7eb",
+      "autoUpgradeMinorVersion": true, "publisher": "Microsoft.Azure.Security", "type":
+      "AzureDiskEncryption", "settings": {"KeyEncryptionKeyURL": "", "VolumeType":
+      "ALL", "EncryptionOperation": "EnableEncryption", "KeyVaultResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002",
+      "KeyEncryptionAlgorithm": "", "KeyVaultURL": "https://vault000002.vault.azure.net",
+      "KekVaultResourceId": ""}}}]}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss1c833Nic", "properties": {"ipConfigurations": [{"name": "vmss1c833IPConfig",
+      "properties": {"loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+      "privateIPAddressVersion": "IPv4", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}],
-      "enableIPForwarding": false}}]}, "extensionProfile": {"extensions": [{"name":
-      "AzureDiskEncryption", "properties": {"forceUpdateTag": "f28b8214-b795-40c6-87ec-4050b6731e45",
-      "publisher": "Microsoft.Azure.Security", "type": "AzureDiskEncryption", "typeHandlerVersion":
-      "2.1", "autoUpgradeMinorVersion": true, "settings": {"KeyVaultURL": "https://vault000002.vault.azure.net",
-      "KeyEncryptionKeyURL": "", "KeyVaultResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002",
-      "KekVaultResourceId": "", "KeyEncryptionAlgorithm": "", "VolumeType": "ALL",
-      "EncryptionOperation": "EnableEncryption"}}}]}}, "overprovision": true, "singlePlacementGroup":
-      true}}\'''''
+      "primary": true, "enableIPForwarding": false, "enableAcceleratedNetworking":
+      false, "dnsSettings": {"dnsServers": []}}}]}, "osProfile": {"secrets": [], "computerNamePrefix":
+      "vmss1c833", "windowsConfiguration": {"provisionVMAgent": true, "enableAutomaticUpdates":
+      true}, "adminUsername": "clitester1"}, "storageProfile": {"osDisk": {"managedDisk":
+      {"storageAccountType": "Standard_LRS"}, "caching": "ReadWrite", "createOption":
+      "FromImage"}, "imageReference": {"publisher": "MicrosoftWindowsServer", "sku":
+      "2016-Datacenter", "version": "latest", "offer": "WindowsServer"}}}}, "location":
+      "westus", "sku": {"capacity": 1, "name": "Standard_D1_v2", "tier": "Standard"}}\'''''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss encryption enable]
       Connection: [keep-alive]
-      Content-Length: ['2533']
+      Content-Length: ['2528']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -857,7 +794,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss109b0\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1c833\",\r\n        \"adminUsername\"\
         : \"clitester1\",\r\n        \"windowsConfiguration\": {\r\n          \"provisionVMAgent\"\
         : true,\r\n          \"enableAutomaticUpdates\": true\r\n        },\r\n  \
         \      \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n    \
@@ -867,34 +804,34 @@ interactions:
         \   },\r\n        \"imageReference\": {\r\n          \"publisher\": \"MicrosoftWindowsServer\"\
         ,\r\n          \"offer\": \"WindowsServer\",\r\n          \"sku\": \"2016-Datacenter\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss109b0Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1c833Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss109b0IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss1c833IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.Azure.Security\",\r\n              \"type\": \"AzureDiskEncryption\"\
-        ,\r\n              \"typeHandlerVersion\": \"2.1\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"\
-        ,\"KeyEncryptionKeyURL\":\"\",\"KeyVaultResourceId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
-        ,\"KekVaultResourceId\":\"\",\"KeyEncryptionAlgorithm\":\"\",\"VolumeType\"\
-        :\"ALL\",\"EncryptionOperation\":\"EnableEncryption\"},\r\n              \"\
-        forceUpdateTag\": \"f28b8214-b795-40c6-87ec-4050b6731e45\"\r\n           \
-        \ },\r\n            \"name\": \"AzureDiskEncryption\"\r\n          }\r\n \
-        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"fa8eae86-670e-4d21-9940-85263738f253\"\
+        ,\r\n              \"typeHandlerVersion\": \"2.2\",\r\n              \"autoUpgradeMinorVersion\"\
+        : true,\r\n              \"settings\": {\"KeyEncryptionKeyURL\":\"\",\"VolumeType\"\
+        :\"ALL\",\"EncryptionOperation\":\"EnableEncryption\",\"KeyVaultResourceId\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        ,\"KeyEncryptionAlgorithm\":\"\",\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"\
+        ,\"KekVaultResourceId\":\"\"},\r\n              \"forceUpdateTag\": \"d989f460-fd2e-44b3-95a4-98f2ed80b7eb\"\
+        \r\n            },\r\n            \"name\": \"AzureDiskEncryption\"\r\n  \
+        \        }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"a45f020e-6c88-4c81-a03c-5a910b381d9e\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"EastUS2EUAP\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/3716ee4a-afd3-4719-8cea-d688de0a4aa8?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/e3cd40ba-3dcb-41ad-ae21-37474f0501d5?api-version=2017-12-01']
       cache-control: [no-cache]
-      content-length: ['3407']
+      content-length: ['3402']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:20:11 GMT']
+      date: ['Sun, 22 Apr 2018 05:38:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -902,8 +839,8 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;39,Microsoft.Compute/CreateVMScaleSet30Min;198,Microsoft.Compute/VmssQueuedVMOperations;4800']
-      x-ms-ratelimit-remaining-subscription-writes: ['1185']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;38,Microsoft.Compute/CreateVMScaleSet30Min;195,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
 - request:
@@ -913,20 +850,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss encryption enable]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/3716ee4a-afd3-4719-8cea-d688de0a4aa8?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/e3cd40ba-3dcb-41ad-ae21-37474f0501d5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:20:10.7257657+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"3716ee4a-afd3-4719-8cea-d688de0a4aa8\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:38:40.5254191+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"e3cd40ba-3dcb-41ad-ae21-37474f0501d5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:20:41 GMT']
+      date: ['Sun, 22 Apr 2018 05:39:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -934,7 +871,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29958']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14948,Microsoft.Compute/GetOperation30Min;29539']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -943,50 +880,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss encryption enable]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/3716ee4a-afd3-4719-8cea-d688de0a4aa8?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/e3cd40ba-3dcb-41ad-ae21-37474f0501d5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:20:10.7257657+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"3716ee4a-afd3-4719-8cea-d688de0a4aa8\"\
-        \r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['134']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:21:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29955']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss encryption enable]
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/3716ee4a-afd3-4719-8cea-d688de0a4aa8?api-version=2017-12-01
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:20:10.7257657+00:00\",\r\
-        \n  \"endTime\": \"2018-03-30T21:21:14.2512297+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"3716ee4a-afd3-4719-8cea-d688de0a4aa8\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:38:40.5254191+00:00\",\r\
+        \n  \"endTime\": \"2018-04-22T05:39:30.3575531+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"e3cd40ba-3dcb-41ad-ae21-37474f0501d5\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:21:44 GMT']
+      date: ['Sun, 22 Apr 2018 05:39:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -994,7 +901,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29953']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14951,Microsoft.Compute/GetOperation30Min;29531']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1003,9 +910,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss encryption enable]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
   response:
@@ -1014,7 +921,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss109b0\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1c833\",\r\n        \"adminUsername\"\
         : \"clitester1\",\r\n        \"windowsConfiguration\": {\r\n          \"provisionVMAgent\"\
         : true,\r\n          \"enableAutomaticUpdates\": true\r\n        },\r\n  \
         \      \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n    \
@@ -1024,33 +931,33 @@ interactions:
         \   },\r\n        \"imageReference\": {\r\n          \"publisher\": \"MicrosoftWindowsServer\"\
         ,\r\n          \"offer\": \"WindowsServer\",\r\n          \"sku\": \"2016-Datacenter\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss109b0Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1c833Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss109b0IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss1c833IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.Azure.Security\",\r\n              \"type\": \"AzureDiskEncryption\"\
-        ,\r\n              \"typeHandlerVersion\": \"2.1\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"\
-        ,\"KeyEncryptionKeyURL\":\"\",\"KeyVaultResourceId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
-        ,\"KekVaultResourceId\":\"\",\"KeyEncryptionAlgorithm\":\"\",\"VolumeType\"\
-        :\"ALL\",\"EncryptionOperation\":\"EnableEncryption\"},\r\n              \"\
-        forceUpdateTag\": \"f28b8214-b795-40c6-87ec-4050b6731e45\"\r\n           \
-        \ },\r\n            \"name\": \"AzureDiskEncryption\"\r\n          }\r\n \
-        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"fa8eae86-670e-4d21-9940-85263738f253\"\
+        ,\r\n              \"typeHandlerVersion\": \"2.2\",\r\n              \"autoUpgradeMinorVersion\"\
+        : true,\r\n              \"settings\": {\"KeyEncryptionKeyURL\":\"\",\"VolumeType\"\
+        :\"ALL\",\"EncryptionOperation\":\"EnableEncryption\",\"KeyVaultResourceId\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        ,\"KeyEncryptionAlgorithm\":\"\",\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"\
+        ,\"KekVaultResourceId\":\"\"},\r\n              \"forceUpdateTag\": \"d989f460-fd2e-44b3-95a4-98f2ed80b7eb\"\
+        \r\n            },\r\n            \"name\": \"AzureDiskEncryption\"\r\n  \
+        \        }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"a45f020e-6c88-4c81-a03c-5a910b381d9e\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"EastUS2EUAP\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3408']
+      content-length: ['3403']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:21:45 GMT']
+      date: ['Sun, 22 Apr 2018 05:39:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1058,7 +965,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;186,Microsoft.Compute/GetVMScaleSet30Min;1486']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;177,Microsoft.Compute/GetVMScaleSet30Min;1457']
     status: {code: 200, message: OK}
 - request:
     body: '{"instanceIds": ["*"]}'
@@ -1069,27 +976,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/manualupgrade?api-version=2017-12-01
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 30 Mar 2018 21:21:46 GMT']
+      date: ['Sun, 22 Apr 2018 05:39:43 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?monitor=true&api-version=2017-12-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?monitor=true&api-version=2017-12-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1199,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;1199,Microsoft.Compute/VmssQueuedVMOperations;4799']
-      x-ms-ratelimit-remaining-subscription-writes: ['1188']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1198,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;1193,Microsoft.Compute/VmssQueuedVMOperations;4799']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['1']
     status: {code: 202, message: Accepted}
 - request:
@@ -1099,20 +1006,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:22:16 GMT']
+      date: ['Sun, 22 Apr 2018 05:40:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1120,7 +1027,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29951']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14952,Microsoft.Compute/GetOperation30Min;29522']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1129,20 +1036,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:22:48 GMT']
+      date: ['Sun, 22 Apr 2018 05:40:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1150,7 +1057,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29948']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14956,Microsoft.Compute/GetOperation30Min;29513']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1159,20 +1066,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:23:19 GMT']
+      date: ['Sun, 22 Apr 2018 05:41:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1180,7 +1087,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29945']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14954,Microsoft.Compute/GetOperation30Min;29503']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1189,20 +1096,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:23:52 GMT']
+      date: ['Sun, 22 Apr 2018 05:41:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1210,7 +1117,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29942']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14951,Microsoft.Compute/GetOperation30Min;29493']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1219,20 +1126,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:24:24 GMT']
+      date: ['Sun, 22 Apr 2018 05:42:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1240,7 +1147,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29939']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14947,Microsoft.Compute/GetOperation30Min;29482']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1249,20 +1156,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:24:56 GMT']
+      date: ['Sun, 22 Apr 2018 05:42:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1270,7 +1177,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29936']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14943,Microsoft.Compute/GetOperation30Min;29470']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1279,20 +1186,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:25:28 GMT']
+      date: ['Sun, 22 Apr 2018 05:43:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1300,7 +1207,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29933']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14939,Microsoft.Compute/GetOperation30Min;29457']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1309,20 +1216,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:26:01 GMT']
+      date: ['Sun, 22 Apr 2018 05:44:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1330,7 +1237,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29930']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14934,Microsoft.Compute/GetOperation30Min;29443']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1339,20 +1246,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:26:33 GMT']
+      date: ['Sun, 22 Apr 2018 05:44:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1360,7 +1267,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29927']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14939,Microsoft.Compute/GetOperation30Min;29429']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1369,20 +1276,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:27:05 GMT']
+      date: ['Sun, 22 Apr 2018 05:45:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1390,7 +1297,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29924']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14937,Microsoft.Compute/GetOperation30Min;29417']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1399,20 +1306,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/47131638-6be9-47df-b438-341c266d2ebc?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:39:43.7486959+00:00\",\r\
+        \n  \"endTime\": \"2018-04-22T05:45:24.9920704+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"47131638-6be9-47df-b438-341c266d2ebc\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['134']
+      content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:27:37 GMT']
+      date: ['Sun, 22 Apr 2018 05:45:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1420,37 +1327,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29921']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss update-instances]
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/bbd9f373-960e-415f-8b88-1cb765dc8d43?api-version=2017-12-01
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:21:46.8715908+00:00\",\r\
-        \n  \"endTime\": \"2018-03-30T21:27:43.951334+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"bbd9f373-960e-415f-8b88-1cb765dc8d43\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['183']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:28:08 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29919']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14932,Microsoft.Compute/GetOperation30Min;29401']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1460,50 +1337,50 @@ interactions:
       CommandName: [vmss encryption show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines?$select=instanceView&$expand=instanceView&api-version=2017-12-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"instanceId\": \"1\",\r\
         \n      \"properties\": {\r\n        \"latestModelApplied\": false,\r\n  \
-        \      \"instanceView\": {\r\n          \"placementGroupId\": \"b6d0ae0d-96fb-4b21-b6d6-54376d24458c\"\
+        \      \"instanceView\": {\r\n          \"placementGroupId\": \"553277d9-f1fa-4214-a489-e6eb8f2ae9e6\"\
         ,\r\n          \"platformUpdateDomain\": 1,\r\n          \"platformFaultDomain\"\
-        : 1,\r\n          \"computerName\": \"vmss109b0000001\",\r\n          \"osName\"\
+        : 1,\r\n          \"computerName\": \"vmss1c833000001\",\r\n          \"osName\"\
         : \"Windows Server 2016 Datacenter\",\r\n          \"osVersion\": \"Microsoft\
         \ Windows NT 6.3.9600.0\",\r\n          \"vmAgent\": {\r\n            \"vmAgentVersion\"\
         : \"2.7.41491.872\",\r\n            \"statuses\": [\r\n              {\r\n\
         \                \"code\": \"ProvisioningState/succeeded\",\r\n          \
         \      \"level\": \"Info\",\r\n                \"displayStatus\": \"Ready\"\
         ,\r\n                \"message\": \"GuestAgent is running and accepting new\
-        \ configurations.\",\r\n                \"time\": \"2018-03-30T21:28:04+00:00\"\
+        \ configurations.\",\r\n                \"time\": \"2018-04-22T05:45:38+00:00\"\
         \r\n              }\r\n            ],\r\n            \"extensionHandlers\"\
         : [\r\n              {\r\n                \"type\": \"Microsoft.Azure.Security.AzureDiskEncryption\"\
-        ,\r\n                \"typeHandlerVersion\": \"2.1.0.0\",\r\n            \
+        ,\r\n                \"typeHandlerVersion\": \"2.2.0.1\",\r\n            \
         \    \"status\": {\r\n                  \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n                  \"level\": \"Info\",\r\n                  \"displayStatus\"\
         : \"Ready\"\r\n                }\r\n              }\r\n            ]\r\n \
         \         },\r\n          \"disks\": [\r\n            {\r\n              \"\
-        name\": \"vmss1_vmss1_1_OsDisk_1_2ba5b3a056714f61b30d844ca1e4d74c\",\r\n \
+        name\": \"vmss1_vmss1_1_OsDisk_1_1dd4f41c66f443e2b963a961bad5011f\",\r\n \
         \             \"encryptionSettings\": [\r\n                {\r\n         \
         \         \"enabled\": true,\r\n                  \"diskEncryptionKey\": {\r\
         \n                    \"sourceVault\": {\r\n                      \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
-        \r\n                    },\r\n                    \"secretUrl\": \"https://vault000002.vault.azure.net/secrets/2EE2952E-6D8D-4330-BB85-0B2343F8E898/d32b0c3b37f6493ebc4e3318e0bca2a7\"\
+        \r\n                    },\r\n                    \"secretUrl\": \"https://vault000002.vault.azure.net/secrets/A9955D84-0665-4BF6-B3AF-082CA362A50C/c4601f8338424b1e84f7438c5954fe14\"\
         \r\n                  }\r\n                }\r\n              ],\r\n     \
         \         \"statuses\": [\r\n                {\r\n                  \"code\"\
         : \"ProvisioningState/succeeded\",\r\n                  \"level\": \"Info\"\
         ,\r\n                  \"displayStatus\": \"Provisioning succeeded\",\r\n\
-        \                  \"time\": \"2018-03-30T21:27:43.873228+00:00\"\r\n    \
+        \                  \"time\": \"2018-04-22T05:45:24.913963+00:00\"\r\n    \
         \            },\r\n                {\r\n                  \"code\": \"EncryptionState/encrypted\"\
         ,\r\n                  \"level\": \"Info\",\r\n                  \"displayStatus\"\
         : \"Encryption is enabled on disk\"\r\n                }\r\n             \
         \ ]\r\n            }\r\n          ],\r\n          \"extensions\": [\r\n  \
         \          {\r\n              \"name\": \"AzureDiskEncryption\",\r\n     \
         \         \"type\": \"Microsoft.Azure.Security.AzureDiskEncryption\",\r\n\
-        \              \"typeHandlerVersion\": \"2.1.0.0\",\r\n              \"statuses\"\
+        \              \"typeHandlerVersion\": \"2.2.0.1\",\r\n              \"statuses\"\
         : [\r\n                {\r\n                  \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n                  \"level\": \"Info\",\r\n                  \"displayStatus\"\
         : \"Provisioning succeeded\",\r\n                  \"message\": \"\"\r\n \
@@ -1511,17 +1388,17 @@ interactions:
         \          \"statuses\": [\r\n            {\r\n              \"code\": \"\
         ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\n \
         \             \"displayStatus\": \"Provisioning succeeded\",\r\n         \
-        \     \"time\": \"2018-03-30T21:27:43.920103+00:00\"\r\n            },\r\n\
+        \     \"time\": \"2018-04-22T05:45:24.9608602+00:00\"\r\n            },\r\n\
         \            {\r\n              \"code\": \"PowerState/running\",\r\n    \
         \          \"level\": \"Info\",\r\n              \"displayStatus\": \"VM running\"\
         \r\n            }\r\n          ]\r\n        },\r\n        \"provisioningState\"\
-        : 0\r\n      },\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_ENCRYPTIONCYC6E2R3QPG2JXBHLZXPLAXDNHR44FODZWMBMGEK7HSKWI3R5IJ/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1\"\
+        : 0\r\n      },\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_ENCRYPTIONO5RMXSAPNIOF7TUVQL3EOSBFNT6YP4LJ336ESGSB3EPRYSPRHLC/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1\"\
         \r\n    }\r\n  ]\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3782']
+      content-length: ['3783']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:28:10 GMT']
+      date: ['Sun, 22 Apr 2018 05:45:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1529,7 +1406,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostGetVMScaleSet3Min;179,Microsoft.Compute/HighCostGetVMScaleSet30Min;895,Microsoft.Compute/VMScaleSetVMViews3Min;4999']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostGetVMScaleSet3Min;179,Microsoft.Compute/HighCostGetVMScaleSet30Min;885,Microsoft.Compute/VMScaleSetVMViews3Min;4999']
       x-ms-request-charge: ['1']
     status: {code: 200, message: OK}
 - request:
@@ -1540,9 +1417,9 @@ interactions:
       CommandName: [vmss show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -1552,7 +1429,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss109b0\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1c833\",\r\n        \"adminUsername\"\
         : \"clitester1\",\r\n        \"windowsConfiguration\": {\r\n          \"provisionVMAgent\"\
         : true,\r\n          \"enableAutomaticUpdates\": true\r\n        },\r\n  \
         \      \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n    \
@@ -1562,33 +1439,33 @@ interactions:
         \   },\r\n        \"imageReference\": {\r\n          \"publisher\": \"MicrosoftWindowsServer\"\
         ,\r\n          \"offer\": \"WindowsServer\",\r\n          \"sku\": \"2016-Datacenter\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss109b0Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1c833Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss109b0IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss1c833IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.Azure.Security\",\r\n              \"type\": \"AzureDiskEncryption\"\
-        ,\r\n              \"typeHandlerVersion\": \"2.1\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"\
-        ,\"KeyEncryptionKeyURL\":\"\",\"KeyVaultResourceId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
-        ,\"KekVaultResourceId\":\"\",\"KeyEncryptionAlgorithm\":\"\",\"VolumeType\"\
-        :\"ALL\",\"EncryptionOperation\":\"EnableEncryption\"},\r\n              \"\
-        forceUpdateTag\": \"f28b8214-b795-40c6-87ec-4050b6731e45\"\r\n           \
-        \ },\r\n            \"name\": \"AzureDiskEncryption\"\r\n          }\r\n \
-        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"fa8eae86-670e-4d21-9940-85263738f253\"\
+        ,\r\n              \"typeHandlerVersion\": \"2.2\",\r\n              \"autoUpgradeMinorVersion\"\
+        : true,\r\n              \"settings\": {\"KeyEncryptionKeyURL\":\"\",\"VolumeType\"\
+        :\"ALL\",\"EncryptionOperation\":\"EnableEncryption\",\"KeyVaultResourceId\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        ,\"KeyEncryptionAlgorithm\":\"\",\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"\
+        ,\"KekVaultResourceId\":\"\"},\r\n              \"forceUpdateTag\": \"d989f460-fd2e-44b3-95a4-98f2ed80b7eb\"\
+        \r\n            },\r\n            \"name\": \"AzureDiskEncryption\"\r\n  \
+        \        }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"a45f020e-6c88-4c81-a03c-5a910b381d9e\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"EastUS2EUAP\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3408']
+      content-length: ['3403']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:28:10 GMT']
+      date: ['Sun, 22 Apr 2018 05:45:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1596,7 +1473,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;199,Microsoft.Compute/GetVMScaleSet30Min;1485']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;199,Microsoft.Compute/GetVMScaleSet30Min;1448']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1606,9 +1483,9 @@ interactions:
       CommandName: [vmss encryption disable]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -1618,7 +1495,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss109b0\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1c833\",\r\n        \"adminUsername\"\
         : \"clitester1\",\r\n        \"windowsConfiguration\": {\r\n          \"provisionVMAgent\"\
         : true,\r\n          \"enableAutomaticUpdates\": true\r\n        },\r\n  \
         \      \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n    \
@@ -1628,33 +1505,33 @@ interactions:
         \   },\r\n        \"imageReference\": {\r\n          \"publisher\": \"MicrosoftWindowsServer\"\
         ,\r\n          \"offer\": \"WindowsServer\",\r\n          \"sku\": \"2016-Datacenter\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss109b0Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1c833Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss109b0IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss1c833IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.Azure.Security\",\r\n              \"type\": \"AzureDiskEncryption\"\
-        ,\r\n              \"typeHandlerVersion\": \"2.1\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"\
-        ,\"KeyEncryptionKeyURL\":\"\",\"KeyVaultResourceId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
-        ,\"KekVaultResourceId\":\"\",\"KeyEncryptionAlgorithm\":\"\",\"VolumeType\"\
-        :\"ALL\",\"EncryptionOperation\":\"EnableEncryption\"},\r\n              \"\
-        forceUpdateTag\": \"f28b8214-b795-40c6-87ec-4050b6731e45\"\r\n           \
-        \ },\r\n            \"name\": \"AzureDiskEncryption\"\r\n          }\r\n \
-        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"fa8eae86-670e-4d21-9940-85263738f253\"\
+        ,\r\n              \"typeHandlerVersion\": \"2.2\",\r\n              \"autoUpgradeMinorVersion\"\
+        : true,\r\n              \"settings\": {\"KeyEncryptionKeyURL\":\"\",\"VolumeType\"\
+        :\"ALL\",\"EncryptionOperation\":\"EnableEncryption\",\"KeyVaultResourceId\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.KeyVault/vaults/vault000002\"\
+        ,\"KeyEncryptionAlgorithm\":\"\",\"KeyVaultURL\":\"https://vault000002.vault.azure.net\"\
+        ,\"KekVaultResourceId\":\"\"},\r\n              \"forceUpdateTag\": \"d989f460-fd2e-44b3-95a4-98f2ed80b7eb\"\
+        \r\n            },\r\n            \"name\": \"AzureDiskEncryption\"\r\n  \
+        \        }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"a45f020e-6c88-4c81-a03c-5a910b381d9e\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"EastUS2EUAP\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3408']
+      content-length: ['3403']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:28:12 GMT']
+      date: ['Sun, 22 Apr 2018 05:47:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1662,39 +1539,38 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;198,Microsoft.Compute/GetVMScaleSet30Min;1484']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;198,Microsoft.Compute/GetVMScaleSet30Min;1447']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"location": "EastUS2EUAP", "tags": {}, "sku": {"name": "Standard_D1_v2",
-      "tier": "Standard", "capacity": 1}, "properties": {"upgradePolicy": {"mode":
-      "Manual", "automaticOSUpgrade": false}, "virtualMachineProfile": {"osProfile":
-      {"computerNamePrefix": "vmss109b0", "adminUsername": "clitester1", "windowsConfiguration":
-      {"provisionVMAgent": true, "enableAutomaticUpdates": true}, "secrets": []},
-      "storageProfile": {"imageReference": {"publisher": "MicrosoftWindowsServer",
-      "offer": "WindowsServer", "sku": "2016-Datacenter", "version": "latest"}, "osDisk":
-      {"caching": "ReadWrite", "createOption": "FromImage", "managedDisk": {"storageAccountType":
-      "Standard_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations": [{"name":
-      "vmss109b0Nic", "properties": {"primary": true, "enableAcceleratedNetworking":
-      false, "dnsSettings": {"dnsServers": []}, "ipConfigurations": [{"name": "vmss109b0IPConfig",
-      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAddressVersion": "IPv4", "loadBalancerBackendAddressPools": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+    body: 'b''{"tags": {}, "properties": {"overprovision": true, "upgradePolicy":
+      {"mode": "Manual", "automaticOSUpgrade": false}, "singlePlacementGroup": true,
+      "virtualMachineProfile": {"extensionProfile": {"extensions": [{"name": "AzureDiskEncryption",
+      "properties": {"typeHandlerVersion": "2.2", "forceUpdateTag": "46c0a068-69a5-4c5e-a33a-1dcc897b80c7",
+      "autoUpgradeMinorVersion": true, "publisher": "Microsoft.Azure.Security", "type":
+      "AzureDiskEncryption", "settings": {"VolumeType": "ALL", "EncryptionOperation":
+      "DisableEncryption"}}}]}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss1c833Nic", "properties": {"ipConfigurations": [{"name": "vmss1c833IPConfig",
+      "properties": {"loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+      "privateIPAddressVersion": "IPv4", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}],
-      "enableIPForwarding": false}}]}, "extensionProfile": {"extensions": [{"name":
-      "AzureDiskEncryption", "properties": {"forceUpdateTag": "ae7370d2-beaf-4a07-bc1a-b7eab345500a",
-      "publisher": "Microsoft.Azure.Security", "type": "AzureDiskEncryption", "typeHandlerVersion":
-      "2.1", "autoUpgradeMinorVersion": true, "settings": {"VolumeType": "ALL", "EncryptionOperation":
-      "DisableEncryption"}}}]}}, "overprovision": true, "singlePlacementGroup": true}}'''
+      "primary": true, "enableIPForwarding": false, "enableAcceleratedNetworking":
+      false, "dnsSettings": {"dnsServers": []}}}]}, "osProfile": {"secrets": [], "computerNamePrefix":
+      "vmss1c833", "windowsConfiguration": {"provisionVMAgent": true, "enableAutomaticUpdates":
+      true}, "adminUsername": "clitester1"}, "storageProfile": {"osDisk": {"managedDisk":
+      {"storageAccountType": "Standard_LRS"}, "caching": "ReadWrite", "createOption":
+      "FromImage"}, "imageReference": {"publisher": "MicrosoftWindowsServer", "sku":
+      "2016-Datacenter", "version": "latest", "offer": "WindowsServer"}}}}, "location":
+      "westus", "sku": {"capacity": 1, "name": "Standard_D1_v2", "tier": "Standard"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss encryption disable]
       Connection: [keep-alive]
-      Content-Length: ['2183']
+      Content-Length: ['2178']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -1704,7 +1580,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss109b0\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1c833\",\r\n        \"adminUsername\"\
         : \"clitester1\",\r\n        \"windowsConfiguration\": {\r\n          \"provisionVMAgent\"\
         : true,\r\n          \"enableAutomaticUpdates\": true\r\n        },\r\n  \
         \      \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n    \
@@ -1714,31 +1590,31 @@ interactions:
         \   },\r\n        \"imageReference\": {\r\n          \"publisher\": \"MicrosoftWindowsServer\"\
         ,\r\n          \"offer\": \"WindowsServer\",\r\n          \"sku\": \"2016-Datacenter\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss109b0Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1c833Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss109b0IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss1c833IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.Azure.Security\",\r\n              \"type\": \"AzureDiskEncryption\"\
-        ,\r\n              \"typeHandlerVersion\": \"2.1\",\r\n              \"autoUpgradeMinorVersion\"\
+        ,\r\n              \"typeHandlerVersion\": \"2.2\",\r\n              \"autoUpgradeMinorVersion\"\
         : true,\r\n              \"settings\": {\"VolumeType\":\"ALL\",\"EncryptionOperation\"\
-        :\"DisableEncryption\"},\r\n              \"forceUpdateTag\": \"ae7370d2-beaf-4a07-bc1a-b7eab345500a\"\
+        :\"DisableEncryption\"},\r\n              \"forceUpdateTag\": \"46c0a068-69a5-4c5e-a33a-1dcc897b80c7\"\
         \r\n            },\r\n            \"name\": \"AzureDiskEncryption\"\r\n  \
         \        }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"fa8eae86-670e-4d21-9940-85263738f253\"\
+        : \"Updating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"a45f020e-6c88-4c81-a03c-5a910b381d9e\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"EastUS2EUAP\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/f44dab6b-dec0-43d6-9788-8f9aef28b782?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/befc4a44-1989-4dfe-ba7e-7c203a79bb15?api-version=2017-12-01']
       cache-control: [no-cache]
-      content-length: ['3067']
+      content-length: ['3062']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:28:14 GMT']
+      date: ['Sun, 22 Apr 2018 05:47:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1746,8 +1622,8 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;39,Microsoft.Compute/CreateVMScaleSet30Min;197,Microsoft.Compute/VmssQueuedVMOperations;4800']
-      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;39,Microsoft.Compute/CreateVMScaleSet30Min;194,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
 - request:
@@ -1757,20 +1633,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss encryption disable]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/f44dab6b-dec0-43d6-9788-8f9aef28b782?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/befc4a44-1989-4dfe-ba7e-7c203a79bb15?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:28:13.9707702+00:00\",\r\
-        \n  \"endTime\": \"2018-03-30T21:28:14.2520218+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"f44dab6b-dec0-43d6-9788-8f9aef28b782\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:47:09.5626186+00:00\",\r\
+        \n  \"endTime\": \"2018-04-22T05:47:09.8282361+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"befc4a44-1989-4dfe-ba7e-7c203a79bb15\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:28:45 GMT']
+      date: ['Sun, 22 Apr 2018 05:47:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1778,7 +1654,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29917']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14952,Microsoft.Compute/GetOperation30Min;29373']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1787,9 +1663,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss encryption disable]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
   response:
@@ -1798,7 +1674,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss109b0\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1c833\",\r\n        \"adminUsername\"\
         : \"clitester1\",\r\n        \"windowsConfiguration\": {\r\n          \"provisionVMAgent\"\
         : true,\r\n          \"enableAutomaticUpdates\": true\r\n        },\r\n  \
         \      \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n    \
@@ -1808,30 +1684,30 @@ interactions:
         \   },\r\n        \"imageReference\": {\r\n          \"publisher\": \"MicrosoftWindowsServer\"\
         ,\r\n          \"offer\": \"WindowsServer\",\r\n          \"sku\": \"2016-Datacenter\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss109b0Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1c833Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss109b0IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss1c833IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.Azure.Security\",\r\n              \"type\": \"AzureDiskEncryption\"\
-        ,\r\n              \"typeHandlerVersion\": \"2.1\",\r\n              \"autoUpgradeMinorVersion\"\
+        ,\r\n              \"typeHandlerVersion\": \"2.2\",\r\n              \"autoUpgradeMinorVersion\"\
         : true,\r\n              \"settings\": {\"VolumeType\":\"ALL\",\"EncryptionOperation\"\
-        :\"DisableEncryption\"},\r\n              \"forceUpdateTag\": \"ae7370d2-beaf-4a07-bc1a-b7eab345500a\"\
+        :\"DisableEncryption\"},\r\n              \"forceUpdateTag\": \"46c0a068-69a5-4c5e-a33a-1dcc897b80c7\"\
         \r\n            },\r\n            \"name\": \"AzureDiskEncryption\"\r\n  \
         \        }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"fa8eae86-670e-4d21-9940-85263738f253\"\
+        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"a45f020e-6c88-4c81-a03c-5a910b381d9e\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"EastUS2EUAP\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3068']
+      content-length: ['3063']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:28:46 GMT']
+      date: ['Sun, 22 Apr 2018 05:47:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1839,7 +1715,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;192,Microsoft.Compute/GetVMScaleSet30Min;1478']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;191,Microsoft.Compute/GetVMScaleSet30Min;1440']
     status: {code: 200, message: OK}
 - request:
     body: '{"instanceIds": ["*"]}'
@@ -1850,27 +1726,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/manualupgrade?api-version=2017-12-01
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/67939b10-5815-4588-b5e5-0f7ee02281fc?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c43184ba-c9df-4cc6-a9f3-a29799cbc314?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 30 Mar 2018 21:28:48 GMT']
+      date: ['Sun, 22 Apr 2018 05:47:41 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/67939b10-5815-4588-b5e5-0f7ee02281fc?monitor=true&api-version=2017-12-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c43184ba-c9df-4cc6-a9f3-a29799cbc314?monitor=true&api-version=2017-12-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1198,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;1199,Microsoft.Compute/VmssQueuedVMOperations;4799']
-      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;238,Microsoft.Compute/VMScaleSetActions30Min;1196,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;1196,Microsoft.Compute/VmssQueuedVMOperations;4799']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['1']
     status: {code: 202, message: Accepted}
 - request:
@@ -1880,20 +1756,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/67939b10-5815-4588-b5e5-0f7ee02281fc?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c43184ba-c9df-4cc6-a9f3-a29799cbc314?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:28:48.1148347+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"67939b10-5815-4588-b5e5-0f7ee02281fc\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:47:41.6419433+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"c43184ba-c9df-4cc6-a9f3-a29799cbc314\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:29:18 GMT']
+      date: ['Sun, 22 Apr 2018 05:48:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1901,7 +1777,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29915']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14954,Microsoft.Compute/GetOperation30Min;29364']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1910,20 +1786,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/operations/67939b10-5815-4588-b5e5-0f7ee02281fc?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c43184ba-c9df-4cc6-a9f3-a29799cbc314?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-03-30T21:28:48.1148347+00:00\",\r\
-        \n  \"endTime\": \"2018-03-30T21:29:22.9039305+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"67939b10-5815-4588-b5e5-0f7ee02281fc\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-22T05:47:41.6419433+00:00\",\r\
+        \n  \"endTime\": \"2018-04-22T05:48:18.3933742+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"c43184ba-c9df-4cc6-a9f3-a29799cbc314\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:29:49 GMT']
+      date: ['Sun, 22 Apr 2018 05:48:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1931,7 +1807,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29913']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14957,Microsoft.Compute/GetOperation30Min;29356']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1941,46 +1817,46 @@ interactions:
       CommandName: [vmss encryption show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines?$select=instanceView&$expand=instanceView&api-version=2017-12-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"instanceId\": \"1\",\r\
         \n      \"properties\": {\r\n        \"latestModelApplied\": false,\r\n  \
-        \      \"instanceView\": {\r\n          \"placementGroupId\": \"b6d0ae0d-96fb-4b21-b6d6-54376d24458c\"\
+        \      \"instanceView\": {\r\n          \"placementGroupId\": \"553277d9-f1fa-4214-a489-e6eb8f2ae9e6\"\
         ,\r\n          \"platformUpdateDomain\": 1,\r\n          \"platformFaultDomain\"\
-        : 1,\r\n          \"computerName\": \"vmss109b0000001\",\r\n          \"osName\"\
+        : 1,\r\n          \"computerName\": \"vmss1c833000001\",\r\n          \"osName\"\
         : \"Windows Server 2016 Datacenter\",\r\n          \"osVersion\": \"Microsoft\
         \ Windows NT 6.3.9600.0\",\r\n          \"vmAgent\": {\r\n            \"vmAgentVersion\"\
         : \"2.7.41491.872\",\r\n            \"statuses\": [\r\n              {\r\n\
         \                \"code\": \"ProvisioningState/succeeded\",\r\n          \
         \      \"level\": \"Info\",\r\n                \"displayStatus\": \"Ready\"\
         ,\r\n                \"message\": \"GuestAgent is running and accepting new\
-        \ configurations.\",\r\n                \"time\": \"2018-03-30T21:29:50+00:00\"\
+        \ configurations.\",\r\n                \"time\": \"2018-04-22T05:48:25+00:00\"\
         \r\n              }\r\n            ],\r\n            \"extensionHandlers\"\
         : [\r\n              {\r\n                \"type\": \"Microsoft.Azure.Security.AzureDiskEncryption\"\
-        ,\r\n                \"typeHandlerVersion\": \"2.1.0.0\",\r\n            \
+        ,\r\n                \"typeHandlerVersion\": \"2.2.0.1\",\r\n            \
         \    \"status\": {\r\n                  \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n                  \"level\": \"Info\",\r\n                  \"displayStatus\"\
         : \"Ready\"\r\n                }\r\n              }\r\n            ]\r\n \
         \         },\r\n          \"disks\": [\r\n            {\r\n              \"\
-        name\": \"vmss1_vmss1_1_OsDisk_1_2ba5b3a056714f61b30d844ca1e4d74c\",\r\n \
+        name\": \"vmss1_vmss1_1_OsDisk_1_1dd4f41c66f443e2b963a961bad5011f\",\r\n \
         \             \"encryptionSettings\": [\r\n                {\r\n         \
         \         \"enabled\": false\r\n                }\r\n              ],\r\n\
         \              \"statuses\": [\r\n                {\r\n                  \"\
         code\": \"ProvisioningState/succeeded\",\r\n                  \"level\": \"\
         Info\",\r\n                  \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n                  \"time\": \"2018-03-30T21:29:22.8257732+00:00\"\r\n\
+        ,\r\n                  \"time\": \"2018-04-22T05:48:18.3465018+00:00\"\r\n\
         \                },\r\n                {\r\n                  \"code\": \"\
         EncryptionState/notEncrypted\",\r\n                  \"level\": \"Info\",\r\
         \n                  \"displayStatus\": \"Disk is not encrypted\"\r\n     \
         \           }\r\n              ]\r\n            }\r\n          ],\r\n    \
         \      \"extensions\": [\r\n            {\r\n              \"name\": \"AzureDiskEncryption\"\
         ,\r\n              \"type\": \"Microsoft.Azure.Security.AzureDiskEncryption\"\
-        ,\r\n              \"typeHandlerVersion\": \"2.1.0.0\",\r\n              \"\
+        ,\r\n              \"typeHandlerVersion\": \"2.2.0.1\",\r\n              \"\
         statuses\": [\r\n                {\r\n                  \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n                  \"level\": \"Info\",\r\n                  \"displayStatus\"\
         : \"Provisioning succeeded\",\r\n                  \"message\": \"Disable\
@@ -1988,17 +1864,17 @@ interactions:
         \   ]\r\n            }\r\n          ],\r\n          \"statuses\": [\r\n  \
         \          {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\
         \n              \"level\": \"Info\",\r\n              \"displayStatus\": \"\
-        Provisioning succeeded\",\r\n              \"time\": \"2018-03-30T21:29:22.8727117+00:00\"\
+        Provisioning succeeded\",\r\n              \"time\": \"2018-04-22T05:48:18.3777735+00:00\"\
         \r\n            },\r\n            {\r\n              \"code\": \"PowerState/running\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
         : \"VM running\"\r\n            }\r\n          ]\r\n        },\r\n       \
-        \ \"provisioningState\": 0\r\n      },\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_ENCRYPTIONCYC6E2R3QPG2JXBHLZXPLAXDNHR44FODZWMBMGEK7HSKWI3R5IJ/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1\"\
+        \ \"provisioningState\": 0\r\n      },\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_ENCRYPTIONO5RMXSAPNIOF7TUVQL3EOSBFNT6YP4LJ336ESGSB3EPRYSPRHLC/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1\"\
         \r\n    }\r\n  ]\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['3325']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:29:50 GMT']
+      date: ['Sun, 22 Apr 2018 05:48:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2006,7 +1882,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostGetVMScaleSet3Min;176,Microsoft.Compute/HighCostGetVMScaleSet30Min;892,Microsoft.Compute/VMScaleSetVMViews3Min;4996']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostGetVMScaleSet3Min;177,Microsoft.Compute/HighCostGetVMScaleSet30Min;882,Microsoft.Compute/VMScaleSetVMViews3Min;4997']
       x-ms-request-charge: ['1']
     status: {code: 200, message: OK}
 - request:
@@ -2017,9 +1893,9 @@ interactions:
       CommandName: [vmss show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -2029,7 +1905,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss109b0\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1c833\",\r\n        \"adminUsername\"\
         : \"clitester1\",\r\n        \"windowsConfiguration\": {\r\n          \"provisionVMAgent\"\
         : true,\r\n          \"enableAutomaticUpdates\": true\r\n        },\r\n  \
         \      \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n    \
@@ -2039,30 +1915,30 @@ interactions:
         \   },\r\n        \"imageReference\": {\r\n          \"publisher\": \"MicrosoftWindowsServer\"\
         ,\r\n          \"offer\": \"WindowsServer\",\r\n          \"sku\": \"2016-Datacenter\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss109b0Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1c833Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss109b0IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss1c833IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]},\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.Azure.Security\",\r\n              \"type\": \"AzureDiskEncryption\"\
-        ,\r\n              \"typeHandlerVersion\": \"2.1\",\r\n              \"autoUpgradeMinorVersion\"\
+        ,\r\n              \"typeHandlerVersion\": \"2.2\",\r\n              \"autoUpgradeMinorVersion\"\
         : true,\r\n              \"settings\": {\"VolumeType\":\"ALL\",\"EncryptionOperation\"\
-        :\"DisableEncryption\"},\r\n              \"forceUpdateTag\": \"ae7370d2-beaf-4a07-bc1a-b7eab345500a\"\
+        :\"DisableEncryption\"},\r\n              \"forceUpdateTag\": \"46c0a068-69a5-4c5e-a33a-1dcc897b80c7\"\
         \r\n            },\r\n            \"name\": \"AzureDiskEncryption\"\r\n  \
         \        }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"fa8eae86-670e-4d21-9940-85263738f253\"\
+        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"a45f020e-6c88-4c81-a03c-5a910b381d9e\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"EastUS2EUAP\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_encryption000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3068']
+      content-length: ['3063']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 30 Mar 2018 21:29:51 GMT']
+      date: ['Sun, 22 Apr 2018 05:48:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2070,7 +1946,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;191,Microsoft.Compute/GetVMScaleSet30Min;1477']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;191,Microsoft.Compute/GetVMScaleSet30Min;1439']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2081,9 +1957,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
           msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+          AZURECLI/2.0.32]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_encryption000001?api-version=2017-05-10
@@ -2092,12 +1968,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 30 Mar 2018 21:29:53 GMT']
+      date: ['Sun, 22 Apr 2018 05:48:43 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGVk1TUzo1RkVOQ1JZUFRJT05DWUM2RTJSM1FQRzJKWEJITHwyMDg0MTI5RkIzMjI3RjgyLUVBU1RVUzJFVUFQIiwiam9iTG9jYXRpb24iOiJlYXN0dXMyZXVhcCJ9?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGVk1TUzo1RkVOQ1JZUFRJT05PNVJNWFNBUE5JT0Y3VFVWUXxGMTZDRDQ0MzRFQUFFMzlELVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -2338,6 +2338,7 @@ class VMDiskEncryptionTest(ScenarioTest):
             'vmss': 'vmss1'
         })
         self.cmd('keyvault create -g {rg} -n {vault} --enabled-for-disk-encryption "true"')
+        time.sleep(60)  # to avoid 504(too many requests) on a newly created vault
         self.cmd('vmss create -g {rg} -n {vmss} --image win2016datacenter --instance-count 1 --admin-username clitester1 --admin-password Test123456789!')
         self.cmd('vmss encryption enable -g {rg} -n {vmss} --disk-encryption-keyvault {vault}')
         self.cmd('vmss update-instances -g {rg} -n {vmss}  --instance-ids "*"')
@@ -2361,6 +2362,7 @@ class VMDiskEncryptionTest(ScenarioTest):
             'vm': 'vm1'
         })
         self.cmd('keyvault create -g {rg} -n {vault} --enabled-for-disk-encryption "true"')
+        time.sleep(60)  # to avoid 504(too many requests) on a newly created vault
         self.cmd('vm create -g {rg} -n {vm} --image win2012datacenter --admin-username clitester1 --admin-password Test123456789!')
         self.cmd('vm encryption enable -g {rg} -n {vm} --disk-encryption-keyvault {vault}')
         self.cmd('vm encryption show -g {rg} -n {vm}', checks=[self.check('disks[0].statuses[0].code', 'EncryptionState/encrypted')])


### PR DESCRIPTION
Old 2 passes flow is still supported through detecting mechanism proposed by ADE team. Supported linux disto list is also updated.

//CC @SudhakaraReddyEvuri 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
