### PR TITLE
Update dependency on azure-devtools

### DIFF
--- a/src/azure-cli-testsdk/HISTORY.rst
+++ b/src/azure-cli-testsdk/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.2
++++++
+* Update the setup.py to limit the dependency on azure-devtools in 0.5.* range.
+
 0.1.1
 +++++
 * Add additional tags to the resource group created by automation

--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 
 CLASSIFIERS = [
     'Development Status :: 3 - Alpha',
@@ -34,7 +34,7 @@ DEPENDENCIES = [
     'jmespath',
     'mock',
     'vcrpy>=1.10.3',
-    'azure-devtools>=0.5.4'
+    'azure-devtools~=0.5.4'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
To avoid a new version to be selected unintentionally.

Long story:

About to release 1.0.0 of `azure-devtools`. However, the newer version will introduce test error. It should not be picked up until the test recordings are rebased. This change will prevent 1.0.0 from being picked up unless the setup is intentionally updated.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
