### PR TITLE
vm create: fix invalid detection logics on vhd blobs

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.0.31
 ++++++
+* vm: fix an invalid detection logic on unmanaged blob uri
 * vm: support disk encryption w/o user provided service principals 
 * BREAKING CHANGE: do not use VM 'ManagedIdentityExtension' for MSI support
 * vmss: support eviction policy

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -199,7 +199,7 @@ def _parse_image_argument(cmd, namespace):
     import re
 
     # 1 - easy check for URI
-    if _is_vhd_blob_uri(namespace.image):
+    if _is_vhd_blob_uri(cmd.cli_ctx, namespace.image):
         return 'uri'
 
     # 2 - check if a fully-qualified ID (assumes it is an image ID)
@@ -1148,7 +1148,7 @@ def _figure_out_storage_source(cli_ctx, resource_group_name, source):
     source_blob_uri = None
     source_disk = None
     source_snapshot = None
-    if _is_vhd_blob_uri(source):
+    if _is_vhd_blob_uri(cli_ctx, source):
         source_blob_uri = source
     elif '/disks/' in source.lower():
         source_disk = source
@@ -1167,15 +1167,14 @@ def _figure_out_storage_source(cli_ctx, resource_group_name, source):
     return (source_blob_uri, source_disk, source_snapshot)
 
 
-def _is_vhd_blob_uri(source):
+def _is_vhd_blob_uri(cli_ctx, source):
     try:
         from urllib.parse import urlparse
     except ImportError:
         from urlparse import urlparse  # pylint: disable=import-error
 
-    # an exiting scheme should be sufficient to head to a blob uri,
-    # as ':' isn't allowed in the name for disk, snapshot, image
-    return bool(urlparse(source).scheme)
+    r = urlparse(source)
+    return bool(r.scheme) and (cli_ctx.cloud.suffixes.storage_endpoint in r.netloc)
 
 
 def process_disk_encryption_namespace(cmd, namespace):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -198,15 +198,11 @@ def _parse_image_argument(cmd, namespace):
     from msrestazure.azure_exceptions import CloudError
     import re
 
-    # 1 - easy check for URI
-    if _is_vhd_blob_uri(cmd.cli_ctx, namespace.image):
-        return 'uri'
-
-    # 2 - check if a fully-qualified ID (assumes it is an image ID)
+    # 1 - check if a fully-qualified ID (assumes it is an image ID)
     if is_valid_resource_id(namespace.image):
         return 'image_id'
 
-    # 3 - attempt to match an URN pattern
+    # 2 - attempt to match an URN pattern
     urn_match = re.match('([^:]*):([^:]*):([^:]*):([^:]*)', namespace.image)
     if urn_match:
         namespace.os_publisher = urn_match.group(1)
@@ -222,6 +218,10 @@ def _parse_image_argument(cmd, namespace):
                 namespace.plan_publisher = image_plan.publisher
 
         return 'urn'
+
+    # unmanaged vhd based images?
+    if _is_vhd_blob_uri(namespace.image):
+        return 'uri'
 
     # 4 - attempt to match an URN alias (most likely)
     from azure.cli.command_modules.vm._actions import load_images_from_aliases_doc
@@ -1148,7 +1148,7 @@ def _figure_out_storage_source(cli_ctx, resource_group_name, source):
     source_blob_uri = None
     source_disk = None
     source_snapshot = None
-    if _is_vhd_blob_uri(cli_ctx, source):
+    if _is_vhd_blob_uri(source):
         source_blob_uri = source
     elif '/disks/' in source.lower():
         source_disk = source
@@ -1167,14 +1167,14 @@ def _figure_out_storage_source(cli_ctx, resource_group_name, source):
     return (source_blob_uri, source_disk, source_snapshot)
 
 
-def _is_vhd_blob_uri(cli_ctx, source):
+def _is_vhd_blob_uri(source):
     try:
         from urllib.parse import urlparse
     except ImportError:
         from urlparse import urlparse  # pylint: disable=import-error
 
-    r = urlparse(source)
-    return bool(r.scheme) and (cli_ctx.cloud.suffixes.storage_endpoint in r.netloc)
+    # ':' is not allowed for image, disk, or snapshot names, so an existing scheme should be reliable
+    return bool(urlparse(source).scheme)
 
 
 def process_disk_encryption_namespace(cmd, namespace):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -76,7 +76,7 @@ class TestActions(unittest.TestCase):
         self.assertEqual(src_blob_uri, test_data)
 
         test_data = '/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/JAVACSMRG6017/providers/Microsoft.Compute/disks/ex.vhd'
-        src_blob_uri, src_disk, src_snapshot = _figure_out_storage_source(TestCli(), 'tg1', test_data)
+        src_blob_uri, src_disk, src_snapshot = _figure_out_storage_source(None, 'tg1', test_data)
         self.assertEqual(src_disk, test_data)
         self.assertFalse(src_snapshot)
         self.assertFalse(src_blob_uri)
@@ -218,7 +218,6 @@ class TestActions(unittest.TestCase):
         np = mock.MagicMock()
         np.image = 'https://foo.blob.core.windows.net/vhds/1'
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
         # action & assert
         self.assertEqual(_parse_image_argument(cmd, np), 'uri')
 
@@ -226,7 +225,6 @@ class TestActions(unittest.TestCase):
         np = mock.MagicMock()
         np.image = '/subscriptions/123/resourceGroups/foo/providers/Microsoft.Compute/images/nixos-imag.vhd'
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
 
         # action & assert
         self.assertEqual(_parse_image_argument(cmd, np), 'image_id')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -217,16 +217,19 @@ class TestActions(unittest.TestCase):
     def test_parse_unmanaged_image_argument(self):
         np = mock.MagicMock()
         np.image = 'https://foo.blob.core.windows.net/vhds/1'
-
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = TestCli()
         # action & assert
-        self.assertEqual(_parse_image_argument(None, np), 'uri')
+        self.assertEqual(_parse_image_argument(cmd, np), 'uri')
 
     def test_parse_managed_image_argument(self):
         np = mock.MagicMock()
         np.image = '/subscriptions/123/resourceGroups/foo/providers/Microsoft.Compute/images/nixos-imag.vhd'
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = TestCli()
 
         # action & assert
-        self.assertEqual(_parse_image_argument(None, np), 'image_id')
+        self.assertEqual(_parse_image_argument(cmd, np), 'image_id')
 
     def test_get_next_subnet_addr_suffix(self):
         result = _get_next_subnet_addr_suffix('10.0.0.0/16', '10.0.0.0/24', 24)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -214,6 +214,20 @@ class TestActions(unittest.TestCase):
                                        "Configuring plan settings will be skipped", 'publisher1:offer1:sku1:1.0.0',
                                        'image not found')
 
+    def test_parse_unmanaged_image_argument(self):
+        np = mock.MagicMock()
+        np.image = 'https://foo.blob.core.windows.net/vhds/1'
+
+        # action & assert
+        self.assertEqual(_parse_image_argument(None, np), 'uri')
+
+    def test_parse_managed_image_argument(self):
+        np = mock.MagicMock()
+        np.image = '/subscriptions/123/resourceGroups/foo/providers/Microsoft.Compute/images/nixos-imag.vhd'
+
+        # action & assert
+        self.assertEqual(_parse_image_argument(None, np), 'image_id')
+
     def test_get_next_subnet_addr_suffix(self):
         result = _get_next_subnet_addr_suffix('10.0.0.0/16', '10.0.0.0/24', 24)
         self.assertEqual(result, '10.0.1.0/24')


### PR DESCRIPTION
Fix #6227 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
