### PR TITLE
Make positional args check more robust.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -386,7 +386,7 @@ class AzArgumentContext(ArgumentsContext):
         # registered for this command.
         command_args = self.command_loader.argument_registry.arguments[self.scope]
         positional_args = {k: v for k, v in command_args.items() if v.settings.get('options_list') == []}
-        if positional_args:
+        if positional_args and dest not in positional_args:
             raise CLIError("command authoring error: commands may have, at most, one positional argument. '{}' already "
                            "has positional argument: {}.".format(self.scope, ' '.join(positional_args.keys())))
 


### PR DESCRIPTION
There is a check to ensure that a given command only has a single positional argument. The linter loads parameters twice, which triggers this check to fail (it will see the previous registration).  This change modifies the check so that if the positional arg being registered is already registered, this is okay. Should fix issue with PR #6241.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
