### PR TITLE
vm/vmss: use patch for updating identities

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+2.0.32
+++++++
+* vm/vmss: use PATCH for updating identities
+
 2.0.31
 ++++++
 * vm: fix an invalid detection logic on unmanaged blob uri

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1739,7 +1739,7 @@ def assign_vmss_identity(cmd, resource_group_name, vmss_name, assign_identity=No
             vmss.identity.identity_ids = external_identities
         if vmss_patch:
             vmss_patch.identity = vmss.identity
-            vmss_patch.sku = vmss.sku
+            vmss_patch.sku = vmss.sku  # workaround https://github.com/Azure/azure-cli/issues/6262
             poller = client.virtual_machine_scale_sets.update(resource_group_name, vmss_name, vmss_patch)
         else:
             poller = client.virtual_machine_scale_sets.create_or_update(resource_group_name, vmss_name, vmss)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -451,6 +451,7 @@ def assign_vm_identity(cmd, resource_group_name, vm_name, assign_identity=None, 
 
         vm.identity = VirtualMachineIdentity(type=identity_types)
         if external_identities:
+            # do in-place update, so the outer method can display the same data
             external_identities[::] = set(external_identities)
             vm.identity.identity_ids = external_identities
 
@@ -1735,6 +1736,7 @@ def assign_vmss_identity(cmd, resource_group_name, vmss_name, assign_identity=No
             identity_types = ResourceIdentityType.system_assigned
         vmss.identity = VirtualMachineScaleSetIdentity(type=identity_types)
         if external_identities:
+            # do in-place update, so the outer method can display the same data
             external_identities[::] = set(external_identities)
             vmss.identity.identity_ids = external_identities
         if vmss_patch:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_msi_no_scope.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_msi_no_scope.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"tags": {"cause": "automation", "date": "2018-04-20T20:49:05Z", "product":
-      "azurecli"}, "location": "westus"}'
+    body: '{"tags": {"product": "azurecli", "cause": "automation", "date": "2018-04-30T20:27:41Z"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -16,12 +16,12 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"cause":"automation","date":"2018-04-20T20:49:05Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-04-30T20:27:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:49:07 GMT']
+      date: ['Mon, 30 Apr 2018 20:27:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -43,12 +43,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"cause":"automation","date":"2018-04-20T20:49:05Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-04-30T20:27:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:49:07 GMT']
+      date: ['Mon, 30 Apr 2018 20:27:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -108,9 +108,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:49:08 GMT']
+      date: ['Mon, 30 Apr 2018 20:27:45 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 20:54:08 GMT']
+      expires: ['Mon, 30 Apr 2018 20:32:45 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -118,12 +118,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [67c5cebdc51a88d94367471216a4e7413ec05f56]
+      x-fastly-request-id: [97eb66715053489a5414c525075b5daf2a86aa23]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['28B4:699E:1996:1B2F:5ADA5243']
-      x-served-by: [cache-dfw18647-DFW]
-      x-timer: ['S1524257348.421910,VS0,VE88']
+      x-github-request-id: ['46B6:1787:7E59B:834FA:5AE77C40']
+      x-served-by: [cache-dfw18621-DFW]
+      x-timer: ['S1525120066.523539,VS0,VE69']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -146,7 +146,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:49:08 GMT']
+      date: ['Mon, 30 Apr 2018 20:27:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -154,38 +154,36 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"mode": "Incremental", "template": {"resources": [{"dependsOn":
-      [], "apiVersion": "2015-06-15", "properties": {"subnets": [{"name": "vm1Subnet",
-      "properties": {"addressPrefix": "10.0.0.0/24"}}], "addressSpace": {"addressPrefixes":
-      ["10.0.0.0/16"]}}, "name": "vm1VNET", "tags": {}, "location": "westus", "type":
-      "Microsoft.Network/virtualNetworks"}, {"dependsOn": [], "apiVersion": "2015-06-15",
-      "properties": {"securityRules": [{"name": "default-allow-ssh", "properties":
-      {"priority": 1000, "sourcePortRange": "*", "protocol": "Tcp", "access": "Allow",
-      "direction": "Inbound", "destinationPortRange": "22", "destinationAddressPrefix":
-      "*", "sourceAddressPrefix": "*"}}]}, "name": "vm1NSG", "tags": {}, "location":
-      "westus", "type": "Microsoft.Network/networkSecurityGroups"}, {"dependsOn":
-      [], "apiVersion": "2018-01-01", "properties": {"publicIPAllocationMethod": null},
-      "name": "vm1PublicIP", "tags": {}, "location": "westus", "type": "Microsoft.Network/publicIPAddresses"},
-      {"dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET", "Microsoft.Network/networkSecurityGroups/vm1NSG",
-      "Microsoft.Network/publicIpAddresses/vm1PublicIP"], "apiVersion": "2015-06-15",
-      "properties": {"ipConfigurations": [{"name": "ipconfigvm1", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}}}],
-      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"}},
-      "name": "vm1VMNic", "tags": {}, "location": "westus", "type": "Microsoft.Network/networkInterfaces"},
-      {"identity": {"type": "SystemAssigned"}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"],
-      "apiVersion": "2017-12-01", "properties": {"networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "storageProfile": {"osDisk": {"createOption": "fromImage", "name": null, "caching":
-      "ReadWrite", "managedDisk": {"storageAccountType": null}}, "imageReference":
-      {"version": "latest", "publisher": "credativ", "offer": "Debian", "sku": "8"}},
-      "osProfile": {"adminPassword": "[parameters(\''adminPassword\'')]", "adminUsername":
-      "admin123", "computerName": "vm1"}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}},
-      "name": "vm1", "tags": {}, "location": "westus", "type": "Microsoft.Compute/virtualMachines"}],
-      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "outputs": {}, "parameters": {"adminPassword": {"metadata": {"description":
-      "Secure adminPassword"}, "type": "securestring"}}, "contentVersion": "1.0.0.0",
-      "variables": {}}, "parameters": {"adminPassword": {"value": "PasswordPassword1!"}}}}'''
+    body: 'b''{"properties": {"parameters": {"adminPassword": {"value": "PasswordPassword1!"}},
+      "template": {"parameters": {"adminPassword": {"metadata": {"description": "Secure
+      adminPassword"}, "type": "securestring"}}, "outputs": {}, "resources": [{"properties":
+      {"subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"}, "name": "vm1Subnet"}],
+      "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}, "type": "Microsoft.Network/virtualNetworks",
+      "name": "vm1VNET", "dependsOn": [], "tags": {}, "apiVersion": "2015-06-15",
+      "location": "westus"}, {"properties": {"securityRules": [{"properties": {"destinationAddressPrefix":
+      "*", "sourcePortRange": "*", "access": "Allow", "direction": "Inbound", "sourceAddressPrefix":
+      "*", "protocol": "Tcp", "destinationPortRange": "22", "priority": 1000}, "name":
+      "default-allow-ssh"}]}, "type": "Microsoft.Network/networkSecurityGroups", "name":
+      "vm1NSG", "dependsOn": [], "tags": {}, "apiVersion": "2015-06-15", "location":
+      "westus"}, {"properties": {"publicIPAllocationMethod": null}, "type": "Microsoft.Network/publicIPAddresses",
+      "name": "vm1PublicIP", "dependsOn": [], "tags": {}, "apiVersion": "2018-01-01",
+      "location": "westus"}, {"properties": {"networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
+      "ipConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "privateIPAllocationMethod": "Dynamic"}, "name": "ipconfigvm1"}]}, "type": "Microsoft.Network/networkInterfaces",
+      "name": "vm1VMNic", "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET",
+      "Microsoft.Network/networkSecurityGroups/vm1NSG", "Microsoft.Network/publicIpAddresses/vm1PublicIP"],
+      "tags": {}, "apiVersion": "2015-06-15", "location": "westus"}, {"properties":
+      {"networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "osProfile": {"adminUsername": "admin123", "adminPassword": "[parameters(\''adminPassword\'')]",
+      "computerName": "vm1"}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "storageProfile":
+      {"osDisk": {"name": null, "createOption": "fromImage", "caching": "ReadWrite",
+      "managedDisk": {"storageAccountType": null}}, "imageReference": {"publisher":
+      "credativ", "offer": "Debian", "version": "latest", "sku": "8"}}}, "identity":
+      {"type": "SystemAssigned"}, "name": "vm1", "apiVersion": "2017-12-01", "dependsOn":
+      ["Microsoft.Network/networkInterfaces/vm1VMNic"], "type": "Microsoft.Compute/virtualMachines",
+      "tags": {}, "location": "westus"}], "variables": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0"}, "mode": "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -200,13 +198,13 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_WzzBUbLW6RIPGdLsOtqDbubxDQK6Lahj","name":"vm_deploy_WzzBUbLW6RIPGdLsOtqDbubxDQK6Lahj","properties":{"templateHash":"6420181823339893758","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T20:49:11.1355929Z","duration":"PT0.5240389S","correlationId":"de8437ee-4543-4476-920c-99e877777e6e","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_ltXF9CYVru9rB7wQp7F7FLNdJH9ARYe3","name":"vm_deploy_ltXF9CYVru9rB7wQp7F7FLNdJH9ARYe3","properties":{"templateHash":"9941935712414859473","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:27:48.854714Z","duration":"PT0.6828762S","correlationId":"8e920224-4e62-4ea5-ab9e-2c22f3f21d99","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_WzzBUbLW6RIPGdLsOtqDbubxDQK6Lahj/operationStatuses/08586773495348660718?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_ltXF9CYVru9rB7wQp7F7FLNdJH9ARYe3/operationStatuses/08586764868173058034?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['2740']
+      content-length: ['2739']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:49:10 GMT']
+      date: ['Mon, 30 Apr 2018 20:27:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -226,14 +224,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773495348660718?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764868173058034?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:49:41 GMT']
+      date: ['Mon, 30 Apr 2018 20:28:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -253,14 +251,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773495348660718?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764868173058034?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:50:11 GMT']
+      date: ['Mon, 30 Apr 2018 20:28:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -280,14 +278,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773495348660718?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764868173058034?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:50:42 GMT']
+      date: ['Mon, 30 Apr 2018 20:29:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -307,14 +305,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773495348660718?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764868173058034?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:12 GMT']
+      date: ['Mon, 30 Apr 2018 20:29:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -334,14 +332,41 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773495348660718?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764868173058034?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 30 Apr 2018 20:30:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764868173058034?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:43 GMT']
+      date: ['Mon, 30 Apr 2018 20:30:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -363,12 +388,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_WzzBUbLW6RIPGdLsOtqDbubxDQK6Lahj","name":"vm_deploy_WzzBUbLW6RIPGdLsOtqDbubxDQK6Lahj","properties":{"templateHash":"6420181823339893758","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T20:51:38.8287284Z","duration":"PT2M28.2171744S","correlationId":"de8437ee-4543-4476-920c-99e877777e6e","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_ltXF9CYVru9rB7wQp7F7FLNdJH9ARYe3","name":"vm_deploy_ltXF9CYVru9rB7wQp7F7FLNdJH9ARYe3","properties":{"templateHash":"9941935712414859473","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T20:30:42.4616246Z","duration":"PT2M54.2897868S","correlationId":"8e920224-4e62-4ea5-ab9e-2c22f3f21d99","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['3807']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:43 GMT']
+      date: ['Mon, 30 Apr 2018 20:30:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -384,22 +409,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f2c715d9-f709-411f-a734-4462f025d358\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"c624e24a-18c5-47a3-a9ff-a7b5a2e56407\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_fdf43e9970ed47388d0a015168d34c98\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_0d664616a95a4da0abe702a420cb4a46\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_fdf43e9970ed47388d0a015168d34c98\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_0d664616a95a4da0abe702a420cb4a46\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -412,30 +437,30 @@ interactions:
         : \"2.2.25\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
         code\": \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\"\
         ,\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\"\
-        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-20T20:51:44+00:00\"\
+        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-30T20:30:54+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_fdf43e9970ed47388d0a015168d34c98\"\
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_0d664616a95a4da0abe702a420cb4a46\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2018-04-20T20:49:55.4031264+00:00\"\r\n            }\r\
+        \       \"time\": \"2018-04-30T20:28:54.3999857+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2018-04-20T20:51:23.6727219+00:00\"\r\n       \
-        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
-        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
-        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
+        ,\r\n          \"time\": \"2018-04-30T20:30:33.637268+00:00\"\r\n        },\r\
+        \n        {\r\n          \"code\": \"PowerState/running\",\r\n          \"\
+        level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n    \
+        \    }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
         ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\
-        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"75828c72-b918-400e-ac4e-5fb70e76d670\"\
+        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"204583ed-2588-4cb5-b30a-6773b943f5aa\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3137']
+      content-length: ['3136']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:44 GMT']
+      date: ['Mon, 30 Apr 2018 20:30:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -443,7 +468,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33587']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33595']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -461,12 +486,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"a52bfc65-9802-425c-abbc-2718eab0dc9e\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"21215366-3828-47dc-94f5-d3e6f52a05b1\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"764b781b-9dcf-49a0-884c-e8bd6d103f68\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"319b709e-0a58-4d1b-b025-473df3124752\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"a52bfc65-9802-425c-abbc-2718eab0dc9e\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"21215366-3828-47dc-94f5-d3e6f52a05b1\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -476,8 +501,8 @@ interactions:
         : \"IPv4\",\r\n          \"isInUseWithService\": false\r\n        }\r\n  \
         \    }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n\
         \      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"\
-        4elkwylk1c4uhmktzyzq5dqpwh.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
-        macAddress\": \"00-0D-3A-33-A7-22\",\r\n    \"enableAcceleratedNetworking\"\
+        2zydb1vb1wqurp2k0gazkujh1d.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
+        macAddress\": \"00-0D-3A-36-DD-B4\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -488,8 +513,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2596']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:45 GMT']
-      etag: [W/"a52bfc65-9802-425c-abbc-2718eab0dc9e"]
+      date: ['Mon, 30 Apr 2018 20:30:55 GMT']
+      etag: [W/"21215366-3828-47dc-94f5-d3e6f52a05b1"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -514,10 +539,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"f260f079-9829-40ab-a29d-db1c102cb822\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"a81a0b53-df76-45c7-bde0-f60abd20c7dd\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"d9310803-4e0e-4175-9dbe-b0c3b58d3081\"\
-        ,\r\n    \"ipAddress\": \"104.42.237.187\",\r\n    \"publicIPAddressVersion\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"5fe74de2-4f73-4797-9692-6f3312359725\"\
+        ,\r\n    \"ipAddress\": \"104.42.75.44\",\r\n    \"publicIPAddressVersion\"\
         : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
         : 4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
@@ -526,10 +551,10 @@ interactions:
         \n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1023']
+      content-length: ['1021']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:45 GMT']
-      etag: [W/"f260f079-9829-40ab-a29d-db1c102cb822"]
+      date: ['Mon, 30 Apr 2018 20:30:56 GMT']
+      etag: [W/"a81a0b53-df76-45c7-bde0-f60abd20c7dd"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -553,12 +578,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"cause":"automation","date":"2018-04-20T20:49:05Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-04-30T20:27:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:45 GMT']
+      date: ['Mon, 30 Apr 2018 20:30:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -618,22 +643,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:46 GMT']
+      date: ['Mon, 30 Apr 2018 20:30:57 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 20:56:46 GMT']
-      source-age: ['299']
+      expires: ['Mon, 30 Apr 2018 20:35:57 GMT']
+      source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [HIT]
-      x-cache-hits: ['1']
+      x-cache: [MISS]
+      x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [806b960a9defc2460bfdb882c3859ac788c124fe]
+      x-fastly-request-id: [07e13faca66fb81af32975e2f519f7154cb7bd1f]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['5988:087E:FE2CC0:10C6C3F:5ADA51B6']
-      x-served-by: [cache-sea1046-SEA]
-      x-timer: ['S1524257506.449201,VS0,VE1']
+      x-github-request-id: ['A162:087B:2B5522E:2DDDC8A:5AE77CFB']
+      x-served-by: [cache-sea1024-SEA]
+      x-timer: ['S1525120257.164419,VS0,VE95']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -653,15 +678,15 @@ interactions:
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"3b5484bf-adc7-44b7-9135-e0ba0a4c3859\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"5bf0fba8-db36-4080-96fe-7090185d9859\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"61ab16f1-d86a-43bd-b153-ce330f8e0fb7\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"ee3070e6-dda1-48a1-bf8a-d181955127db\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vm1Subnet\",\r\n           \
         \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"3b5484bf-adc7-44b7-9135-e0ba0a4c3859\\\"\
+        ,\r\n            \"etag\": \"W/\\\"5bf0fba8-db36-4080-96fe-7090185d9859\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
@@ -674,7 +699,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1684']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:46 GMT']
+      date: ['Mon, 30 Apr 2018 20:30:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -684,38 +709,38 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"mode": "Incremental", "template": {"resources": [{"dependsOn":
-      [], "apiVersion": "2018-01-01", "properties": {"publicIPAllocationMethod": "Dynamic"},
-      "name": "vmss1LBPublicIP", "tags": {}, "location": "westus", "type": "Microsoft.Network/publicIPAddresses"},
-      {"dependsOn": ["Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"], "apiVersion":
-      "2018-01-01", "properties": {"backendAddressPools": [{"name": "vmss1LBBEPool"}],
-      "frontendIPConfigurations": [{"name": "loadBalancerFrontEnd", "properties":
-      {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}}}],
-      "inboundNatPools": [{"name": "vmss1LBNatPool", "properties": {"frontendPortRangeEnd":
-      "50119", "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
+    body: 'b''{"properties": {"parameters": {"adminPassword": {"value": "PasswordPassword1!"}},
+      "template": {"parameters": {"adminPassword": {"metadata": {"description": "Secure
+      adminPassword"}, "type": "securestring"}}, "outputs": {"VMSS": {"type": "object",
+      "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]"}},
+      "resources": [{"properties": {"publicIPAllocationMethod": "Dynamic"}, "type":
+      "Microsoft.Network/publicIPAddresses", "name": "vmss1LBPublicIP", "dependsOn":
+      [], "tags": {}, "apiVersion": "2018-01-01", "location": "westus"}, {"properties":
+      {"frontendIPConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}},
+      "name": "loadBalancerFrontEnd"}], "inboundNatPools": [{"properties": {"frontendPortRangeStart":
+      "50000", "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
       \''vmss1LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"},
-      "backendPort": 22, "frontendPortRangeStart": "50000", "protocol": "tcp"}}]},
-      "name": "vmss1LB", "tags": {}, "location": "westus", "type": "Microsoft.Network/loadBalancers"},
-      {"identity": {"type": "SystemAssigned"}, "dependsOn": ["Microsoft.Network/loadBalancers/vmss1LB"],
-      "apiVersion": "2017-12-01", "properties": {"overprovision": true, "singlePlacementGroup":
-      null, "virtualMachineProfile": {"storageProfile": {"osDisk": {"createOption":
-      "FromImage", "caching": "ReadWrite", "managedDisk": {"storageAccountType": null}},
-      "imageReference": {"version": "latest", "publisher": "credativ", "offer": "Debian",
-      "sku": "8"}}, "networkProfile": {"networkInterfaceConfigurations": [{"name":
-      "vmss10d39Nic", "properties": {"ipConfigurations": [{"name": "vmss10d39IPConfig",
-      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
-      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}]}}],
-      "primary": "true"}}]}, "osProfile": {"computerNamePrefix": "vmss10d39", "adminPassword":
-      "[parameters(\''adminPassword\'')]", "adminUsername": "admin123"}}, "upgradePolicy":
-      {"mode": "manual"}}, "name": "vmss1", "sku": {"name": "Standard_D1_v2", "capacity":
-      2}, "tags": {}, "location": "westus", "type": "Microsoft.Compute/virtualMachineScaleSets"}],
-      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "outputs": {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
-      \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
-      "type": "object"}}, "parameters": {"adminPassword": {"metadata": {"description":
-      "Secure adminPassword"}, "type": "securestring"}}, "contentVersion": "1.0.0.0",
-      "variables": {}}, "parameters": {"adminPassword": {"value": "PasswordPassword1!"}}}}'''
+      "frontendPortRangeEnd": "50119", "backendPort": 22, "protocol": "tcp"}, "name":
+      "vmss1LBNatPool"}], "backendAddressPools": [{"name": "vmss1LBBEPool"}]}, "type":
+      "Microsoft.Network/loadBalancers", "name": "vmss1LB", "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"],
+      "tags": {}, "apiVersion": "2018-01-01", "location": "westus"}, {"properties":
+      {"upgradePolicy": {"mode": "manual"}, "singlePlacementGroup": null, "overprovision":
+      true, "virtualMachineProfile": {"networkProfile": {"networkInterfaceConfigurations":
+      [{"properties": {"primary": "true", "ipConfigurations": [{"properties": {"loadBalancerInboundNatPools":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}]},
+      "name": "vmss1f322IPConfig"}]}, "name": "vmss1f322Nic"}]}, "osProfile": {"adminUsername":
+      "admin123", "adminPassword": "[parameters(\''adminPassword\'')]", "computerNamePrefix":
+      "vmss1f322"}, "storageProfile": {"osDisk": {"createOption": "FromImage", "caching":
+      "ReadWrite", "managedDisk": {"storageAccountType": null}}, "imageReference":
+      {"publisher": "credativ", "offer": "Debian", "version": "latest", "sku": "8"}}}},
+      "sku": {"capacity": 2, "name": "Standard_D1_v2"}, "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "apiVersion": "2017-12-01", "dependsOn": ["Microsoft.Network/loadBalancers/vmss1LB"],
+      "name": "vmss1", "identity": {"type": "SystemAssigned"}, "tags": {}, "location":
+      "westus"}], "variables": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0"}, "mode": "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -730,13 +755,13 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_mPAwbnEthdSVxOnlVN7ymgyExG6oQAPb","name":"vmss_deploy_mPAwbnEthdSVxOnlVN7ymgyExG6oQAPb","properties":{"templateHash":"5233980176556935383","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T20:51:52.1534148Z","duration":"PT4.1722801S","correlationId":"4fde8a70-a270-4725-9436-766464570622","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_vajJ6jD9jGc5ScY12dmRCA46eFs1TGUE","name":"vmss_deploy_vajJ6jD9jGc5ScY12dmRCA46eFs1TGUE","properties":{"templateHash":"3030533199704089772","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:31:00.2533655Z","duration":"PT0.5383276S","correlationId":"91d57c57-82a1-42c2-b2f3-523f267bbe51","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_mPAwbnEthdSVxOnlVN7ymgyExG6oQAPb/operationStatuses/08586773493774964873?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_vajJ6jD9jGc5ScY12dmRCA46eFs1TGUE/operationStatuses/08586764866257625955?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['2064']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:51:51 GMT']
+      date: ['Mon, 30 Apr 2018 20:30:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -756,14 +781,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773493774964873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764866257625955?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:52:22 GMT']
+      date: ['Mon, 30 Apr 2018 20:31:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -783,14 +808,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773493774964873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764866257625955?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:52:52 GMT']
+      date: ['Mon, 30 Apr 2018 20:32:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -810,14 +835,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773493774964873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764866257625955?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:53:23 GMT']
+      date: ['Mon, 30 Apr 2018 20:32:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -837,14 +862,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773493774964873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764866257625955?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:53:53 GMT']
+      date: ['Mon, 30 Apr 2018 20:33:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -864,14 +889,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773493774964873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764866257625955?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:54:23 GMT']
+      date: ['Mon, 30 Apr 2018 20:33:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -891,14 +916,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773493774964873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764866257625955?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:54:54 GMT']
+      date: ['Mon, 30 Apr 2018 20:34:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -920,12 +945,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_mPAwbnEthdSVxOnlVN7ymgyExG6oQAPb","name":"vmss_deploy_mPAwbnEthdSVxOnlVN7ymgyExG6oQAPb","properties":{"templateHash":"5233980176556935383","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T20:54:34.2042253Z","duration":"PT2M46.2230906S","correlationId":"4fde8a70-a270-4725-9436-766464570622","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss10d39","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss10d39Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss10d39IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"f54f74f7-b1db-4920-98d3-93fec0826833"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_vajJ6jD9jGc5ScY12dmRCA46eFs1TGUE","name":"vmss_deploy_vajJ6jD9jGc5ScY12dmRCA46eFs1TGUE","properties":{"templateHash":"3030533199704089772","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T20:33:43.4795036Z","duration":"PT2M43.7644657S","correlationId":"91d57c57-82a1-42c2-b2f3-523f267bbe51","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss1f322","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss1f322Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss1f322IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"0da76e86-4dd1-4250-ad35-923608bd7ab2"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['4415']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:54:54 GMT']
+      date: ['Mon, 30 Apr 2018 20:34:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -941,7 +966,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -952,7 +977,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss10d39\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f322\",\r\n        \"adminUsername\"\
         : \"admin123\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
@@ -961,18 +986,18 @@ interactions:
         \        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"\
         credativ\",\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss10d39Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1f322Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss10d39IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
+        :[{\"name\":\"vmss1f322IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"f54f74f7-b1db-4920-98d3-93fec0826833\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"0da76e86-4dd1-4250-ad35-923608bd7ab2\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n \
-        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"9230c2f6-b5a8-447b-80a4-cb4b27f3020c\"\
+        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"7ba3fd0c-6ac3-4f83-943d-921d195a2dac\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -980,7 +1005,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2615']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:54:55 GMT']
+      date: ['Mon, 30 Apr 2018 20:34:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1005,12 +1030,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"cause":"automation","date":"2018-04-20T20:49:05Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-04-30T20:27:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:54:55 GMT']
+      date: ['Mon, 30 Apr 2018 20:34:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1070,22 +1095,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:54:56 GMT']
+      date: ['Mon, 30 Apr 2018 20:34:07 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 20:59:56 GMT']
-      source-age: ['0']
+      expires: ['Mon, 30 Apr 2018 20:39:07 GMT']
+      source-age: ['191']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
+      x-cache: [HIT]
+      x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [9f2e744b9d383c0793e9a7ae6373976d84371230]
+      x-fastly-request-id: [d916b361051f88ba77fcede01ce2838ab7f96b51]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['5310:69A1:1AE57:1BDE1:5ADA539F']
-      x-served-by: [cache-dfw18621-DFW]
-      x-timer: ['S1524257696.132018,VS0,VE41']
+      x-github-request-id: ['A162:087B:2B5522E:2DDDC8A:5AE77CFB']
+      x-served-by: [cache-sea1041-SEA]
+      x-timer: ['S1525120448.853237,VS0,VE0']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -1105,27 +1130,27 @@ interactions:
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"ac8d7868-c904-494e-b6d4-5444e00b0de1\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"04af7e07-b342-4428-acd6-c230fcfe6d2f\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"61ab16f1-d86a-43bd-b153-ce330f8e0fb7\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"ee3070e6-dda1-48a1-bf8a-d181955127db\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vm1Subnet\",\r\n           \
         \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"ac8d7868-c904-494e-b6d4-5444e00b0de1\\\"\
+        ,\r\n            \"etag\": \"W/\\\"04af7e07-b342-4428-acd6-c230fcfe6d2f\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
         \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss10d39Nic/ipConfigurations/vmss10d39IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1f322Nic/ipConfigurations/vmss1f322IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss10d39Nic/ipConfigurations/vmss10d39IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1f322Nic/ipConfigurations/vmss1f322IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss10d39Nic/ipConfigurations/vmss10d39IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss1f322Nic/ipConfigurations/vmss1f322IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss10d39Nic/ipConfigurations/vmss10d39IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss1f322Nic/ipConfigurations/vmss1f322IPConfig\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
         \n        ],\r\n        \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\"\
         : false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n\
@@ -1134,7 +1159,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3088']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:54:56 GMT']
+      date: ['Mon, 30 Apr 2018 20:34:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1144,33 +1169,33 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"mode": "Incremental", "template": {"resources": [{"dependsOn":
-      [], "apiVersion": "2015-06-15", "properties": {"securityRules": [{"name": "default-allow-ssh",
-      "properties": {"priority": 1000, "sourcePortRange": "*", "protocol": "Tcp",
-      "access": "Allow", "direction": "Inbound", "destinationPortRange": "22", "destinationAddressPrefix":
-      "*", "sourceAddressPrefix": "*"}}]}, "name": "vm2NSG", "tags": {}, "location":
-      "westus", "type": "Microsoft.Network/networkSecurityGroups"}, {"dependsOn":
-      [], "apiVersion": "2018-01-01", "properties": {"publicIPAllocationMethod": null},
-      "name": "vm2PublicIP", "tags": {}, "location": "westus", "type": "Microsoft.Network/publicIPAddresses"},
-      {"dependsOn": ["Microsoft.Network/networkSecurityGroups/vm2NSG", "Microsoft.Network/publicIpAddresses/vm2PublicIP"],
-      "apiVersion": "2015-06-15", "properties": {"ipConfigurations": [{"name": "ipconfigvm2",
-      "properties": {"privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}}}],
-      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"}},
-      "name": "vm2VMNic", "tags": {}, "location": "westus", "type": "Microsoft.Network/networkInterfaces"},
-      {"dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"], "apiVersion":
-      "2017-12-01", "properties": {"networkProfile": {"networkInterfaces": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
-      "storageProfile": {"osDisk": {"createOption": "fromImage", "name": null, "caching":
-      "ReadWrite", "managedDisk": {"storageAccountType": null}}, "imageReference":
-      {"version": "latest", "publisher": "credativ", "offer": "Debian", "sku": "8"}},
-      "osProfile": {"adminPassword": "[parameters(\''adminPassword\'')]", "adminUsername":
-      "admin123", "computerName": "vm2"}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}},
-      "name": "vm2", "tags": {}, "location": "westus", "type": "Microsoft.Compute/virtualMachines"}],
-      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "outputs": {}, "parameters": {"adminPassword": {"metadata": {"description":
-      "Secure adminPassword"}, "type": "securestring"}}, "contentVersion": "1.0.0.0",
-      "variables": {}}, "parameters": {"adminPassword": {"value": "PasswordPassword1!"}}}}'''
+    body: 'b''{"properties": {"parameters": {"adminPassword": {"value": "PasswordPassword1!"}},
+      "template": {"parameters": {"adminPassword": {"metadata": {"description": "Secure
+      adminPassword"}, "type": "securestring"}}, "outputs": {}, "resources": [{"properties":
+      {"securityRules": [{"properties": {"destinationAddressPrefix": "*", "sourcePortRange":
+      "*", "access": "Allow", "direction": "Inbound", "sourceAddressPrefix": "*",
+      "protocol": "Tcp", "destinationPortRange": "22", "priority": 1000}, "name":
+      "default-allow-ssh"}]}, "type": "Microsoft.Network/networkSecurityGroups", "name":
+      "vm2NSG", "dependsOn": [], "tags": {}, "apiVersion": "2015-06-15", "location":
+      "westus"}, {"properties": {"publicIPAllocationMethod": null}, "type": "Microsoft.Network/publicIPAddresses",
+      "name": "vm2PublicIP", "dependsOn": [], "tags": {}, "apiVersion": "2018-01-01",
+      "location": "westus"}, {"properties": {"networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},
+      "ipConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"},
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "privateIPAllocationMethod": "Dynamic"}, "name": "ipconfigvm2"}]}, "type": "Microsoft.Network/networkInterfaces",
+      "name": "vm2VMNic", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm2NSG",
+      "Microsoft.Network/publicIpAddresses/vm2PublicIP"], "tags": {}, "apiVersion":
+      "2015-06-15", "location": "westus"}, {"properties": {"networkProfile": {"networkInterfaces":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
+      "osProfile": {"adminUsername": "admin123", "adminPassword": "[parameters(\''adminPassword\'')]",
+      "computerName": "vm2"}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "storageProfile":
+      {"osDisk": {"name": null, "createOption": "fromImage", "caching": "ReadWrite",
+      "managedDisk": {"storageAccountType": null}}, "imageReference": {"publisher":
+      "credativ", "offer": "Debian", "version": "latest", "sku": "8"}}}, "type": "Microsoft.Compute/virtualMachines",
+      "name": "vm2", "dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"],
+      "tags": {}, "apiVersion": "2017-12-01", "location": "westus"}], "variables":
+      {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0"}, "mode": "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1185,13 +1210,13 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_ItdPLge1jMzJlSD4y4bStXCS4F7LVIEd","name":"vm_deploy_ItdPLge1jMzJlSD4y4bStXCS4F7LVIEd","properties":{"templateHash":"814205895018880072","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T20:54:58.6242251Z","duration":"PT0.603295S","correlationId":"e94fc348-57bf-4c67-94ea-87f44a149592","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_GUtNES1kbv7Tqi3NUperTih8pQAK4w9c","name":"vm_deploy_GUtNES1kbv7Tqi3NUperTih8pQAK4w9c","properties":{"templateHash":"3691852791372661292","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:34:10.9731526Z","duration":"PT0.7594478S","correlationId":"634caa53-70ab-46ff-80cb-015bb958767d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_ItdPLge1jMzJlSD4y4bStXCS4F7LVIEd/operationStatuses/08586773491874566947?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_GUtNES1kbv7Tqi3NUperTih8pQAK4w9c/operationStatuses/08586764864352639167?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['2400']
+      content-length: ['2402']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:54:58 GMT']
+      date: ['Mon, 30 Apr 2018 20:34:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1211,14 +1236,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773491874566947?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764864352639167?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:55:28 GMT']
+      date: ['Mon, 30 Apr 2018 20:34:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1238,14 +1263,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773491874566947?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764864352639167?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:55:59 GMT']
+      date: ['Mon, 30 Apr 2018 20:35:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1265,14 +1290,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773491874566947?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764864352639167?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:56:29 GMT']
+      date: ['Mon, 30 Apr 2018 20:35:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1292,14 +1317,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773491874566947?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764864352639167?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:56:59 GMT']
+      date: ['Mon, 30 Apr 2018 20:36:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1319,14 +1344,41 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773491874566947?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764864352639167?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 30 Apr 2018 20:36:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764864352639167?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:57:29 GMT']
+      date: ['Mon, 30 Apr 2018 20:37:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1348,12 +1400,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_ItdPLge1jMzJlSD4y4bStXCS4F7LVIEd","name":"vm_deploy_ItdPLge1jMzJlSD4y4bStXCS4F7LVIEd","properties":{"templateHash":"814205895018880072","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T20:57:12.8047765Z","duration":"PT2M14.7838464S","correlationId":"e94fc348-57bf-4c67-94ea-87f44a149592","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vm_deploy_GUtNES1kbv7Tqi3NUperTih8pQAK4w9c","name":"vm_deploy_GUtNES1kbv7Tqi3NUperTih8pQAK4w9c","properties":{"templateHash":"3691852791372661292","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T20:36:55.0565683Z","duration":"PT2M44.8428635S","correlationId":"634caa53-70ab-46ff-80cb-015bb958767d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3264']
+      content-length: ['3265']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:57:30 GMT']
+      date: ['Mon, 30 Apr 2018 20:37:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1369,22 +1421,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f8222ecf-9473-4082-aa30-07c80d9e9690\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd2aaca8-271c-4934-8090-eb68e6e0e8d9\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08\",\r\n        \"createOption\"\
+        : \"vm2_OsDisk_1_c08a19f7443847d39d02b912be56e25b\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_c08a19f7443847d39d02b912be56e25b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -1397,17 +1449,17 @@ interactions:
         : \"2.2.25\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
         code\": \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\"\
         ,\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\"\
-        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-20T20:57:29+00:00\"\
+        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-30T20:37:15+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08\"\
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm2_OsDisk_1_c08a19f7443847d39d02b912be56e25b\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2018-04-20T20:55:31.8138963+00:00\"\r\n            }\r\
+        \       \"time\": \"2018-04-30T20:34:53.7966426+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2018-04-20T20:56:52.4623859+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2018-04-30T20:36:44.5490259+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
@@ -1417,7 +1469,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2967']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:57:30 GMT']
+      date: ['Mon, 30 Apr 2018 20:37:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1425,7 +1477,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33587']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33590']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1443,12 +1495,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"3ad7fa80-1999-4ff4-a500-a4de65c210be\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"d4e2e90e-75b1-42b4-8156-a9003c6bf3c7\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"fe6686a9-3b5f-4292-89d4-a1e49f4fa111\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"675e4e0b-cb2a-4954-a295-4ccfdea51dc9\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm2\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
-        ,\r\n        \"etag\": \"W/\\\"3ad7fa80-1999-4ff4-a500-a4de65c210be\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d4e2e90e-75b1-42b4-8156-a9003c6bf3c7\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.6\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -1458,8 +1510,8 @@ interactions:
         : \"IPv4\",\r\n          \"isInUseWithService\": false\r\n        }\r\n  \
         \    }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n\
         \      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"\
-        4elkwylk1c4uhmktzyzq5dqpwh.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
-        macAddress\": \"00-0D-3A-33-AA-20\",\r\n    \"enableAcceleratedNetworking\"\
+        2zydb1vb1wqurp2k0gazkujh1d.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
+        macAddress\": \"00-0D-3A-37-D5-36\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -1470,8 +1522,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2596']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:57:31 GMT']
-      etag: [W/"3ad7fa80-1999-4ff4-a500-a4de65c210be"]
+      date: ['Mon, 30 Apr 2018 20:37:18 GMT']
+      etag: [W/"d4e2e90e-75b1-42b4-8156-a9003c6bf3c7"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1496,10 +1548,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"397d62a1-2cb8-4d05-9909-80808c0cdbfd\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"45668ea3-7af1-438e-8bc7-6b6019ff27f3\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"2d9f858e-8ea2-4dce-b564-03ea4ad8a828\"\
-        ,\r\n    \"ipAddress\": \"52.160.47.111\",\r\n    \"publicIPAddressVersion\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"18815658-def8-421d-83dc-73a377724222\"\
+        ,\r\n    \"ipAddress\": \"104.42.75.251\",\r\n    \"publicIPAddressVersion\"\
         : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
         : 4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
@@ -1510,8 +1562,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1022']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:57:31 GMT']
-      etag: [W/"397d62a1-2cb8-4d05-9909-80808c0cdbfd"]
+      date: ['Mon, 30 Apr 2018 20:37:19 GMT']
+      etag: [W/"45668ea3-7af1-438e-8bc7-6b6019ff27f3"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1529,22 +1581,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f8222ecf-9473-4082-aa30-07c80d9e9690\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd2aaca8-271c-4934-8090-eb68e6e0e8d9\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08\",\r\n        \"createOption\"\
+        : \"vm2_OsDisk_1_c08a19f7443847d39d02b912be56e25b\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_c08a19f7443847d39d02b912be56e25b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -1559,7 +1611,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1709']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:57:42 GMT']
+      date: ['Mon, 30 Apr 2018 20:37:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1567,43 +1619,34 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4194,Microsoft.Compute/LowCostGet30Min;33586']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4194,Microsoft.Compute/LowCostGet30Min;33589']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"identity": {"type": "SystemAssigned"}, "tags": {}, "location": "westus",
-      "properties": {"networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
-      "storageProfile": {"dataDisks": [], "osDisk": {"createOption": "FromImage",
-      "caching": "ReadWrite", "managedDisk": {"storageAccountType": "Premium_LRS",
-      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08"},
-      "name": "vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08", "osType": "Linux",
-      "diskSizeGB": 30}, "imageReference": {"sku": "8", "publisher": "credativ", "offer":
-      "Debian", "version": "latest"}}, "osProfile": {"linuxConfiguration": {"disablePasswordAuthentication":
-      false}, "adminUsername": "admin123", "secrets": [], "computerName": "vm2"},
-      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}}'''
+    body: '{"identity": {"type": "SystemAssigned"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm identity assign]
       Connection: [keep-alive]
-      Content-Length: ['1117']
+      Content-Length: ['40']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f8222ecf-9473-4082-aa30-07c80d9e9690\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd2aaca8-271c-4934-8090-eb68e6e0e8d9\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08\",\r\n        \"createOption\"\
+        : \"vm2_OsDisk_1_c08a19f7443847d39d02b912be56e25b\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_c08a19f7443847d39d02b912be56e25b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -1613,16 +1656,16 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
         tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\",\r\n\
-        \    \"principalId\": \"33015473-79de-4ac6-b155-736be634c18e\",\r\n    \"\
+        \    \"principalId\": \"3bd397ef-8928-474c-8ccc-8295f6354950\",\r\n    \"\
         tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2\"\
         ,\r\n  \"name\": \"vm2\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/549101f7-2ce6-42af-818b-f21b1e7e6c27?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/cfbf4840-b023-4f5f-ab14-a9da011d816f?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['1878']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:57:45 GMT']
+      date: ['Mon, 30 Apr 2018 20:37:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1630,7 +1673,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;238,Microsoft.Compute/PutVM30Min;1197']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;239,Microsoft.Compute/PutVM30Min;1197']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -1641,19 +1684,19 @@ interactions:
       CommandName: [vm identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/549101f7-2ce6-42af-818b-f21b1e7e6c27?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/cfbf4840-b023-4f5f-ab14-a9da011d816f?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T20:57:45.2457668+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T20:57:57.6212725+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"549101f7-2ce6-42af-818b-f21b1e7e6c27\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:37:32.9342795+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T20:37:45.3609656+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"cfbf4840-b023-4f5f-ab14-a9da011d816f\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:58:15 GMT']
+      date: ['Mon, 30 Apr 2018 20:38:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1661,7 +1704,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29956']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29952']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1671,21 +1714,21 @@ interactions:
       CommandName: [vm identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f8222ecf-9473-4082-aa30-07c80d9e9690\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd2aaca8-271c-4934-8090-eb68e6e0e8d9\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08\",\r\n        \"createOption\"\
+        : \"vm2_OsDisk_1_c08a19f7443847d39d02b912be56e25b\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_a55c896c910042cd89b7998a4b0efa08\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_c08a19f7443847d39d02b912be56e25b\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -1695,7 +1738,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
         tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\",\r\n\
-        \    \"principalId\": \"33015473-79de-4ac6-b155-736be634c18e\",\r\n    \"\
+        \    \"principalId\": \"3bd397ef-8928-474c-8ccc-8295f6354950\",\r\n    \"\
         tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachines/vm2\"\
         ,\r\n  \"name\": \"vm2\"\r\n}"}
@@ -1703,7 +1746,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1879']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:58:16 GMT']
+      date: ['Mon, 30 Apr 2018 20:38:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1711,7 +1754,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4190,Microsoft.Compute/LowCostGet30Min;33582']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4190,Microsoft.Compute/LowCostGet30Min;33585']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1728,12 +1771,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"cause":"automation","date":"2018-04-20T20:49:05Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001","name":"cli_test_msi_no_scope000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-04-30T20:27:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:58:16 GMT']
+      date: ['Mon, 30 Apr 2018 20:38:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1793,9 +1836,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:58:17 GMT']
+      date: ['Mon, 30 Apr 2018 20:38:06 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 21:03:17 GMT']
+      expires: ['Mon, 30 Apr 2018 20:43:06 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -1803,12 +1846,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [0681458f399f02253a4323f3752e2a75f3d66e79]
+      x-fastly-request-id: [1360d3e0b18d108c9267e13f3d66f7922e00b50b]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['44B0:087B:D204AE:DE3D62:5ADA5468']
-      x-served-by: [cache-sea1032-SEA]
-      x-timer: ['S1524257897.104077,VS0,VE93']
+      x-github-request-id: ['DB32:0874:10A8208:11B328B:5AE77EAE']
+      x-served-by: [cache-sea1030-SEA]
+      x-timer: ['S1525120686.333585,VS0,VE87']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -1828,23 +1871,23 @@ interactions:
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"56d42ea8-a87c-4c45-b1d8-800215b2b4c6\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"808061eb-1f43-44e9-80e4-c46fc1b60203\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"61ab16f1-d86a-43bd-b153-ce330f8e0fb7\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"ee3070e6-dda1-48a1-bf8a-d181955127db\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vm1Subnet\",\r\n           \
         \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"56d42ea8-a87c-4c45-b1d8-800215b2b4c6\\\"\
+        ,\r\n            \"etag\": \"W/\\\"808061eb-1f43-44e9-80e4-c46fc1b60203\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
         \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss10d39Nic/ipConfigurations/vmss10d39IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1f322Nic/ipConfigurations/vmss1f322IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss10d39Nic/ipConfigurations/vmss10d39IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss1f322Nic/ipConfigurations/vmss1f322IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
@@ -1855,7 +1898,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2679']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:58:16 GMT']
+      date: ['Mon, 30 Apr 2018 20:38:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1865,37 +1908,38 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"mode": "Incremental", "template": {"resources": [{"dependsOn":
-      [], "apiVersion": "2018-01-01", "properties": {"publicIPAllocationMethod": "Dynamic"},
-      "name": "vmss2LBPublicIP", "tags": {}, "location": "westus", "type": "Microsoft.Network/publicIPAddresses"},
-      {"dependsOn": ["Microsoft.Network/publicIpAddresses/vmss2LBPublicIP"], "apiVersion":
-      "2018-01-01", "properties": {"backendAddressPools": [{"name": "vmss2LBBEPool"}],
-      "frontendIPConfigurations": [{"name": "loadBalancerFrontEnd", "properties":
-      {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}}}],
-      "inboundNatPools": [{"name": "vmss2LBNatPool", "properties": {"frontendPortRangeEnd":
-      "50119", "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
+    body: 'b''{"properties": {"parameters": {"adminPassword": {"value": "PasswordPassword1!"}},
+      "template": {"parameters": {"adminPassword": {"metadata": {"description": "Secure
+      adminPassword"}, "type": "securestring"}}, "outputs": {"VMSS": {"type": "object",
+      "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''vmss2\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]"}},
+      "resources": [{"properties": {"publicIPAllocationMethod": "Dynamic"}, "type":
+      "Microsoft.Network/publicIPAddresses", "name": "vmss2LBPublicIP", "dependsOn":
+      [], "tags": {}, "apiVersion": "2018-01-01", "location": "westus"}, {"properties":
+      {"frontendIPConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}},
+      "name": "loadBalancerFrontEnd"}], "inboundNatPools": [{"properties": {"frontendPortRangeStart":
+      "50000", "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
       \''vmss2LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"},
-      "backendPort": 22, "frontendPortRangeStart": "50000", "protocol": "tcp"}}]},
-      "name": "vmss2LB", "tags": {}, "location": "westus", "type": "Microsoft.Network/loadBalancers"},
-      {"sku": {"name": "Standard_D1_v2", "capacity": 2}, "apiVersion": "2017-12-01",
-      "dependsOn": ["Microsoft.Network/loadBalancers/vmss2LB"], "properties": {"overprovision":
-      true, "singlePlacementGroup": null, "virtualMachineProfile": {"storageProfile":
-      {"osDisk": {"createOption": "FromImage", "caching": "ReadWrite", "managedDisk":
-      {"storageAccountType": null}}, "imageReference": {"version": "latest", "publisher":
-      "credativ", "offer": "Debian", "sku": "8"}}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"name": "vmss2900dNic", "properties": {"ipConfigurations": [{"name": "vmss2900dIPConfig",
-      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}],
-      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}]}}],
-      "primary": "true"}}]}, "osProfile": {"computerNamePrefix": "vmss2900d", "adminPassword":
-      "[parameters(\''adminPassword\'')]", "adminUsername": "admin123"}}, "upgradePolicy":
-      {"mode": "manual"}}, "name": "vmss2", "tags": {}, "location": "westus", "type":
-      "Microsoft.Compute/virtualMachineScaleSets"}], "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "outputs": {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
-      \''vmss2\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
-      "type": "object"}}, "parameters": {"adminPassword": {"metadata": {"description":
-      "Secure adminPassword"}, "type": "securestring"}}, "contentVersion": "1.0.0.0",
-      "variables": {}}, "parameters": {"adminPassword": {"value": "PasswordPassword1!"}}}}'''
+      "frontendPortRangeEnd": "50119", "backendPort": 22, "protocol": "tcp"}, "name":
+      "vmss2LBNatPool"}], "backendAddressPools": [{"name": "vmss2LBBEPool"}]}, "type":
+      "Microsoft.Network/loadBalancers", "name": "vmss2LB", "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss2LBPublicIP"],
+      "tags": {}, "apiVersion": "2018-01-01", "location": "westus"}, {"properties":
+      {"upgradePolicy": {"mode": "manual"}, "singlePlacementGroup": null, "overprovision":
+      true, "virtualMachineProfile": {"networkProfile": {"networkInterfaceConfigurations":
+      [{"properties": {"primary": "true", "ipConfigurations": [{"properties": {"loadBalancerInboundNatPools":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}],
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}]},
+      "name": "vmss273d3IPConfig"}]}, "name": "vmss273d3Nic"}]}, "osProfile": {"adminUsername":
+      "admin123", "adminPassword": "[parameters(\''adminPassword\'')]", "computerNamePrefix":
+      "vmss273d3"}, "storageProfile": {"osDisk": {"createOption": "FromImage", "caching":
+      "ReadWrite", "managedDisk": {"storageAccountType": null}}, "imageReference":
+      {"publisher": "credativ", "offer": "Debian", "version": "latest", "sku": "8"}}}},
+      "sku": {"capacity": 2, "name": "Standard_D1_v2"}, "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "apiVersion": "2017-12-01", "dependsOn": ["Microsoft.Network/loadBalancers/vmss2LB"],
+      "name": "vmss2", "tags": {}, "location": "westus"}], "variables": {}, "$schema":
+      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0"}, "mode": "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1910,18 +1954,18 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_NvJOZHpqezAbo8FtHyFx9Y9SPbYCPjUz","name":"vmss_deploy_NvJOZHpqezAbo8FtHyFx9Y9SPbYCPjUz","properties":{"templateHash":"3467317927846071006","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T20:58:21.2084779Z","duration":"PT2.5500149S","correlationId":"99620f5b-c958-4913-a22c-db78109c3f68","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_saPFf8CX1ts1bqKzutm5VqLSFXKSI2ba","name":"vmss_deploy_saPFf8CX1ts1bqKzutm5VqLSFXKSI2ba","properties":{"templateHash":"10022329497166416549","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:38:09.9283831Z","duration":"PT0.62675S","correlationId":"4a8e6b9c-0e61-492f-97dd-aed1df2dd15d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_NvJOZHpqezAbo8FtHyFx9Y9SPbYCPjUz/operationStatuses/08586773489868191660?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_saPFf8CX1ts1bqKzutm5VqLSFXKSI2ba/operationStatuses/08586764861961759910?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['2064']
+      content-length: ['2063']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:58:21 GMT']
+      date: ['Mon, 30 Apr 2018 20:38:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1936,14 +1980,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773489868191660?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764861961759910?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:58:51 GMT']
+      date: ['Mon, 30 Apr 2018 20:38:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1963,14 +2007,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773489868191660?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764861961759910?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:59:21 GMT']
+      date: ['Mon, 30 Apr 2018 20:39:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1990,14 +2034,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773489868191660?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764861961759910?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 20:59:51 GMT']
+      date: ['Mon, 30 Apr 2018 20:39:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -2017,14 +2061,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773489868191660?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764861961759910?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:00:22 GMT']
+      date: ['Mon, 30 Apr 2018 20:40:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -2044,14 +2088,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773489868191660?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764861961759910?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:00:52 GMT']
+      date: ['Mon, 30 Apr 2018 20:40:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -2071,14 +2115,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773489868191660?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764861961759910?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:01:23 GMT']
+      date: ['Mon, 30 Apr 2018 20:41:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -2100,12 +2144,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_NvJOZHpqezAbo8FtHyFx9Y9SPbYCPjUz","name":"vmss_deploy_NvJOZHpqezAbo8FtHyFx9Y9SPbYCPjUz","properties":{"templateHash":"3467317927846071006","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:00:59.4599228Z","duration":"PT2M40.8014598S","correlationId":"99620f5b-c958-4913-a22c-db78109c3f68","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss2900d","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss2900dNic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss2900dIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"93ae4390-70ed-41fa-bc5d-b041c825c15d"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Resources/deployments/vmss_deploy_saPFf8CX1ts1bqKzutm5VqLSFXKSI2ba","name":"vmss_deploy_saPFf8CX1ts1bqKzutm5VqLSFXKSI2ba","properties":{"templateHash":"10022329497166416549","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T20:40:47.8713266Z","duration":"PT2M38.5696935S","correlationId":"4a8e6b9c-0e61-492f-97dd-aed1df2dd15d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss273d3","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss273d3Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss273d3IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"50c825bd-fe14-4211-a4a0-4124c8118226"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['4415']
+      content-length: ['4416']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:01:24 GMT']
+      date: ['Mon, 30 Apr 2018 20:41:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -2121,7 +2165,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -2132,7 +2176,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss2900d\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss273d3\",\r\n        \"adminUsername\"\
         : \"admin123\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
@@ -2141,15 +2185,15 @@ interactions:
         \        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"\
         credativ\",\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss2900dNic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss273d3Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss2900dIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
+        :[{\"name\":\"vmss273d3IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"93ae4390-70ed-41fa-bc5d-b041c825c15d\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"50c825bd-fe14-4211-a4a0-4124c8118226\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2\"\
         ,\r\n  \"name\": \"vmss2\"\r\n}"}
@@ -2157,7 +2201,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2445']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:01:24 GMT']
+      date: ['Mon, 30 Apr 2018 20:41:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2168,33 +2212,20 @@ interactions:
       x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;192,Microsoft.Compute/GetVMScaleSet30Min;1484']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"sku": {"name": "Standard_D1_v2", "tier": "Standard", "capacity": 2},
-      "identity": {"type": "SystemAssigned"}, "tags": {}, "location": "westus", "properties":
-      {"overprovision": true, "singlePlacementGroup": true, "virtualMachineProfile":
-      {"storageProfile": {"imageReference": {"sku": "8", "publisher": "credativ",
-      "offer": "Debian", "version": "latest"}, "osDisk": {"createOption": "FromImage",
-      "caching": "ReadWrite", "managedDisk": {"storageAccountType": "Standard_LRS"}}},
-      "networkProfile": {"networkInterfaceConfigurations": [{"name": "vmss2900dNic",
-      "properties": {"dnsSettings": {"dnsServers": []}, "ipConfigurations": [{"name":
-      "vmss2900dIPConfig", "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}],
-      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}],
-      "privateIPAddressVersion": "IPv4"}}], "enableIPForwarding": false, "enableAcceleratedNetworking":
-      false, "primary": true}}]}, "osProfile": {"linuxConfiguration": {"disablePasswordAuthentication":
-      false}, "computerNamePrefix": "vmss2900d", "adminUsername": "admin123", "secrets":
-      []}}, "upgradePolicy": {"mode": "Manual", "automaticOSUpgrade": false}}}'''
+    body: '{"sku": {"capacity": 2, "name": "Standard_D1_v2", "tier": "Standard"},
+      "identity": {"type": "SystemAssigned"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
-      Content-Length: ['1799']
+      Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2?api-version=2017-12-01
   response:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
@@ -2202,7 +2233,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss2900d\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss273d3\",\r\n        \"adminUsername\"\
         : \"admin123\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
@@ -2211,27 +2242,27 @@ interactions:
         \        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"\
         credativ\",\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss2900dNic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss273d3Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss2900dIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
+        :[{\"name\":\"vmss273d3IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"93ae4390-70ed-41fa-bc5d-b041c825c15d\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"50c825bd-fe14-4211-a4a0-4124c8118226\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n \
-        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"70ac6964-b301-4d72-80ea-dca7699d2aff\"\
+        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"e590fad8-b1fa-49ef-a068-b97e509e8f95\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2\"\
         ,\r\n  \"name\": \"vmss2\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/193200a0-284f-45a2-a309-fbd264962887?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/50d6da40-46f4-4123-9e58-4b245c8fef09?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['2614']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:01:27 GMT']
+      date: ['Mon, 30 Apr 2018 20:41:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2239,7 +2270,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;38,Microsoft.Compute/CreateVMScaleSet30Min;197,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1199,Microsoft.Compute/VmssQueuedVMOperations;4800']
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
@@ -2251,19 +2282,19 @@ interactions:
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/193200a0-284f-45a2-a309-fbd264962887?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/50d6da40-46f4-4123-9e58-4b245c8fef09?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:01:27.1781781+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"193200a0-284f-45a2-a309-fbd264962887\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:41:19.7350466+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"50d6da40-46f4-4123-9e58-4b245c8fef09\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:01:57 GMT']
+      date: ['Mon, 30 Apr 2018 20:41:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2271,7 +2302,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29943']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29936']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2281,19 +2312,49 @@ interactions:
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/193200a0-284f-45a2-a309-fbd264962887?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/50d6da40-46f4-4123-9e58-4b245c8fef09?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:01:27.1781781+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T21:02:23.1045403+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"193200a0-284f-45a2-a309-fbd264962887\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:41:19.7350466+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"50d6da40-46f4-4123-9e58-4b245c8fef09\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 30 Apr 2018 20:42:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29933']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss identity assign]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/50d6da40-46f4-4123-9e58-4b245c8fef09?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:41:19.7350466+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T20:42:24.6003927+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"50d6da40-46f4-4123-9e58-4b245c8fef09\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:02:28 GMT']
+      date: ['Mon, 30 Apr 2018 20:42:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2301,7 +2362,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29940']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29931']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2311,7 +2372,7 @@ interactions:
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2?api-version=2017-12-01
@@ -2321,7 +2382,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss2900d\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss273d3\",\r\n        \"adminUsername\"\
         : \"admin123\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
@@ -2330,18 +2391,18 @@ interactions:
         \        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"\
         credativ\",\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss2900dNic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss273d3Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss2900dIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
+        :[{\"name\":\"vmss273d3IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"93ae4390-70ed-41fa-bc5d-b041c825c15d\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"50c825bd-fe14-4211-a4a0-4124c8118226\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n \
-        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"70ac6964-b301-4d72-80ea-dca7699d2aff\"\
+        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"e590fad8-b1fa-49ef-a068-b97e509e8f95\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_msi_no_scope000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2\"\
         ,\r\n  \"name\": \"vmss2\"\r\n}"}
@@ -2349,7 +2410,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2615']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:02:28 GMT']
+      date: ['Mon, 30 Apr 2018 20:42:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2357,7 +2418,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;186,Microsoft.Compute/GetVMScaleSet30Min;1478']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;181,Microsoft.Compute/GetVMScaleSet30Min;1473']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2379,9 +2440,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 20 Apr 2018 21:02:29 GMT']
+      date: ['Mon, 30 Apr 2018 20:42:54 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGTVNJOjVGTk86NUZTQ09QRTJaT0xHVkpKS0I3NjVURkQ0Tnw2RTA4RjQ3RkRERTVCREE3LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGTVNJOjVGTk86NUZTQ09QRUhXWlpYQlhNVUhJNVNCTjczN3w5MkZGOTg2RTA5MzdGNTk2LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_explicit_msi.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_explicit_msi.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"tags": {"product": "azurecli", "date": "2018-04-20T21:04:34Z", "cause":
-      "automation"}, "location": "westcentralus"}'
+    body: '{"tags": {"date": "2018-04-30T20:15:42Z", "cause": "automation", "product":
+      "azurecli"}, "location": "westcentralus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -16,17 +16,17 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"product":"azurecli","date":"2018-04-20T21:04:34Z","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"date":"2018-04-30T20:15:42Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['281']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:04:35 GMT']
+      date: ['Mon, 30 Apr 2018 20:15:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -43,12 +43,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"product":"azurecli","date":"2018-04-20T21:04:34Z","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"date":"2018-04-30T20:15:42Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['281']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:04:36 GMT']
+      date: ['Mon, 30 Apr 2018 20:15:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -70,19 +70,19 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1?api-version=2015-08-31-preview
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1","name":"id1","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"267988c9-e248-4b37-86a3-ca032f893687","clientId":"06cb04f5-c51e-4ccd-a45c-cc25c4277f1e","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=267988c9-e248-4b37-86a3-ca032f893687&aid=06cb04f5-c51e-4ccd-a45c-cc25c4277f1e"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1","name":"id1","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"18da5396-9de2-4e25-b474-5d869ed6f84d","clientId":"dea1d13a-c672-4ef8-955b-c643b1e3e9a4","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=18da5396-9de2-4e25-b474-5d869ed6f84d&aid=dea1d13a-c672-4ef8-955b-c643b1e3e9a4"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['789']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:04:40 GMT']
+      date: ['Mon, 30 Apr 2018 20:15:50 GMT']
       expires: ['-1']
       location: [/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1]
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -99,12 +99,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"product":"azurecli","date":"2018-04-20T21:04:34Z","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"date":"2018-04-30T20:15:42Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['281']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:04:40 GMT']
+      date: ['Mon, 30 Apr 2018 20:15:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -126,19 +126,19 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2?api-version=2015-08-31-preview
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2","name":"id2","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"c32d6ba9-d494-4427-ae95-ac5f36deccf7","clientId":"37e0d585-8dbd-4373-8991-05ee8a037180","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=c32d6ba9-d494-4427-ae95-ac5f36deccf7&aid=37e0d585-8dbd-4373-8991-05ee8a037180"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2","name":"id2","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"bea7565f-7e8e-4551-81c5-4cb6846e72c8","clientId":"3449ecec-5b60-49cd-8b9f-e72acb509342","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=bea7565f-7e8e-4551-81c5-4cb6846e72c8&aid=3449ecec-5b60-49cd-8b9f-e72acb509342"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['789']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:04:42 GMT']
+      date: ['Mon, 30 Apr 2018 20:15:54 GMT']
       expires: ['-1']
       location: [/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2]
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -155,12 +155,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"product":"azurecli","date":"2018-04-20T21:04:34Z","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"date":"2018-04-30T20:15:42Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['281']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:04:42 GMT']
+      date: ['Mon, 30 Apr 2018 20:15:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -220,22 +220,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:04:43 GMT']
+      date: ['Mon, 30 Apr 2018 20:15:55 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 21:09:43 GMT']
-      source-age: ['53']
+      expires: ['Mon, 30 Apr 2018 20:20:55 GMT']
+      source-age: ['165']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
       x-cache: [HIT]
       x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [f61f4a64fc798e4d127c39cf0cb130d2e3fc2e07]
+      x-fastly-request-id: [06d3948ff79392fe3e3ac5a6cce975fd8323129b]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['DCDC:087B:D22E58:DE69FD:5ADA55B6']
-      x-served-by: [cache-sea1029-SEA]
-      x-timer: ['S1524258284.501869,VS0,VE1']
+      x-github-request-id: ['E472:1788:D277F:DA365:5AE778D6']
+      x-served-by: [cache-dfw18634-DFW]
+      x-timer: ['S1525119356.687571,VS0,VE1']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -258,7 +258,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:04:42 GMT']
+      date: ['Mon, 30 Apr 2018 20:15:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -266,40 +266,39 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"mode": "Incremental", "template": {"variables": {},
-      "outputs": {}, "resources": [{"name": "vm2VNET", "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/virtualNetworks", "tags": {}, "location": "westcentralus",
-      "dependsOn": [], "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
-      "subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"}, "name": "vm2Subnet"}]}},
-      {"apiVersion": "2015-06-15", "properties": {"securityRules": [{"properties":
-      {"sourcePortRange": "*", "sourceAddressPrefix": "*", "priority": 1000, "destinationAddressPrefix":
-      "*", "protocol": "Tcp", "direction": "Inbound", "destinationPortRange": "22",
-      "access": "Allow"}, "name": "default-allow-ssh"}]}, "name": "vm2NSG", "tags":
-      {}, "location": "westcentralus", "dependsOn": [], "type": "Microsoft.Network/networkSecurityGroups"},
-      {"apiVersion": "2018-01-01", "properties": {"publicIPAllocationMethod": null},
-      "name": "vm2PublicIP", "tags": {}, "location": "westcentralus", "dependsOn":
-      [], "type": "Microsoft.Network/publicIPAddresses"}, {"apiVersion": "2015-06-15",
-      "properties": {"networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},
-      "ipConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"},
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet"},
-      "privateIPAllocationMethod": "Dynamic"}, "name": "ipconfigvm2"}]}, "name": "vm2VMNic",
-      "tags": {}, "location": "westcentralus", "dependsOn": ["Microsoft.Network/virtualNetworks/vm2VNET",
-      "Microsoft.Network/networkSecurityGroups/vm2NSG", "Microsoft.Network/publicIpAddresses/vm2PublicIP"],
-      "type": "Microsoft.Network/networkInterfaces"}, {"apiVersion": "2017-12-01",
-      "identity": {"identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
-      "type": "UserAssigned"}, "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"},
-      "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
-      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
-      "Canonical", "version": "latest", "sku": "16.04-LTS"}, "osDisk": {"createOption":
-      "fromImage", "caching": "ReadWrite", "managedDisk": {"storageAccountType": null},
-      "name": null}}, "osProfile": {"computerName": "vm2", "linuxConfiguration": {"ssh":
-      {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys", "keyData":
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}, "disablePasswordAuthentication": true}, "adminUsername":
-      "ubuntuadmin"}}, "name": "vm2", "tags": {}, "location": "westcentralus", "dependsOn":
-      ["Microsoft.Network/networkInterfaces/vm2VMNic"], "type": "Microsoft.Compute/virtualMachines"}],
-      "contentVersion": "1.0.0.0", "parameters": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
-      "parameters": {}}}'''
+    body: 'b''{"properties": {"mode": "Incremental", "template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "resources": [{"tags": {}, "properties": {"subnets": [{"properties": {"addressPrefix":
+      "10.0.0.0/24"}, "name": "vm2Subnet"}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}},
+      "type": "Microsoft.Network/virtualNetworks", "name": "vm2VNET", "dependsOn":
+      [], "apiVersion": "2015-06-15", "location": "westcentralus"}, {"tags": {}, "properties":
+      {"securityRules": [{"properties": {"sourceAddressPrefix": "*", "destinationPortRange":
+      "22", "priority": 1000, "protocol": "Tcp", "sourcePortRange": "*", "direction":
+      "Inbound", "destinationAddressPrefix": "*", "access": "Allow"}, "name": "default-allow-ssh"}]},
+      "type": "Microsoft.Network/networkSecurityGroups", "name": "vm2NSG", "dependsOn":
+      [], "apiVersion": "2015-06-15", "location": "westcentralus"}, {"tags": {}, "properties":
+      {"publicIPAllocationMethod": null}, "type": "Microsoft.Network/publicIPAddresses",
+      "name": "vm2PublicIP", "dependsOn": [], "apiVersion": "2018-01-01", "location":
+      "westcentralus"}, {"tags": {}, "properties": {"networkSecurityGroup": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},
+      "ipConfigurations": [{"properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet"},
+      "privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}},
+      "name": "ipconfigvm2"}]}, "type": "Microsoft.Network/networkInterfaces", "name":
+      "vm2VMNic", "dependsOn": ["Microsoft.Network/virtualNetworks/vm2VNET", "Microsoft.Network/networkSecurityGroups/vm2NSG",
+      "Microsoft.Network/publicIpAddresses/vm2PublicIP"], "apiVersion": "2015-06-15",
+      "location": "westcentralus"}, {"tags": {}, "properties": {"hardwareProfile":
+      {"vmSize": "Standard_DS1_v2"}, "networkProfile": {"networkInterfaces": [{"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
+      "osProfile": {"linuxConfiguration": {"ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n"}]}, "disablePasswordAuthentication": true}, "computerName":
+      "vm2", "adminUsername": "ubuntuadmin"}, "storageProfile": {"osDisk": {"managedDisk":
+      {"storageAccountType": null}, "createOption": "fromImage", "name": null, "caching":
+      "ReadWrite"}, "imageReference": {"sku": "16.04-LTS", "publisher": "Canonical",
+      "offer": "UbuntuServer", "version": "latest"}}}, "type": "Microsoft.Compute/virtualMachines",
+      "name": "vm2", "identity": {"type": "UserAssigned", "identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]},
+      "dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"], "apiVersion":
+      "2017-12-01", "location": "westcentralus"}], "outputs": {}, "contentVersion":
+      "1.0.0.0", "variables": {}, "parameters": {}}, "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -314,18 +313,18 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_2zdHO9YSIxMjU6TcfFV6f53mrNb4FbKa","name":"vm_deploy_2zdHO9YSIxMjU6TcfFV6f53mrNb4FbKa","properties":{"templateHash":"7175680507684518406","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T21:04:46.2754601Z","duration":"PT1.0954188S","correlationId":"25859ab3-916f-4559-aa4d-2edf88184c33","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm2VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_piNYW1S0qe3QzEGcu3Smyc3ofoZyOJCf","name":"vm_deploy_piNYW1S0qe3QzEGcu3Smyc3ofoZyOJCf","properties":{"templateHash":"93369272063390507","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:15:58.8002205Z","duration":"PT0.622656S","correlationId":"a8ffd74a-cab5-4624-8808-2b7a23cfb8bd","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm2VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_2zdHO9YSIxMjU6TcfFV6f53mrNb4FbKa/operationStatuses/08586773486002975968?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_piNYW1S0qe3QzEGcu3Smyc3ofoZyOJCf/operationStatuses/08586764875273000644?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['2351']
+      content-length: ['2348']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:04:46 GMT']
+      date: ['Mon, 30 Apr 2018 20:15:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -340,14 +339,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773486002975968?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764875273000644?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:05:16 GMT']
+      date: ['Mon, 30 Apr 2018 20:16:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -367,14 +366,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773486002975968?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764875273000644?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:05:46 GMT']
+      date: ['Mon, 30 Apr 2018 20:16:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -394,14 +393,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773486002975968?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764875273000644?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:06:17 GMT']
+      date: ['Mon, 30 Apr 2018 20:17:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -421,14 +420,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773486002975968?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764875273000644?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:06:47 GMT']
+      date: ['Mon, 30 Apr 2018 20:18:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -448,68 +447,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773486002975968?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:07:17 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773486002975968?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:07:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773486002975968?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764875273000644?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:18 GMT']
+      date: ['Mon, 30 Apr 2018 20:18:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -531,12 +476,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_2zdHO9YSIxMjU6TcfFV6f53mrNb4FbKa","name":"vm_deploy_2zdHO9YSIxMjU6TcfFV6f53mrNb4FbKa","properties":{"templateHash":"7175680507684518406","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:08:02.7581427Z","duration":"PT3M17.5781014S","correlationId":"25859ab3-916f-4559-aa4d-2edf88184c33","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm2VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_piNYW1S0qe3QzEGcu3Smyc3ofoZyOJCf","name":"vm_deploy_piNYW1S0qe3QzEGcu3Smyc3ofoZyOJCf","properties":{"templateHash":"93369272063390507","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T20:18:03.580271Z","duration":"PT2M5.4027065S","correlationId":"a8ffd74a-cab5-4624-8808-2b7a23cfb8bd","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm2VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3143']
+      content-length: ['3139']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:19 GMT']
+      date: ['Mon, 30 Apr 2018 20:18:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -552,22 +497,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2?$expand=instanceView&api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"71e6b0ee-8dd7-4782-ac29-ca00f2f73c37\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"1a45e6bd-0119-49cb-bbea-f406b5188174\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm2_OsDisk_1_9668e040899e4600beb723d1b9c39fd7\",\r\n   \
+        \     \"name\": \"vm2_OsDisk_1_45f42e69a7c547959e31d9f961c492d9\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_9668e040899e4600beb723d1b9c39fd7\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_45f42e69a7c547959e31d9f961c492d9\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -584,17 +529,17 @@ interactions:
         : \"2.2.25\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
         code\": \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\"\
         ,\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\"\
-        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-20T21:08:19+00:00\"\
+        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-30T20:18:33+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm2_OsDisk_1_9668e040899e4600beb723d1b9c39fd7\"\
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm2_OsDisk_1_45f42e69a7c547959e31d9f961c492d9\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2018-04-20T21:05:18.8289727+00:00\"\r\n            }\r\
+        \       \"time\": \"2018-04-30T20:16:33.4706013+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2018-04-20T21:07:56.3443937+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2018-04-30T20:18:01.5947823+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
@@ -607,7 +552,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3661']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:19 GMT']
+      date: ['Mon, 30 Apr 2018 20:18:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -633,12 +578,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"919ac235-50d9-485f-ac28-9404dcc651e2\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"8bcea85f-6bd8-4f9f-b1f9-0b196dc67519\\\"\",\r\n \
         \ \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"3e9e882e-8555-41b2-a1a1-ddba886c56a5\",\r\n    \"ipConfigurations\": [\r\
+        \ \"0c780422-31d9-421e-b002-a415a291db7c\",\r\n    \"ipConfigurations\": [\r\
         \n      {\r\n        \"name\": \"ipconfigvm2\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
-        ,\r\n        \"etag\": \"W/\\\"919ac235-50d9-485f-ac28-9404dcc651e2\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"8bcea85f-6bd8-4f9f-b1f9-0b196dc67519\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -648,8 +593,8 @@ interactions:
         : \"IPv4\",\r\n          \"isInUseWithService\": false\r\n        }\r\n  \
         \    }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n\
         \      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"\
-        e44zhhlgy5vepcfau4a0c553jh.yx.internal.cloudapp.net\"\r\n    },\r\n    \"\
-        macAddress\": \"00-0D-3A-F8-B8-93\",\r\n    \"enableAcceleratedNetworking\"\
+        2pn15lybjcjebktqjrgg53zdid.yx.internal.cloudapp.net\"\r\n    },\r\n    \"\
+        macAddress\": \"00-0D-3A-F8-97-DA\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -660,8 +605,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2273']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:20 GMT']
-      etag: [W/"919ac235-50d9-485f-ac28-9404dcc651e2"]
+      date: ['Mon, 30 Apr 2018 20:18:35 GMT']
+      etag: [W/"8bcea85f-6bd8-4f9f-b1f9-0b196dc67519"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -686,10 +631,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"9e0dc55c-7fad-45f0-855a-5629f7eefcff\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"97303c50-76d2-40c9-bf62-8500ec69909c\\\"\",\r\n \
         \ \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"d68f8360-b47d-4f1c-afae-0a4537bb421d\",\r\n    \"ipAddress\": \"52.161.146.68\"\
+        \ \"697d4f92-cc6b-40e4-8db7-20c0c6d93d68\",\r\n    \"ipAddress\": \"13.78.129.101\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\
         \n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
@@ -700,8 +645,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['919']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:20 GMT']
-      etag: [W/"9e0dc55c-7fad-45f0-855a-5629f7eefcff"]
+      date: ['Mon, 30 Apr 2018 20:18:36 GMT']
+      etag: [W/"97303c50-76d2-40c9-bf62-8500ec69909c"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -725,12 +670,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"product":"azurecli","date":"2018-04-20T21:04:34Z","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"date":"2018-04-30T20:15:42Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['281']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:20 GMT']
+      date: ['Mon, 30 Apr 2018 20:18:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -790,22 +735,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:21 GMT']
+      date: ['Mon, 30 Apr 2018 20:18:37 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 21:13:21 GMT']
-      source-age: ['271']
+      expires: ['Mon, 30 Apr 2018 20:23:37 GMT']
+      source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [HIT]
-      x-cache-hits: ['1']
+      x-cache: [MISS]
+      x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [693db1b14cc19beb0ccf5d6510ff8faadf342e5c]
+      x-fastly-request-id: [67b1256a980b659e9a73107364475e9dc62bdc32]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['DCDC:087B:D22E58:DE69FD:5ADA55B6']
-      x-served-by: [cache-sea1025-SEA]
-      x-timer: ['S1524258501.297291,VS0,VE1']
+      x-github-request-id: ['E5B6:1785:1B43C:1CB46:5AE77A1D']
+      x-served-by: [cache-dfw18643-DFW]
+      x-timer: ['S1525119518.919803,VS0,VE78']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -825,15 +770,15 @@ interactions:
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm2VNET\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"77f5cb68-3716-46ea-a2bd-b92c3a45b49a\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"e083e1b0-4b89-4dd5-981b-ac70549c5408\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westcentralus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n\
         \        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\"\
-        : \"9d93bd27-c766-47ea-88a0-a781a17ffd4f\",\r\n        \"addressSpace\": {\r\
+        : \"afbfdbe3-4801-4092-aa70-4c4c6ff72343\",\r\n        \"addressSpace\": {\r\
         \n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n    \
         \      ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n      \
         \      \"name\": \"vm2Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"77f5cb68-3716-46ea-a2bd-b92c3a45b49a\\\"\
+        ,\r\n            \"etag\": \"W/\\\"e083e1b0-4b89-4dd5-981b-ac70549c5408\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
@@ -846,7 +791,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1526']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:20 GMT']
+      date: ['Mon, 30 Apr 2018 20:18:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -876,7 +821,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['615']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:21 GMT']
+      date: ['Mon, 30 Apr 2018 20:18:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -889,40 +834,41 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"mode": "Incremental", "template": {"variables": {},
-      "outputs": {}, "resources": [{"apiVersion": "2015-06-15", "properties": {"securityRules":
-      [{"properties": {"sourcePortRange": "*", "sourceAddressPrefix": "*", "priority":
-      1000, "destinationAddressPrefix": "*", "protocol": "Tcp", "direction": "Inbound",
-      "destinationPortRange": "22", "access": "Allow"}, "name": "default-allow-ssh"}]},
-      "name": "vm1NSG", "tags": {}, "location": "westcentralus", "dependsOn": [],
-      "type": "Microsoft.Network/networkSecurityGroups"}, {"apiVersion": "2018-01-01",
-      "properties": {"publicIPAllocationMethod": null}, "name": "vm1PublicIP", "tags":
-      {}, "location": "westcentralus", "dependsOn": [], "type": "Microsoft.Network/publicIPAddresses"},
-      {"apiVersion": "2015-06-15", "properties": {"networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
-      "ipConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet"},
-      "privateIPAllocationMethod": "Dynamic"}, "name": "ipconfigvm1"}]}, "name": "vm1VMNic",
-      "tags": {}, "location": "westcentralus", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm1NSG",
-      "Microsoft.Network/publicIpAddresses/vm1PublicIP"], "type": "Microsoft.Network/networkInterfaces"},
-      {"apiVersion": "2015-07-01", "properties": {"principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]", "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001",
-      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"},
-      "type": "Microsoft.Authorization/roleAssignments", "dependsOn": ["Microsoft.Compute/virtualMachines/vm1"],
-      "name": "c7a1336b-d70d-4ab9-bb54-678b55711653"}, {"apiVersion": "2017-12-01",
-      "identity": {"identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"],
-      "type": "SystemAssigned,UserAssigned"}, "properties": {"hardwareProfile": {"vmSize":
-      "Standard_DS1_v2"}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
-      "Canonical", "version": "latest", "sku": "16.04-LTS"}, "osDisk": {"createOption":
-      "fromImage", "caching": "ReadWrite", "managedDisk": {"storageAccountType": null},
-      "name": null}}, "osProfile": {"computerName": "vm1", "linuxConfiguration": {"ssh":
-      {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys", "keyData":
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}, "disablePasswordAuthentication": true}, "adminUsername":
-      "ubuntuadmin"}}, "name": "vm1", "tags": {}, "location": "westcentralus", "dependsOn":
-      ["Microsoft.Network/networkInterfaces/vm1VMNic"], "type": "Microsoft.Compute/virtualMachines"}],
-      "contentVersion": "1.0.0.0", "parameters": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
-      "parameters": {}}}'''
+    body: 'b''{"properties": {"mode": "Incremental", "template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "resources": [{"tags": {}, "properties": {"securityRules": [{"properties": {"sourceAddressPrefix":
+      "*", "destinationPortRange": "22", "priority": 1000, "protocol": "Tcp", "sourcePortRange":
+      "*", "direction": "Inbound", "destinationAddressPrefix": "*", "access": "Allow"},
+      "name": "default-allow-ssh"}]}, "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "vm1NSG", "dependsOn": [], "apiVersion": "2015-06-15", "location": "westcentralus"},
+      {"tags": {}, "properties": {"publicIPAllocationMethod": null}, "type": "Microsoft.Network/publicIPAddresses",
+      "name": "vm1PublicIP", "dependsOn": [], "apiVersion": "2018-01-01", "location":
+      "westcentralus"}, {"tags": {}, "properties": {"networkSecurityGroup": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
+      "ipConfigurations": [{"properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm2VNET/subnets/vm2Subnet"},
+      "privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}},
+      "name": "ipconfigvm1"}]}, "type": "Microsoft.Network/networkInterfaces", "name":
+      "vm1VMNic", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm1NSG",
+      "Microsoft.Network/publicIpAddresses/vm1PublicIP"], "apiVersion": "2015-06-15",
+      "location": "westcentralus"}, {"dependsOn": ["Microsoft.Compute/virtualMachines/vm1"],
+      "properties": {"scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001",
+      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
+      "principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default\'',
+      \''2015-08-31-PREVIEW\'').principalId]"}, "apiVersion": "2015-07-01", "name":
+      "3709e7a5-58d7-4fc4-b1db-dc738e528519", "type": "Microsoft.Authorization/roleAssignments"},
+      {"tags": {}, "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"},
+      "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "osProfile": {"linuxConfiguration": {"ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n"}]}, "disablePasswordAuthentication": true}, "computerName":
+      "vm1", "adminUsername": "ubuntuadmin"}, "storageProfile": {"osDisk": {"managedDisk":
+      {"storageAccountType": null}, "createOption": "fromImage", "name": null, "caching":
+      "ReadWrite"}, "imageReference": {"sku": "16.04-LTS", "publisher": "Canonical",
+      "offer": "UbuntuServer", "version": "latest"}}}, "type": "Microsoft.Compute/virtualMachines",
+      "name": "vm1", "identity": {"type": "SystemAssigned,UserAssigned", "identityIds":
+      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]},
+      "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"], "apiVersion":
+      "2017-12-01", "location": "westcentralus"}], "outputs": {}, "contentVersion":
+      "1.0.0.0", "variables": {}, "parameters": {}}, "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -937,13 +883,13 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_KvBfHI4ZvDczrHsGdu5L43uauqLHU587","name":"vm_deploy_KvBfHI4ZvDczrHsGdu5L43uauqLHU587","properties":{"templateHash":"6693483803684490192","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T21:08:23.8286283Z","duration":"PT0.5309693S","correlationId":"854621cb-693d-4d55-addd-712e21886f9b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/c7a1336b-d70d-4ab9-bb54-678b55711653","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"c7a1336b-d70d-4ab9-bb54-678b55711653"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_n51SGYebimU3z8ZoULziNWfX6dT8qBwn","name":"vm_deploy_n51SGYebimU3z8ZoULziNWfX6dT8qBwn","properties":{"templateHash":"2983330409983825735","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:18:41.9289134Z","duration":"PT0.6028816S","correlationId":"1d9f5f9f-e7bd-421b-8e73-6a1657a3842a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/3709e7a5-58d7-4fc4-b1db-dc738e528519","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"3709e7a5-58d7-4fc4-b1db-dc738e528519"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_KvBfHI4ZvDczrHsGdu5L43uauqLHU587/operationStatuses/08586773483821799692?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_n51SGYebimU3z8ZoULziNWfX6dT8qBwn/operationStatuses/08586764873641515972?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['3060']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:24 GMT']
+      date: ['Mon, 30 Apr 2018 20:18:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -963,14 +909,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773483821799692?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764873641515972?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:08:54 GMT']
+      date: ['Mon, 30 Apr 2018 20:19:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -990,14 +936,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773483821799692?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764873641515972?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:09:24 GMT']
+      date: ['Mon, 30 Apr 2018 20:19:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1017,14 +963,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773483821799692?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764873641515972?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:09:54 GMT']
+      date: ['Mon, 30 Apr 2018 20:20:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1044,14 +990,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773483821799692?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764873641515972?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:10:24 GMT']
+      date: ['Mon, 30 Apr 2018 20:20:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1071,14 +1017,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773483821799692?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764873641515972?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:10:55 GMT']
+      date: ['Mon, 30 Apr 2018 20:21:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1100,12 +1046,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_KvBfHI4ZvDczrHsGdu5L43uauqLHU587","name":"vm_deploy_KvBfHI4ZvDczrHsGdu5L43uauqLHU587","properties":{"templateHash":"6693483803684490192","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:10:46.9589867Z","duration":"PT2M23.6613277S","correlationId":"854621cb-693d-4d55-addd-712e21886f9b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/c7a1336b-d70d-4ab9-bb54-678b55711653","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"c7a1336b-d70d-4ab9-bb54-678b55711653"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/c7a1336b-d70d-4ab9-bb54-678b55711653"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_n51SGYebimU3z8ZoULziNWfX6dT8qBwn","name":"vm_deploy_n51SGYebimU3z8ZoULziNWfX6dT8qBwn","properties":{"templateHash":"2983330409983825735","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T20:20:50.7618726Z","duration":"PT2M9.4358408S","correlationId":"1d9f5f9f-e7bd-421b-8e73-6a1657a3842a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"networkInterfaces","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/3709e7a5-58d7-4fc4-b1db-dc738e528519","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"3709e7a5-58d7-4fc4-b1db-dc738e528519"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/3709e7a5-58d7-4fc4-b1db-dc738e528519"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3887']
+      content-length: ['3886']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:10:55 GMT']
+      date: ['Mon, 30 Apr 2018 20:21:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1121,22 +1067,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1153,23 +1099,23 @@ interactions:
         : \"2.2.25\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
         code\": \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\"\
         ,\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\"\
-        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-20T21:10:55+00:00\"\
+        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-30T20:21:15+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2018-04-20T21:08:54.9067924+00:00\"\r\n            }\r\
+        \       \"time\": \"2018-04-30T20:19:12.4688965+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2018-04-20T21:10:22.2661715+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2018-04-30T20:20:28.4523024+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
         ,\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\"\
         : {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"e2c5bc05-4eed-408f-86ce-4464557de5df\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"c1d8e70d-966f-4914-b151-d8bfbdc79418\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
@@ -1177,7 +1123,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3794']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:10:55 GMT']
+      date: ['Mon, 30 Apr 2018 20:21:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1185,7 +1131,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4191,Microsoft.Compute/LowCostGet30Min;33590']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4194,Microsoft.Compute/LowCostGet30Min;33590']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1203,12 +1149,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"de0cd383-9383-4c32-8634-041ce923a0a8\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"511097c0-4120-4086-a1f9-122e29dab335\\\"\",\r\n \
         \ \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"0f334643-66ce-4515-83f9-ccb50c8c6f79\",\r\n    \"ipConfigurations\": [\r\
+        \ \"dbde6704-31e7-4ee9-acf4-d9c8ff2e096f\",\r\n    \"ipConfigurations\": [\r\
         \n      {\r\n        \"name\": \"ipconfigvm1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"de0cd383-9383-4c32-8634-041ce923a0a8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"511097c0-4120-4086-a1f9-122e29dab335\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -1218,8 +1164,8 @@ interactions:
         : \"IPv4\",\r\n          \"isInUseWithService\": false\r\n        }\r\n  \
         \    }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n\
         \      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"\
-        e44zhhlgy5vepcfau4a0c553jh.yx.internal.cloudapp.net\"\r\n    },\r\n    \"\
-        macAddress\": \"00-0D-3A-F8-93-7E\",\r\n    \"enableAcceleratedNetworking\"\
+        2pn15lybjcjebktqjrgg53zdid.yx.internal.cloudapp.net\"\r\n    },\r\n    \"\
+        macAddress\": \"00-0D-3A-F8-D4-7F\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -1230,8 +1176,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2273']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:10:56 GMT']
-      etag: [W/"de0cd383-9383-4c32-8634-041ce923a0a8"]
+      date: ['Mon, 30 Apr 2018 20:21:16 GMT']
+      etag: [W/"511097c0-4120-4086-a1f9-122e29dab335"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1256,10 +1202,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"23e54168-5702-4d44-bf12-bb35017244c6\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"6c10303c-c4e8-43bf-bce6-ae9d85e6ec1b\\\"\",\r\n \
         \ \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"b089a399-335d-4559-9995-96a5ae48787a\",\r\n    \"ipAddress\": \"52.161.146.66\"\
+        \ \"9057541c-4780-48e7-9650-3e93b74d77ff\",\r\n    \"ipAddress\": \"13.78.131.98\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\
         \n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
@@ -1268,10 +1214,10 @@ interactions:
         \n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['919']
+      content-length: ['918']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:11:02 GMT']
-      etag: [W/"23e54168-5702-4d44-bf12-bb35017244c6"]
+      date: ['Mon, 30 Apr 2018 20:21:18 GMT']
+      etag: [W/"6c10303c-c4e8-43bf-bce6-ae9d85e6ec1b"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1289,22 +1235,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1318,7 +1264,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -1327,7 +1273,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2535']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:11:07 GMT']
+      date: ['Mon, 30 Apr 2018 20:21:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1335,7 +1281,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4194,Microsoft.Compute/LowCostGet30Min;33589']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4193,Microsoft.Compute/LowCostGet30Min;33589']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1346,22 +1292,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1375,7 +1321,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -1384,7 +1330,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2535']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:11:20 GMT']
+      date: ['Mon, 30 Apr 2018 20:21:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1392,47 +1338,36 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4193,Microsoft.Compute/LowCostGet30Min;33588']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4192,Microsoft.Compute/LowCostGet30Min;33588']
     status: {code: 200, message: OK}
 - request:
     body: 'b''{"identity": {"type": "SystemAssigned, UserAssigned", "identityIds":
       ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2",
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]},
-      "tags": {}, "location": "westcentralus", "properties": {"osProfile": {"computerName":
-      "vm1", "linuxConfiguration": {"ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}, "disablePasswordAuthentication": true}, "secrets":
-      [], "adminUsername": "ubuntuadmin"}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
-      "Canonical", "version": "latest", "sku": "16.04-LTS"}, "osDisk": {"caching":
-      "ReadWrite", "managedDisk": {"storageAccountType": "Premium_LRS", "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18"},
-      "createOption": "FromImage", "diskSizeGB": 30, "osType": "Linux", "name": "vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18"},
-      "dataDisks": []}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}}'''
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm identity assign]
       Connection: [keep-alive]
-      Content-Length: ['1861']
+      Content-Length: ['379']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1446,18 +1381,18 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/1e1f2d73-216d-4fb2-8d35-0f0cc08a8a28?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/90ffa120-5a40-4271-bda0-b344a0a0ecc1?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['2695']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:11:22 GMT']
+      date: ['Mon, 30 Apr 2018 20:21:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1476,49 +1411,19 @@ interactions:
       CommandName: [vm identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/1e1f2d73-216d-4fb2-8d35-0f0cc08a8a28?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/90ffa120-5a40-4271-bda0-b344a0a0ecc1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:11:22.4068357+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1e1f2d73-216d-4fb2-8d35-0f0cc08a8a28\"\
-        \r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['134']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:11:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29967']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm identity assign]
-      Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/1e1f2d73-216d-4fb2-8d35-0f0cc08a8a28?api-version=2017-12-01
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:11:22.4068357+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T21:12:02.5318129+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"1e1f2d73-216d-4fb2-8d35-0f0cc08a8a28\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:21:42.8274372+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T20:22:02.4834343+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"90ffa120-5a40-4271-bda0-b344a0a0ecc1\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:12:22 GMT']
+      date: ['Mon, 30 Apr 2018 20:22:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1526,7 +1431,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29964']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29977']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1536,21 +1441,21 @@ interactions:
       CommandName: [vm identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1564,7 +1469,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
@@ -1574,7 +1479,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2696']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:12:23 GMT']
+      date: ['Mon, 30 Apr 2018 20:22:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1582,7 +1487,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4189,Microsoft.Compute/LowCostGet30Min;33584']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4192,Microsoft.Compute/LowCostGet30Min;33587']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1593,22 +1498,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1622,7 +1527,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
@@ -1632,7 +1537,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2696']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:12:24 GMT']
+      date: ['Mon, 30 Apr 2018 20:22:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1640,7 +1545,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4188,Microsoft.Compute/LowCostGet30Min;33583']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4190,Microsoft.Compute/LowCostGet30Min;33585']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1651,22 +1556,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1680,7 +1585,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
@@ -1690,7 +1595,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2696']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:12:35 GMT']
+      date: ['Mon, 30 Apr 2018 20:22:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1698,46 +1603,35 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4187,Microsoft.Compute/LowCostGet30Min;33582']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4189,Microsoft.Compute/LowCostGet30Min;33584']
     status: {code: 200, message: OK}
 - request:
     body: 'b''{"identity": {"type": "SystemAssigned, UserAssigned", "identityIds":
-      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2"]},
-      "tags": {}, "location": "westcentralus", "properties": {"osProfile": {"computerName":
-      "vm1", "linuxConfiguration": {"ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}, "disablePasswordAuthentication": true}, "secrets":
-      [], "adminUsername": "ubuntuadmin"}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
-      "Canonical", "version": "latest", "sku": "16.04-LTS"}, "osDisk": {"caching":
-      "ReadWrite", "managedDisk": {"storageAccountType": "Premium_LRS", "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18"},
-      "createOption": "FromImage", "diskSizeGB": 30, "osType": "Linux", "name": "vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18"},
-      "dataDisks": []}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}}'''
+      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2"]}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm identity remove]
       Connection: [keep-alive]
-      Content-Length: ['1707']
+      Content-Length: ['225']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1751,17 +1645,17 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/8d714357-cd65-47f8-a5c3-3d5b14365c87?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/ab63a1a3-d900-48d9-8234-2b9e0b7e0ef6?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['2534']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:12:37 GMT']
+      date: ['Mon, 30 Apr 2018 20:22:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1780,19 +1674,19 @@ interactions:
       CommandName: [vm identity remove]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/8d714357-cd65-47f8-a5c3-3d5b14365c87?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/ab63a1a3-d900-48d9-8234-2b9e0b7e0ef6?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:12:37.7036303+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T21:12:48.7817056+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"8d714357-cd65-47f8-a5c3-3d5b14365c87\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:22:39.8579593+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T20:22:51.1390236+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"ab63a1a3-d900-48d9-8234-2b9e0b7e0ef6\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:13:07 GMT']
+      date: ['Mon, 30 Apr 2018 20:23:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1800,7 +1694,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14992,Microsoft.Compute/GetOperation30Min;29962']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14993,Microsoft.Compute/GetOperation30Min;29974']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1810,21 +1704,21 @@ interactions:
       CommandName: [vm identity remove]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1838,7 +1732,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -1847,7 +1741,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2535']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:13:08 GMT']
+      date: ['Mon, 30 Apr 2018 20:23:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1855,7 +1749,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4184,Microsoft.Compute/LowCostGet30Min;33578']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4183,Microsoft.Compute/LowCostGet30Min;33578']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1866,22 +1760,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1895,7 +1789,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -1904,7 +1798,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2535']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:13:20 GMT']
+      date: ['Mon, 30 Apr 2018 20:23:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1912,7 +1806,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4183,Microsoft.Compute/LowCostGet30Min;33577']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4182,Microsoft.Compute/LowCostGet30Min;33577']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1923,22 +1817,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -1952,7 +1846,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned,\
-        \ UserAssigned\",\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\"\
+        \ UserAssigned\",\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n    \"\
         identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
@@ -1961,7 +1855,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2535']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:13:31 GMT']
+      date: ['Mon, 30 Apr 2018 20:23:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1969,45 +1863,34 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4182,Microsoft.Compute/LowCostGet30Min;33576']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4181,Microsoft.Compute/LowCostGet30Min;33576']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"identity": {"type": "SystemAssigned"}, "tags": {}, "location": "westcentralus",
-      "properties": {"osProfile": {"computerName": "vm1", "linuxConfiguration": {"ssh":
-      {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys", "keyData":
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}, "disablePasswordAuthentication": true}, "secrets":
-      [], "adminUsername": "ubuntuadmin"}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
-      "Canonical", "version": "latest", "sku": "16.04-LTS"}, "osDisk": {"caching":
-      "ReadWrite", "managedDisk": {"storageAccountType": "Premium_LRS", "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18"},
-      "createOption": "FromImage", "diskSizeGB": 30, "osType": "Linux", "name": "vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18"},
-      "dataDisks": []}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}}'''
+    body: '{"identity": {"type": "SystemAssigned"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm identity remove]
       Connection: [keep-alive]
-      Content-Length: ['1522']
+      Content-Length: ['40']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2021,16 +1904,16 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\"\
-        ,\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\",\r\n  \
+        ,\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\",\r\n  \
         \  \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/a58a84db-6d99-432e-8bed-4fb8a849decc?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/b4d8acb6-69c8-45d9-b596-bfd2ca478db1?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['2330']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:13:33 GMT']
+      date: ['Mon, 30 Apr 2018 20:23:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2049,19 +1932,19 @@ interactions:
       CommandName: [vm identity remove]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/a58a84db-6d99-432e-8bed-4fb8a849decc?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/b4d8acb6-69c8-45d9-b596-bfd2ca478db1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:13:33.6722917+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T21:13:37.4067487+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"a58a84db-6d99-432e-8bed-4fb8a849decc\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:23:37.0759513+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T20:23:42.357161+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"b4d8acb6-69c8-45d9-b596-bfd2ca478db1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['184']
+      content-length: ['183']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:14:03 GMT']
+      date: ['Mon, 30 Apr 2018 20:24:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2069,7 +1952,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14991,Microsoft.Compute/GetOperation30Min;29960']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14993,Microsoft.Compute/GetOperation30Min;29972']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2079,21 +1962,21 @@ interactions:
       CommandName: [vm identity remove]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2107,7 +1990,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\"\
-        ,\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\",\r\n  \
+        ,\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\",\r\n  \
         \  \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
@@ -2115,7 +1998,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2331']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:14:03 GMT']
+      date: ['Mon, 30 Apr 2018 20:24:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2134,22 +2017,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f12071fd-ada8-4247-9149-2031d3143f09\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"32e259cd-eebc-4375-9ab1-a359ef60135f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
         \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
-        \     \"name\": \"vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\",\r\n   \
+        \     \"name\": \"vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\",\r\n   \
         \     \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d597df5e99244714b24da0e808f61b18\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_39e3336ffa874c48ba42f0c6798c1474\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntuadmin\",\r\n      \"linuxConfiguration\"\
@@ -2163,7 +2046,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\"\
         ,\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\"\
-        ,\r\n    \"principalId\": \"e2c5bc05-4eed-408f-86ce-4464557de5df\",\r\n  \
+        ,\r\n    \"principalId\": \"c1d8e70d-966f-4914-b151-d8bfbdc79418\",\r\n  \
         \  \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
@@ -2171,7 +2054,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2331']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:14:16 GMT']
+      date: ['Mon, 30 Apr 2018 20:24:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2201,12 +2084,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 20 Apr 2018 21:14:16 GMT']
+      date: ['Mon, 30 Apr 2018 20:24:21 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdNS0tKM01OUUtWLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdKMldUREVZQlRJLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_msi.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_msi.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"location": "westus", "tags": {"cause": "automation", "date": "2018-04-20T21:18:24Z",
-      "product": "azurecli"}}'
+    body: '{"tags": {"date": "2018-04-30T21:02:57Z", "cause": "automation", "product":
+      "azurecli"}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -16,12 +16,12 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001","name":"cli_test_vm_msi000001","location":"westus","tags":{"cause":"automation","date":"2018-04-20T21:18:24Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001","name":"cli_test_vm_msi000001","location":"westus","tags":{"date":"2018-04-30T21:02:57Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:18:27 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -43,12 +43,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001","name":"cli_test_vm_msi000001","location":"westus","tags":{"cause":"automation","date":"2018-04-20T21:18:24Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001","name":"cli_test_vm_msi000001","location":"westus","tags":{"date":"2018-04-30T21:02:57Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:18:27 GMT']
+      date: ['Mon, 30 Apr 2018 21:03:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -108,22 +108,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:18:28 GMT']
+      date: ['Mon, 30 Apr 2018 21:03:01 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 21:23:28 GMT']
-      source-age: ['0']
+      expires: ['Mon, 30 Apr 2018 21:08:01 GMT']
+      source-age: ['281']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
+      x-cache: [HIT]
+      x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [4fd0da486fdf99bb1ead0f029756c27bc5505977]
+      x-fastly-request-id: [87d4d6b74a1e35ce5b1f67c6912bee6c91e20fb3]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['751C:69A1:32B2B:34A51:5ADA5924']
-      x-served-by: [cache-dfw18620-DFW]
-      x-timer: ['S1524259109.757303,VS0,VE77']
+      x-github-request-id: ['8B42:087E:3264C83:3537A38:5AE7836C']
+      x-served-by: [cache-sea1032-SEA]
+      x-timer: ['S1525122182.769613,VS0,VE0']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -146,7 +146,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:18:28 GMT']
+      date: ['Mon, 30 Apr 2018 21:03:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -174,7 +174,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['733']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:18:28 GMT']
+      date: ['Mon, 30 Apr 2018 21:03:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -187,43 +187,43 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"template": {"parameters": {"adminPassword": {"metadata":
-      {"description": "Secure adminPassword"}, "type": "securestring"}}, "$schema":
-      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "variables": {}, "resources": [{"name": "vm1VNET", "apiVersion": "2015-06-15",
-      "tags": {}, "dependsOn": [], "type": "Microsoft.Network/virtualNetworks", "location":
-      "westus", "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
-      "subnets": [{"name": "vm1Subnet", "properties": {"addressPrefix": "10.0.0.0/24"}}]}},
-      {"name": "vm1NSG", "apiVersion": "2015-06-15", "dependsOn": [], "tags": {},
-      "type": "Microsoft.Network/networkSecurityGroups", "location": "westus", "properties":
-      {"securityRules": [{"name": "default-allow-ssh", "properties": {"access": "Allow",
-      "direction": "Inbound", "protocol": "Tcp", "sourcePortRange": "*", "sourceAddressPrefix":
-      "*", "destinationPortRange": "22", "destinationAddressPrefix": "*", "priority":
-      1000}}]}}, {"name": "vm1PublicIP", "apiVersion": "2018-01-01", "dependsOn":
-      [], "tags": {}, "type": "Microsoft.Network/publicIPAddresses", "location": "westus",
-      "properties": {"publicIPAllocationMethod": null}}, {"name": "vm1VMNic", "apiVersion":
-      "2015-06-15", "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET", "Microsoft.Network/networkSecurityGroups/vm1NSG",
-      "Microsoft.Network/publicIpAddresses/vm1PublicIP"], "tags": {}, "type": "Microsoft.Network/networkInterfaces",
-      "location": "westus", "properties": {"ipConfigurations": [{"name": "ipconfigvm1",
-      "properties": {"privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}}}],
-      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"}}},
-      {"name": "1e4ef5d0-433f-4f78-954b-56b0e9dd4bd9", "apiVersion": "2015-07-01",
-      "type": "Microsoft.Authorization/roleAssignments", "properties": {"scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001",
+    body: 'b''{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"adminPassword": {"metadata": {"description":
+      "Secure adminPassword"}, "type": "securestring"}}, "variables": {}, "resources":
+      [{"tags": {}, "name": "vm1VNET", "properties": {"subnets": [{"name": "vm1Subnet",
+      "properties": {"addressPrefix": "10.0.0.0/24"}}], "addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}}, "location": "westus", "dependsOn": [], "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2015-06-15"}, {"tags": {}, "name": "vm1NSG", "properties": {"securityRules":
+      [{"name": "default-allow-ssh", "properties": {"protocol": "Tcp", "direction":
+      "Inbound", "sourcePortRange": "*", "destinationAddressPrefix": "*", "sourceAddressPrefix":
+      "*", "access": "Allow", "priority": 1000, "destinationPortRange": "22"}}]},
+      "location": "westus", "dependsOn": [], "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2015-06-15"}, {"tags": {}, "name": "vm1PublicIP", "properties":
+      {"publicIPAllocationMethod": null}, "location": "westus", "dependsOn": [], "type":
+      "Microsoft.Network/publicIPAddresses", "apiVersion": "2018-01-01"}, {"tags":
+      {}, "name": "vm1VMNic", "properties": {"ipConfigurations": [{"name": "ipconfigvm1",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"}},
+      "location": "westus", "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET",
+      "Microsoft.Network/networkSecurityGroups/vm1NSG", "Microsoft.Network/publicIpAddresses/vm1PublicIP"],
+      "type": "Microsoft.Network/networkInterfaces", "apiVersion": "2015-06-15"},
+      {"name": "5fdbcc3f-e730-4cb3-935f-3086fc782126", "properties": {"scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001",
       "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
       "principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]"}, "dependsOn": ["Microsoft.Compute/virtualMachines/vm1"]},
-      {"name": "vm1", "apiVersion": "2017-12-01", "identity": {"type": "SystemAssigned"},
-      "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"], "tags": {}, "type":
-      "Microsoft.Compute/virtualMachines", "location": "westus", "properties": {"hardwareProfile":
-      {"vmSize": "Standard_DS1_v2"}, "networkProfile": {"networkInterfaces": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      \''2015-08-31-PREVIEW\'').principalId]"}, "dependsOn": ["Microsoft.Compute/virtualMachines/vm1"],
+      "type": "Microsoft.Authorization/roleAssignments", "apiVersion": "2015-07-01"},
+      {"tags": {}, "identity": {"type": "SystemAssigned"}, "name": "vm1", "properties":
+      {"storageProfile": {"imageReference": {"publisher": "credativ", "offer": "Debian",
+      "version": "latest", "sku": "8"}, "osDisk": {"createOption": "fromImage", "managedDisk":
+      {"storageAccountType": null}, "caching": "ReadWrite", "name": null}}, "networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
       "osProfile": {"adminUsername": "admin123", "computerName": "vm1", "adminPassword":
-      "[parameters(\''adminPassword\'')]"}, "storageProfile": {"imageReference": {"offer":
-      "Debian", "publisher": "credativ", "version": "latest", "sku": "8"}, "osDisk":
-      {"managedDisk": {"storageAccountType": null}, "name": null, "caching": "ReadWrite",
-      "createOption": "fromImage"}}}}], "contentVersion": "1.0.0.0", "outputs": {}},
-      "mode": "Incremental", "parameters": {"adminPassword": {"value": "PasswordPassword1!"}}}}'''
+      "[parameters(\''adminPassword\'')]"}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}},
+      "location": "westus", "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"],
+      "type": "Microsoft.Compute/virtualMachines", "apiVersion": "2017-12-01"}], "outputs":
+      {}}, "parameters": {"adminPassword": {"value": "PasswordPassword1!"}}, "mode":
+      "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -238,18 +238,18 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_tFnmFdwx5afFvLVKl6umzPClegqyP8h8","name":"vm_deploy_tFnmFdwx5afFvLVKl6umzPClegqyP8h8","properties":{"templateHash":"11874213004604147869","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T21:18:31.8530897Z","duration":"PT0.5751071S","correlationId":"487789c2-7b44-4fb6-afd8-4fa73c56a0c7","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Authorization/roleAssignments/1e4ef5d0-433f-4f78-954b-56b0e9dd4bd9","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"1e4ef5d0-433f-4f78-954b-56b0e9dd4bd9"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_joT7sqHYupSPL8p5clI7IEpiUUSxq7mz","name":"vm_deploy_joT7sqHYupSPL8p5clI7IEpiUUSxq7mz","properties":{"templateHash":"18111438558746324970","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T21:03:05.8752498Z","duration":"PT0.7486095S","correlationId":"729f5ef3-de3d-4b4f-af14-1c32de6722f4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Authorization/roleAssignments/5fdbcc3f-e730-4cb3-935f-3086fc782126","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"5fdbcc3f-e730-4cb3-935f-3086fc782126"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_tFnmFdwx5afFvLVKl6umzPClegqyP8h8/operationStatuses/08586773477741996505?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_joT7sqHYupSPL8p5clI7IEpiUUSxq7mz/operationStatuses/08586764847003510013?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['3905']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:18:31 GMT']
+      date: ['Mon, 30 Apr 2018 21:03:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -264,14 +264,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773477741996505?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764847003510013?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:19:01 GMT']
+      date: ['Mon, 30 Apr 2018 21:03:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -291,14 +291,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773477741996505?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764847003510013?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:19:32 GMT']
+      date: ['Mon, 30 Apr 2018 21:04:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -318,14 +318,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773477741996505?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764847003510013?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:20:02 GMT']
+      date: ['Mon, 30 Apr 2018 21:04:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -345,14 +345,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773477741996505?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764847003510013?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:20:33 GMT']
+      date: ['Mon, 30 Apr 2018 21:05:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -372,14 +372,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773477741996505?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764847003510013?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:03 GMT']
+      date: ['Mon, 30 Apr 2018 21:05:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -401,12 +401,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_tFnmFdwx5afFvLVKl6umzPClegqyP8h8","name":"vm_deploy_tFnmFdwx5afFvLVKl6umzPClegqyP8h8","properties":{"templateHash":"11874213004604147869","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:20:56.6771937Z","duration":"PT2M25.3992111S","correlationId":"487789c2-7b44-4fb6-afd8-4fa73c56a0c7","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Authorization/roleAssignments/1e4ef5d0-433f-4f78-954b-56b0e9dd4bd9","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"1e4ef5d0-433f-4f78-954b-56b0e9dd4bd9"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Authorization/roleAssignments/1e4ef5d0-433f-4f78-954b-56b0e9dd4bd9"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_joT7sqHYupSPL8p5clI7IEpiUUSxq7mz","name":"vm_deploy_joT7sqHYupSPL8p5clI7IEpiUUSxq7mz","properties":{"templateHash":"18111438558746324970","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T21:05:33.07948Z","duration":"PT2M27.9528397S","correlationId":"729f5ef3-de3d-4b4f-af14-1c32de6722f4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Authorization/roleAssignments/5fdbcc3f-e730-4cb3-935f-3086fc782126","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"5fdbcc3f-e730-4cb3-935f-3086fc782126"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Authorization/roleAssignments/5fdbcc3f-e730-4cb3-935f-3086fc782126"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['5211']
+      content-length: ['5209']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:03 GMT']
+      date: ['Mon, 30 Apr 2018 21:05:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -422,22 +422,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"83f7c5b4-09ec-48fd-8b18-b9b18801eb1d\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"4469c598-11b1-436c-9516-1e172d7b3c31\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_7887647ed86d44aa97959a71079ca7ad\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_d8263c0903d34d08885d42d2b9690053\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_7887647ed86d44aa97959a71079ca7ad\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_d8263c0903d34d08885d42d2b9690053\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -450,22 +450,22 @@ interactions:
         : \"2.2.25\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
         code\": \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\"\
         ,\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\"\
-        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-20T21:21:03+00:00\"\
+        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-30T21:05:41+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_7887647ed86d44aa97959a71079ca7ad\"\
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_d8263c0903d34d08885d42d2b9690053\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2018-04-20T21:19:12.6207923+00:00\"\r\n            }\r\
+        \       \"time\": \"2018-04-30T21:03:41.2384043+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2018-04-20T21:20:42.7891344+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2018-04-30T21:05:13.8275134+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
         ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\
-        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"ee616164-5081-40b7-835d-b6cd07bba588\"\
+        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"b1990c1a-7c9f-4efa-b176-6990dc19820d\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
@@ -473,7 +473,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3137']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:05 GMT']
+      date: ['Mon, 30 Apr 2018 21:05:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -481,7 +481,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4196,Microsoft.Compute/LowCostGet30Min;33576']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33588']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -499,12 +499,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"2df17691-181b-406f-a659-f5a6478de414\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"19050249-6778-4567-b57d-7c1eb3b583ab\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"ea86d313-d64d-4be5-919a-387cb30d9457\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"352854e4-57ff-4d49-bd15-76d9003640cb\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"2df17691-181b-406f-a659-f5a6478de414\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"19050249-6778-4567-b57d-7c1eb3b583ab\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -514,8 +514,8 @@ interactions:
         : \"IPv4\",\r\n          \"isInUseWithService\": false\r\n        }\r\n  \
         \    }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n\
         \      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"\
-        opunxpznyvwefmu1nkxps34yzb.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
-        macAddress\": \"00-0D-3A-37-5B-3A\",\r\n    \"enableAcceleratedNetworking\"\
+        q52ueobbhsye3bhg2hrektrwid.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
+        macAddress\": \"00-0D-3A-32-1A-85\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -526,8 +526,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2596']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:05 GMT']
-      etag: [W/"2df17691-181b-406f-a659-f5a6478de414"]
+      date: ['Mon, 30 Apr 2018 21:05:42 GMT']
+      etag: [W/"19050249-6778-4567-b57d-7c1eb3b583ab"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -552,10 +552,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"cc63ba63-de85-444d-85e5-449678984872\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"32e85821-ed4a-42c2-8ac9-10b34d35a02a\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"6ca2f1f5-be29-4679-b957-26f8eb14db60\"\
-        ,\r\n    \"ipAddress\": \"52.160.67.62\",\r\n    \"publicIPAddressVersion\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"5ff5f9b6-29fb-4c9d-bb1b-ae7469b834a3\"\
+        ,\r\n    \"ipAddress\": \"104.42.58.26\",\r\n    \"publicIPAddressVersion\"\
         : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
         : 4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
@@ -566,8 +566,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1021']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:06 GMT']
-      etag: [W/"cc63ba63-de85-444d-85e5-449678984872"]
+      date: ['Mon, 30 Apr 2018 21:05:42 GMT']
+      etag: [W/"32e85821-ed4a-42c2-8ac9-10b34d35a02a"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -591,12 +591,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001","name":"cli_test_vm_msi000001","location":"westus","tags":{"cause":"automation","date":"2018-04-20T21:18:24Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001","name":"cli_test_vm_msi000001","location":"westus","tags":{"date":"2018-04-30T21:02:57Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:06 GMT']
+      date: ['Mon, 30 Apr 2018 21:05:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -656,9 +656,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:06 GMT']
+      date: ['Mon, 30 Apr 2018 21:05:43 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 21:26:06 GMT']
+      expires: ['Mon, 30 Apr 2018 21:10:43 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -666,12 +666,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [36f676f2ef3666ea11dc2eb5cc811bf3c132499a]
+      x-fastly-request-id: [e386b4446be8262d26e11192656d4f12ff863195]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['1EDA:087E:FF93E2:10DEA8F:5ADA59C2']
-      x-served-by: [cache-sea1050-SEA]
-      x-timer: ['S1524259267.687110,VS0,VE93']
+      x-github-request-id: ['D3D6:087E:3269FAD:353D239:5AE78527']
+      x-served-by: [cache-sea1036-SEA]
+      x-timer: ['S1525122343.483063,VS0,VE121']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -691,15 +691,15 @@ interactions:
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"c919ed9f-fd9a-4760-bff7-716f9ed67ef7\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"178bbfc8-f0bd-4fd0-a36c-1ef97fc0b7ae\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"bfdbe873-c52d-426c-b29b-6aaef977d8c9\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"3842f987-3c21-4eb0-84e6-e1e2454e3643\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vm1Subnet\",\r\n           \
         \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"c919ed9f-fd9a-4760-bff7-716f9ed67ef7\\\"\
+        ,\r\n            \"etag\": \"W/\\\"178bbfc8-f0bd-4fd0-a36c-1ef97fc0b7ae\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
@@ -712,7 +712,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1684']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:06 GMT']
+      date: ['Mon, 30 Apr 2018 21:05:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -742,7 +742,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['615']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:07 GMT']
+      date: ['Mon, 30 Apr 2018 21:05:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -755,41 +755,41 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"template": {"parameters": {"adminPassword": {"metadata":
-      {"description": "Secure adminPassword"}, "type": "securestring"}}, "$schema":
-      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "variables": {}, "resources": [{"name": "vm2NSG", "apiVersion": "2015-06-15",
-      "dependsOn": [], "tags": {}, "type": "Microsoft.Network/networkSecurityGroups",
-      "location": "westus", "properties": {"securityRules": [{"name": "rdp", "properties":
-      {"access": "Allow", "direction": "Inbound", "protocol": "Tcp", "sourcePortRange":
-      "*", "sourceAddressPrefix": "*", "destinationPortRange": "3389", "destinationAddressPrefix":
-      "*", "priority": 1000}}]}}, {"name": "vm2PublicIP", "apiVersion": "2018-01-01",
-      "dependsOn": [], "tags": {}, "type": "Microsoft.Network/publicIPAddresses",
-      "location": "westus", "properties": {"publicIPAllocationMethod": null}}, {"name":
-      "vm2VMNic", "apiVersion": "2015-06-15", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm2NSG",
-      "Microsoft.Network/publicIpAddresses/vm2PublicIP"], "tags": {}, "type": "Microsoft.Network/networkInterfaces",
-      "location": "westus", "properties": {"ipConfigurations": [{"name": "ipconfigvm2",
-      "properties": {"privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}}}],
-      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"}}},
-      {"name": "vm1/Microsoft.Authorization/92cadef5-177b-4c30-8a6f-0aba78b296f8",
-      "apiVersion": "2015-07-01", "type": "Microsoft.Compute/virtualMachines/providers/roleAssignments",
+    body: 'b''{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"adminPassword": {"metadata": {"description":
+      "Secure adminPassword"}, "type": "securestring"}}, "variables": {}, "resources":
+      [{"tags": {}, "name": "vm2NSG", "properties": {"securityRules": [{"name": "rdp",
+      "properties": {"protocol": "Tcp", "direction": "Inbound", "sourcePortRange":
+      "*", "destinationAddressPrefix": "*", "sourceAddressPrefix": "*", "access":
+      "Allow", "priority": 1000, "destinationPortRange": "3389"}}]}, "location": "westus",
+      "dependsOn": [], "type": "Microsoft.Network/networkSecurityGroups", "apiVersion":
+      "2015-06-15"}, {"tags": {}, "name": "vm2PublicIP", "properties": {"publicIPAllocationMethod":
+      null}, "location": "westus", "dependsOn": [], "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2018-01-01"}, {"tags": {}, "name": "vm2VMNic", "properties":
+      {"ipConfigurations": [{"name": "ipconfigvm2", "properties": {"subnet": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"}},
+      "location": "westus", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm2NSG",
+      "Microsoft.Network/publicIpAddresses/vm2PublicIP"], "type": "Microsoft.Network/networkInterfaces",
+      "apiVersion": "2015-06-15"}, {"name": "vm1/Microsoft.Authorization/38af785c-da80-4270-8d5e-2bd3144df442",
       "properties": {"scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1",
       "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
       "principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]"}, "dependsOn": ["Microsoft.Compute/virtualMachines/vm2"]},
-      {"name": "vm2", "apiVersion": "2017-12-01", "identity": {"type": "SystemAssigned"},
-      "dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"], "tags": {}, "type":
-      "Microsoft.Compute/virtualMachines", "location": "westus", "properties": {"hardwareProfile":
-      {"vmSize": "Standard_DS1_v2"}, "networkProfile": {"networkInterfaces": [{"id":
+      \''2015-08-31-PREVIEW\'').principalId]"}, "dependsOn": ["Microsoft.Compute/virtualMachines/vm2"],
+      "type": "Microsoft.Compute/virtualMachines/providers/roleAssignments", "apiVersion":
+      "2015-07-01"}, {"tags": {}, "identity": {"type": "SystemAssigned"}, "name":
+      "vm2", "properties": {"storageProfile": {"imageReference": {"publisher": "MicrosoftWindowsServer",
+      "offer": "WindowsServer", "version": "latest", "sku": "2016-Datacenter"}, "osDisk":
+      {"createOption": "fromImage", "managedDisk": {"storageAccountType": null}, "caching":
+      "ReadWrite", "name": null}}, "networkProfile": {"networkInterfaces": [{"id":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
       "osProfile": {"adminUsername": "admin123", "computerName": "vm2", "adminPassword":
-      "[parameters(\''adminPassword\'')]"}, "storageProfile": {"imageReference": {"offer":
-      "WindowsServer", "publisher": "MicrosoftWindowsServer", "version": "latest",
-      "sku": "2016-Datacenter"}, "osDisk": {"managedDisk": {"storageAccountType":
-      null}, "name": null, "caching": "ReadWrite", "createOption": "fromImage"}}}}],
-      "contentVersion": "1.0.0.0", "outputs": {}}, "mode": "Incremental", "parameters":
-      {"adminPassword": {"value": "PasswordPassword1!"}}}}'''
+      "[parameters(\''adminPassword\'')]"}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}},
+      "location": "westus", "dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"],
+      "type": "Microsoft.Compute/virtualMachines", "apiVersion": "2017-12-01"}], "outputs":
+      {}}, "parameters": {"adminPassword": {"value": "PasswordPassword1!"}}, "mode":
+      "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -804,18 +804,18 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_dkGLIICynL7EfWsQZgd0YkKvzm5RktVR","name":"vm_deploy_dkGLIICynL7EfWsQZgd0YkKvzm5RktVR","properties":{"templateHash":"4049160538728599299","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T21:21:09.274328Z","duration":"PT0.6241502S","correlationId":"1e288efb-0b82-4fbe-b649-68e8e8b2d067","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/92cadef5-177b-4c30-8a6f-0aba78b296f8","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/92cadef5-177b-4c30-8a6f-0aba78b296f8"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_qXtbR6QOoYn3UbzPlkBZKukcfa7lW9On","name":"vm_deploy_qXtbR6QOoYn3UbzPlkBZKukcfa7lW9On","properties":{"templateHash":"2128722026096851522","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T21:05:47.9324367Z","duration":"PT0.6352694S","correlationId":"ff37ec24-f44c-454c-a761-86a1710f9a50","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/38af785c-da80-4270-8d5e-2bd3144df442","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/38af785c-da80-4270-8d5e-2bd3144df442"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_dkGLIICynL7EfWsQZgd0YkKvzm5RktVR/operationStatuses/08586773476168274500?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_qXtbR6QOoYn3UbzPlkBZKukcfa7lW9On/operationStatuses/08586764845381804701?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['3629']
+      content-length: ['3630']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:08 GMT']
+      date: ['Mon, 30 Apr 2018 21:05:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -830,14 +830,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:21:39 GMT']
+      date: ['Mon, 30 Apr 2018 21:06:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -857,14 +857,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:22:09 GMT']
+      date: ['Mon, 30 Apr 2018 21:06:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -884,14 +884,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:22:39 GMT']
+      date: ['Mon, 30 Apr 2018 21:07:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -911,14 +911,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:23:09 GMT']
+      date: ['Mon, 30 Apr 2018 21:07:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -938,14 +938,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:23:40 GMT']
+      date: ['Mon, 30 Apr 2018 21:08:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -965,14 +965,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:24:11 GMT']
+      date: ['Mon, 30 Apr 2018 21:08:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -992,14 +992,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:24:41 GMT']
+      date: ['Mon, 30 Apr 2018 21:09:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1019,14 +1019,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:25:12 GMT']
+      date: ['Mon, 30 Apr 2018 21:09:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1046,14 +1046,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:25:42 GMT']
+      date: ['Mon, 30 Apr 2018 21:10:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1073,14 +1073,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:26:12 GMT']
+      date: ['Mon, 30 Apr 2018 21:10:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1100,203 +1100,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:26:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:27:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:27:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:28:14 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:28:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:29:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:29:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773476168274500?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764845381804701?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:15 GMT']
+      date: ['Mon, 30 Apr 2018 21:11:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1318,12 +1129,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_dkGLIICynL7EfWsQZgd0YkKvzm5RktVR","name":"vm_deploy_dkGLIICynL7EfWsQZgd0YkKvzm5RktVR","properties":{"templateHash":"4049160538728599299","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:29:58.5874615Z","duration":"PT8M49.9372837S","correlationId":"1e288efb-0b82-4fbe-b649-68e8e8b2d067","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/92cadef5-177b-4c30-8a6f-0aba78b296f8","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/92cadef5-177b-4c30-8a6f-0aba78b296f8"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/92cadef5-177b-4c30-8a6f-0aba78b296f8"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_qXtbR6QOoYn3UbzPlkBZKukcfa7lW9On","name":"vm_deploy_qXtbR6QOoYn3UbzPlkBZKukcfa7lW9On","properties":{"templateHash":"2128722026096851522","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T21:10:57.859828Z","duration":"PT5M10.5626607S","correlationId":"ff37ec24-f44c-454c-a761-86a1710f9a50","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/38af785c-da80-4270-8d5e-2bd3144df442","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/38af785c-da80-4270-8d5e-2bd3144df442"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/38af785c-da80-4270-8d5e-2bd3144df442"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['4780']
+      content-length: ['4779']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:15 GMT']
+      date: ['Mon, 30 Apr 2018 21:11:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1339,22 +1150,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2?$expand=instanceView&api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bea17dbf-2d88-4b59-a2ff-6d115f52d995\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"6f55907e-02ee-49b1-a3e8-ea4afd7b74cd\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"\
         WindowsServer\",\r\n        \"sku\": \"2016-Datacenter\",\r\n        \"version\"\
         : \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"\
-        Windows\",\r\n        \"name\": \"vm2_OsDisk_1_34414f4d31ef491b8b65c123ba640404\"\
+        Windows\",\r\n        \"name\": \"vm2_OsDisk_1_180834d688c34d5da9eb57b2ddbf0d57\"\
         ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_34414f4d31ef491b8b65c123ba640404\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_180834d688c34d5da9eb57b2ddbf0d57\"\
         \r\n        },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"windowsConfiguration\"\
@@ -1366,30 +1177,30 @@ interactions:
         \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/Unavailable\"\
         ,\r\n            \"level\": \"Warning\",\r\n            \"displayStatus\"\
         : \"Not Ready\",\r\n            \"message\": \"VM status blob is found but\
-        \ not yet populated.\",\r\n            \"time\": \"2018-04-20T21:30:17+00:00\"\
+        \ not yet populated.\",\r\n            \"time\": \"2018-04-30T21:11:28+00:00\"\
         \r\n          }\r\n        ]\r\n      },\r\n      \"disks\": [\r\n       \
-        \ {\r\n          \"name\": \"vm2_OsDisk_1_34414f4d31ef491b8b65c123ba640404\"\
+        \ {\r\n          \"name\": \"vm2_OsDisk_1_180834d688c34d5da9eb57b2ddbf0d57\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2018-04-20T21:21:35.4508996+00:00\"\r\n            }\r\
+        \       \"time\": \"2018-04-30T21:06:13.8320004+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2018-04-20T21:29:27.3181984+00:00\"\r\n       \
-        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
-        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
-        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
+        ,\r\n          \"time\": \"2018-04-30T21:10:30.785149+00:00\"\r\n        },\r\
+        \n        {\r\n          \"code\": \"PowerState/running\",\r\n          \"\
+        level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n    \
+        \    }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
         ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\
-        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"be47d0a0-5201-4f3e-b414-1b87e1cf3288\"\
+        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"aae3eec4-a965-40d5-86c0-86f0b6476054\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm2\"\
         ,\r\n  \"name\": \"vm2\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3119']
+      content-length: ['3118']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:16 GMT']
+      date: ['Mon, 30 Apr 2018 21:11:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1397,7 +1208,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4192,Microsoft.Compute/LowCostGet30Min;33583']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33586']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1415,12 +1226,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"20f30f5f-8482-4350-bb19-186a2e20756b\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"2baec5a0-4667-4786-a95a-ef04d070c64a\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"96128e65-1d69-40ba-a080-a12c9ccaaa64\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8b29221a-980e-40c0-b5ea-be9d28f0fd37\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm2\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
-        ,\r\n        \"etag\": \"W/\\\"20f30f5f-8482-4350-bb19-186a2e20756b\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"2baec5a0-4667-4786-a95a-ef04d070c64a\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -1430,8 +1241,8 @@ interactions:
         : \"IPv4\",\r\n          \"isInUseWithService\": false\r\n        }\r\n  \
         \    }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n\
         \      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"\
-        opunxpznyvwefmu1nkxps34yzb.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
-        macAddress\": \"00-0D-3A-37-5A-8C\",\r\n    \"enableAcceleratedNetworking\"\
+        q52ueobbhsye3bhg2hrektrwid.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
+        macAddress\": \"00-0D-3A-32-16-40\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -1442,8 +1253,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2596']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:17 GMT']
-      etag: [W/"20f30f5f-8482-4350-bb19-186a2e20756b"]
+      date: ['Mon, 30 Apr 2018 21:11:29 GMT']
+      etag: [W/"2baec5a0-4667-4786-a95a-ef04d070c64a"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1468,10 +1279,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"d8aed0c0-9ea7-44ba-a2af-2862466814df\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"52759593-c909-4bbc-879f-af63dd13cd16\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"883d2515-0162-40f3-a470-242b7170054c\"\
-        ,\r\n    \"ipAddress\": \"52.160.65.68\",\r\n    \"publicIPAddressVersion\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"f851ecb8-e568-401d-aaf0-07725b651f0c\"\
+        ,\r\n    \"ipAddress\": \"104.42.56.37\",\r\n    \"publicIPAddressVersion\"\
         : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
         : 4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
@@ -1482,8 +1293,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1021']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:17 GMT']
-      etag: [W/"d8aed0c0-9ea7-44ba-a2af-2862466814df"]
+      date: ['Mon, 30 Apr 2018 21:11:29 GMT']
+      etag: [W/"52759593-c909-4bbc-879f-af63dd13cd16"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1507,12 +1318,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001","name":"cli_test_vm_msi000001","location":"westus","tags":{"cause":"automation","date":"2018-04-20T21:18:24Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001","name":"cli_test_vm_msi000001","location":"westus","tags":{"date":"2018-04-30T21:02:57Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:18 GMT']
+      date: ['Mon, 30 Apr 2018 21:11:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1572,9 +1383,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:18 GMT']
+      date: ['Mon, 30 Apr 2018 21:11:31 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 21:35:18 GMT']
+      expires: ['Mon, 30 Apr 2018 21:16:31 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -1582,12 +1393,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [918535a0159b76abf711f9bc332470a2f4199a0d]
+      x-fastly-request-id: [026472bdb4798403c7bf6c22c9a16477b38836bd]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['6FD6:087E:FFE90C:10E4561:5ADA5BEA']
-      x-served-by: [cache-sea1028-SEA]
-      x-timer: ['S1524259818.329513,VS0,VE90']
+      x-github-request-id: ['6DB2:087B:2B6B7E9:2DF59DE:5AE78683']
+      x-served-by: [cache-sea1036-SEA]
+      x-timer: ['S1525122691.077235,VS0,VE92']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -1607,15 +1418,15 @@ interactions:
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"86fbe60f-5944-45b1-bb1d-16de8771fc2e\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"08322562-0ee5-432a-8910-bde9de494cac\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"bfdbe873-c52d-426c-b29b-6aaef977d8c9\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"3842f987-3c21-4eb0-84e6-e1e2454e3643\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vm1Subnet\",\r\n           \
         \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"86fbe60f-5944-45b1-bb1d-16de8771fc2e\\\"\
+        ,\r\n            \"etag\": \"W/\\\"08322562-0ee5-432a-8910-bde9de494cac\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
@@ -1630,7 +1441,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1977']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:18 GMT']
+      date: ['Mon, 30 Apr 2018 21:11:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1640,33 +1451,34 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"template": {"parameters": {"adminPassword": {"metadata":
-      {"description": "Secure adminPassword"}, "type": "securestring"}}, "$schema":
-      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "variables": {}, "resources": [{"name": "vm3NSG", "apiVersion": "2015-06-15",
-      "dependsOn": [], "tags": {}, "type": "Microsoft.Network/networkSecurityGroups",
-      "location": "westus", "properties": {"securityRules": [{"name": "default-allow-ssh",
-      "properties": {"access": "Allow", "direction": "Inbound", "protocol": "Tcp",
-      "sourcePortRange": "*", "sourceAddressPrefix": "*", "destinationPortRange":
-      "22", "destinationAddressPrefix": "*", "priority": 1000}}]}}, {"name": "vm3PublicIP",
-      "apiVersion": "2018-01-01", "dependsOn": [], "tags": {}, "type": "Microsoft.Network/publicIPAddresses",
-      "location": "westus", "properties": {"publicIPAllocationMethod": null}}, {"name":
-      "vm3VMNic", "apiVersion": "2015-06-15", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm3NSG",
-      "Microsoft.Network/publicIpAddresses/vm3PublicIP"], "tags": {}, "type": "Microsoft.Network/networkInterfaces",
-      "location": "westus", "properties": {"ipConfigurations": [{"name": "ipconfigvm3",
-      "properties": {"privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}}}],
-      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"}}},
-      {"name": "vm3", "apiVersion": "2017-12-01", "dependsOn": ["Microsoft.Network/networkInterfaces/vm3VMNic"],
-      "tags": {}, "type": "Microsoft.Compute/virtualMachines", "location": "westus",
-      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile":
-      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"}]},
+    body: 'b''{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"adminPassword": {"metadata": {"description":
+      "Secure adminPassword"}, "type": "securestring"}}, "variables": {}, "resources":
+      [{"tags": {}, "name": "vm3NSG", "properties": {"securityRules": [{"name": "default-allow-ssh",
+      "properties": {"protocol": "Tcp", "direction": "Inbound", "sourcePortRange":
+      "*", "destinationAddressPrefix": "*", "sourceAddressPrefix": "*", "access":
+      "Allow", "priority": 1000, "destinationPortRange": "22"}}]}, "location": "westus",
+      "dependsOn": [], "type": "Microsoft.Network/networkSecurityGroups", "apiVersion":
+      "2015-06-15"}, {"tags": {}, "name": "vm3PublicIP", "properties": {"publicIPAllocationMethod":
+      null}, "location": "westus", "dependsOn": [], "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2018-01-01"}, {"tags": {}, "name": "vm3VMNic", "properties":
+      {"ipConfigurations": [{"name": "ipconfigvm3", "properties": {"subnet": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"}},
+      "location": "westus", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm3NSG",
+      "Microsoft.Network/publicIpAddresses/vm3PublicIP"], "type": "Microsoft.Network/networkInterfaces",
+      "apiVersion": "2015-06-15"}, {"tags": {}, "name": "vm3", "properties": {"storageProfile":
+      {"imageReference": {"publisher": "credativ", "offer": "Debian", "version": "latest",
+      "sku": "8"}, "osDisk": {"createOption": "fromImage", "managedDisk": {"storageAccountType":
+      null}, "caching": "ReadWrite", "name": null}}, "networkProfile": {"networkInterfaces":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"}]},
       "osProfile": {"adminUsername": "admin123", "computerName": "vm3", "adminPassword":
-      "[parameters(\''adminPassword\'')]"}, "storageProfile": {"imageReference": {"offer":
-      "Debian", "publisher": "credativ", "version": "latest", "sku": "8"}, "osDisk":
-      {"managedDisk": {"storageAccountType": null}, "name": null, "caching": "ReadWrite",
-      "createOption": "fromImage"}}}}], "contentVersion": "1.0.0.0", "outputs": {}},
-      "mode": "Incremental", "parameters": {"adminPassword": {"value": "PasswordPassword1!"}}}}'''
+      "[parameters(\''adminPassword\'')]"}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}},
+      "location": "westus", "dependsOn": ["Microsoft.Network/networkInterfaces/vm3VMNic"],
+      "type": "Microsoft.Compute/virtualMachines", "apiVersion": "2017-12-01"}], "outputs":
+      {}}, "parameters": {"adminPassword": {"value": "PasswordPassword1!"}}, "mode":
+      "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1681,18 +1493,18 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_S6ZlN9Jbg3zPat3RrEf2UE5lFJVfQAko","name":"vm_deploy_S6ZlN9Jbg3zPat3RrEf2UE5lFJVfQAko","properties":{"templateHash":"1363635709474109453","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T21:30:20.8386022Z","duration":"PT0.7942045S","correlationId":"5ca29644-b787-45ef-9edc-6600cea8a874","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_ukd9dqDfTTkPpeqDtun3FVy36OJdliQd","name":"vm_deploy_ukd9dqDfTTkPpeqDtun3FVy36OJdliQd","properties":{"templateHash":"5941642201138359549","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T21:11:34.2609191Z","duration":"PT0.6038312S","correlationId":"ed9a54b3-1297-4253-9239-0adeda378c3f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_S6ZlN9Jbg3zPat3RrEf2UE5lFJVfQAko/operationStatuses/08586773470654332240?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_ukd9dqDfTTkPpeqDtun3FVy36OJdliQd/operationStatuses/08586764841918205473?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['2402']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:20 GMT']
+      date: ['Mon, 30 Apr 2018 21:11:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1707,14 +1519,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773470654332240?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764841918205473?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:30:50 GMT']
+      date: ['Mon, 30 Apr 2018 21:12:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1734,14 +1546,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773470654332240?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764841918205473?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:31:21 GMT']
+      date: ['Mon, 30 Apr 2018 21:12:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1761,14 +1573,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773470654332240?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764841918205473?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:31:51 GMT']
+      date: ['Mon, 30 Apr 2018 21:13:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1788,14 +1600,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773470654332240?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764841918205473?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:32:22 GMT']
+      date: ['Mon, 30 Apr 2018 21:13:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1815,14 +1627,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773470654332240?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764841918205473?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:32:53 GMT']
+      date: ['Mon, 30 Apr 2018 21:14:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1844,12 +1656,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_S6ZlN9Jbg3zPat3RrEf2UE5lFJVfQAko","name":"vm_deploy_S6ZlN9Jbg3zPat3RrEf2UE5lFJVfQAko","properties":{"templateHash":"1363635709474109453","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:32:31.17814Z","duration":"PT2M11.1337423S","correlationId":"5ca29644-b787-45ef-9edc-6600cea8a874","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Resources/deployments/vm_deploy_ukd9dqDfTTkPpeqDtun3FVy36OJdliQd","name":"vm_deploy_ukd9dqDfTTkPpeqDtun3FVy36OJdliQd","properties":{"templateHash":"5941642201138359549","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T21:13:50.0401187Z","duration":"PT2M16.3830308S","correlationId":"ed9a54b3-1297-4253-9239-0adeda378c3f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3263']
+      content-length: ['3265']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:32:53 GMT']
+      date: ['Mon, 30 Apr 2018 21:14:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1865,22 +1677,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3?$expand=instanceView&api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3?api-version=2017-12-01&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"01be29e9-117d-4fe8-9bbd-baf99d4416d5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"adf777ca-9816-47f9-8d53-0498a7f4649d\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_8093de9691844ecea059e2ee56f9407f\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8093de9691844ecea059e2ee56f9407f\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -1893,17 +1705,17 @@ interactions:
         : \"2.2.25\",\r\n        \"statuses\": [\r\n          {\r\n            \"\
         code\": \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\"\
         ,\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\"\
-        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-20T21:32:51+00:00\"\
+        : \"Guest Agent is running\",\r\n            \"time\": \"2018-04-30T21:14:10+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20\"\
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm3_OsDisk_1_8093de9691844ecea059e2ee56f9407f\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2018-04-20T21:30:52.9786437+00:00\"\r\n            }\r\
+        \       \"time\": \"2018-04-30T21:12:05.3241942+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2018-04-20T21:32:18.1068985+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2018-04-30T21:13:41.3228392+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
@@ -1913,7 +1725,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2967']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:32:54 GMT']
+      date: ['Mon, 30 Apr 2018 21:14:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1921,7 +1733,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4188,Microsoft.Compute/LowCostGet30Min;33572']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4192,Microsoft.Compute/LowCostGet30Min;33578']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1939,12 +1751,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm3VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"dad94413-9ffc-45ec-9dbd-49351f9176ce\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"efa33b28-6ecf-4088-8614-1f184d354a5b\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"be9ec628-dce1-4d23-932d-84ad76d3043f\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"2cbddee8-faec-40ec-a7ec-6f8486f04bad\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm3\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic/ipConfigurations/ipconfigvm3\"\
-        ,\r\n        \"etag\": \"W/\\\"dad94413-9ffc-45ec-9dbd-49351f9176ce\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"efa33b28-6ecf-4088-8614-1f184d354a5b\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.6\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -1954,8 +1766,8 @@ interactions:
         : \"IPv4\",\r\n          \"isInUseWithService\": false\r\n        }\r\n  \
         \    }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n\
         \      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"\
-        opunxpznyvwefmu1nkxps34yzb.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
-        macAddress\": \"00-0D-3A-36-B7-D6\",\r\n    \"enableAcceleratedNetworking\"\
+        q52ueobbhsye3bhg2hrektrwid.dx.internal.cloudapp.net\"\r\n    },\r\n    \"\
+        macAddress\": \"00-0D-3A-32-2E-71\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -1966,8 +1778,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2596']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:32:54 GMT']
-      etag: [W/"dad94413-9ffc-45ec-9dbd-49351f9176ce"]
+      date: ['Mon, 30 Apr 2018 21:14:10 GMT']
+      etag: [W/"efa33b28-6ecf-4088-8614-1f184d354a5b"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1992,10 +1804,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm3PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"d2ecc140-dccc-4762-8458-a2fc6aa87023\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"5a0c70e2-1a67-4fd7-bc59-0626844adee5\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"639e7b2e-5cb7-448a-bb00-5d99d02684a5\"\
-        ,\r\n    \"ipAddress\": \"13.91.241.84\",\r\n    \"publicIPAddressVersion\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"540a7d7e-125f-41aa-b4c4-707732081fd7\"\
+        ,\r\n    \"ipAddress\": \"104.42.62.212\",\r\n    \"publicIPAddressVersion\"\
         : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
         : 4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic/ipConfigurations/ipconfigvm3\"\
@@ -2004,10 +1816,10 @@ interactions:
         \n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1021']
+      content-length: ['1022']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:32:55 GMT']
-      etag: [W/"d2ecc140-dccc-4762-8458-a2fc6aa87023"]
+      date: ['Mon, 30 Apr 2018 21:14:11 GMT']
+      etag: [W/"5a0c70e2-1a67-4fd7-bc59-0626844adee5"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2037,7 +1849,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['615']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:32:55 GMT']
+      date: ['Mon, 30 Apr 2018 21:14:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -2058,22 +1870,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"01be29e9-117d-4fe8-9bbd-baf99d4416d5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"adf777ca-9816-47f9-8d53-0498a7f4649d\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_8093de9691844ecea059e2ee56f9407f\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8093de9691844ecea059e2ee56f9407f\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -2088,7 +1900,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1709']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:33:06 GMT']
+      date: ['Mon, 30 Apr 2018 21:14:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2096,43 +1908,34 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4187,Microsoft.Compute/LowCostGet30Min;33571']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4191,Microsoft.Compute/LowCostGet30Min;33577']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"tags": {}, "location": "westus", "identity": {"type": "SystemAssigned"},
-      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile":
-      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"}]},
-      "storageProfile": {"dataDisks": [], "imageReference": {"offer": "Debian", "publisher":
-      "credativ", "version": "latest", "sku": "8"}, "osDisk": {"name": "vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20",
-      "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20",
-      "storageAccountType": "Premium_LRS"}, "diskSizeGB": 30, "osType": "Linux", "caching":
-      "ReadWrite", "createOption": "FromImage"}}, "osProfile": {"adminUsername": "admin123",
-      "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication": false},
-      "computerName": "vm3"}}}'''
+    body: '{"identity": {"type": "SystemAssigned"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm identity assign]
       Connection: [keep-alive]
-      Content-Length: ['1117']
+      Content-Length: ['40']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"01be29e9-117d-4fe8-9bbd-baf99d4416d5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"adf777ca-9816-47f9-8d53-0498a7f4649d\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_8093de9691844ecea059e2ee56f9407f\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8093de9691844ecea059e2ee56f9407f\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -2142,16 +1945,16 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
         tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\",\r\n\
-        \    \"principalId\": \"95c9dbaa-f0af-443d-97e7-9e0bf938d2c8\",\r\n    \"\
+        \    \"principalId\": \"fd2ecb00-bc85-4aa1-b08b-b6e520d2c8b1\",\r\n    \"\
         tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3\"\
         ,\r\n  \"name\": \"vm3\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/b485f388-3fb3-4b97-b8fc-f20a15be853b?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/6f4f17eb-f2c3-4e10-a89e-35afda208f2c?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['1878']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:33:08 GMT']
+      date: ['Mon, 30 Apr 2018 21:14:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2170,19 +1973,19 @@ interactions:
       CommandName: [vm identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/b485f388-3fb3-4b97-b8fc-f20a15be853b?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/6f4f17eb-f2c3-4e10-a89e-35afda208f2c?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:33:08.6401676+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T21:33:20.5527614+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"b485f388-3fb3-4b97-b8fc-f20a15be853b\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T21:14:25.2923352+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T21:14:44.5270261+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"6f4f17eb-f2c3-4e10-a89e-35afda208f2c\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:33:39 GMT']
+      date: ['Mon, 30 Apr 2018 21:14:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2190,7 +1993,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29908']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29858']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2200,21 +2003,21 @@ interactions:
       CommandName: [vm identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"01be29e9-117d-4fe8-9bbd-baf99d4416d5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"adf777ca-9816-47f9-8d53-0498a7f4649d\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_8093de9691844ecea059e2ee56f9407f\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_32bdd680698b431688438ff9aec99c20\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8093de9691844ecea059e2ee56f9407f\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -2224,7 +2027,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
         tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\",\r\n\
-        \    \"principalId\": \"95c9dbaa-f0af-443d-97e7-9e0bf938d2c8\",\r\n    \"\
+        \    \"principalId\": \"fd2ecb00-bc85-4aa1-b08b-b6e520d2c8b1\",\r\n    \"\
         tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm3\"\
         ,\r\n  \"name\": \"vm3\"\r\n}"}
@@ -2232,7 +2035,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1879']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:33:39 GMT']
+      date: ['Mon, 30 Apr 2018 21:14:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2240,11 +2043,11 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4184,Microsoft.Compute/LowCostGet30Min;33567']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4190,Microsoft.Compute/LowCostGet30Min;33576']
     status: {code: 200, message: OK}
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
-      "principalId": "95c9dbaa-f0af-443d-97e7-9e0bf938d2c8"}}'
+      "principalId": "fd2ecb00-bc85-4aa1-b08b-b6e520d2c8b1"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -2259,19 +2062,19 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2018-01-01-preview
   response:
-    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"95c9dbaa-f0af-443d-97e7-9e0bf938d2c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","createdOn":"2018-04-20T21:33:41.0731186Z","updatedOn":"2018-04-20T21:33:41.0731186Z","createdBy":null,"updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'}
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"fd2ecb00-bc85-4aa1-b08b-b6e520d2c8b1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1","createdOn":"2018-04-30T21:14:58.6590559Z","updatedOn":"2018-04-30T21:14:58.6590559Z","createdBy":null,"updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_msi000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['999']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:33:44 GMT']
+      date: ['Mon, 30 Apr 2018 21:15:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
       set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
       x-ms-request-charge: ['5']
       x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
@@ -2295,12 +2098,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 20 Apr 2018 21:33:46 GMT']
+      date: ['Mon, 30 Apr 2018 21:15:04 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGVk06NUZNU0lYQ0ozWlBEQjc0RTNZU1ZTS0dYRUFFNU1RM3wzNjNBNzg2QzA2MTdCMTgxLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGVk06NUZNU0lUVkJNV1hFWlFQN09PM1JFWFRTSTRTVVlJSXw4REM0MTVEQjFENzlEQ0UzLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_explicit_msi.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_explicit_msi.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"tags": {"cause": "automation", "product": "azurecli", "date": "2018-04-20T21:41:01Z"},
-      "location": "westcentralus"}'
+    body: '{"tags": {"cause": "automation", "date": "2018-04-30T20:58:10Z", "product":
+      "azurecli"}, "location": "westcentralus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -16,17 +16,17 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-20T21:41:01Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"cause":"automation","date":"2018-04-30T20:58:10Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['281']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:03 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -43,12 +43,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-20T21:41:01Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"cause":"automation","date":"2018-04-30T20:58:10Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['281']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:04 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -70,12 +70,12 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1?api-version=2015-08-31-preview
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1","name":"id1","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"89905265-de1d-455e-b992-34df86b0f58c","clientId":"0414a8fc-0c45-43af-8422-8a4ff15190bd","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=89905265-de1d-455e-b992-34df86b0f58c&aid=0414a8fc-0c45-43af-8422-8a4ff15190bd"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1","name":"id1","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"411f3cf8-18db-4ff6-88f9-b130e807914d","clientId":"c6ac9f14-7f00-4629-87d1-8cd5dcf73644","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=411f3cf8-18db-4ff6-88f9-b130e807914d&aid=c6ac9f14-7f00-4629-87d1-8cd5dcf73644"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['789']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:05 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:16 GMT']
       expires: ['-1']
       location: [/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1]
       pragma: [no-cache]
@@ -99,12 +99,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-20T21:41:01Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"cause":"automation","date":"2018-04-30T20:58:10Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['281']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:05 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -126,12 +126,12 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2?api-version=2015-08-31-preview
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2","name":"id2","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"2beb3526-88fc-4e05-a3b7-ded1a4a82dbf","clientId":"f131b1f9-a147-4942-a9d9-59090d5325a4","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=2beb3526-88fc-4e05-a3b7-ded1a4a82dbf&aid=f131b1f9-a147-4942-a9d9-59090d5325a4"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2","name":"id2","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"westcentralus","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"67c4d28f-b818-4ad4-9188-a562d359b80a","clientId":"36787699-5c63-4076-a19a-aac664a508b4","clientSecretUrl":"https://control-westcentralus.identity.azure.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2/credentials?tid=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a&oid=67c4d28f-b818-4ad4-9188-a562d359b80a&aid=36787699-5c63-4076-a19a-aac664a508b4"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['789']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:08 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:18 GMT']
       expires: ['-1']
       location: [/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2]
       pragma: [no-cache]
@@ -155,12 +155,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-20T21:41:01Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westcentralus","tags":{"cause":"automation","date":"2018-04-30T20:58:10Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['281']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:08 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -220,9 +220,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:09 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:20 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 21:46:09 GMT']
+      expires: ['Mon, 30 Apr 2018 21:03:20 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -230,12 +230,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [d2e2d77797449383ba6f0fb50ce21a6961317c60]
+      x-fastly-request-id: [d2367021e1ef6ef630750edf1db9a0e4064c4c0c]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['AE36:69A1:49F3A:4CD23:5ADA5E75']
-      x-served-by: [cache-dfw18628-DFW]
-      x-timer: ['S1524260469.394502,VS0,VE38']
+      x-github-request-id: ['8B42:087E:3264C83:3537A38:5AE7836C']
+      x-served-by: [cache-sea1021-SEA]
+      x-timer: ['S1525121901.758845,VS0,VE99']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -258,7 +258,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:09 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -286,7 +286,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['615']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:09 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -299,51 +299,50 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"parameters": {}, "template": {"outputs": {"VMSS": {"value":
-      "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'', \''vmss1\''),providers(\''Microsoft.Compute\'',
-      \''virtualMachineScaleSets\'').apiVersions[0])]", "type": "object"}}, "$schema":
-      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "resources": [{"type": "Microsoft.Network/virtualNetworks",
-      "name": "vmss1VNET", "dependsOn": [], "properties": {"subnets": [{"properties":
-      {"addressPrefix": "10.0.0.0/24"}, "name": "vmss1Subnet"}], "addressSpace": {"addressPrefixes":
-      ["10.0.0.0/16"]}}, "location": "westcentralus", "tags": {}, "apiVersion": "2015-06-15"},
-      {"type": "Microsoft.Network/publicIPAddresses", "name": "vmss1LBPublicIP", "dependsOn":
-      [], "properties": {"publicIPAllocationMethod": "Dynamic"}, "apiVersion": "2018-01-01",
-      "tags": {}, "location": "westcentralus"}, {"type": "Microsoft.Network/loadBalancers",
-      "name": "vmss1LB", "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
-      "Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"], "properties": {"backendAddressPools":
-      [{"name": "vmss1LBBEPool"}], "frontendIPConfigurations": [{"properties": {"publicIPAddress":
-      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}},
-      "name": "loadBalancerFrontEnd"}], "inboundNatPools": [{"properties": {"backendPort":
-      22, "frontendPortRangeEnd": "50119", "protocol": "tcp", "frontendPortRangeStart":
-      "50000", "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
-      \''vmss1LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}},
-      "name": "vmss1LBNatPool"}]}, "location": "westcentralus", "tags": {}, "apiVersion":
-      "2018-01-01"}, {"properties": {"principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
-      "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001"},
-      "type": "Microsoft.Authorization/roleAssignments", "name": "7542b65b-086c-46c4-862e-0f732081e36e",
+    body: 'b''{"properties": {"mode": "Incremental", "template": {"contentVersion":
+      "1.0.0.0", "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "outputs": {"VMSS": {"type": "object", "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]"}},
+      "resources": [{"name": "vmss1VNET", "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "subnets": [{"name": "vmss1Subnet", "properties": {"addressPrefix":
+      "10.0.0.0/24"}}]}, "tags": {}, "location": "westcentralus", "type": "Microsoft.Network/virtualNetworks",
+      "dependsOn": [], "apiVersion": "2015-06-15"}, {"name": "vmss1LBPublicIP", "properties":
+      {"publicIPAllocationMethod": "Dynamic"}, "tags": {}, "location": "westcentralus",
+      "type": "Microsoft.Network/publicIPAddresses", "dependsOn": [], "apiVersion":
+      "2018-01-01"}, {"name": "vmss1LB", "properties": {"frontendIPConfigurations":
+      [{"name": "loadBalancerFrontEnd", "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}}}],
+      "inboundNatPools": [{"name": "vmss1LBNatPool", "properties": {"protocol": "tcp",
+      "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
+      \''vmss1LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"},
+      "frontendPortRangeEnd": "50119", "backendPort": 22, "frontendPortRangeStart":
+      "50000"}}], "backendAddressPools": [{"name": "vmss1LBBEPool"}]}, "tags": {},
+      "location": "westcentralus", "type": "Microsoft.Network/loadBalancers", "dependsOn":
+      ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"],
+      "apiVersion": "2018-01-01"}, {"type": "Microsoft.Authorization/roleAssignments",
+      "name": "d47d0626-94f1-459b-aace-6b533bb2aa7b", "properties": {"roleDefinitionId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
+      "principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default\'',
+      \''2015-08-31-PREVIEW\'').principalId]", "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001"},
       "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss1"], "apiVersion":
-      "2015-07-01"}, {"type": "Microsoft.Compute/virtualMachineScaleSets", "name":
-      "vmss1", "sku": {"name": "Standard_D1_v2", "capacity": 1}, "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
-      "Microsoft.Network/loadBalancers/vmss1LB"], "properties": {"singlePlacementGroup":
-      null, "virtualMachineProfile": {"osProfile": {"linuxConfiguration": {"disablePasswordAuthentication":
-      true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}}, "computerNamePrefix": "vmss12ac4", "adminUsername":
-      "ubuntuadmin"}, "networkProfile": {"networkInterfaceConfigurations": [{"properties":
-      {"ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]},
-      "name": "vmss12ac4IPConfig"}], "primary": "true"}, "name": "vmss12ac4Nic"}]},
-      "storageProfile": {"osDisk": {"caching": "ReadWrite", "createOption": "FromImage",
-      "managedDisk": {"storageAccountType": null}}, "imageReference": {"offer": "UbuntuServer",
-      "sku": "16.04-LTS", "publisher": "Canonical", "version": "latest"}}}, "overprovision":
-      true, "upgradePolicy": {"mode": "manual"}}, "identity": {"type": "SystemAssigned,UserAssigned",
-      "identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]},
-      "apiVersion": "2017-12-01", "tags": {}, "location": "westcentralus"}], "variables":
-      {}, "parameters": {}}, "mode": "Incremental"}}'''
+      "2015-07-01"}, {"identity": {"type": "SystemAssigned,UserAssigned", "identityIds":
+      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]},
+      "name": "vmss1", "properties": {"overprovision": true, "singlePlacementGroup":
+      null, "upgradePolicy": {"mode": "manual"}, "virtualMachineProfile": {"osProfile":
+      {"computerNamePrefix": "vmss1f4b1", "linuxConfiguration": {"ssh": {"publicKeys":
+      [{"path": "/home/ubuntuadmin/.ssh/authorized_keys", "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n"}]}, "disablePasswordAuthentication": true}, "adminUsername":
+      "ubuntuadmin"}, "networkProfile": {"networkInterfaceConfigurations": [{"name":
+      "vmss1f4b1Nic", "properties": {"primary": "true", "ipConfigurations": [{"name":
+      "vmss1f4b1IPConfig", "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
+      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}]}}]}}]},
+      "storageProfile": {"osDisk": {"caching": "ReadWrite", "managedDisk": {"storageAccountType":
+      null}, "createOption": "FromImage"}, "imageReference": {"publisher": "Canonical",
+      "sku": "16.04-LTS", "version": "latest", "offer": "UbuntuServer"}}}}, "tags":
+      {}, "location": "westcentralus", "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "sku": {"capacity": 1, "name": "Standard_D1_v2"}, "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
+      "Microsoft.Network/loadBalancers/vmss1LB"], "apiVersion": "2017-12-01"}], "variables":
+      {}, "parameters": {}}, "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -358,18 +357,18 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_XYqXOeksuce1CCJQ8H4wh4y7Lzv8TosD","name":"vmss_deploy_XYqXOeksuce1CCJQ8H4wh4y7Lzv8TosD","properties":{"templateHash":"10177470951981375994","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T21:41:12.7992764Z","duration":"PT0.8678821S","correlationId":"18ff6237-dabf-45e8-b6a8-24f69d261ac4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"loadBalancers","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/7542b65b-086c-46c4-862e-0f732081e36e","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"7542b65b-086c-46c4-862e-0f732081e36e"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_V2ng3sgkLsU08vfer565Amq7T6T6XlrE","name":"vmss_deploy_V2ng3sgkLsU08vfer565Amq7T6T6XlrE","properties":{"templateHash":"11171044671441263919","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:58:24.529076Z","duration":"PT0.5396181S","correlationId":"ae86a944-16d8-4498-8cf3-1128ba97364e","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"loadBalancers","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/d47d0626-94f1-459b-aace-6b533bb2aa7b","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"d47d0626-94f1-459b-aace-6b533bb2aa7b"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_XYqXOeksuce1CCJQ8H4wh4y7Lzv8TosD/operationStatuses/08586773464135462501?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_V2ng3sgkLsU08vfer565Amq7T6T6XlrE/operationStatuses/08586764849814881716?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['3334']
+      content-length: ['3333']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:12 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -384,14 +383,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773464135462501?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764849814881716?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:41:42 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -411,14 +410,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773464135462501?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764849814881716?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:42:12 GMT']
+      date: ['Mon, 30 Apr 2018 20:59:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -438,14 +437,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773464135462501?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764849814881716?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:42:43 GMT']
+      date: ['Mon, 30 Apr 2018 20:59:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -465,14 +464,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773464135462501?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764849814881716?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:43:14 GMT']
+      date: ['Mon, 30 Apr 2018 21:00:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -492,41 +491,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773464135462501?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:43:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773464135462501?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764849814881716?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:44:14 GMT']
+      date: ['Mon, 30 Apr 2018 21:00:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -548,14 +520,14 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_XYqXOeksuce1CCJQ8H4wh4y7Lzv8TosD","name":"vmss_deploy_XYqXOeksuce1CCJQ8H4wh4y7Lzv8TosD","properties":{"templateHash":"10177470951981375994","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:43:53.4765437Z","duration":"PT2M41.5451494S","correlationId":"18ff6237-dabf-45e8-b6a8-24f69d261ac4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"loadBalancers","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/7542b65b-086c-46c4-862e-0f732081e36e","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"7542b65b-086c-46c4-862e-0f732081e36e"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss12ac4","adminUsername":"ubuntuadmin","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/ubuntuadmin/.ssh/authorized_keys","keyData":"ssh-rsa
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_V2ng3sgkLsU08vfer565Amq7T6T6XlrE","name":"vmss_deploy_V2ng3sgkLsU08vfer565Amq7T6T6XlrE","properties":{"templateHash":"11171044671441263919","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T21:00:47.5244335Z","duration":"PT2M23.5349756S","correlationId":"ae86a944-16d8-4498-8cf3-1128ba97364e","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westcentralus"]},{"resourceType":"publicIPAddresses","locations":["westcentralus"]},{"resourceType":"loadBalancers","locations":["westcentralus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westcentralus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/d47d0626-94f1-459b-aace-6b533bb2aa7b","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"d47d0626-94f1-459b-aace-6b533bb2aa7b"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss1f4b1","adminUsername":"ubuntuadmin","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/ubuntuadmin/.ssh/authorized_keys","keyData":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-        yugangw@YUGANGW1\n"}]}},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"16.04-LTS","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss12ac4Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss12ac4IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"870b96a0-b04a-4dee-ac96-7f3350db7f78"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/7542b65b-086c-46c4-862e-0f732081e36e"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
+        yugangw@YUGANGW1\n"}]}},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"16.04-LTS","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss1f4b1Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss1f4b1IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"65549d1d-f229-445f-aef3-b6cb94de9322"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/d47d0626-94f1-459b-aace-6b533bb2aa7b"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['6196']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:44:15 GMT']
+      date: ['Mon, 30 Apr 2018 21:00:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -571,7 +543,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -582,7 +554,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -596,19 +568,19 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -616,7 +588,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3236']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:44:15 GMT']
+      date: ['Mon, 30 Apr 2018 21:00:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -635,7 +607,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -646,7 +618,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -660,19 +632,19 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -680,7 +652,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3236']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:44:16 GMT']
+      date: ['Mon, 30 Apr 2018 21:01:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -699,7 +671,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -710,7 +682,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -724,19 +696,19 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -744,7 +716,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3236']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:44:16 GMT']
+      date: ['Mon, 30 Apr 2018 21:01:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -755,39 +727,22 @@ interactions:
       x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;190,Microsoft.Compute/GetVMScaleSet30Min;1490']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"singlePlacementGroup": true, "virtualMachineProfile":
-      {"osProfile": {"secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
-      true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}}, "computerNamePrefix": "vmss12ac4", "adminUsername":
-      "ubuntuadmin"}, "networkProfile": {"networkInterfaceConfigurations": [{"properties":
-      {"ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAddressVersion": "IPv4", "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]},
-      "name": "vmss12ac4IPConfig"}], "enableAcceleratedNetworking": false, "dnsSettings":
-      {"dnsServers": []}, "primary": true, "enableIPForwarding": false}, "name": "vmss12ac4Nic"}]},
-      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
-      "Canonical", "sku": "16.04-LTS", "version": "latest"}, "osDisk": {"caching":
-      "ReadWrite", "managedDisk": {"storageAccountType": "Standard_LRS"}, "createOption":
-      "FromImage"}}}, "upgradePolicy": {"automaticOSUpgrade": false, "mode": "Manual"},
-      "overprovision": true}, "tags": {}, "sku": {"name": "Standard_D1_v2", "capacity":
-      1, "tier": "Standard"}, "identity": {"type": "SystemAssigned, UserAssigned",
-      "identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2",
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"]},
-      "location": "westcentralus"}'''
+    body: 'b''{"identity": {"type": "SystemAssigned, UserAssigned", "identityIds":
+      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2"]},
+      "sku": {"capacity": 1, "name": "Standard_D1_v2", "tier": "Standard"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
-      Content-Length: ['2492']
+      Content-Length: ['449']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
   response:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
@@ -795,7 +750,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -809,29 +764,29 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
-        ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
-        ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
+        ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/3c27f1d3-a3ae-48a3-8252-520e31f412dc?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5beec9b3-4c1d-4e99-b25f-7516bc6bc86d?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['3396']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:44:17 GMT']
+      date: ['Mon, 30 Apr 2018 21:01:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -839,7 +794,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;38,Microsoft.Compute/CreateVMScaleSet30Min;198,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1199,Microsoft.Compute/VmssQueuedVMOperations;4800']
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
@@ -851,19 +806,19 @@ interactions:
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/3c27f1d3-a3ae-48a3-8252-520e31f412dc?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5beec9b3-4c1d-4e99-b25f-7516bc6bc86d?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:44:18.1239235+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T21:44:44.3581781+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"3c27f1d3-a3ae-48a3-8252-520e31f412dc\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T21:01:02.5253558+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"5beec9b3-4c1d-4e99-b25f-7516bc6bc86d\"\
+        \r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['184']
+      content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:44:47 GMT']
+      date: ['Mon, 30 Apr 2018 21:01:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -871,7 +826,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29975']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29990']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -881,7 +836,37 @@ interactions:
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5beec9b3-4c1d-4e99-b25f-7516bc6bc86d?api-version=2017-12-01
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T21:01:02.5253558+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T21:01:29.6043243+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"5beec9b3-4c1d-4e99-b25f-7516bc6bc86d\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['184']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 30 Apr 2018 21:01:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29988']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss identity assign]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -891,7 +876,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -905,28 +890,28 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
-        ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
-        ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
+        ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['3397']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:44:48 GMT']
+      date: ['Mon, 30 Apr 2018 21:01:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -934,7 +919,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;189,Microsoft.Compute/GetVMScaleSet30Min;1489']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;188,Microsoft.Compute/GetVMScaleSet30Min;1488']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -945,7 +930,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -956,7 +941,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -970,28 +955,28 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
-        ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
-        ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
+        ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['3397']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:44:49 GMT']
+      date: ['Mon, 30 Apr 2018 21:01:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -999,7 +984,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;188,Microsoft.Compute/GetVMScaleSet30Min;1488']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;185,Microsoft.Compute/GetVMScaleSet30Min;1485']
     status: {code: 200, message: OK}
 - request:
     body: '{"instanceIds": ["*"]}'
@@ -1011,7 +996,7 @@ interactions:
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: POST
@@ -1019,17 +1004,17 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5985b1c0-b447-4032-b22e-fc9adafffa62?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/c11c1b58-fbc9-4d6a-9270-151a4ebd3c50?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 20 Apr 2018 21:44:50 GMT']
+      date: ['Mon, 30 Apr 2018 21:01:53 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5985b1c0-b447-4032-b22e-fc9adafffa62?monitor=true&api-version=2017-12-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/c11c1b58-fbc9-4d6a-9270-151a4ebd3c50?monitor=true&api-version=2017-12-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1199,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;1197,Microsoft.Compute/VmssQueuedVMOperations;4799']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;238,Microsoft.Compute/VMScaleSetActions30Min;1198,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;1197,Microsoft.Compute/VmssQueuedVMOperations;4799']
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
       x-ms-request-charge: ['1']
     status: {code: 202, message: Accepted}
@@ -1041,19 +1026,19 @@ interactions:
       CommandName: [vmss update-instances]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/5985b1c0-b447-4032-b22e-fc9adafffa62?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/c11c1b58-fbc9-4d6a-9270-151a4ebd3c50?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:44:50.6550903+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T21:44:57.4987602+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"5985b1c0-b447-4032-b22e-fc9adafffa62\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T21:01:53.8238355+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T21:01:56.5738354+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"c11c1b58-fbc9-4d6a-9270-151a4ebd3c50\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:45:20 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1061,7 +1046,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29981']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29986']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1072,7 +1057,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -1083,7 +1068,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -1097,28 +1082,28 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
-        ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
-        ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1\"\
+        ,\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['3397']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:45:21 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1129,38 +1114,21 @@ interactions:
       x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;182,Microsoft.Compute/GetVMScaleSet30Min;1482']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"singlePlacementGroup": true, "virtualMachineProfile":
-      {"osProfile": {"secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
-      true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}}, "computerNamePrefix": "vmss12ac4", "adminUsername":
-      "ubuntuadmin"}, "networkProfile": {"networkInterfaceConfigurations": [{"properties":
-      {"ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAddressVersion": "IPv4", "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]},
-      "name": "vmss12ac4IPConfig"}], "enableAcceleratedNetworking": false, "dnsSettings":
-      {"dnsServers": []}, "primary": true, "enableIPForwarding": false}, "name": "vmss12ac4Nic"}]},
-      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
-      "Canonical", "sku": "16.04-LTS", "version": "latest"}, "osDisk": {"caching":
-      "ReadWrite", "managedDisk": {"storageAccountType": "Standard_LRS"}, "createOption":
-      "FromImage"}}}, "upgradePolicy": {"automaticOSUpgrade": false, "mode": "Manual"},
-      "overprovision": true}, "tags": {}, "sku": {"name": "Standard_D1_v2", "capacity":
-      1, "tier": "Standard"}, "identity": {"type": "SystemAssigned, UserAssigned",
-      "identityIds": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2"]},
-      "location": "westcentralus"}'''
+    body: 'b''{"identity": {"type": "SystemAssigned, UserAssigned", "identityIds":
+      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2"]},
+      "sku": {"capacity": 1, "name": "Standard_D1_v2", "tier": "Standard"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss identity remove]
       Connection: [keep-alive]
-      Content-Length: ['2338']
+      Content-Length: ['295']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
   response:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
@@ -1168,7 +1136,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -1182,28 +1150,28 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/9408b181-f2d1-4901-ac7d-60e5d41b325c?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/8100f2f5-bc0e-4283-879b-8bd72c12f7a1?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['3235']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:45:26 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1211,8 +1179,8 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;38,Microsoft.Compute/CreateVMScaleSet30Min;197,Microsoft.Compute/VmssQueuedVMOperations;4800']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;237,Microsoft.Compute/VMScaleSetActions30Min;1197,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
 - request:
@@ -1223,19 +1191,19 @@ interactions:
       CommandName: [vmss identity remove]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/9408b181-f2d1-4901-ac7d-60e5d41b325c?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/8100f2f5-bc0e-4283-879b-8bd72c12f7a1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:45:26.9518124+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T21:45:27.4830775+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"9408b181-f2d1-4901-ac7d-60e5d41b325c\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T21:02:26.9028269+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T21:02:27.5591098+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"8100f2f5-bc0e-4283-879b-8bd72c12f7a1\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:45:57 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1243,7 +1211,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29979']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29984']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1253,7 +1221,7 @@ interactions:
       CommandName: [vmss identity remove]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -1263,7 +1231,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -1277,19 +1245,19 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -1297,7 +1265,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3236']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:45:57 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1305,7 +1273,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;176,Microsoft.Compute/GetVMScaleSet30Min;1476']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;179,Microsoft.Compute/GetVMScaleSet30Min;1479']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1316,7 +1284,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -1327,7 +1295,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -1341,19 +1309,19 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -1361,7 +1329,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3236']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:45:58 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1369,7 +1337,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;175,Microsoft.Compute/GetVMScaleSet30Min;1475']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;177,Microsoft.Compute/GetVMScaleSet30Min;1477']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1380,7 +1348,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -1391,7 +1359,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -1405,19 +1373,19 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
         \ {\r\n    \"type\": \"SystemAssigned, UserAssigned\",\r\n    \"principalId\"\
-        : \"6c219011-8263-437d-99f6-e395b7926d75\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
+        : \"0f8a181c-e1a0-4348-b725-5040c1d968bd\",\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\
         ,\r\n    \"identityIds\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.managedidentity/userassignedidentities/id2\"\
         \r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -1425,7 +1393,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3236']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:45:58 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1433,40 +1401,23 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;174,Microsoft.Compute/GetVMScaleSet30Min;1474']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;176,Microsoft.Compute/GetVMScaleSet30Min;1476']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"singlePlacementGroup": true, "virtualMachineProfile":
-      {"osProfile": {"secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
-      true, "ssh": {"publicKeys": [{"path": "/home/ubuntuadmin/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n"}]}}, "computerNamePrefix": "vmss12ac4", "adminUsername":
-      "ubuntuadmin"}, "networkProfile": {"networkInterfaceConfigurations": [{"properties":
-      {"ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools": [{"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAddressVersion": "IPv4", "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]},
-      "name": "vmss12ac4IPConfig"}], "enableAcceleratedNetworking": false, "dnsSettings":
-      {"dnsServers": []}, "primary": true, "enableIPForwarding": false}, "name": "vmss12ac4Nic"}]},
-      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
-      "Canonical", "sku": "16.04-LTS", "version": "latest"}, "osDisk": {"caching":
-      "ReadWrite", "managedDisk": {"storageAccountType": "Standard_LRS"}, "createOption":
-      "FromImage"}}}, "upgradePolicy": {"automaticOSUpgrade": false, "mode": "Manual"},
-      "overprovision": true}, "tags": {}, "sku": {"name": "Standard_D1_v2", "capacity":
-      1, "tier": "Standard"}, "identity": {"type": "SystemAssigned"}, "location":
-      "westcentralus"}'''
+    body: '{"identity": {"type": "SystemAssigned"}, "sku": {"capacity": 1, "name":
+      "Standard_D1_v2", "tier": "Standard"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss identity remove]
       Connection: [keep-alive]
-      Content-Length: ['2153']
+      Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
   response:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
@@ -1474,7 +1425,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -1488,27 +1439,27 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
-        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"6c219011-8263-437d-99f6-e395b7926d75\"\
+        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"0f8a181c-e1a0-4348-b725-5040c1d968bd\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/ede013bc-429c-4991-88a4-f5c9df66cd39?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/c0a153e5-09c7-4bc7-83f5-2c9201a4cc26?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['3031']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:45:59 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1516,8 +1467,8 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;37,Microsoft.Compute/CreateVMScaleSet30Min;196,Microsoft.Compute/VmssQueuedVMOperations;4800']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;236,Microsoft.Compute/VMScaleSetActions30Min;1196,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
 - request:
@@ -1528,19 +1479,19 @@ interactions:
       CommandName: [vmss identity remove]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/ede013bc-429c-4991-88a4-f5c9df66cd39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westcentralus/operations/c0a153e5-09c7-4bc7-83f5-2c9201a4cc26?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:46:00.1237027+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T21:46:00.4830775+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"ede013bc-429c-4991-88a4-f5c9df66cd39\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T21:02:42.0283185+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T21:02:42.3408217+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"c0a153e5-09c7-4bc7-83f5-2c9201a4cc26\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:46:30 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1548,7 +1499,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14991,Microsoft.Compute/GetOperation30Min;29977']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29983']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1558,7 +1509,7 @@ interactions:
       CommandName: [vmss identity remove]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-12-01
@@ -1568,7 +1519,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -1582,18 +1533,18 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
-        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"6c219011-8263-437d-99f6-e395b7926d75\"\
+        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"0f8a181c-e1a0-4348-b725-5040c1d968bd\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -1601,7 +1552,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3032']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:46:30 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1609,7 +1560,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;177,Microsoft.Compute/GetVMScaleSet30Min;1470']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;173,Microsoft.Compute/GetVMScaleSet30Min;1473']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1620,7 +1571,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -1631,7 +1582,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss12ac4\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1f4b1\",\r\n        \"adminUsername\"\
         : \"ubuntuadmin\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n     \
         \         {\r\n                \"path\": \"/home/ubuntuadmin/.ssh/authorized_keys\"\
@@ -1645,18 +1596,18 @@ interactions:
         Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\"\
         : \"16.04-LTS\",\r\n          \"version\": \"latest\"\r\n        }\r\n   \
         \   },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"\
-        name\":\"vmss12ac4Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        name\":\"vmss1f4b1Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"\
-        ipConfigurations\":[{\"name\":\"vmss12ac4IPConfig\",\"properties\":{\"subnet\"\
+        ipConfigurations\":[{\"name\":\"vmss1f4b1IPConfig\",\"properties\":{\"subnet\"\
         :{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"870b96a0-b04a-4dee-ac96-7f3350db7f78\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"65549d1d-f229-445f-aef3-b6cb94de9322\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"identity\":\
-        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"6c219011-8263-437d-99f6-e395b7926d75\"\
+        \ {\r\n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"0f8a181c-e1a0-4348-b725-5040c1d968bd\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -1664,7 +1615,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3032']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:46:31 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1672,7 +1623,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;176,Microsoft.Compute/GetVMScaleSet30Min;1469']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;171,Microsoft.Compute/GetVMScaleSet30Min;1471']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1694,9 +1645,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 20 Apr 2018 21:46:32 GMT']
+      date: ['Mon, 30 Apr 2018 21:02:56 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkc3QlFWV01NRE9CLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdRVEtUNVNQTlJTLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_msi.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_msi.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"tags": {"date": "2018-04-20T21:49:29Z", "cause": "automation", "product":
-      "azurecli"}, "location": "westus"}'
+    body: '{"location": "westus", "tags": {"cause": "automation", "product": "azurecli",
+      "date": "2018-04-30T20:45:20Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -16,17 +16,17 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001","name":"cli_test_vmss_msi000001","location":"westus","tags":{"date":"2018-04-20T21:49:29Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001","name":"cli_test_vmss_msi000001","location":"westus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-30T20:45:20Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:49:31 GMT']
+      date: ['Mon, 30 Apr 2018 20:45:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -43,12 +43,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001","name":"cli_test_vmss_msi000001","location":"westus","tags":{"date":"2018-04-20T21:49:29Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001","name":"cli_test_vmss_msi000001","location":"westus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-30T20:45:20Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:49:32 GMT']
+      date: ['Mon, 30 Apr 2018 20:45:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -108,9 +108,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:49:32 GMT']
+      date: ['Mon, 30 Apr 2018 20:45:24 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 21:54:32 GMT']
+      expires: ['Mon, 30 Apr 2018 20:50:24 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -118,12 +118,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [d3e5defe39d7d69abeb4b24015e22b2f8c82afbd]
+      x-fastly-request-id: [e20dcdebba48576f469a3d01d28d7919b0b1838c]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['D142:69A1:5252F:55861:5ADA606C']
-      x-served-by: [cache-dfw18622-DFW]
-      x-timer: ['S1524260972.481530,VS0,VE91']
+      x-github-request-id: ['FBD4:1788:F4801:FD6E0:5AE78063']
+      x-served-by: [cache-dfw18620-DFW]
+      x-timer: ['S1525121124.000205,VS0,VE67']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -146,7 +146,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:49:32 GMT']
+      date: ['Mon, 30 Apr 2018 20:45:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -174,7 +174,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['733']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:49:32 GMT']
+      date: ['Mon, 30 Apr 2018 20:45:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -188,46 +188,48 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: 'b''{"properties": {"parameters": {"adminPassword": {"value": "PasswordPassword1!"}},
-      "template": {"parameters": {"adminPassword": {"metadata": {"description": "Secure
-      adminPassword"}, "type": "securestring"}}, "contentVersion": "1.0.0.0", "outputs":
-      {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
-      \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
-      "type": "object"}}, "variables": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "resources": [{"properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
-      "subnets": [{"name": "vmss1Subnet", "properties": {"addressPrefix": "10.0.0.0/24"}}]},
-      "type": "Microsoft.Network/virtualNetworks", "apiVersion": "2015-06-15", "name":
-      "vmss1VNET", "tags": {}, "location": "westus", "dependsOn": []}, {"properties":
-      {"publicIPAllocationMethod": "Dynamic"}, "dependsOn": [], "apiVersion": "2018-01-01",
-      "name": "vmss1LBPublicIP", "tags": {}, "location": "westus", "type": "Microsoft.Network/publicIPAddresses"},
-      {"properties": {"inboundNatPools": [{"name": "vmss1LBNatPool", "properties":
-      {"backendPort": 22, "frontendPortRangeStart": "50000", "protocol": "tcp", "frontendPortRangeEnd":
-      "50119", "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
-      \''vmss1LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}}}],
-      "backendAddressPools": [{"name": "vmss1LBBEPool"}], "frontendIPConfigurations":
-      [{"name": "loadBalancerFrontEnd", "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}}}]},
-      "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"],
-      "apiVersion": "2018-01-01", "name": "vmss1LB", "tags": {}, "location": "westus",
-      "type": "Microsoft.Network/loadBalancers"}, {"apiVersion": "2015-07-01", "name":
-      "06b97425-5b0e-44e0-8c87-e15f94b2949b", "properties": {"scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001",
+      "template": {"resources": [{"name": "vmss1VNET", "properties": {"addressSpace":
+      {"addressPrefixes": ["10.0.0.0/16"]}, "subnets": [{"name": "vmss1Subnet", "properties":
+      {"addressPrefix": "10.0.0.0/24"}}]}, "dependsOn": [], "location": "westus",
+      "type": "Microsoft.Network/virtualNetworks", "tags": {}, "apiVersion": "2015-06-15"},
+      {"name": "vmss1LBPublicIP", "properties": {"publicIPAllocationMethod": "Dynamic"},
+      "dependsOn": [], "location": "westus", "type": "Microsoft.Network/publicIPAddresses",
+      "tags": {}, "apiVersion": "2018-01-01"}, {"name": "vmss1LB", "properties": {"frontendIPConfigurations":
+      [{"name": "loadBalancerFrontEnd", "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"}}}],
+      "inboundNatPools": [{"name": "vmss1LBNatPool", "properties": {"frontendIPConfiguration":
+      {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'', \''vmss1LB\''),
+      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}, "protocol":
+      "tcp", "backendPort": 22, "frontendPortRangeStart": "50000", "frontendPortRangeEnd":
+      "50119"}}], "backendAddressPools": [{"name": "vmss1LBBEPool"}]}, "dependsOn":
+      ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/publicIpAddresses/vmss1LBPublicIP"],
+      "location": "westus", "type": "Microsoft.Network/loadBalancers", "tags": {},
+      "apiVersion": "2018-01-01"}, {"type": "Microsoft.Authorization/roleAssignments",
+      "name": "3c7b38ed-b63c-441c-be89-986e30c6044b", "properties": {"roleDefinitionId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001",
       "principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"},
-      "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss1"], "type": "Microsoft.Authorization/roleAssignments"},
-      {"properties": {"singlePlacementGroup": null, "virtualMachineProfile": {"storageProfile":
-      {"osDisk": {"managedDisk": {"storageAccountType": null}, "createOption": "FromImage",
-      "caching": "ReadWrite"}, "imageReference": {"offer": "Debian", "version": "latest",
-      "publisher": "credativ", "sku": "8"}}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"name": "vmss17120Nic", "properties": {"primary": "true", "ipConfigurations":
-      [{"name": "vmss17120IPConfig", "properties": {"loadBalancerInboundNatPools":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
+      \''2015-08-31-PREVIEW\'').principalId]"}, "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss1"],
+      "apiVersion": "2015-07-01"}, {"name": "vmss1", "properties": {"overprovision":
+      true, "upgradePolicy": {"mode": "manual"}, "virtualMachineProfile": {"osProfile":
+      {"computerNamePrefix": "vmss1c8e9", "adminUsername": "admin123", "adminPassword":
+      "[parameters(\''adminPassword\'')]"}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss1c8e9Nic", "properties": {"primary": "true", "ipConfigurations":
+      [{"name": "vmss1c8e9IPConfig", "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
       "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}}}]}}]},
-      "osProfile": {"adminUsername": "admin123", "computerNamePrefix": "vmss17120",
-      "adminPassword": "[parameters(\''adminPassword\'')]"}}, "upgradePolicy": {"mode":
-      "manual"}, "overprovision": true}, "identity": {"type": "SystemAssigned"}, "dependsOn":
-      ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/loadBalancers/vmss1LB"],
-      "apiVersion": "2017-12-01", "name": "vmss1", "tags": {}, "location": "westus",
-      "type": "Microsoft.Compute/virtualMachineScaleSets", "sku": {"name": "Standard_D1_v2",
-      "capacity": 1}}]}, "mode": "Incremental"}}'''
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]},
+      "storageProfile": {"imageReference": {"offer": "Debian", "version": "latest",
+      "publisher": "credativ", "sku": "8"}, "osDisk": {"caching": "ReadWrite", "createOption":
+      "FromImage", "managedDisk": {"storageAccountType": null}}}}, "singlePlacementGroup":
+      null}, "location": "westus", "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
+      "Microsoft.Network/loadBalancers/vmss1LB"], "sku": {"name": "Standard_D1_v2",
+      "capacity": 1}, "type": "Microsoft.Compute/virtualMachineScaleSets", "tags":
+      {}, "identity": {"type": "SystemAssigned"}, "apiVersion": "2017-12-01"}], "contentVersion":
+      "1.0.0.0", "parameters": {"adminPassword": {"type": "securestring", "metadata":
+      {"description": "Secure adminPassword"}}}, "variables": {}, "outputs": {"VMSS":
+      {"type": "object", "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]"}},
+      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
+      "mode": "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -242,18 +244,18 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_KKOMuZAlMpfzRGWsrW9MwQJVKRzFnvaw","name":"vmss_deploy_KKOMuZAlMpfzRGWsrW9MwQJVKRzFnvaw","properties":{"templateHash":"12577855011321894066","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T21:49:35.4925258Z","duration":"PT0.723177S","correlationId":"eb8e5aef-4784-4ccc-8a4b-e04b181c6153","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Authorization/roleAssignments/06b97425-5b0e-44e0-8c87-e15f94b2949b","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"06b97425-5b0e-44e0-8c87-e15f94b2949b"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_ZyYI4uwyYlwV5S16zMxIMi06in0bxd24","name":"vmss_deploy_ZyYI4uwyYlwV5S16zMxIMi06in0bxd24","properties":{"templateHash":"10505529856893327662","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:45:27.4400507Z","duration":"PT0.5264785S","correlationId":"f45b27ab-c17e-4e9a-b292-87bef3bceb20","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Authorization/roleAssignments/3c7b38ed-b63c-441c-be89-986e30c6044b","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"3c7b38ed-b63c-441c-be89-986e30c6044b"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_KKOMuZAlMpfzRGWsrW9MwQJVKRzFnvaw/operationStatuses/08586773459107082843?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_ZyYI4uwyYlwV5S16zMxIMi06in0bxd24/operationStatuses/08586764857585640599?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['3894']
+      content-length: ['3895']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:49:35 GMT']
+      date: ['Mon, 30 Apr 2018 20:45:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -268,14 +270,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773459107082843?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764857585640599?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:50:05 GMT']
+      date: ['Mon, 30 Apr 2018 20:45:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -295,14 +297,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773459107082843?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764857585640599?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:50:35 GMT']
+      date: ['Mon, 30 Apr 2018 20:46:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -322,14 +324,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773459107082843?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764857585640599?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:51:06 GMT']
+      date: ['Mon, 30 Apr 2018 20:46:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -349,14 +351,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773459107082843?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764857585640599?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:51:36 GMT']
+      date: ['Mon, 30 Apr 2018 20:47:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -376,14 +378,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773459107082843?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764857585640599?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:52:07 GMT']
+      date: ['Mon, 30 Apr 2018 20:48:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -403,14 +405,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773459107082843?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764857585640599?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:52:36 GMT']
+      date: ['Mon, 30 Apr 2018 20:48:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -432,12 +434,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_KKOMuZAlMpfzRGWsrW9MwQJVKRzFnvaw","name":"vmss_deploy_KKOMuZAlMpfzRGWsrW9MwQJVKRzFnvaw","properties":{"templateHash":"12577855011321894066","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:52:29.5938905Z","duration":"PT2M54.8245417S","correlationId":"eb8e5aef-4784-4ccc-8a4b-e04b181c6153","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Authorization/roleAssignments/06b97425-5b0e-44e0-8c87-e15f94b2949b","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"06b97425-5b0e-44e0-8c87-e15f94b2949b"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss17120","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss17120Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss17120IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"e2a80773-a7a0-4d45-8937-68375adf1d28"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Authorization/roleAssignments/06b97425-5b0e-44e0-8c87-e15f94b2949b"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_ZyYI4uwyYlwV5S16zMxIMi06in0bxd24","name":"vmss_deploy_ZyYI4uwyYlwV5S16zMxIMi06in0bxd24","properties":{"templateHash":"10505529856893327662","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T20:48:17.662792Z","duration":"PT2M50.7492198S","correlationId":"f45b27ab-c17e-4e9a-b292-87bef3bceb20","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss1LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Authorization/roleAssignments/3c7b38ed-b63c-441c-be89-986e30c6044b","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"3c7b38ed-b63c-441c-be89-986e30c6044b"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss1c8e9","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss1c8e9Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss1c8e9IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"670be6b2-1ef1-443f-8a56-972dccc9102e"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Authorization/roleAssignments/3c7b38ed-b63c-441c-be89-986e30c6044b"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['6695']
+      content-length: ['6694']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:52:37 GMT']
+      date: ['Mon, 30 Apr 2018 20:48:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -453,7 +455,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -464,7 +466,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss17120\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss1c8e9\",\r\n        \"adminUsername\"\
         : \"admin123\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
@@ -473,18 +475,18 @@ interactions:
         \        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"\
         credativ\",\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss17120Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1c8e9Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss17120IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss1c8e9IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"e2a80773-a7a0-4d45-8937-68375adf1d28\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"670be6b2-1ef1-443f-8a56-972dccc9102e\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n \
-        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"a1e4affa-c44e-4f13-9da6-5372d522d55a\"\
+        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"81f55b2e-e8a0-404a-be94-9db10b9ae13b\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -492,7 +494,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2619']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:52:38 GMT']
+      date: ['Mon, 30 Apr 2018 20:48:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -500,7 +502,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;192,Microsoft.Compute/GetVMScaleSet30Min;1492']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;190,Microsoft.Compute/GetVMScaleSet30Min;1462']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -517,12 +519,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001","name":"cli_test_vmss_msi000001","location":"westus","tags":{"date":"2018-04-20T21:49:29Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001","name":"cli_test_vmss_msi000001","location":"westus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-30T20:45:20Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:52:38 GMT']
+      date: ['Mon, 30 Apr 2018 20:48:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -582,22 +584,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:52:39 GMT']
+      date: ['Mon, 30 Apr 2018 20:48:35 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 21:57:39 GMT']
-      source-age: ['0']
+      expires: ['Mon, 30 Apr 2018 20:53:35 GMT']
+      source-age: ['191']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
+      x-cache: [HIT]
+      x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [bcdcf32b3e72a1f293b2d78c605a8e5e9a793187]
+      x-fastly-request-id: [ab61057d8bbe1ddbcb6002fbc0cf8366ecb50111]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['92F2:087B:D3F54E:E04CD1:5ADA6127']
-      x-served-by: [cache-sea1050-SEA]
-      x-timer: ['S1524261159.408495,VS0,VE101']
+      x-github-request-id: ['FBD4:1788:F4801:FD6E0:5AE78063']
+      x-served-by: [cache-dfw18625-DFW]
+      x-timer: ['S1525121315.048642,VS0,VE1']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -617,21 +619,21 @@ interactions:
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vmss1VNET\"\
         ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"b6ec1906-b5ee-42fc-a40d-1d5db4b7d104\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"a886974b-8960-4ad5-b271-0e1581f7bba1\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"2f668b40-cdfc-4657-8a04-d0a580ec0ff7\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"32a61e9f-77ee-42cf-b494-ac9c3918c102\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vmss1Subnet\",\r\n         \
         \   \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"b6ec1906-b5ee-42fc-a40d-1d5db4b7d104\\\"\
+        ,\r\n            \"etag\": \"W/\\\"a886974b-8960-4ad5-b271-0e1581f7bba1\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
-        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss17120Nic/ipConfigurations/vmss17120IPConfig\"\
+        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1c8e9Nic/ipConfigurations/vmss1c8e9IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss17120Nic/ipConfigurations/vmss17120IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1c8e9Nic/ipConfigurations/vmss1c8e9IPConfig\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
         \n        ],\r\n        \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\"\
         : false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n\
@@ -640,7 +642,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2103']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:52:39 GMT']
+      date: ['Mon, 30 Apr 2018 20:48:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -670,7 +672,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['615']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:52:39 GMT']
+      date: ['Mon, 30 Apr 2018 20:48:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -684,42 +686,44 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: 'b''{"properties": {"parameters": {"adminPassword": {"value": "PasswordPassword1!"}},
-      "template": {"parameters": {"adminPassword": {"metadata": {"description": "Secure
-      adminPassword"}, "type": "securestring"}}, "contentVersion": "1.0.0.0", "outputs":
-      {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
-      \''vmss2\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
-      "type": "object"}}, "variables": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "resources": [{"properties": {"publicIPAllocationMethod": "Dynamic"}, "dependsOn":
-      [], "apiVersion": "2018-01-01", "name": "vmss2LBPublicIP", "tags": {}, "location":
-      "westus", "type": "Microsoft.Network/publicIPAddresses"}, {"properties": {"inboundNatPools":
-      [{"name": "vmss2LBNatPool", "properties": {"backendPort": 3389, "frontendPortRangeStart":
-      "50000", "protocol": "tcp", "frontendPortRangeEnd": "50119", "frontendIPConfiguration":
+      "template": {"resources": [{"name": "vmss2LBPublicIP", "properties": {"publicIPAllocationMethod":
+      "Dynamic"}, "dependsOn": [], "location": "westus", "type": "Microsoft.Network/publicIPAddresses",
+      "tags": {}, "apiVersion": "2018-01-01"}, {"name": "vmss2LB", "properties": {"frontendIPConfigurations":
+      [{"name": "loadBalancerFrontEnd", "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}}}],
+      "inboundNatPools": [{"name": "vmss2LBNatPool", "properties": {"frontendIPConfiguration":
       {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'', \''vmss2LB\''),
-      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}}}], "backendAddressPools":
-      [{"name": "vmss2LBBEPool"}], "frontendIPConfigurations": [{"name": "loadBalancerFrontEnd",
-      "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}}}]},
-      "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss2LBPublicIP"], "apiVersion":
-      "2018-01-01", "name": "vmss2LB", "tags": {}, "location": "westus", "type": "Microsoft.Network/loadBalancers"},
-      {"apiVersion": "2015-07-01", "name": "vmss1/Microsoft.Authorization/6f9b96c6-2814-4dab-b8c0-5e403a318d1b",
-      "properties": {"scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1",
+      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}, "protocol":
+      "tcp", "backendPort": 3389, "frontendPortRangeStart": "50000", "frontendPortRangeEnd":
+      "50119"}}], "backendAddressPools": [{"name": "vmss2LBBEPool"}]}, "dependsOn":
+      ["Microsoft.Network/publicIpAddresses/vmss2LBPublicIP"], "location": "westus",
+      "type": "Microsoft.Network/loadBalancers", "tags": {}, "apiVersion": "2018-01-01"},
+      {"type": "Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments",
+      "name": "vmss1/Microsoft.Authorization/5c35834b-d8b1-4580-b37f-7af7d3fd5396",
+      "properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
+      "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1",
       "principalId": "[reference(\''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"},
-      "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss2"], "type": "Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments"},
-      {"properties": {"singlePlacementGroup": null, "virtualMachineProfile": {"storageProfile":
-      {"osDisk": {"managedDisk": {"storageAccountType": null}, "createOption": "FromImage",
-      "caching": "ReadWrite"}, "imageReference": {"offer": "WindowsServer", "version":
-      "latest", "publisher": "MicrosoftWindowsServer", "sku": "2016-Datacenter"}},
-      "networkProfile": {"networkInterfaceConfigurations": [{"name": "vmss2acf8Nic",
-      "properties": {"primary": "true", "ipConfigurations": [{"name": "vmss2acf8IPConfig",
-      "properties": {"loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}],
+      \''2015-08-31-PREVIEW\'').principalId]"}, "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss2"],
+      "apiVersion": "2015-07-01"}, {"name": "vmss2", "properties": {"overprovision":
+      true, "upgradePolicy": {"mode": "manual"}, "virtualMachineProfile": {"osProfile":
+      {"computerNamePrefix": "vmss232b8", "adminUsername": "admin123", "adminPassword":
+      "[parameters(\''adminPassword\'')]"}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmss232b8Nic", "properties": {"primary": "true", "ipConfigurations":
+      [{"name": "vmss232b8IPConfig", "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
       "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}}}]}}]},
-      "osProfile": {"adminUsername": "admin123", "computerNamePrefix": "vmss2acf8",
-      "adminPassword": "[parameters(\''adminPassword\'')]"}}, "upgradePolicy": {"mode":
-      "manual"}, "overprovision": true}, "identity": {"type": "SystemAssigned"}, "dependsOn":
-      ["Microsoft.Network/loadBalancers/vmss2LB"], "apiVersion": "2017-12-01", "name":
-      "vmss2", "tags": {}, "location": "westus", "type": "Microsoft.Compute/virtualMachineScaleSets",
-      "sku": {"name": "Standard_D1_v2", "capacity": 1}}]}, "mode": "Incremental"}}'''
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}]}}]}}]},
+      "storageProfile": {"imageReference": {"offer": "WindowsServer", "version": "latest",
+      "publisher": "MicrosoftWindowsServer", "sku": "2016-Datacenter"}, "osDisk":
+      {"caching": "ReadWrite", "createOption": "FromImage", "managedDisk": {"storageAccountType":
+      null}}}}, "singlePlacementGroup": null}, "location": "westus", "dependsOn":
+      ["Microsoft.Network/loadBalancers/vmss2LB"], "sku": {"name": "Standard_D1_v2",
+      "capacity": 1}, "type": "Microsoft.Compute/virtualMachineScaleSets", "tags":
+      {}, "identity": {"type": "SystemAssigned"}, "apiVersion": "2017-12-01"}], "contentVersion":
+      "1.0.0.0", "parameters": {"adminPassword": {"type": "securestring", "metadata":
+      {"description": "Secure adminPassword"}}}, "variables": {}, "outputs": {"VMSS":
+      {"type": "object", "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''vmss2\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]"}},
+      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
+      "mode": "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -734,18 +738,18 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_RYRVMdKxA6IUytg9UfvWp0wMXo7IUoyz","name":"vmss_deploy_RYRVMdKxA6IUytg9UfvWp0wMXo7IUoyz","properties":{"templateHash":"2938930381769660363","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T21:52:42.4897252Z","duration":"PT0.6573554S","correlationId":"d9245ad8-43fd-4bb9-a660-5235a76ade7b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.Authorization/roleAssignments/6f9b96c6-2814-4dab-b8c0-5e403a318d1b","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments","resourceName":"vmss1/Microsoft.Authorization/6f9b96c6-2814-4dab-b8c0-5e403a318d1b"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_5MBYktWB5P5qCjQrfN3ZyXkXF1LxvfRc","name":"vmss_deploy_5MBYktWB5P5qCjQrfN3ZyXkXF1LxvfRc","properties":{"templateHash":"6878443123994027337","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:48:38.5396191Z","duration":"PT0.5890421S","correlationId":"3593f2ea-eb17-410a-b1d0-a724fd660700","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.Authorization/roleAssignments/5c35834b-d8b1-4580-b37f-7af7d3fd5396","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments","resourceName":"vmss1/Microsoft.Authorization/5c35834b-d8b1-4580-b37f-7af7d3fd5396"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_RYRVMdKxA6IUytg9UfvWp0wMXo7IUoyz/operationStatuses/08586773457236452568?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_5MBYktWB5P5qCjQrfN3ZyXkXF1LxvfRc/operationStatuses/08586764855675270550?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['3360']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:52:42 GMT']
+      date: ['Mon, 30 Apr 2018 20:48:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -760,14 +764,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773457236452568?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:53:12 GMT']
+      date: ['Mon, 30 Apr 2018 20:49:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -787,14 +791,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773457236452568?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:53:42 GMT']
+      date: ['Mon, 30 Apr 2018 20:49:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -814,14 +818,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773457236452568?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:54:13 GMT']
+      date: ['Mon, 30 Apr 2018 20:50:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -841,14 +845,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773457236452568?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:54:43 GMT']
+      date: ['Mon, 30 Apr 2018 20:50:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -868,14 +872,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773457236452568?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:55:14 GMT']
+      date: ['Mon, 30 Apr 2018 20:51:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -895,14 +899,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773457236452568?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:55:44 GMT']
+      date: ['Mon, 30 Apr 2018 20:51:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -922,14 +926,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773457236452568?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:56:14 GMT']
+      date: ['Mon, 30 Apr 2018 20:52:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -949,14 +953,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773457236452568?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:56:45 GMT']
+      date: ['Mon, 30 Apr 2018 20:52:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -976,14 +980,41 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773457236452568?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 30 Apr 2018 20:53:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
+          msrest_azure/0.4.26 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.32]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764855675270550?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:57:15 GMT']
+      date: ['Mon, 30 Apr 2018 20:53:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1005,12 +1036,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_RYRVMdKxA6IUytg9UfvWp0wMXo7IUoyz","name":"vmss_deploy_RYRVMdKxA6IUytg9UfvWp0wMXo7IUoyz","properties":{"templateHash":"2938930381769660363","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:56:56.0170424Z","duration":"PT4M14.1846726S","correlationId":"d9245ad8-43fd-4bb9-a660-5235a76ade7b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.Authorization/roleAssignments/6f9b96c6-2814-4dab-b8c0-5e403a318d1b","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments","resourceName":"vmss1/Microsoft.Authorization/6f9b96c6-2814-4dab-b8c0-5e403a318d1b"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss2acf8","adminUsername":"admin123","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2016-Datacenter","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss2acf8Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss2acf8IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"95309519-04f7-40af-9c25-c3fb3c8d80ca"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.Authorization/roleAssignments/6f9b96c6-2814-4dab-b8c0-5e403a318d1b"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_5MBYktWB5P5qCjQrfN3ZyXkXF1LxvfRc","name":"vmss_deploy_5MBYktWB5P5qCjQrfN3ZyXkXF1LxvfRc","properties":{"templateHash":"6878443123994027337","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T20:53:17.4117738Z","duration":"PT4M39.4611968S","correlationId":"3593f2ea-eb17-410a-b1d0-a724fd660700","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.Authorization/roleAssignments/5c35834b-d8b1-4580-b37f-7af7d3fd5396","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments","resourceName":"vmss1/Microsoft.Authorization/5c35834b-d8b1-4580-b37f-7af7d3fd5396"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss232b8","adminUsername":"admin123","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2016-Datacenter","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss232b8Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss232b8IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"c78a9d54-dc13-4eae-9926-187d0ea8f133"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.Authorization/roleAssignments/5c35834b-d8b1-4580-b37f-7af7d3fd5396"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['6065']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:57:15 GMT']
+      date: ['Mon, 30 Apr 2018 20:53:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1026,7 +1057,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -1037,7 +1068,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss2acf8\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss232b8\",\r\n        \"adminUsername\"\
         : \"admin123\",\r\n        \"windowsConfiguration\": {\r\n          \"provisionVMAgent\"\
         : true,\r\n          \"enableAutomaticUpdates\": true\r\n        },\r\n  \
         \      \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n    \
@@ -1047,18 +1078,18 @@ interactions:
         \   },\r\n        \"imageReference\": {\r\n          \"publisher\": \"MicrosoftWindowsServer\"\
         ,\r\n          \"offer\": \"WindowsServer\",\r\n          \"sku\": \"2016-Datacenter\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss2acf8Nic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss232b8Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss2acf8IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss232b8IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"95309519-04f7-40af-9c25-c3fb3c8d80ca\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"c78a9d54-dc13-4eae-9926-187d0ea8f133\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n \
-        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"1f900b5c-edf3-4ffd-995d-e1dce040c9e1\"\
+        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"5742aa08-01f1-469b-91fd-f66640ca6c37\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2\"\
         ,\r\n  \"name\": \"vmss2\"\r\n}"}
@@ -1066,7 +1097,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2685']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:57:16 GMT']
+      date: ['Mon, 30 Apr 2018 20:53:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1074,7 +1105,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;192,Microsoft.Compute/GetVMScaleSet30Min;1484']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;190,Microsoft.Compute/GetVMScaleSet30Min;1452']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1091,12 +1122,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001","name":"cli_test_vmss_msi000001","location":"westus","tags":{"date":"2018-04-20T21:49:29Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001","name":"cli_test_vmss_msi000001","location":"westus","tags":{"cause":"automation","product":"azurecli","date":"2018-04-30T20:45:20Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:57:16 GMT']
+      date: ['Mon, 30 Apr 2018 20:53:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1156,9 +1187,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:57:17 GMT']
+      date: ['Mon, 30 Apr 2018 20:53:48 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 20 Apr 2018 22:02:17 GMT']
+      expires: ['Mon, 30 Apr 2018 20:58:48 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -1166,12 +1197,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [b1319deb19049a80c8654dfc757d709344ebdf87]
+      x-fastly-request-id: [3fa177b0c4cf5a698b86206a5d61d8a75491a772]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['A930:69A1:5A68B:5DE7C:5ADA623C']
-      x-served-by: [cache-dfw18628-DFW]
-      x-timer: ['S1524261438.732808,VS0,VE72']
+      x-github-request-id: ['4E52:1788:FD8AD:106CC8:5AE7825C']
+      x-served-by: [cache-dfw18648-DFW]
+      x-timer: ['S1525121628.171272,VS0,VE65']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -1191,23 +1222,23 @@ interactions:
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vmss1VNET\"\
         ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"6eaf626a-9991-48c2-8a49-92499e727fd7\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"7ec33735-43b4-4f8f-983e-f06264ca0323\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"2f668b40-cdfc-4657-8a04-d0a580ec0ff7\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"32a61e9f-77ee-42cf-b494-ac9c3918c102\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vmss1Subnet\",\r\n         \
         \   \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"6eaf626a-9991-48c2-8a49-92499e727fd7\\\"\
+        ,\r\n            \"etag\": \"W/\\\"7ec33735-43b4-4f8f-983e-f06264ca0323\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
-        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss17120Nic/ipConfigurations/vmss17120IPConfig\"\
+        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1c8e9Nic/ipConfigurations/vmss1c8e9IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/virtualMachines/0/networkInterfaces/vmss2acf8Nic/ipConfigurations/vmss2acf8IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/virtualMachines/0/networkInterfaces/vmss232b8Nic/ipConfigurations/vmss232b8IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/virtualMachines/1/networkInterfaces/vmss2acf8Nic/ipConfigurations/vmss2acf8IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/virtualMachines/1/networkInterfaces/vmss232b8Nic/ipConfigurations/vmss232b8IPConfig\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
         \n        ],\r\n        \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\"\
         : false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n\
@@ -1216,7 +1247,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2454']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:57:17 GMT']
+      date: ['Mon, 30 Apr 2018 20:53:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1227,37 +1258,36 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: 'b''{"properties": {"parameters": {"adminPassword": {"value": "PasswordPassword1!"}},
-      "template": {"parameters": {"adminPassword": {"metadata": {"description": "Secure
-      adminPassword"}, "type": "securestring"}}, "contentVersion": "1.0.0.0", "outputs":
-      {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
-      \''vmss3\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
-      "type": "object"}}, "variables": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "resources": [{"properties": {"publicIPAllocationMethod": "Dynamic"}, "dependsOn":
-      [], "apiVersion": "2018-01-01", "name": "vmss3LBPublicIP", "tags": {}, "location":
-      "westus", "type": "Microsoft.Network/publicIPAddresses"}, {"properties": {"inboundNatPools":
-      [{"name": "vmss3LBNatPool", "properties": {"backendPort": 22, "frontendPortRangeStart":
-      "50000", "protocol": "tcp", "frontendPortRangeEnd": "50119", "frontendIPConfiguration":
+      "template": {"resources": [{"name": "vmss3LBPublicIP", "properties": {"publicIPAllocationMethod":
+      "Dynamic"}, "dependsOn": [], "location": "westus", "type": "Microsoft.Network/publicIPAddresses",
+      "tags": {}, "apiVersion": "2018-01-01"}, {"name": "vmss3LB", "properties": {"frontendIPConfigurations":
+      [{"name": "loadBalancerFrontEnd", "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP"}}}],
+      "inboundNatPools": [{"name": "vmss3LBNatPool", "properties": {"frontendIPConfiguration":
       {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'', \''vmss3LB\''),
-      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}}}], "backendAddressPools":
-      [{"name": "vmss3LBBEPool"}], "frontendIPConfigurations": [{"name": "loadBalancerFrontEnd",
-      "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP"}}}]},
-      "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss3LBPublicIP"], "apiVersion":
-      "2018-01-01", "name": "vmss3LB", "tags": {}, "location": "westus", "type": "Microsoft.Network/loadBalancers"},
-      {"properties": {"singlePlacementGroup": null, "virtualMachineProfile": {"storageProfile":
-      {"osDisk": {"managedDisk": {"storageAccountType": null}, "createOption": "FromImage",
-      "caching": "ReadWrite"}, "imageReference": {"offer": "Debian", "version": "latest",
-      "publisher": "credativ", "sku": "8"}}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"name": "vmss3a57fNic", "properties": {"primary": "true", "ipConfigurations":
-      [{"name": "vmss3a57fIPConfig", "properties": {"loadBalancerInboundNatPools":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool"}],
+      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}, "protocol":
+      "tcp", "backendPort": 22, "frontendPortRangeStart": "50000", "frontendPortRangeEnd":
+      "50119"}}], "backendAddressPools": [{"name": "vmss3LBBEPool"}]}, "dependsOn":
+      ["Microsoft.Network/publicIpAddresses/vmss3LBPublicIP"], "location": "westus",
+      "type": "Microsoft.Network/loadBalancers", "tags": {}, "apiVersion": "2018-01-01"},
+      {"name": "vmss3", "properties": {"overprovision": true, "upgradePolicy": {"mode":
+      "manual"}, "virtualMachineProfile": {"osProfile": {"computerNamePrefix": "vmss3a8d8",
+      "adminUsername": "admin123", "adminPassword": "[parameters(\''adminPassword\'')]"},
+      "networkProfile": {"networkInterfaceConfigurations": [{"name": "vmss3a8d8Nic",
+      "properties": {"primary": "true", "ipConfigurations": [{"name": "vmss3a8d8IPConfig",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
       "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool"}],
-      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}}}]}}]},
-      "osProfile": {"adminUsername": "admin123", "computerNamePrefix": "vmss3a57f",
-      "adminPassword": "[parameters(\''adminPassword\'')]"}}, "upgradePolicy": {"mode":
-      "manual"}, "overprovision": true}, "dependsOn": ["Microsoft.Network/loadBalancers/vmss3LB"],
-      "apiVersion": "2017-12-01", "name": "vmss3", "tags": {}, "location": "westus",
-      "type": "Microsoft.Compute/virtualMachineScaleSets", "sku": {"name": "Standard_D1_v2",
-      "capacity": 1}}]}, "mode": "Incremental"}}'''
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool"}]}}]}}]},
+      "storageProfile": {"imageReference": {"offer": "Debian", "version": "latest",
+      "publisher": "credativ", "sku": "8"}, "osDisk": {"caching": "ReadWrite", "createOption":
+      "FromImage", "managedDisk": {"storageAccountType": null}}}}, "singlePlacementGroup":
+      null}, "location": "westus", "dependsOn": ["Microsoft.Network/loadBalancers/vmss3LB"],
+      "sku": {"name": "Standard_D1_v2", "capacity": 1}, "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "tags": {}, "apiVersion": "2017-12-01"}], "contentVersion": "1.0.0.0", "parameters":
+      {"adminPassword": {"type": "securestring", "metadata": {"description": "Secure
+      adminPassword"}}}, "variables": {}, "outputs": {"VMSS": {"type": "object", "value":
+      "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'', \''vmss3\''),providers(\''Microsoft.Compute\'',
+      \''virtualMachineScaleSets\'').apiVersions[0])]"}}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
+      "mode": "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1272,13 +1302,13 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_fvxVOA0jJofLjOdA7qHT7kbmsZadX43W","name":"vmss_deploy_fvxVOA0jJofLjOdA7qHT7kbmsZadX43W","properties":{"templateHash":"3584689867287071050","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-20T21:57:20.4728302Z","duration":"PT0.9345386S","correlationId":"c9d2c348-bcfb-4686-9db6-69e0e082a24f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss3LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss3"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_Eljp1AqAjvbWiWdRoNP7Dzr1WrKifDPl","name":"vmss_deploy_Eljp1AqAjvbWiWdRoNP7Dzr1WrKifDPl","properties":{"templateHash":"17517073068599432145","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-30T20:53:51.0365334Z","duration":"PT0.6130732S","correlationId":"28589a71-0d6f-49ad-a548-300f1d6e3829","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss3LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss3"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_fvxVOA0jJofLjOdA7qHT7kbmsZadX43W/operationStatuses/08586773454459393502?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_Eljp1AqAjvbWiWdRoNP7Dzr1WrKifDPl/operationStatuses/08586764852550541717?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['2064']
+      content-length: ['2065']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:57:20 GMT']
+      date: ['Mon, 30 Apr 2018 20:53:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1298,14 +1328,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773454459393502?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764852550541717?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:57:50 GMT']
+      date: ['Mon, 30 Apr 2018 20:54:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1325,14 +1355,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773454459393502?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764852550541717?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:58:21 GMT']
+      date: ['Mon, 30 Apr 2018 20:54:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1352,14 +1382,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773454459393502?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764852550541717?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:58:51 GMT']
+      date: ['Mon, 30 Apr 2018 20:55:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1379,14 +1409,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773454459393502?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764852550541717?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:59:21 GMT']
+      date: ['Mon, 30 Apr 2018 20:55:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1406,14 +1436,14 @@ interactions:
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586773454459393502?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586764852550541717?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:59:52 GMT']
+      date: ['Mon, 30 Apr 2018 20:56:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1435,12 +1465,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_fvxVOA0jJofLjOdA7qHT7kbmsZadX43W","name":"vmss_deploy_fvxVOA0jJofLjOdA7qHT7kbmsZadX43W","properties":{"templateHash":"3584689867287071050","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-20T21:59:39.5092205Z","duration":"PT2M19.9709289S","correlationId":"c9d2c348-bcfb-4686-9db6-69e0e082a24f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss3LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss3"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss3a57f","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss3a57fNic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss3a57fIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"e682f6ec-53fe-4b6a-bfe2-3f4643088b35"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Resources/deployments/vmss_deploy_Eljp1AqAjvbWiWdRoNP7Dzr1WrKifDPl","name":"vmss_deploy_Eljp1AqAjvbWiWdRoNP7Dzr1WrKifDPl","properties":{"templateHash":"17517073068599432145","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-30T20:56:23.8567999Z","duration":"PT2M33.4333397S","correlationId":"28589a71-0d6f-49ad-a548-300f1d6e3829","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss3LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss3"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual","automaticOSUpgrade":false},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss3a8d8","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss3a8d8Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"vmss3a8d8IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"e81af0ac-0438-46e1-9391-c7ba82aaadfb"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['4419']
+      content-length: ['4420']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:59:51 GMT']
+      date: ['Mon, 30 Apr 2018 20:56:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1468,7 +1498,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['615']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:59:52 GMT']
+      date: ['Mon, 30 Apr 2018 20:56:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
@@ -1489,7 +1519,7 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
     method: GET
@@ -1500,7 +1530,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss3a57f\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss3a8d8\",\r\n        \"adminUsername\"\
         : \"admin123\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
@@ -1509,15 +1539,15 @@ interactions:
         \        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"\
         credativ\",\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss3a57fNic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss3a8d8Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss3a57fIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss3a8d8IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"e682f6ec-53fe-4b6a-bfe2-3f4643088b35\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"e81af0ac-0438-46e1-9391-c7ba82aaadfb\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3\"\
         ,\r\n  \"name\": \"vmss3\"\r\n}"}
@@ -1525,7 +1555,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2449']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:59:53 GMT']
+      date: ['Mon, 30 Apr 2018 20:56:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1533,36 +1563,23 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;191,Microsoft.Compute/GetVMScaleSet30Min;1476']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;186,Microsoft.Compute/GetVMScaleSet30Min;1439']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"singlePlacementGroup": true, "virtualMachineProfile":
-      {"storageProfile": {"osDisk": {"managedDisk": {"storageAccountType": "Standard_LRS"},
-      "createOption": "FromImage", "caching": "ReadWrite"}, "imageReference": {"offer":
-      "Debian", "version": "latest", "publisher": "credativ", "sku": "8"}}, "networkProfile":
-      {"networkInterfaceConfigurations": [{"name": "vmss3a57fNic", "properties": {"enableIPForwarding":
-      false, "dnsSettings": {"dnsServers": []}, "enableAcceleratedNetworking": false,
-      "primary": true, "ipConfigurations": [{"name": "vmss3a57fIPConfig", "properties":
-      {"loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool"}],
-      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool"}],
-      "privateIPAddressVersion": "IPv4", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}}}]}}]},
-      "osProfile": {"adminUsername": "admin123", "computerNamePrefix": "vmss3a57f",
-      "linuxConfiguration": {"disablePasswordAuthentication": false}, "secrets": []}},
-      "upgradePolicy": {"mode": "Manual", "automaticOSUpgrade": false}, "overprovision":
-      true}, "identity": {"type": "SystemAssigned"}, "location": "westus", "tags":
-      {}, "sku": {"name": "Standard_D1_v2", "tier": "Standard", "capacity": 1}}'''
+    body: '{"identity": {"type": "SystemAssigned"}, "sku": {"name": "Standard_D1_v2",
+      "tier": "Standard", "capacity": 1}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
-      Content-Length: ['1803']
+      Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
       accept-language: [en-US]
-    method: PUT
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3?api-version=2017-12-01
   response:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
@@ -1570,7 +1587,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss3a57f\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss3a8d8\",\r\n        \"adminUsername\"\
         : \"admin123\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
@@ -1579,27 +1596,27 @@ interactions:
         \        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"\
         credativ\",\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss3a57fNic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss3a8d8Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss3a57fIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss3a8d8IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"e682f6ec-53fe-4b6a-bfe2-3f4643088b35\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"e81af0ac-0438-46e1-9391-c7ba82aaadfb\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n \
-        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"7822c249-75a6-4693-8be1-161923f9b0ae\"\
+        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"fcf1c990-27dd-434d-8851-e3126d5b9a7c\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3\"\
         ,\r\n  \"name\": \"vmss3\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/49f93b44-fe70-4a75-86ea-b28b2ec454e4?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1da022cc-a4bc-4fa1-8dff-0244bed008b6?api-version=2017-12-01']
       cache-control: [no-cache]
       content-length: ['2618']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 21:59:56 GMT']
+      date: ['Mon, 30 Apr 2018 20:56:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1607,8 +1624,8 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateVMScaleSet3Min;38,Microsoft.Compute/CreateVMScaleSet30Min;196,Microsoft.Compute/VmssQueuedVMOperations;4800']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1198,Microsoft.Compute/VmssQueuedVMOperations;4800']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-ms-request-charge: ['0']
     status: {code: 200, message: OK}
 - request:
@@ -1619,19 +1636,19 @@ interactions:
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/49f93b44-fe70-4a75-86ea-b28b2ec454e4?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1da022cc-a4bc-4fa1-8dff-0244bed008b6?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:59:56.3372153+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"49f93b44-fe70-4a75-86ea-b28b2ec454e4\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:56:29.5764704+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1da022cc-a4bc-4fa1-8dff-0244bed008b6\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 22:00:26 GMT']
+      date: ['Mon, 30 Apr 2018 20:57:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1639,7 +1656,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29934']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29867']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1649,19 +1666,19 @@ interactions:
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/49f93b44-fe70-4a75-86ea-b28b2ec454e4?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1da022cc-a4bc-4fa1-8dff-0244bed008b6?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:59:56.3372153+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"49f93b44-fe70-4a75-86ea-b28b2ec454e4\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:56:29.5764704+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1da022cc-a4bc-4fa1-8dff-0244bed008b6\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 22:00:56 GMT']
+      date: ['Mon, 30 Apr 2018 20:57:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1669,7 +1686,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14982,Microsoft.Compute/GetOperation30Min;29931']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29864']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1679,49 +1696,19 @@ interactions:
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/49f93b44-fe70-4a75-86ea-b28b2ec454e4?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1da022cc-a4bc-4fa1-8dff-0244bed008b6?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:59:56.3372153+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"49f93b44-fe70-4a75-86ea-b28b2ec454e4\"\
-        \r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['134']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 22:01:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29928']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss identity assign]
-      Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/49f93b44-fe70-4a75-86ea-b28b2ec454e4?api-version=2017-12-01
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-20T21:59:56.3372153+00:00\",\r\
-        \n  \"endTime\": \"2018-04-20T22:01:31.0761798+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"49f93b44-fe70-4a75-86ea-b28b2ec454e4\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-04-30T20:56:29.5764704+00:00\",\r\
+        \n  \"endTime\": \"2018-04-30T20:57:56.1754948+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"1da022cc-a4bc-4fa1-8dff-0244bed008b6\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 22:01:58 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1729,7 +1716,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29926']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29861']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1739,7 +1726,7 @@ interactions:
       CommandName: [vmss identity assign]
       Connection: [keep-alive]
       User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.26 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          msrest_azure/0.4.26 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.32]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3?api-version=2017-12-01
@@ -1749,7 +1736,7 @@ interactions:
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\",\r\n      \"automaticOSUpgrade\": false\r\n  \
         \  },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n  \
-        \      \"computerNamePrefix\": \"vmss3a57f\",\r\n        \"adminUsername\"\
+        \      \"computerNamePrefix\": \"vmss3a8d8\",\r\n        \"adminUsername\"\
         : \"admin123\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\"\
         : false\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
         : {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\"\
@@ -1758,18 +1745,18 @@ interactions:
         \        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"\
         credativ\",\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss3a57fNic\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss3a8d8Nic\"\
         ,\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"\
         dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\"\
-        :[{\"name\":\"vmss3a57fIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        :[{\"name\":\"vmss3a8d8IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"e682f6ec-53fe-4b6a-bfe2-3f4643088b35\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"e81af0ac-0438-46e1-9391-c7ba82aaadfb\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n \
-        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"7822c249-75a6-4693-8be1-161923f9b0ae\"\
+        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"fcf1c990-27dd-434d-8851-e3126d5b9a7c\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3\"\
         ,\r\n  \"name\": \"vmss3\"\r\n}"}
@@ -1777,7 +1764,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2619']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 22:01:59 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1785,11 +1772,11 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;181,Microsoft.Compute/GetVMScaleSet30Min;1465']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetVMScaleSet3Min;178,Microsoft.Compute/GetVMScaleSet30Min;1430']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"principalId": "7822c249-75a6-4693-8be1-161923f9b0ae",
-      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"}}'
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
+      "principalId": "fcf1c990-27dd-434d-8851-e3126d5b9a7c"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1804,20 +1791,20 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2018-01-01-preview
   response:
-    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"7822c249-75a6-4693-8be1-161923f9b0ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","createdOn":"2018-04-20T22:02:00.8533539Z","updatedOn":"2018-04-20T22:02:00.8533539Z","createdBy":null,"updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'}
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"fcf1c990-27dd-434d-8851-e3126d5b9a7c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","createdOn":"2018-04-30T20:58:04.2764097Z","updatedOn":"2018-04-30T20:58:04.2764097Z","createdBy":null,"updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_msi000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['1019']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 20 Apr 2018 22:02:02 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/10.0]
       set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-      x-ms-request-charge: ['3']
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      x-ms-request-charge: ['4']
       x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
@@ -1840,12 +1827,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 20 Apr 2018 22:02:03 GMT']
+      date: ['Mon, 30 Apr 2018 20:58:08 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGVk1TUzo1Rk1TSVFPQlI1QVVBVjdKN01TWFRTVDJWQjJITnw0MjVEMjM1QTA4NzRGNUQwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGVk1TUzo1Rk1TSVczSUE0VkNOQlVMN1NXNlVONDVHVEJVRHw0REYyQzZBREI5OTA5NjgxLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.31"
+VERSION = "2.0.32"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
(Not for //build release)
The main purpose is to by-pass the access check on linked resources which otherwise would block the whole operation e.g. if the users has access to the VMSS, but not on the LB.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
