### PR TITLE
Remove incorrect example for 'az role definition update'

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -232,35 +232,6 @@ helps['role definition update'] = """
         - name: --role-definition
           type: string
           short-summary: Description of a role as JSON, or a path to a file containing a JSON description.
-    examples:
-        - name: Create a role with read-only access to storage and network resources, and the ability to start or restart VMs.
-          text: |
-                az role definition create --role-definition '{
-                    "Name": "Contoso On-call",
-                    "Description": "Perform VM actions and read storage and network information."
-                    "Actions": [
-                        "Microsoft.Compute/*/read",
-                        "Microsoft.Compute/virtualMachines/start/action",
-                        "Microsoft.Compute/virtualMachines/restart/action",
-                        "Microsoft.Network/*/read",
-                        "Microsoft.Storage/*/read",
-                        "Microsoft.Authorization/*/read",
-                        "Microsoft.Resources/subscriptions/resourceGroups/read",
-                        "Microsoft.Resources/subscriptions/resourceGroups/resources/read",
-                        "Microsoft.Insights/alertRules/*",
-                        "Microsoft.Support/*"
-                    ],
-                    "DataActions": [
-                        "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*"
-                    ],
-                    "NotDataActions": [
-                        "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write"
-                    ],
-                    "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
-                }'
-        - name: Create a role from a file containing a JSON description.
-          text: >
-            az role definition create --role-definition ad-role.json
 """
 helps['ad'] = """
     type: group


### PR DESCRIPTION
The example is an 'create' command while this is actually an 'update' command.
Closes https://github.com/Azure/azure-cli/issues/5504

---