### PR TITLE
[Network] Fix Network Watcher Show-Topology

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.1.2
+++++++
+* `network watcher show-topology`: Fix issue where command would not work with vnet and/or subnet name. [#6326](https://github.com/Azure/azure-cli/issues/6326)
+
 2.1.1
 ++++++
 * `network watcher`: Fix issue where certain commands would claim Network Watcher is not enabled for regions when it actually is. [#6264](https://github.com/Azure/azure-cli/issues/6264)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -943,7 +943,7 @@ def process_nw_topology_namespace(cmd, namespace):
             raise subnet_usage
         if subnet_id:
             rg = parse_resource_id(subnet_id)['resource_group']
-            namespace.target_subnet = SubResource(subnet)
+            namespace.target_subnet = SubResource(id=subnet)
         else:
             subnet_id = subnet_id or resource_id(
                 subscription=subscription_id,
@@ -956,7 +956,7 @@ def process_nw_topology_namespace(cmd, namespace):
             )
             namespace.target_resource_group_name = None
             namespace.target_vnet = None
-            namespace.target_subnet = SubResource(subnet_id)
+            namespace.target_subnet = SubResource(id=subnet_id)
     elif vnet:
         # targeting vnet - OK
         vnet_usage = CLIError('usage error: --vnet ID | --vnet NAME --resource-group NAME')
@@ -966,7 +966,7 @@ def process_nw_topology_namespace(cmd, namespace):
             raise vnet_usage
         if vnet_id:
             rg = parse_resource_id(vnet_id)['resource_group']
-            namespace.target_vnet = SubResource(vnet)
+            namespace.target_vnet = SubResource(id=vnet)
         else:
             vnet_id = vnet_id or resource_id(
                 subscription=subscription_id,
@@ -976,7 +976,7 @@ def process_nw_topology_namespace(cmd, namespace):
                 name=vnet
             )
             namespace.target_resource_group_name = None
-            namespace.target_vnet = SubResource(vnet_id)
+            namespace.target_vnet = SubResource(id=vnet_id)
     else:
         raise CLIError('usage error: --resource-group NAME | --vnet NAME_OR_ID | --subnet NAME_OR_ID')
 

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.1.1"
+VERSION = "2.1.2"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fix #6326.

Regression due to Autorest3 and the fact that the Network Watcher tests don't re-record reliably.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
