### PR TITLE
Add timeout to the telemetry sender

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry_upload.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry_upload.py
@@ -38,7 +38,7 @@ class LimitedRetrySender(SynchronousSender):
         request = HTTPClient.Request(self._service_endpoint_uri, bytearray(request_payload, 'utf-8'),
                                      {'Accept': 'application/json', 'Content-Type': 'application/json; charset=utf-8'})
         try:
-            response = HTTPClient.urlopen(request)
+            response = HTTPClient.urlopen(request, timeout=10)
             status_code = response.getcode()
             if 200 <= status_code < 300:
                 return


### PR DESCRIPTION
This is used to avoid uploader from run into the situation when
Applicaiton Insight service is unresponsive.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
