### PR TITLE
Add exception unwrapping for template-based creates.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -91,6 +91,13 @@ class ArmTemplateBuilder(object):
         return json.loads(json.dumps(self.parameters))
 
 
+def handle_template_based_exception(ex):
+    try:
+        raise CLIError(ex.inner_exception.error.message)
+    except AttributeError:
+        raise CLIError(ex)
+
+
 def handle_long_running_operation_exception(ex):
     import azure.cli.core.telemetry as telemetry
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -6,7 +6,7 @@
 # pylint: disable=line-too-long
 
 from azure.cli.core.commands import DeploymentOutputLongRunningOperation
-from azure.cli.core.commands.arm import deployment_validate_table_format
+from azure.cli.core.commands.arm import deployment_validate_table_format, handle_template_based_exception
 from azure.cli.core.commands import CliCommandType
 from azure.cli.core.util import empty_on_404
 
@@ -218,7 +218,7 @@ def load_command_table(self, _):
 
     # region ApplicationGateways
     with self.command_group('network application-gateway', network_ag_sdk) as g:
-        g.custom_command('create', 'create_application_gateway', transform=DeploymentOutputLongRunningOperation(self.cli_ctx), supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_ag_create_namespace)
+        g.custom_command('create', 'create_application_gateway', transform=DeploymentOutputLongRunningOperation(self.cli_ctx), supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_ag_create_namespace, exception_handler=handle_template_based_exception)
         g.command('delete', 'delete', supports_no_wait=True)
         g.command('show', 'get', exception_handler=empty_on_404)
         g.custom_command('list', 'list_application_gateways')
@@ -385,7 +385,7 @@ def load_command_table(self, _):
     # region LoadBalancers
     with self.command_group('network lb', network_lb_sdk) as g:
         g.command('show', 'get', exception_handler=empty_on_404)
-        g.custom_command('create', 'create_load_balancer', transform=DeploymentOutputLongRunningOperation(self.cli_ctx), supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_lb_create_namespace)
+        g.custom_command('create', 'create_load_balancer', transform=DeploymentOutputLongRunningOperation(self.cli_ctx), supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_lb_create_namespace, exception_handler=handle_template_based_exception)
         g.command('delete', 'delete')
         g.custom_command('list', 'list_lbs')
         g.generic_update_command('update')
@@ -666,7 +666,7 @@ def load_command_table(self, _):
 
     # region VirtualNetworkGatewayConnections
     with self.command_group('network vpn-connection', network_vpn_sdk) as g:
-        g.custom_command('create', 'create_vpn_connection', transform=DeploymentOutputLongRunningOperation(self.cli_ctx), table_transformer=deployment_validate_table_format, validator=process_vpn_connection_create_namespace)
+        g.custom_command('create', 'create_vpn_connection', transform=DeploymentOutputLongRunningOperation(self.cli_ctx), table_transformer=deployment_validate_table_format, validator=process_vpn_connection_create_namespace, exception_handler=handle_template_based_exception)
         g.command('delete', 'delete')
         g.command('show', 'get', exception_handler=empty_on_404, transform=transform_vpn_connection)
         g.command('list', 'list', transform=transform_vpn_connection_list)

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -2,6 +2,12 @@
 
 Release History
 ===============
+
+2.0.29
+++++++
+* Minor changes
+
+
 2.0.28
 ++++++
 * Minor changes

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 from azure.cli.core.util import empty_on_404
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands import CliCommandType
+from azure.cli.core.commands.arm import handle_template_based_exception
 
 from azure.cli.command_modules.resource._client_factory import (
     cf_resource_groups, cf_providers, cf_features, cf_tags, cf_deployments,
@@ -185,12 +186,12 @@ def load_command_table(self, _):
         g.command('remove-value', 'delete_value')
 
     with self.command_group('group deployment', resource_deployment_sdk) as g:
-        g.custom_command('create', 'deploy_arm_template', supports_no_wait=True, validator=process_deployment_create_namespace)
+        g.custom_command('create', 'deploy_arm_template', supports_no_wait=True, validator=process_deployment_create_namespace, exception_handler=handle_template_based_exception)
         g.command('list', 'list_by_resource_group', table_transformer=transform_deployments_list, min_api='2017-05-10')
         g.command('list', 'list', table_transformer=transform_deployments_list, max_api='2016-09-01')
         g.command('show', 'get', exception_handler=empty_on_404)
         g.command('delete', 'delete')
-        g.custom_command('validate', 'validate_arm_template', table_transformer=deployment_validate_table_format)
+        g.custom_command('validate', 'validate_arm_template', table_transformer=deployment_validate_table_format, exception_handler=handle_template_based_exception)
         g.custom_command('export', 'export_deployment_as_template')
         g.generic_wait_command('wait')
 

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.28"
+VERSION = "2.0.29"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+2.0.33
+++++++
+* Minor fixes.
+
 2.0.32
 ++++++
 * vm/vmss update: expose `--license-type`

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -22,7 +22,7 @@ from azure.cli.command_modules.vm._validators import (
     process_msi_namespace, process_remove_identity_namespace, process_vm_secret_format)
 
 from azure.cli.core.commands import DeploymentOutputLongRunningOperation, CliCommandType
-from azure.cli.core.commands.arm import deployment_validate_table_format
+from azure.cli.core.commands.arm import deployment_validate_table_format, handle_template_based_exception
 from azure.cli.core.util import empty_on_404
 
 
@@ -164,7 +164,7 @@ def load_command_table(self, _):
         g.custom_command('identity show', 'show_vm_identity')
 
         g.custom_command('capture', 'capture_vm')
-        g.custom_command('create', 'create_vm', transform=transform_vm_create_output, supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_vm_create_namespace)
+        g.custom_command('create', 'create_vm', transform=transform_vm_create_output, supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_vm_create_namespace, exception_handler=handle_template_based_exception)
         g.command('convert', 'convert_to_managed_disks', min_api='2016-04-30-preview')
         g.command('deallocate', 'deallocate', supports_no_wait=True)
         g.command('delete', 'delete', confirmation=True, supports_no_wait=True)
@@ -189,7 +189,7 @@ def load_command_table(self, _):
 
     with self.command_group('vm availability-set', compute_availset_sdk) as g:
         g.custom_command('convert', 'convert_av_set_to_managed_disk', min_api='2016-04-30-preview')
-        g.custom_command('create', 'create_av_set', table_transformer=deployment_validate_table_format, supports_no_wait=True)
+        g.custom_command('create', 'create_av_set', table_transformer=deployment_validate_table_format, supports_no_wait=True, exception_handler=handle_template_based_exception)
         g.command('delete', 'delete')
         g.command('list', 'list')
         g.command('list-sizes', 'list_available_sizes')
@@ -266,7 +266,7 @@ def load_command_table(self, _):
         g.custom_command('identity assign', 'assign_vmss_identity', validator=process_assign_identity_namespace)
         g.custom_command('identity remove', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01')
         g.custom_command('identity show', 'show_vmss_identity')
-        g.custom_command('create', 'create_vmss', transform=DeploymentOutputLongRunningOperation(self.cli_ctx, 'Starting vmss create'), supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_vmss_create_namespace)
+        g.custom_command('create', 'create_vmss', transform=DeploymentOutputLongRunningOperation(self.cli_ctx, 'Starting vmss create'), supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_vmss_create_namespace, exception_handler=handle_template_based_exception)
         g.custom_command('deallocate', 'deallocate_vmss', supports_no_wait=True)
         g.command('delete', 'delete', supports_no_wait=True)
         g.custom_command('delete-instances', 'delete_vmss_instances', supports_no_wait=True)

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.32"
+VERSION = "2.0.33"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Closes #6231.

Adds the unwrapping logic to all template-based creates, although the original issue was only reported with VM. The issue might be limited to compute, but adding the logic doesn't hurt Network or Resource.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
