### PR TITLE
[Monitor] Make Monitor exception handler case insensitive.

### DIFF
--- a/src/command_modules/azure-cli-monitor/HISTORY.rst
+++ b/src/command_modules/azure-cli-monitor/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.7
++++++
+* Minor fixes.
+
 0.1.6
 +++++
 * Minor fixes.

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_exception_handler.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_exception_handler.py
@@ -11,9 +11,10 @@ def monitor_exception_handler(ex):
     if isinstance(ex, ErrorResponseException):
         # work around for issue: https://github.com/Azure/azure-sdk-for-python/issues/1556
         error_payload = ex.response.json()
-        if 'Code' in error_payload and 'Message' in error_payload:
-            message = '{}.'.format(error_payload['Message']) if error_payload['Message'] else 'Operation failed.'
-            code = '[Code: "{}"]'.format(error_payload['Code']) if error_payload['Code'] else ''
+        error_payload = {k.lower(): v for k, v in error_payload.items()}
+        if 'code' in error_payload and 'message' in error_payload:
+            message = '{}.'.format(error_payload['message']) if error_payload['message'] else 'Operation failed.'
+            code = '[Code: "{}"]'.format(error_payload['code']) if error_payload['code'] else ''
             raise CLIError('{} {}'.format(message, code))
         else:
             raise CLIError(ex)

--- a/src/command_modules/azure-cli-monitor/setup.py
+++ b/src/command_modules/azure-cli-monitor/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.6"
+VERSION = "0.1.7"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Partially address #6120. Makes the Monitor exception handling logic case-insensitive for the payload keys to ensure that the Code is displayed as intended.

The rest of that issue belongs with the service team.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
