### PR TITLE
Minor fix in _rudimentary_get_command

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -11,6 +11,7 @@ Release History
 * Improves piping scenarios from commands when using `--ids`. Supports `-o tsv` with a query specified or `-o json`
   without specifying a query.
 * Display command suggestions on error if users have typo in their commands
+* More friendly error when users type `az ''`
 
 2.0.31
 ++++++

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -359,7 +359,7 @@ class AzCliCommandInvoker(CommandInvoker):
         nouns = []
         command_names = self.commands_loader.command_table.keys()
         for arg in args:
-            if arg[0] != '-':
+            if arg and arg[0] != '-':
                 nouns.append(arg)
             else:
                 break


### PR DESCRIPTION
---
Currently, if you type `az ''` or `az <some commands> ''`, it will output an unfriendly error message:
![image](https://user-images.githubusercontent.com/10557231/39203646-3e5538a8-47aa-11e8-985c-cc3350be4108.png)

This fix will output a more user-friendly error message:
![image](https://user-images.githubusercontent.com/10557231/39203665-4d897456-47aa-11e8-86d0-4112cf62c4fa.png)



This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
