### PR TITLE
ad app update: allow setting random properties

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -692,6 +692,8 @@ def set_properties(instance, expression):
             if hasattr(instance, make_snake_case(name)):
                 setattr(instance, make_snake_case(name), value)
             else:
+                if instance.additional_properties is None:
+                    instance.additional_properties = {}
                 instance.additional_properties[name] = value
                 instance.enable_additional_properties_sending()
                 logger.warning(
@@ -874,9 +876,9 @@ def _update_instance(instance, part, path):  # pylint: disable=too-many-return-s
 
         if hasattr(instance, make_snake_case(part)):
             return getattr(instance, make_snake_case(part), None)
-        elif hasattr(instance, 'additional_properties') and (part in instance.additional_properties):
+        elif part in getattr(instance, 'additional_properties', {}):
             instance.enable_additional_properties_sending()
-            return instance.additional_properties.get[part]
+            return instance.additional_properties[part]
         raise AttributeError()
     except (AttributeError, KeyError):
         throw_and_show_options(instance, part, path)

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -807,7 +807,7 @@ def make_snake_case(s):
 def make_camel_case(s):
     if isinstance(s, str):
         parts = s.split('_')
-        return parts[0].lower() + ''.join(p.capitalize() for p in parts[1:])
+        return (parts[0].lower() + ''.join(p.capitalize() for p in parts[1:])) if len(parts) > 1 else s
     return s
 
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
@@ -235,7 +235,7 @@ class GenericUpdateTest(unittest.TestCase):
                 raise ex
             raise AssertionError("exception not raised for ''".format(message))
 
-        missing_remove_message = "Couldn't find 'doesntExist' in ''. Available options: ['additional1', 'emptyDict', 'emptyDictOfDicts', 'emptyList', 'emptyProp', 'myDict', 'myList', 'myListOfCamelDicts', 'myListOfObjects', 'myListOfSnakeDicts', 'myProp']"
+        missing_remove_message = "Couldn't find 'doesntExist' in ''. Available options: ['additional1', 'additionalList', 'emptyDict', 'emptyDictOfDicts', 'emptyList', 'emptyProp', 'myDict', 'myList', 'myListOfCamelDicts', 'myListOfObjects', 'myListOfSnakeDicts', 'myProp', 'myTestObject']"
         _execute_with_error('genupdate --remove doesntExist',
                             missing_remove_message,
                             'remove non-existent property by name')

--- a/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
@@ -33,6 +33,7 @@ class ObjectTestObject(object):
         self.my_string = str(str_val)
         self.my_int = int(int_val)
         self.my_bool = bool(bool_val)
+        self.additional_properties = None
 
 
 class TestObject(Model):
@@ -63,7 +64,8 @@ class TestObject(Model):
         self.empty_dict_of_dicts = {'dict': {'dict2': None}}
         self.empty_dict = {'dict3': None}
 
-        self.additional_properties = {'additional1': 'addition value #1'}
+        self.additional_properties = {'additional1': 'addition value #1', 'additionalList': []}
+        self.my_test_object = ObjectTestObject('myKeyAA', 1, False)
 
 
 def _prepare_test_loader():
@@ -131,6 +133,9 @@ class GenericUpdateTest(unittest.TestCase):
         cli.invoke('genupdate --set additional1=v1'.split())
         self.assertEqual(my_obj.additional_properties['additional1'], 'v1')
 
+        cli.invoke('genupdate --set my_test_object.additional1=v1'.split())  # for unknown properties, we also set as additional_proeprties
+        self.assertEqual(my_obj.my_test_object.additional_properties['additional1'], 'v1')
+
         # Test the different ways of indexing into a list of objects or dictionaries by filter
         cli.invoke('genupdate --set myListOfCamelDicts[myKey=value_2].myKey="foo=bar"'.split())
         self.assertEqual(my_obj.my_list_of_camel_dicts[1]['myKey'],
@@ -177,6 +182,9 @@ class GenericUpdateTest(unittest.TestCase):
         self.assertEqual(len(my_obj.my_prop), 1, 'nullify property, add two and remove one')
         self.assertEqual(my_obj.my_prop[0], 'str2', 'nullify property, add two and remove one')
 
+        cli.invoke('genupdate --add additionalList listMember1'.split())
+        self.assertEqual(my_obj.additional_properties['additionalList'][0], 'listMember1',
+                         'add a value to an array inside additional_properties')
         # Test various --add to lists
         cli.invoke('genupdate --set myList=[]'.split())
         cli.invoke(shlex.split('genupdate --add myList value1'))

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.0.24
 ++++++
-* ad app update: allow setting random properties
+* ad app update: add generic update support
 
 2.0.23
 ++++++

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.0.24
 ++++++
-* Minor fixes.
+* ad app update: allow setting random properties
 
 2.0.23
 ++++++

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -147,7 +147,7 @@ helps['ad app update'] = """
                 }]
         - name: update an application's group membership claims to "All"
           text: >
-                az ad app update --id e042ec79-34cd-498f-9d9f-123456781234 --additional-properties groupMembershipClaims=All
+                az ad app update --id e042ec79-34cd-498f-9d9f-123456781234 --set groupMembershipClaims=All
 
 """
 helps['ad user list'] = """

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -145,6 +145,10 @@ helps['ad app update'] = """
                         }
                    ]
                 }]
+        - name: update an application's group membership claims to "All"
+          text: >
+                az ad app update --id e042ec79-34cd-498f-9d9f-123456781234 --additional-properties groupMembershipClaims=All
+
 """
 helps['ad user list'] = """
     type: command

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -46,7 +46,7 @@ def load_arguments(self, _):
         c.argument('identifier', options_list=['--id'], help='identifier uri, application id, or object id of the associated application')
 
     with self.argument_context('ad app update') as c:
-        c.argument('additional_properties', nargs='+', help="space separated '<name>=<value>' pairs representing random properties not captured by explicit arguments")
+        c.ignore('object_id')
 
     with self.argument_context('ad sp create-for-rbac') as c:
         c.argument('scopes', nargs='+')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -45,9 +45,6 @@ def load_arguments(self, _):
     with self.argument_context('ad sp create') as c:
         c.argument('identifier', options_list=['--id'], help='identifier uri, application id, or object id of the associated application')
 
-    with self.argument_context('ad app update') as c:
-        c.ignore('object_id')
-
     with self.argument_context('ad sp create-for-rbac') as c:
         c.argument('scopes', nargs='+')
         c.argument('role', completer=get_role_definition_name_completion_list)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -39,14 +39,14 @@ def load_arguments(self, _):
                    help="resource scopes and roles the application requires access to. Should be in manifest json format. See examples below for details")
         c.argument('native_app', arg_type=get_three_state_flag(), help="an application which can be installed on a user's device or computer")
 
-    with self.argument_context('ad') as c:
-        c.ignore('additional_properties')
-
     with self.argument_context('ad sp') as c:
         c.argument('identifier', options_list=['--id'], help='service principal name, or object id')
 
     with self.argument_context('ad sp create') as c:
         c.argument('identifier', options_list=['--id'], help='identifier uri, application id, or object id of the associated application')
+
+    with self.argument_context('ad app update') as c:
+        c.argument('additional_properties', nargs='+', help="space separated '<name>=<value>' pairs representing random properties not captured by explicit arguments")
 
     with self.argument_context('ad sp create-for-rbac') as c:
         c.argument('scopes', nargs='+')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
@@ -63,6 +63,8 @@ def load_command_table(self, _):
         client_factory=get_graph_client_groups
     )
 
+    role_custom = CliCommandType(operations_tmpl='azure.cli.command_modules.role.custom#{}')
+
     with self.command_group('role definition') as g:
         g.custom_command('list', 'list_role_definitions', table_transformer=transform_definition_list)
         g.custom_command('delete', 'delete_role_definition')
@@ -80,7 +82,9 @@ def load_command_table(self, _):
         g.custom_command('delete', 'delete_application')
         g.custom_command('list', 'list_apps')
         g.custom_command('show', 'show_application', exception_handler=empty_on_404)
-        g.custom_command('update', 'update_application')
+        g.generic_update_command('update', setter_name='patch_application', setter_type=role_custom,
+                                 getter_name='show_application', getter_type=role_custom,
+                                 custom_func_name='update_application', custom_func_type=role_custom)
 
     with self.command_group('ad sp', resource_type=PROFILE_TYPE, min_api='2017-03-10') as g:
         g.custom_command('create', 'create_service_principal')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -603,12 +603,10 @@ def create_application(client, display_name, homepage=None, identifier_uris=None
     return result
 
 
-def update_application(client, identifier, display_name=None, homepage=None,
+def update_application(cmd, instance, display_name=None, homepage=None,
                        identifier_uris=None, password=None, reply_urls=None, key_value=None,
                        key_type=None, key_usage=None, start_date=None, end_date=None, available_to_other_tenants=None,
-                       oauth2_allow_implicit_flow=None, required_resource_accesses=None, additional_properties=None):
-    object_id = _resolve_application(client, identifier)
-
+                       oauth2_allow_implicit_flow=None, required_resource_accesses=None):
     password_creds, key_creds, required_accesses = None, None, None
     if any([key_value, key_type, key_usage, start_date, end_date]):
         password_creds, key_creds = _build_application_creds(password, key_value, key_type,
@@ -626,20 +624,14 @@ def update_application(client, identifier, display_name=None, homepage=None,
                                                   available_to_other_tenants=available_to_other_tenants,
                                                   required_resource_access=required_accesses,
                                                   oauth2_allow_implicit_flow=oauth2_allow_implicit_flow)
-    if additional_properties:
-        app_patch_param.enable_additional_properties_sending()
-        if app_patch_param.additional_properties is None:
-            app_patch_param.additional_properties = {}
 
-        for p in additional_properties:
-            name, value = p.split('=')
-            try:
-                value = shell_safe_json_parse(value)  # see whether it is a json
-            except CLIError:
-                pass
-            app_patch_param.additional_properties[name] = value
+    return app_patch_param
 
-    return client.patch(object_id, app_patch_param)
+
+def patch_application(cmd, identifier, parameters):
+    graph_client = _graph_client_factory(cmd.cli_ctx)
+    object_id = _resolve_application(graph_client.applications, identifier)
+    return graph_client.applications.patch(object_id, parameters)
 
 
 def _build_application_accesses(required_resource_accesses):

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -603,7 +603,7 @@ def create_application(client, display_name, homepage=None, identifier_uris=None
     return result
 
 
-def update_application(cmd, instance, display_name=None, homepage=None,
+def update_application(instance, display_name=None, homepage=None,  # pylint: disable=unused-argument
                        identifier_uris=None, password=None, reply_urls=None, key_value=None,
                        key_type=None, key_usage=None, start_date=None, end_date=None, available_to_other_tenants=None,
                        oauth2_allow_implicit_flow=None, required_resource_accesses=None):

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -606,7 +606,7 @@ def create_application(client, display_name, homepage=None, identifier_uris=None
 def update_application(client, identifier, display_name=None, homepage=None,
                        identifier_uris=None, password=None, reply_urls=None, key_value=None,
                        key_type=None, key_usage=None, start_date=None, end_date=None, available_to_other_tenants=None,
-                       oauth2_allow_implicit_flow=None, required_resource_accesses=None):
+                       oauth2_allow_implicit_flow=None, required_resource_accesses=None, additional_properties=None):
     object_id = _resolve_application(client, identifier)
 
     password_creds, key_creds, required_accesses = None, None, None
@@ -626,6 +626,19 @@ def update_application(client, identifier, display_name=None, homepage=None,
                                                   available_to_other_tenants=available_to_other_tenants,
                                                   required_resource_access=required_accesses,
                                                   oauth2_allow_implicit_flow=oauth2_allow_implicit_flow)
+    if additional_properties:
+        app_patch_param.enable_additional_properties_sending()
+        if app_patch_param.additional_properties is None:
+            app_patch_param.additional_properties = {}
+
+        for p in additional_properties:
+            name, value = p.split('=')
+            try:
+                value = shell_safe_json_parse(value)  # see whether it is a json
+            except CLIError:
+                pass
+            app_patch_param.additional_properties[name] = value
+
     return client.patch(object_id, app_patch_param)
 
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_application_set_scenario.yaml
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_application_set_scenario.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: 'b''{"homepage": "http://cli-graph000001", "availableToOtherTenants": false,
-      "identifierUris": ["http://cli-graph000001"], "displayName": "cli-graph000001"}'''
+    body: 'b''{"homepage": "http://cli-graph000001", "displayName": "cli-graph000001",
+      "availableToOtherTenants": false, "identifierUris": ["http://cli-graph000001"]}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -9,38 +9,38 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['149']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"2ee40ff9-c740-4378-b658-0772b3bc2a30","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"82b55d52-9557-4aaa-9c54-f185454c6aa7","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaContentType":"application/json;odata=minimalmetadata;
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaContentType":"application/json;odata=minimalmetadata;
         charset=utf-8","logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"f4b58339-a058-4445-9b01-b131d3bedd7d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1736']
+      content-length: ['1768']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 18 Mar 2018 03:03:38 GMT']
-      duration: ['5393254']
+      date: ['Sat, 12 May 2018 00:57:17 GMT']
+      duration: ['8048633']
       expires: ['-1']
-      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/2ee40ff9-c740-4378-b658-0772b3bc2a30/Microsoft.DirectoryServices.Application']
-      ocp-aad-diagnostics-server-name: [QOIMKIIdK/ceXUr9GAU3ThLEQHRhyDj1NpVX1Mv+k1o=]
-      ocp-aad-session-key: [XvkKCjGO92Ae4b8xQ4KY25somuM20W0lt_mY7qpb5BsnPYrTmTIU72SBF6-VU0_MzwpvwsIpq5P7fGCUC0R6kboOEuLQhl_Bg-FgmKRWzXbg1tXBl4NplAqSYRlItdvtQtx4P6zHcl4Werq-2phw-afrAAfdsyRmIhyt3WEYkycoQeYoSYk74UdpVjzCD7yKgiTtu_CvpXjStsTKF7OP1Q.7_lE5He1BbJ2T8iTdB1lqRJc163RiPNx6fIRgVIZ0pE]
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/58d930aa-ba59-4c10-9d75-3f830229aa01/Microsoft.DirectoryServices.Application']
+      ocp-aad-diagnostics-server-name: [NorBiSXbBacugIOc9PINP1SvB49TAti3iq1gEzH+f90=]
+      ocp-aad-session-key: [z6LGHxE-pgNk-yThMu7z-Gv2L_roQShHK_AnummPGWZXvMQojhuAg4Pkboa06SHlZGiZTB4unoY2zM5_YLy6SD4PsmsFCDxSlesFOgd_bMFWa0U6qgWDdq6RUCxf5VMoHLVBPHu5MAQDnXGB6kFZMQ.gPYOSTPqJVeBe05i4AUAt8_m2dUvsv5dCBknQESGvDk]
       pragma: [no-cache]
-      request-id: [7ebb99cf-088f-4b60-9f2c-f95bb0b4ea24]
+      request-id: [24fc5137-7899-4f78-a1f1-6130d18163bc]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -50,36 +50,36 @@ interactions:
       CommandName: [ad app show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"2ee40ff9-c740-4378-b658-0772b3bc2a30","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"82b55d52-9557-4aaa-9c54-f185454c6aa7","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"f4b58339-a058-4445-9b01-b131d3bedd7d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1653']
+      content-length: ['1685']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 18 Mar 2018 03:03:38 GMT']
-      duration: ['515912']
+      date: ['Sat, 12 May 2018 00:57:18 GMT']
+      duration: ['519435']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [zYFOqxuM54Aw2TyX3bLhJZ/cB4A9F8cptTJtgCGrP+c=]
-      ocp-aad-session-key: [siz77p5FQYERRkpwH-o5cF70_S4h8b0N1CdW2uEDOlUQpjLhWfgoo5kyPEIgmBOkZdMUi7OY9OGL7K8nMdVZxsv_136Oqe8q8w9B_b7-SG0wh3wkA2BVaXd5dwqIHTj3Z5QNidgZLTWkLZb-LUiI7m1ks1P7ujCvu2_SQckLqANKAnC7O8wM5KMMhuKCX0ZLukbOroJXzZzCRlMIcOhtgQ.579lOq2RSQ7m5kp6F04d042sppDqJSS2_o3yOIPyULU]
+      ocp-aad-diagnostics-server-name: [cNcMQJ1oxb51WRRiXzCCai1HkMelF0SUywxI2UqetqU=]
+      ocp-aad-session-key: [zOQGtrxf2chVdwUihfSgrhuCR2Yx0mpx1S__IQRWtSdc08FSkNWHMJ30ilLqRc9yK7EvhQ4oCUn2Fnzs-5L8Ki2f4oFnWRbX5FxNEmnG6x2gTXklIuOzxRx-VVlp0tbpdycmRrPYYXymwvcXm2GGVQ.xDeIcOKKMf3uc9Ey6hD-2t0j6bWi31xPNfJidj7Gvf8]
       pragma: [no-cache]
-      request-id: [f9ff3418-d349-4ca0-a35d-8932d760c483]
+      request-id: [3161d6f5-2ca7-41e6-84f3-2579989e34db]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -89,36 +89,36 @@ interactions:
       CommandName: [ad app show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/2ee40ff9-c740-4378-b658-0772b3bc2a30?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"2ee40ff9-c740-4378-b658-0772b3bc2a30","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"82b55d52-9557-4aaa-9c54-f185454c6aa7","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"f4b58339-a058-4445-9b01-b131d3bedd7d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1650']
+      content-length: ['1682']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 18 Mar 2018 03:03:39 GMT']
-      duration: ['1270206']
+      date: ['Sat, 12 May 2018 00:57:18 GMT']
+      duration: ['632413']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [3/hPBrNk3bWDiI3Le668U3KnfkdAVCOsHPHBA7wvvMs=]
-      ocp-aad-session-key: [2YooP1lZrTdneI1EInd0v-s56lqXTTxHkqoq1tRO6KQGWXuaYGe-lJkQqoS0CvmDQykJ5QGHssggs3D_uzBVFZsjyVZLXntW5kFHbTWTO0kNNtyp7f-eMpAQvjougyjQlny2px-qUsnnzXh2GIUJd4-ulgNSVpKo3okG1xL2QMq3zBxlsPNlhSQW63Sw-p7QJl50uaeYMG4o4x9ZJ3yENw.jtbXzIseojUbQX8076SrDkOmWNgwjky9PSp4aK-g6Rk]
+      ocp-aad-diagnostics-server-name: [BQUIGmRRyeHSEXkgch2q1Q3MYXFFtGhoXfkp3cvu3XA=]
+      ocp-aad-session-key: [aNvWsSjrQxjP2Su-8eldZB-VJuetpHTgdwp_c5U5be9D478VvQpgCRyNn1kT90ZnJSmQn1oyibWkI9CZ-prmfZAFzQRbVIsg7dAS6djb_JW_90MaUJfy3tcFiaPSQaEuFWdO2xTpOKaD-YQeerDrvw.KtspiVh7u6k9ROFPvnnaGKsuFApnHBF861eRYrJZCUA]
       pragma: [no-cache]
-      request-id: [8251b7e5-f082-40cb-8db5-599a3dc1a923]
+      request-id: [a6111d6c-d2ff-4149-b117-f6f4c0b4a205]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -128,36 +128,36 @@ interactions:
       CommandName: [ad app list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=startswith%28displayName%2C%27cli-graph000001%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"2ee40ff9-c740-4378-b658-0772b3bc2a30","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"82b55d52-9557-4aaa-9c54-f185454c6aa7","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"f4b58339-a058-4445-9b01-b131d3bedd7d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1653']
+      content-length: ['1685']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 18 Mar 2018 03:03:38 GMT']
-      duration: ['561963']
+      date: ['Sat, 12 May 2018 00:57:19 GMT']
+      duration: ['555595']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [zYFOqxuM54Aw2TyX3bLhJZ/cB4A9F8cptTJtgCGrP+c=]
-      ocp-aad-session-key: [fOpUZPot_F2ivXd73VcJzb5RtBaS61NrUHKPHFhVrj-ejh_13DOwSeLQevEWfuUevnQkZF1n5Wjs3WSX93x1Sh3sSc6dEbg6EmXBL3EqqYy8XjBjfOHF7ZeHTGo7ScT9DGn2mBe1tooScE9WRS6cMKvwq-tChC-9Q-vEE9l6a6q5yRLI_1LFzz7pez9MvllKA9RFUQ_fY2VXUo8B5Ci2mQ.ChFa6aygf_fC7GSeExpf3S01681nafxrAUNGkqg_KTs]
+      ocp-aad-diagnostics-server-name: [BQUIGmRRyeHSEXkgch2q1Q3MYXFFtGhoXfkp3cvu3XA=]
+      ocp-aad-session-key: [AtsmVijoD-dWwCTARzs_ORg9v77SHvIMcRWLdrimDuKd6PGlv9ncVVsRGlkYVF5bn5yHCRVrIfxMbs0tFUkSJ24I2bhbT8lxzNgiF275c_9A-wqrnrA6vSYybH7vycRUqxdMuNQQ1nuO-0h1nHtfOw.v14almD8a6PbMITdhZHJVLjyyDR5GlFVH42P3P7__o8]
       pragma: [no-cache]
-      request-id: [3e03b42c-b5b7-4faf-963e-ed62ecc8be32]
+      request-id: [c2219022-831f-4dd2-b40f-eae7a2688fb0]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -167,36 +167,36 @@ interactions:
       CommandName: [ad app update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"2ee40ff9-c740-4378-b658-0772b3bc2a30","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"82b55d52-9557-4aaa-9c54-f185454c6aa7","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"f4b58339-a058-4445-9b01-b131d3bedd7d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1653']
+      content-length: ['1685']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 18 Mar 2018 03:03:39 GMT']
-      duration: ['931468']
+      date: ['Sat, 12 May 2018 00:57:19 GMT']
+      duration: ['561739']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [qYRMY4Vlalnb7yxIpW6ww7pcooH6r14016oqk2Q7Ve4=]
-      ocp-aad-session-key: [mW7RZRZrj_zM4RnpsUlk_iuSJ7fKoHOXK8r_IOBoUh-mgWrC4Bq5ssKBdqltx4yWt5ZBH4Q-6Cd6De_UQp1Ikd4r6Da-B3MBsz17Ew8j-xonTINVUlcrbhVRG8puwM7mT9eocUKiW0T7F2Xk6rljfTtI0QF26YLvW2o3hjWpYbKE0gCwvtFhE-dQqpbDTqdQ2LlP0A_WI5fR6DVpcLYs0Q.1kVdHwYqD_jKAaoLS7hLpRj_BZJwK-LmB0s7TKXspR8]
+      ocp-aad-diagnostics-server-name: [tAfU859m9TMv99RRajlEbUsi/5BnvcvCFalsXAVDmG0=]
+      ocp-aad-session-key: [ewUUwgCSVKsWUOqVBjMHZDL-CQFycF39VUBVB83TQnrhw75HM-pzUtMe3S1WmCjrl85gJddDoLvtuMNEOh__ju2lsEZTdDsWcQFTxVOnwo1LpMrxN-j4ui4FB5c0YxUzPH-k7DA6GrK-T6AJszLlTQ.2DR-9CFBI3FGqQeTnoutPuzqoIXAyE66NcBlh9086sc]
       pragma: [no-cache]
-      request-id: [e444b3bd-1cd5-44a4-aae2-ee924fe3fffc]
+      request-id: [fa7e6f67-05fc-489c-9268-13cb68d1986a]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: '{"replyUrls": ["http://azureclitest-replyuri"]}'
@@ -207,30 +207,30 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['47']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/2ee40ff9-c740-4378-b658-0772b3bc2a30?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       dataserviceversion: [1.0;]
-      date: ['Sun, 18 Mar 2018 03:03:39 GMT']
-      duration: ['1667575']
+      date: ['Sat, 12 May 2018 00:57:20 GMT']
+      duration: ['3280959']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [gkzsLeMnNX5MBrbEJaZ8vPZibER/4Ly6FEdhXhYlNVM=]
-      ocp-aad-session-key: [dTnewafxzSLIKuVK83HYyHPFLwR06-jWNXyYp9motuhZNXDZshQnZN6qk1IX6fq_-mSB6UJJ_PoXIVrB7AgQD3LwvPz_q6a6dC4pOxF1J0jyEHyEFVP2SXhsTXhG-fsM_5VxIq0dcYS-Jc3Rdna7geyNuoGZLU37NIROzmnCw5cLwoWLPDi1rshPj1NTyJHjx024Wk4niddNEMc-pQ106Q.FwEw_Ohktl9kcGBbhhI1PMdazVi85kqcmyyAehUsQNU]
+      ocp-aad-diagnostics-server-name: [TF7V9cFPmZmQJjy/0crfkRiCbrtTUG3VKT/zd0mx1Gc=]
+      ocp-aad-session-key: [hHHX_lUesNT0rauEVysLIZ2KmGrlnDPEdIjTVgPenvWCBOhECFEsuwhXApDIBxGUxIg5-Z5iyLus9MUXDYHZbZ-ds0uA6srZNDs03-4bFZAX0r_jRUU9qCXb-btJ4d-YBO0txyFMdbeIF2tNbaRlYA.i-fW_t1inCrdLxNpRAwf0vWUTlajnyebVsTDnnehCJ0]
       pragma: [no-cache]
-      request-id: [5b9d4069-8435-46ff-848f-40a5dd20a61e]
+      request-id: [335d858a-3ed4-4af8-9234-8acb9f7f1352]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 204, message: No Content}
 - request:
     body: null
@@ -240,36 +240,36 @@ interactions:
       CommandName: [ad app show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"2ee40ff9-c740-4378-b658-0772b3bc2a30","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"82b55d52-9557-4aaa-9c54-f185454c6aa7","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"f4b58339-a058-4445-9b01-b131d3bedd7d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1683']
+      content-length: ['1715']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 18 Mar 2018 03:03:40 GMT']
-      duration: ['640842']
+      date: ['Sat, 12 May 2018 00:57:20 GMT']
+      duration: ['912485']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [ueBU+Ctw2NpjhaqIeDGmz36cCklGr4Ik3hSndonrJ8s=]
-      ocp-aad-session-key: [hh3hLSA8RVmCWG3w1RoPmbKOLITwmUqwC52xdEQgZ9bHF8O1Q3tXUVMSFup-dCMTBl54rJ77Zx8qHNflXF95kTPkMC7bTh3nbWHDd3a5QuhOYiLhJQwWPl6lXGJKVzBT7JT6xY7fMGdf2fC1G4_j5hu2b-hmROO-h4iAAC0RgiPyjnouTcs2JC7y7-CObTqXfyhRFq0C683ZWl3XgUeWjA.Feh6cVrTRd66yCMhHcQZLSTke6m3EP29kwvLP2ye7sw]
+      ocp-aad-diagnostics-server-name: [PkCvv/QKIhw9uu/OmXUHm5LBeaURLjYgLYT6Rc6GAzs=]
+      ocp-aad-session-key: [0Y6IlG76vJpaD7lXwSeE5WmYZWM1XN6d6ba3orI37h-xV-ARdj0OU0fuOoyt46KHjtdXFSJ1hdSRC2H22CfT92ytBrhBwLVp1EUHWBPsdwDn-Hgmy7g_KGRoZLPH7OF1lQe2Z0oU3NFIam729V-Dtw.hWU1MecvQ3toXKcV_hKPaW-2UkfsSI0LuTEaxubOuZQ]
       pragma: [no-cache]
-      request-id: [6a3342eb-973b-4778-9125-4fffe230dc51]
+      request-id: [7bdf770b-38a5-4ea9-ac46-f8f83d96ec7d]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -279,36 +279,187 @@ interactions:
       CommandName: [ad app show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/2ee40ff9-c740-4378-b658-0772b3bc2a30?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"2ee40ff9-c740-4378-b658-0772b3bc2a30","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"82b55d52-9557-4aaa-9c54-f185454c6aa7","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"f4b58339-a058-4445-9b01-b131d3bedd7d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1680']
+      content-length: ['1712']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 18 Mar 2018 03:03:41 GMT']
-      duration: ['676195']
+      date: ['Sat, 12 May 2018 00:57:20 GMT']
+      duration: ['1942980']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [yo7gGIR8p2AKdMvGsbqq80cJNXf386pKLuwu8mM0wZ4=]
-      ocp-aad-session-key: [qx7qkPNGtum8AafxmhS-PaNrvM0T4O9x1ey8BTEZ3qw4pvmwHDyC8etJrwbRRvfXSfpegVNO9LRbiuEWC6swewndZ9IriOhnsgPdfV9qZIhb3Q6bSi_myLm45TXv4Yz3k93k3Hiiu_oQ91TzERC0VicGM2hjnLCiDk5I2JgRFuMcg-WcIiLhX8tqBqKBAm1oKay0JgyXuaiKW9SqFj838A.M9TDoqmUdFY_2-NtY1PtWQBJu1jfkHzrihg2XS63JfE]
+      ocp-aad-diagnostics-server-name: [LgXAcbVEU6vczw1+dJY77u/nuJ5/uLYq6pT3Y4X/6fM=]
+      ocp-aad-session-key: [cdlZdT0a9PJ8CG-hkJlUX7_rHYedMOjDnRcxFZBetON3HlUGb-UOSRMaxkmI6PnWRCk3OhjlQyeqEJMKnzfoNnpc6pVdAFkgVSgf30e9D082W0My0PxdFa6-wTUrMWv66US4f0ou1aoNdQEa7BSYLQ.FLnfB3swpmJAZFqoBWksi9WFUHzVKRn2GCKoYvqXePg]
       pragma: [no-cache]
-      request-id: [07f59b27-a5d7-433d-bf54-2ea1e6708ce6]
+      request-id: [5e6576cd-3d01-4a93-a3ed-87915b6a72e7]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1715']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Sat, 12 May 2018 00:57:21 GMT']
+      duration: ['510061']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [O4KpSJbi5/6YCC+tDQQlh4m8zzG+ja7BdgLs4Moxbzs=]
+      ocp-aad-session-key: [eFtW7kyyo8X68-8eFREouudUKh4Q-cEPOa6gU3yt5JBwi1zYFq2i2dDp3iqri40c7LBtCI__rAAwWeyAuG7s0giDTVO-gPvpR_m0QbbJtQt-ltWJsKN6I-zH_k8RdaplzGwXP81kQcgA9vY2x_P7TA.tik7MCLH_MTEtbDEDmI-PyV3FHH1xhIkhwp-CEe_aFA]
+      pragma: [no-cache]
+      request-id: [3d4f8c12-5a96-4895-8431-4c5f86c789fc]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"oauth2AllowUrlPathMatching": true}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      Content-Length: ['36']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
+      accept-language: [en-US]
+    method: PATCH
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
+  response:
+    body: {string: ''}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      dataserviceversion: [1.0;]
+      date: ['Sat, 12 May 2018 00:57:22 GMT']
+      duration: ['2197254']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [HsKElesTxiLgdPMB0FbOxcZnfgWfQ52qrxu3V/VUL9s=]
+      ocp-aad-session-key: [UQm7RuipU78wMxqpSKCHYQNZT9hK770ACut0QaoYGASismAhRj3712DpiLJvxQrjl5DEFs7nkg-A-l9I3DdUCMiElykbEYC-PVALxxRpZ3WTZkWSiOpP6JW-oHQ1-L1jfn3FvcJ2d57lcvIxDzsHgg.I9oCO_FSi86AdlObEqBHWPmrG5UMkyZRJAemltfW_rg]
+      pragma: [no-cache]
+      request-id: [2868ae7e-2190-42b8-afde-71cc3d3cc455]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1714']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Sat, 12 May 2018 00:57:23 GMT']
+      duration: ['520195']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [2Gv1gQSfiKJpA3rt4Mi13yQYs8l/cSGK1elzeDUE/p8=]
+      ocp-aad-session-key: [RmPFo4T5wcWnv0Pove0PelMbC1j1B-ZXAo_35JyxELxLI7GdzumysZV6P0zfihrbu2gUwzX48fvWn0U_NlTDe8LwHeMbdp3fffnut-WseFTvt2YX5uFOhf5n68iJqkryAKviCdTNI8OIAQPn2rzosg.25JSaCy2q3HD0iMK3XH6yAm6DW3Kbl_LBR3mKe2rF9o]
+      pragma: [no-cache]
+      request-id: [2f809478-1a73-4f6c-b4da-021d2d6324f5]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app show]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1711']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Sat, 12 May 2018 00:57:23 GMT']
+      duration: ['522524']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [j09aoTbAUsdzg7+m9vDZMYigxTNv65xA75jqf1mNUDY=]
+      ocp-aad-session-key: [NbtycMz75KAIY_mNJ0FoA4M_KAPm3kYSUQIt5M5z5eLigo3fgcWMoEDzvPakRiwmAXJALNcjVwnfE92SRIs_iP7rSesBhq0uzJPeeg3GtWipL4GcGxUPvkk2ZP-IliHR9IFYyyYTGnehEowUm70qaQ.je0ppUIy_JKumqnKl-N7VbHzdcwUIkbTwkd7ewk7S5c]
+      pragma: [no-cache]
+      request-id: [6a111ca9-db07-4c14-827a-8164d615abbc]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -318,36 +469,36 @@ interactions:
       CommandName: [ad app delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"2ee40ff9-c740-4378-b658-0772b3bc2a30","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"82b55d52-9557-4aaa-9c54-f185454c6aa7","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"f4b58339-a058-4445-9b01-b131d3bedd7d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1683']
+      content-length: ['1714']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 18 Mar 2018 03:03:41 GMT']
-      duration: ['557762']
+      date: ['Sat, 12 May 2018 00:57:23 GMT']
+      duration: ['527111']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [Ue2UV8B6ZYWFsQUzr339mGXmtrQLUAOUbjZYr6eKxHw=]
-      ocp-aad-session-key: [U17ZSR2NocKBTJXG8b8gftIwT3fEFto2NwBraqllA2y1r82PcW5wAD5PmYCLrOYwkXLaEZzVKORB4VQZjnPEDI2_quCRMv0TKBCIFQ4F2JgRD_ZEaIUxnkuLfb7aZ2M-6wLuEL_FZnCJh7ixJH_dK7SgmO9nycqz_DE4aSefa9bbs3Ancn3lUqcdNBEoXgNMBk8bAAil-H-EfqCUc75_2Q._yLUiwc28WA4TGFOpliXInmqBFqojeyKNck-fmKBb7U]
+      ocp-aad-diagnostics-server-name: [8mo13EoRWl9K4HjFXKNL8x6iE55Dhc42u2WqP8pxZGA=]
+      ocp-aad-session-key: [1yHe3-VWHtX0XZNtqZRYUW8u9Co9crQh2XfB8c2A_LvXukCycte39eT5Py-H3Y1m2ORXb9RqX-yyV45S8ZLkymLepCGkTpyhTOKtq4M3Ui_XBEtGWRtwxWEWfDud1JvxvXqJSub6QFnbo8MURsBHMA.2ZHmdT3POoGn05V9bpfYEl3eeIEdvOci4Hn2rY0IQhQ]
       pragma: [no-cache]
-      request-id: [d0313d87-1942-4f1d-a328-2f410f9b578c]
+      request-id: [6b176f85-b185-4fb4-ad9b-1ff8ebb18982]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -358,30 +509,30 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/2ee40ff9-c740-4378-b658-0772b3bc2a30?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       dataserviceversion: [1.0;]
-      date: ['Sun, 18 Mar 2018 03:03:42 GMT']
-      duration: ['2414732']
+      date: ['Sat, 12 May 2018 00:57:24 GMT']
+      duration: ['2281139']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [2/OO1DBlsN9Tt3bUcO4UhTMA41ZH6bC9vTECDGTrVeQ=]
-      ocp-aad-session-key: [RmY_c7TWoKRUz2QHmqkK398gjj2hyBa-zqb_f0U0HB69bqXXjHcvQ0_WH3CkF28JQAbAk6I8mLFblamA1nMsMC9dXa-PSr8s7P86H7GLW2APlLRi79xlVbm4BGKnugthiFTxgKgAZWJegpg5Guqa-E237JADGKtfvLk00j5NEAf_P16xou_0XGZWwTCj5S2AQKAQLcFkz3ffU2wnXMnz-A.rGEyVS7YOsnzFph264hIFxXZeLheBam5pCnnOm5sUWo]
+      ocp-aad-diagnostics-server-name: [1Sw93lDg24rWQqiNnfxG0tmtbhuAcSA9P0X1MIiqPnE=]
+      ocp-aad-session-key: [sBg3tNiatjLnutah4DkTmLkw3rf8FzTx0nXEuDSDvz3S1kTh2dhORVQN1Cz0ZDHu-8hrV7KH3vzx8m0V8lh3WVYXDtcpBuDYwrdU-uLVO6mUyj9jJzG74_C9C38R5HZJJlcKOXzm4pp0X_8Y2-NKJA.dWPnpaLiF8DsRh7vO8VZRsZyl6hiR9lVs2Bv-aXecog]
       pragma: [no-cache]
-      request-id: [eef0e677-8fc9-4376-8902-479c25d1087f]
+      request-id: [dd13a6be-4471-4cbc-86b0-2c59dbb6077f]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 204, message: No Content}
 - request:
     body: null
@@ -391,8 +542,8 @@ interactions:
       CommandName: [ad app list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.4 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.22 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.30]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
@@ -404,18 +555,18 @@ interactions:
       content-length: ['161']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 18 Mar 2018 03:03:41 GMT']
-      duration: ['544119']
+      date: ['Sat, 12 May 2018 00:57:25 GMT']
+      duration: ['471042']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [HQ5deQpwcsPe4hh8xoHwaI2OVqdobLjJJnUjAQRcE5o=]
-      ocp-aad-session-key: [QrmvsBPVhnuPYNtDxCqI7wx3WYVU-DGgY2WJBD-b9KTk1MKMNRsucMQ2VwW6irKHsfVGToRpKZh1RNr02w9AQYxe4Ic-F1ALOL1SNGAzbYAdPkib7iZY-5X4HovbyIq89OksqpkNUyPj83pqTyiSXH8JL2ZNakOdmcUydv5o1_4XOQCBR6W1J2oudibevgaJdfJ1qfLxgxIotqOlir56WA.3bKKeqJ6VGB1JLDJxXfcKqEhibUWM5gTyYcpjSGpw4E]
+      ocp-aad-diagnostics-server-name: [pXlXQrc9MSPlRSTdMmTrsa5qwcKpymyDfVLM9CfOb1k=]
+      ocp-aad-session-key: [aTpY0NGfNgY5qyC-mhfYqwPTd6iclbXRaB1n9LsuT440dBRLLO8OG6I5sx2j4rDTjY0xbN_E4A3bkim_4m9V-KKaIQ4uAV6cNf7AJkMM58OwQs8zyQwJP8zkAh35IF7PK0HbrT4HlD6Oof1vHp0NFw.WPNL2tFC9IGCuz_LR7uTITSfjOkaVMDZ0nGt_cZvgeQ]
       pragma: [no-cache]
-      request-id: [1bc2ee00-6bc7-462f-bf11-1d3564b33fcf]
+      request-id: [b3d03974-5be3-4d17-ac4f-f70436b43033]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
-      x-powered-by: [ASP.NET]
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_application_set_scenario.yaml
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_application_set_scenario.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: 'b''{"homepage": "http://cli-graph000001", "displayName": "cli-graph000001",
-      "availableToOtherTenants": false, "identifierUris": ["http://cli-graph000001"]}'''
+    body: 'b''{"availableToOtherTenants": false, "displayName": "cli-graph000001",
+      "homepage": "http://cli-graph000001", "identifierUris": ["http://cli-graph000001"]}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -15,26 +15,26 @@ interactions:
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaContentType":"application/json;odata=minimalmetadata;
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaContentType":"application/json;odata=minimalmetadata;
         charset=utf-8","logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1768']
+      content-length: ['1758']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:17 GMT']
-      duration: ['8048633']
+      date: ['Tue, 15 May 2018 00:25:33 GMT']
+      duration: ['4383890']
       expires: ['-1']
-      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/58d930aa-ba59-4c10-9d75-3f830229aa01/Microsoft.DirectoryServices.Application']
-      ocp-aad-diagnostics-server-name: [NorBiSXbBacugIOc9PINP1SvB49TAti3iq1gEzH+f90=]
-      ocp-aad-session-key: [z6LGHxE-pgNk-yThMu7z-Gv2L_roQShHK_AnummPGWZXvMQojhuAg4Pkboa06SHlZGiZTB4unoY2zM5_YLy6SD4PsmsFCDxSlesFOgd_bMFWa0U6qgWDdq6RUCxf5VMoHLVBPHu5MAQDnXGB6kFZMQ.gPYOSTPqJVeBe05i4AUAt8_m2dUvsv5dCBknQESGvDk]
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b/Microsoft.DirectoryServices.Application']
+      ocp-aad-diagnostics-server-name: [OQLywiI52PNERwXzjFjjauDsq3Wqe1LaqVZPFAotG7Q=]
+      ocp-aad-session-key: [ymzKRb3ATieUTnEUvKg48s1WzfWRCRJwz-ISqgRmuODAq6TS94qtGtPJs1K6H0cQqKw00ONnEQF-nJ31G2mXc_OcvcRhJVwkMyIidEbYoXjEx2H3UoL0aCLrYwR68ASx_8F4-L8Y10BlsgIshfUjjA.neA0TwzzVmuGMbZvuQwxtX9JU0jyso4eZCbrkPy_3x8]
       pragma: [no-cache]
-      request-id: [24fc5137-7899-4f78-a1f1-6130d18163bc]
+      request-id: [e4d8a25b-70b3-427b-89bd-f558802d03ed]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -54,26 +54,26 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1685']
+      content-length: ['1675']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:18 GMT']
-      duration: ['519435']
+      date: ['Tue, 15 May 2018 00:25:33 GMT']
+      duration: ['382453']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [cNcMQJ1oxb51WRRiXzCCai1HkMelF0SUywxI2UqetqU=]
-      ocp-aad-session-key: [zOQGtrxf2chVdwUihfSgrhuCR2Yx0mpx1S__IQRWtSdc08FSkNWHMJ30ilLqRc9yK7EvhQ4oCUn2Fnzs-5L8Ki2f4oFnWRbX5FxNEmnG6x2gTXklIuOzxRx-VVlp0tbpdycmRrPYYXymwvcXm2GGVQ.xDeIcOKKMf3uc9Ey6hD-2t0j6bWi31xPNfJidj7Gvf8]
+      ocp-aad-diagnostics-server-name: [gXfFarcv2ysN8TtqVPgD1PYEnzY+oOLIPXpP5S4Cj3o=]
+      ocp-aad-session-key: [BzYxfi241b8p8OhTIk52lbOCJgpPHuJdGMg5oyfuwToeDCA1Cz270BJCaj4q_hqLiLOOewpVjeXFYWQ5mD1CCULR1RzaMElCo3IJFCzkbxBrajZHYb19uP-Xth8Ikk-edoY2C_tgkSqX6YCvcb539w.oACOdoRb5MzQc0ESXpSHlgNhOKgCqAQpcnMnDrUqy7E]
       pragma: [no-cache]
-      request-id: [3161d6f5-2ca7-41e6-84f3-2579989e34db]
+      request-id: [1bbcbb67-56d1-4357-a4bb-3f089a2574de]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -93,26 +93,26 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1682']
+      content-length: ['1672']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:18 GMT']
-      duration: ['632413']
+      date: ['Tue, 15 May 2018 00:25:34 GMT']
+      duration: ['407976']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [BQUIGmRRyeHSEXkgch2q1Q3MYXFFtGhoXfkp3cvu3XA=]
-      ocp-aad-session-key: [aNvWsSjrQxjP2Su-8eldZB-VJuetpHTgdwp_c5U5be9D478VvQpgCRyNn1kT90ZnJSmQn1oyibWkI9CZ-prmfZAFzQRbVIsg7dAS6djb_JW_90MaUJfy3tcFiaPSQaEuFWdO2xTpOKaD-YQeerDrvw.KtspiVh7u6k9ROFPvnnaGKsuFApnHBF861eRYrJZCUA]
+      ocp-aad-diagnostics-server-name: [IENUBJawjVCNeOFfPW1GFeJcp26vWA0p4gBL1NaxNik=]
+      ocp-aad-session-key: [5YbH7SDN_Weozg25G2pb2R4bdVEGWzh5fvQAbbextbs4UGgnvmr7qEpteBlbZmClRxSFEhxZ-K1DZCXbZVasbkURWNR-x8dp_-gxKpzyRMjfcniYVJiCWzuBCWlxEVSN78JqWs-QoN_v2Zf6JEA2Zg.qVdeq8fPqFgcszd-qW4100UHqztQaQnq0bdt-OhyiwQ]
       pragma: [no-cache]
-      request-id: [a6111d6c-d2ff-4149-b117-f6f4c0b4a205]
+      request-id: [ce6d8f29-def4-4719-b696-fcaacd69b5bc]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -132,26 +132,26 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=startswith%28displayName%2C%27cli-graph000001%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=startswith%28displayName%2C%27cli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1685']
+      content-length: ['1675']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:19 GMT']
-      duration: ['555595']
+      date: ['Tue, 15 May 2018 00:25:34 GMT']
+      duration: ['438403']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [BQUIGmRRyeHSEXkgch2q1Q3MYXFFtGhoXfkp3cvu3XA=]
-      ocp-aad-session-key: [AtsmVijoD-dWwCTARzs_ORg9v77SHvIMcRWLdrimDuKd6PGlv9ncVVsRGlkYVF5bn5yHCRVrIfxMbs0tFUkSJ24I2bhbT8lxzNgiF275c_9A-wqrnrA6vSYybH7vycRUqxdMuNQQ1nuO-0h1nHtfOw.v14almD8a6PbMITdhZHJVLjyyDR5GlFVH42P3P7__o8]
+      ocp-aad-diagnostics-server-name: [Fo1QicrIhHj2KR1ZzWvNa2KLRHgOjpt7/hmcNDActAs=]
+      ocp-aad-session-key: [j-7OhLLFqjPHvM51tJVT5W7zE1EDGsRYdkdJStLQ9h17cdAWb7vTGv6SueL9hKW0Y0WwggoYFHcTxdzNQ_NnFuRtzxp3vhmhTb7MRrTmni0O1NhdB6BEojyG84TQVxh823QV5trSY9NM_3_43bRGUw.eS4p9CgCzjRnfTTPt6tvzWN8IMN4YAfC_W4aJ5f5lWc]
       pragma: [no-cache]
-      request-id: [c2219022-831f-4dd2-b40f-eae7a2688fb0]
+      request-id: [df5cd47d-569b-4445-8913-fd789620c3fc]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -171,26 +171,104 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1685']
+      content-length: ['1675']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:19 GMT']
-      duration: ['561739']
+      date: ['Tue, 15 May 2018 00:25:34 GMT']
+      duration: ['903560']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [tAfU859m9TMv99RRajlEbUsi/5BnvcvCFalsXAVDmG0=]
-      ocp-aad-session-key: [ewUUwgCSVKsWUOqVBjMHZDL-CQFycF39VUBVB83TQnrhw75HM-pzUtMe3S1WmCjrl85gJddDoLvtuMNEOh__ju2lsEZTdDsWcQFTxVOnwo1LpMrxN-j4ui4FB5c0YxUzPH-k7DA6GrK-T6AJszLlTQ.2DR-9CFBI3FGqQeTnoutPuzqoIXAyE66NcBlh9086sc]
+      ocp-aad-diagnostics-server-name: [k+a8loBjbxraN1otxCzpa/lm7sS3uSMfCmXQCJ5UeOg=]
+      ocp-aad-session-key: [EVitoopZTz1iHaCuxSW87iwJlAoL6x6Pvm9TjvLS6PUeJstv5Hrlvd01-JiEqDKnK5-1-5ASDgITILjabfsW8nQsIVRQOQ-H4vYK8-c2BcerZzduXdMQl9t_o93H-3zk4Ih9A9O-ltcsZQpDySpMIQ.iW1MLNifJTcvi5_rLYC_LFrrywcMU6j5dVmp4bbWdlM]
       pragma: [no-cache]
-      request-id: [fa7e6f67-05fc-489c-9268-13cb68d1986a]
+      request-id: [01fd30bc-4fe6-4d97-9c59-f936abcd364e]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1672']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 15 May 2018 00:25:34 GMT']
+      duration: ['389340']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [wyZ2chLc7keUKHMJZ5WTQztb1eGl2liBganf3B36Fuk=]
+      ocp-aad-session-key: [_sW0QHe_4cfOc_Qdk8XvZPj1rhzy_AOEl8ce10gC_3x4gr6k2h_UslCbI9NGpnM2DV1THu9n8dKBJPYVLm5BejwILm3tEvsZR3VwlG8xW4fBE-wWtVFQmwvAJUXdyHV0BIN4FbxaUmWcIh6x5kuCLg.ahgdN6PXOVMOke4q1Bn6_OdbZyouCim8Zrv7MYDwT3U]
+      pragma: [no-cache]
+      request-id: [bf4ef639-a12e-442f-af11-c5af4eb48999]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1675']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 15 May 2018 00:25:34 GMT']
+      duration: ['561544']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [HsKElesTxiLgdPMB0FbOxcZnfgWfQ52qrxu3V/VUL9s=]
+      ocp-aad-session-key: [2kCaOraLOIIt6aEfVoFcHC-CvTSTgQz-vmNI0yWI3oLmEMsAgFRBfjlq5HcGtJowPDAKxI_cbqu7D7TLh-f0IEYI1ExcviwFac7TeGwe5MFyMfGciBSdW0jZD1nK_6X1WLN7zYQlD7nbYT-Qbaj5sw.GVrInR4OyCLbUGpzpzr_J64uDEz_m8ZqAeQHN5jVg6c]
+      pragma: [no-cache]
+      request-id: [89834c8b-b606-412c-8a73-3ca6a2e1ef19]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -211,20 +289,20 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       dataserviceversion: [1.0;]
-      date: ['Sat, 12 May 2018 00:57:20 GMT']
-      duration: ['3280959']
+      date: ['Tue, 15 May 2018 00:25:34 GMT']
+      duration: ['2625937']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [TF7V9cFPmZmQJjy/0crfkRiCbrtTUG3VKT/zd0mx1Gc=]
-      ocp-aad-session-key: [hHHX_lUesNT0rauEVysLIZ2KmGrlnDPEdIjTVgPenvWCBOhECFEsuwhXApDIBxGUxIg5-Z5iyLus9MUXDYHZbZ-ds0uA6srZNDs03-4bFZAX0r_jRUU9qCXb-btJ4d-YBO0txyFMdbeIF2tNbaRlYA.i-fW_t1inCrdLxNpRAwf0vWUTlajnyebVsTDnnehCJ0]
+      ocp-aad-diagnostics-server-name: [rFMv6jCt7k8n9zj2NyMLkO1fEa5ijjfeyD4ZP3WWKYs=]
+      ocp-aad-session-key: [4DkgpFnaffcMkHLptnBWuoPYnN7vQ0o1SLT2MvR-dT3Sw7q4TG4fItPRaz-Ze4eE6rF-bgoBbGIkzYpxSEStMwv1mHbRNMts1oejNwlbrfY0520izYlL5FFFr12Phqc_B-QjkQdhqzWUBYusyUPu9Q.qH73HSikG3bg0gXMmGTp1SazHp4NJNIxSjn_fsVOi2A]
       pragma: [no-cache]
-      request-id: [335d858a-3ed4-4af8-9234-8acb9f7f1352]
+      request-id: [d6a98ba9-cd61-4cca-b090-5242827cce12]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -244,26 +322,26 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1715']
+      content-length: ['1705']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:20 GMT']
-      duration: ['912485']
+      date: ['Tue, 15 May 2018 00:25:35 GMT']
+      duration: ['359511']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [PkCvv/QKIhw9uu/OmXUHm5LBeaURLjYgLYT6Rc6GAzs=]
-      ocp-aad-session-key: [0Y6IlG76vJpaD7lXwSeE5WmYZWM1XN6d6ba3orI37h-xV-ARdj0OU0fuOoyt46KHjtdXFSJ1hdSRC2H22CfT92ytBrhBwLVp1EUHWBPsdwDn-Hgmy7g_KGRoZLPH7OF1lQe2Z0oU3NFIam729V-Dtw.hWU1MecvQ3toXKcV_hKPaW-2UkfsSI0LuTEaxubOuZQ]
+      ocp-aad-diagnostics-server-name: [gXfFarcv2ysN8TtqVPgD1PYEnzY+oOLIPXpP5S4Cj3o=]
+      ocp-aad-session-key: [1iQhMEKI2sXkpxNg64cgvqqTShbHngX0uMI2G7ojkReFNG5s7UehMSk0FW_8yHh0a6UfFboEt1B_hdA6YR4cqH_y_LrDH3fdybv3xqTktTBS9l61shChsCStxKKKQarPwHMYOXNtCR-kp2-_hks__g.M-9N1wbBiS4V8OKLx5Ist__EEOGGxLZR-ci9dm3g7ig]
       pragma: [no-cache]
-      request-id: [7bdf770b-38a5-4ea9-ac46-f8f83d96ec7d]
+      request-id: [21abd020-cca6-4728-8ec5-049526547ccf]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -283,26 +361,26 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1712']
+      content-length: ['1702']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:20 GMT']
-      duration: ['1942980']
+      date: ['Tue, 15 May 2018 00:25:36 GMT']
+      duration: ['628909']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [LgXAcbVEU6vczw1+dJY77u/nuJ5/uLYq6pT3Y4X/6fM=]
-      ocp-aad-session-key: [cdlZdT0a9PJ8CG-hkJlUX7_rHYedMOjDnRcxFZBetON3HlUGb-UOSRMaxkmI6PnWRCk3OhjlQyeqEJMKnzfoNnpc6pVdAFkgVSgf30e9D082W0My0PxdFa6-wTUrMWv66US4f0ou1aoNdQEa7BSYLQ.FLnfB3swpmJAZFqoBWksi9WFUHzVKRn2GCKoYvqXePg]
+      ocp-aad-diagnostics-server-name: [8FSoKn5C+xKnzMxVB24u9W0B3o/Ls6Mt3pri2fVg6OA=]
+      ocp-aad-session-key: [9c-6rqXeL-M1oILPhlPDhUpUyoLYY2fawUTPAxR9AwMZiw_vmqymz-5D-7O3Tevx69DGRaRu_3_mzRQnbRx2BTo2LfIybP3tmqAELCu5rRXAQd5B8wjZy5N3tUMqrlD95b-OtmUarAYU_2ohAw2xDw.L-yme7F0lkzyfyUEIYut9WgooBtl0yeEORkOx_0qi_c]
       pragma: [no-cache]
-      request-id: [5e6576cd-3d01-4a93-a3ed-87915b6a72e7]
+      request-id: [012b7612-8000-4000-bcbd-9b1d4165873e]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -322,26 +400,104 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1715']
+      content-length: ['1705']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:21 GMT']
-      duration: ['510061']
+      date: ['Tue, 15 May 2018 00:25:36 GMT']
+      duration: ['363911']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [O4KpSJbi5/6YCC+tDQQlh4m8zzG+ja7BdgLs4Moxbzs=]
-      ocp-aad-session-key: [eFtW7kyyo8X68-8eFREouudUKh4Q-cEPOa6gU3yt5JBwi1zYFq2i2dDp3iqri40c7LBtCI__rAAwWeyAuG7s0giDTVO-gPvpR_m0QbbJtQt-ltWJsKN6I-zH_k8RdaplzGwXP81kQcgA9vY2x_P7TA.tik7MCLH_MTEtbDEDmI-PyV3FHH1xhIkhwp-CEe_aFA]
+      ocp-aad-diagnostics-server-name: [uCCQbpgVHNC8rue1lL9wVVx/oAWeG8jNKc51+E8x6H4=]
+      ocp-aad-session-key: [hqH6XqghAN_SdpUDR-Gt1nNl67-x4AzHc7NlHNxHRRD07c8zvZMt7ybT7vJghf_9aZv0LD8RvgMrgPiy9IHjhAVF2TCjR0sVttM1tfKweGKBOhO6URpWbtsXnTL0cS2i8eHeTPrwPk-Yk3URQ76ErA.Uu7tq5uprboZPDT5zHtdqzuRrDhjmR6ZvRPTmP-VUJg]
       pragma: [no-cache]
-      request-id: [3d4f8c12-5a96-4895-8431-4c5f86c789fc]
+      request-id: [c77785f9-6db7-4fc1-93f9-e247da7b38cf]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1702']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 15 May 2018 00:25:35 GMT']
+      duration: ['1334340']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [N0M3YZBHM6R48FUQoMpphT0YYue9AYIC839ozsEY+h0=]
+      ocp-aad-session-key: [xR7U4ItFG6hrcxt0wIThJEeBJg-cBN7yfYkkl4juw9kzkYLR8KD1f0AG8v_8ahtDjXdBdj6A6g3u80vx432_XyKq0D_omEK_EI883cl8gwHEIrP_64jE2EhDUqo_YFZg1435GPcr5USbRD9dcGJHEQ.rwpe_Cw9rE7dafxzzkrvKEmkzCMfCHAZ_zTb0Cr3NcM]
+      pragma: [no-cache]
+      request-id: [03c2e9bd-91f3-4b61-b874-008c72b24374]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1705']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 15 May 2018 00:25:36 GMT']
+      duration: ['442502']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [tqsvrwCmDhrCSNHu2t6CdV0LI4CjAgREZGXRcEu5W18=]
+      ocp-aad-session-key: [j-ynoRWgpHJbNPlFIzCilDx2kzAmaaWxc5_Lc6ulpHGZAfUOvaoNwvjSHrjeMLaWaesGSK9U-QXQxt-5qwPR7g91_3Wf2ld3NwIBgtlg_H9qp0sOY83r0DsgCHyqOGLXgR6uphUGa6QCXFQWyBSCKw.HHsRrXOUNKBHPWVkHREr3qGacjZeNwex3CfD3H_pIHk]
+      pragma: [no-cache]
+      request-id: [e4754b34-1330-49c7-9317-7c830d9fc131]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -362,20 +518,20 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       dataserviceversion: [1.0;]
-      date: ['Sat, 12 May 2018 00:57:22 GMT']
-      duration: ['2197254']
+      date: ['Tue, 15 May 2018 00:25:36 GMT']
+      duration: ['1393181']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [HsKElesTxiLgdPMB0FbOxcZnfgWfQ52qrxu3V/VUL9s=]
-      ocp-aad-session-key: [UQm7RuipU78wMxqpSKCHYQNZT9hK770ACut0QaoYGASismAhRj3712DpiLJvxQrjl5DEFs7nkg-A-l9I3DdUCMiElykbEYC-PVALxxRpZ3WTZkWSiOpP6JW-oHQ1-L1jfn3FvcJ2d57lcvIxDzsHgg.I9oCO_FSi86AdlObEqBHWPmrG5UMkyZRJAemltfW_rg]
+      ocp-aad-diagnostics-server-name: [sjU31wcZZQkSllvwYiJGtga5DQTbyVp6msGr4BIoWXU=]
+      ocp-aad-session-key: [e7mjcyyQDmr8QAicPP-nLKFZLA7DtjyJErb7rYDImrW1vh0efe8J6XjEES7rcyLpCHiPm6ne3QvE7LbA9qs2a4x7m9tU3sjxmobATokQxQzt4iELoiR6-39aC7do9HZlBp_HMxdQlxgnK8QOMY43jA.JYjcKg7o63wghBz3sv54Afu-3NVSa8X9iZyfYuCwNJI]
       pragma: [no-cache]
-      request-id: [2868ae7e-2190-42b8-afde-71cc3d3cc455]
+      request-id: [fed05a46-38e4-458f-9dc3-318fc481c46b]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -395,26 +551,26 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1714']
+      content-length: ['1704']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:23 GMT']
-      duration: ['520195']
+      date: ['Tue, 15 May 2018 00:25:37 GMT']
+      duration: ['451847']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [2Gv1gQSfiKJpA3rt4Mi13yQYs8l/cSGK1elzeDUE/p8=]
-      ocp-aad-session-key: [RmPFo4T5wcWnv0Pove0PelMbC1j1B-ZXAo_35JyxELxLI7GdzumysZV6P0zfihrbu2gUwzX48fvWn0U_NlTDe8LwHeMbdp3fffnut-WseFTvt2YX5uFOhf5n68iJqkryAKviCdTNI8OIAQPn2rzosg.25JSaCy2q3HD0iMK3XH6yAm6DW3Kbl_LBR3mKe2rF9o]
+      ocp-aad-diagnostics-server-name: [qbLQHeemSYnF6GFzxWPxyco92r/HwDdCBwNHurdokdI=]
+      ocp-aad-session-key: [fCGxrqPexVNv3ziLZTzf7OYwELZmbhCKPdXYEz37l_Zij_uLw7LFm8Bx-BsQJxKslIW3DsvhMTuJgXMffM4vgpk9U9QoAreTttinbSZn6mkj2o2-mPRBIfSp84WBPhVy_4kxZrLiGMpONcHchEf43Q.8xF7GOymBrjG4S3R7FDwZ07FvDAAiqrBf8F3y7pb_i4]
       pragma: [no-cache]
-      request-id: [2f809478-1a73-4f6c-b4da-021d2d6324f5]
+      request-id: [b7a87bd9-fa1d-4f8a-8b1f-b2766ea6b8bf]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -434,26 +590,26 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1711']
+      content-length: ['1701']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:23 GMT']
-      duration: ['522524']
+      date: ['Tue, 15 May 2018 00:25:37 GMT']
+      duration: ['368711']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [j09aoTbAUsdzg7+m9vDZMYigxTNv65xA75jqf1mNUDY=]
-      ocp-aad-session-key: [NbtycMz75KAIY_mNJ0FoA4M_KAPm3kYSUQIt5M5z5eLigo3fgcWMoEDzvPakRiwmAXJALNcjVwnfE92SRIs_iP7rSesBhq0uzJPeeg3GtWipL4GcGxUPvkk2ZP-IliHR9IFYyyYTGnehEowUm70qaQ.je0ppUIy_JKumqnKl-N7VbHzdcwUIkbTwkd7ewk7S5c]
+      ocp-aad-diagnostics-server-name: [hBrSXgYT6AiW34OnRqqllTrcBhIOEaEk4E+/a+pb/0s=]
+      ocp-aad-session-key: [efLN3NVevT_zyF0zeRNMAMzM5Nc9oWmYvmetmrAkYcVIUkqX__dOLMXWHuKLZFv4UOxdmkf2ExNNqQSAwzGA58mLtSWwsMrnaiG-lwVYmt4QWOfbU9CqSkF7S21q1jwoxfJQTC18qUqueTS4o4ryyA.741H5I8N8udrF4MquZWoUt9XDHNxF9e6XWohcvej_zk]
       pragma: [no-cache]
-      request-id: [6a111ca9-db07-4c14-827a-8164d615abbc]
+      request-id: [eff3a84a-823b-4260-b37b-4bac52e17630]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -473,26 +629,26 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"58d930aa-ba59-4c10-9d75-3f830229aa01","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"86ebcbd6-db50-47f5-92c5-718475a2cd0f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"e6896ffc-365f-430e-a576-d6f859023fa9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logoUrl":null,"oauth2AllowIdTokenImplicitFlow":false,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"9e86c363-ad9d-4d46-98f4-d760d385a64e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"a2edbfcd-448c-4982-b740-90ac6680502f","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":null,"tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1714']
+      content-length: ['1704']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:23 GMT']
-      duration: ['527111']
+      date: ['Tue, 15 May 2018 00:25:37 GMT']
+      duration: ['809744']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [8mo13EoRWl9K4HjFXKNL8x6iE55Dhc42u2WqP8pxZGA=]
-      ocp-aad-session-key: [1yHe3-VWHtX0XZNtqZRYUW8u9Co9crQh2XfB8c2A_LvXukCycte39eT5Py-H3Y1m2ORXb9RqX-yyV45S8ZLkymLepCGkTpyhTOKtq4M3Ui_XBEtGWRtwxWEWfDud1JvxvXqJSub6QFnbo8MURsBHMA.2ZHmdT3POoGn05V9bpfYEl3eeIEdvOci4Hn2rY0IQhQ]
+      ocp-aad-diagnostics-server-name: [Pv4UBIo2f7FKm/qOeGQAbn1U4hE/glaJfHaiirx+LwU=]
+      ocp-aad-session-key: [wD3twfH394uY7rhDrp-7uFwW7kGvMl_ZS4gwvV1Z9U8LqhrBPq3RDSgZcEGdWhkZ30y-YQr6W1579otG9TQ70R3Mr0RnVhLu4mxsQvJBDASuVeUkCxPN_kaTSKd8C2gx9p58pOYODKs2F9tk4j5jCA.PtyFm9jEx0nVOsY6Xl1driNVDYhvi8TcJ5aW_IaKxoc]
       pragma: [no-cache]
-      request-id: [6b176f85-b185-4fb4-ad9b-1ff8ebb18982]
+      request-id: [ef7e3c11-73b6-48a4-9151-fd1bf1e6684d]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -513,20 +669,20 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/58d930aa-ba59-4c10-9d75-3f830229aa01?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/9a0f948f-9dda-4ec8-bbd9-99d5b39fe00b?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       dataserviceversion: [1.0;]
-      date: ['Sat, 12 May 2018 00:57:24 GMT']
-      duration: ['2281139']
+      date: ['Tue, 15 May 2018 00:25:38 GMT']
+      duration: ['1102318']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [1Sw93lDg24rWQqiNnfxG0tmtbhuAcSA9P0X1MIiqPnE=]
-      ocp-aad-session-key: [sBg3tNiatjLnutah4DkTmLkw3rf8FzTx0nXEuDSDvz3S1kTh2dhORVQN1Cz0ZDHu-8hrV7KH3vzx8m0V8lh3WVYXDtcpBuDYwrdU-uLVO6mUyj9jJzG74_C9C38R5HZJJlcKOXzm4pp0X_8Y2-NKJA.dWPnpaLiF8DsRh7vO8VZRsZyl6hiR9lVs2Bv-aXecog]
+      ocp-aad-diagnostics-server-name: [03tJtVtrK59o2WrrDjJFasNQO9BoGoGL+dG53QSLpQQ=]
+      ocp-aad-session-key: [A4xrxp-RqTmw8hhMmutN_UY3Ax-BBLU0D6IJ-9fND89YyMe7ea7Vt4v5oo14Pq6eYzAcarjlJ7zdcKZKPvBEJ6bw3jApRXWNzQ5ylXMMoX9RfeI50GYcA2rmPHVk3XV2e42OG__Mc4tPq4-20rOFMA.ToOJogCfaSvk9jgcWGIxk6nTniL7BXPvfUCOy96t-y8]
       pragma: [no-cache]
-      request-id: [dd13a6be-4471-4cbc-86b0-2c59dbb6077f]
+      request-id: [5bc0e583-354a-4d88-ae58-f57179e67796]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -546,7 +702,7 @@ interactions:
           msrest_azure/0.4.29 azure-graphrbac/0.40.0 Azure-SDK-For-Python AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
     body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[]}'}
     headers:
@@ -555,13 +711,13 @@ interactions:
       content-length: ['161']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sat, 12 May 2018 00:57:25 GMT']
-      duration: ['471042']
+      date: ['Tue, 15 May 2018 00:25:37 GMT']
+      duration: ['527472']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [pXlXQrc9MSPlRSTdMmTrsa5qwcKpymyDfVLM9CfOb1k=]
-      ocp-aad-session-key: [aTpY0NGfNgY5qyC-mhfYqwPTd6iclbXRaB1n9LsuT440dBRLLO8OG6I5sx2j4rDTjY0xbN_E4A3bkim_4m9V-KKaIQ4uAV6cNf7AJkMM58OwQs8zyQwJP8zkAh35IF7PK0HbrT4HlD6Oof1vHp0NFw.WPNL2tFC9IGCuz_LR7uTITSfjOkaVMDZ0nGt_cZvgeQ]
+      ocp-aad-diagnostics-server-name: [QcP18MNEK2rsGylMGJVNHi5HXYCSyZTWD43M/CKGhl4=]
+      ocp-aad-session-key: [Pog2X6CtAD9cCPgLmHCbHfLID-yF0DF4mKR_Pp-RbaW3b2-RnR9kmRNyCmMA1F0ON8UlUifC_BGrr_V2ORc2M_fKlwpEr8yxTt48hcY-1gbBbRyJM_GN3q1ugE5j_nJ44u_f6Ikq2r7D9Otr-PvaFQ.XYaHqeqSclA0-hS1v5M4NPkvuogM1DKPhaQjqxloRpA]
       pragma: [no-cache]
-      request-id: [b3d03974-5be3-4d17-ac4f-f70436b43033]
+      request-id: [a1b91292-ea84-4b50-8be1-995d5c42de2f]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -110,6 +110,11 @@ class ApplicationSetScenarioTest(ScenarioTest):
         self.cmd('ad app show --id {app}',
                  checks=self.check('replyUrls[0]', '{reply_uri}'))
 
+        # update through generic --additional-properties
+        self.cmd('ad app update --id {app} --additional-properties oauth2AllowUrlPathMatching=true')
+        self.cmd('ad app show --id {app}',
+                 checks=self.check('oauth2AllowUrlPathMatching', True))
+
         # delete app
         self.cmd('ad app delete --id {app}')
         self.cmd('ad app list --identifier-uri {app}',

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -111,7 +111,7 @@ class ApplicationSetScenarioTest(ScenarioTest):
                  checks=self.check('replyUrls[0]', '{reply_uri}'))
 
         # update through generic --additional-properties
-        self.cmd('ad app update --id {app} --additional-properties oauth2AllowUrlPathMatching=true')
+        self.cmd('ad app update --id {app} --set oauth2AllowUrlPathMatching=true')
         self.cmd('ad app show --id {app}',
                  checks=self.check('oauth2AllowUrlPathMatching', True))
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -110,7 +110,7 @@ class ApplicationSetScenarioTest(ScenarioTest):
         self.cmd('ad app show --id {app}',
                  checks=self.check('replyUrls[0]', '{reply_uri}'))
 
-        # update through generic --additional-properties
+        # invoke generic update
         self.cmd('ad app update --id {app} --set oauth2AllowUrlPathMatching=true')
         self.cmd('ad app show --id {app}',
                  checks=self.check('oauth2AllowUrlPathMatching', True))

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role_commands_thru_mock.py
@@ -310,15 +310,9 @@ class TestRoleMocked(unittest.TestCase):
         faked_graph_client.applications.create.side_effect = GraphErrorException(_test_deserializer, None)
 
     def test_update_application_to_be_single_tenant(self):
-        graph_app_client = mock.MagicMock()
-        app_mock = mock.MagicMock()
-        test_object_id = '11111111-2222-3333-4444-555555555555'
-        app_mock.object_id = test_object_id
-        graph_app_client.list.return_value = [app_mock]
-
-        update_application(graph_app_client, 'http://any-client', available_to_other_tenants=True)
-        graph_app_client.patch.assert_called_with(test_object_id,
-                                                  ApplicationUpdateParameters(available_to_other_tenants=True))
+        instance = update_application(None, 'http://any-client', available_to_other_tenants=True)
+        self.assertTrue(isinstance(instance, ApplicationUpdateParameters))
+        self.assertEqual(instance.available_to_other_tenants, True)
 
     @mock.patch('azure.cli.command_modules.role.custom._graph_client_factory', autospec=True)
     def test_list_sp_pwd_creds(self, graph_client_mock):


### PR DESCRIPTION
Fix #6097 
@tjprescott, could you please take a look? Note, I have tried to apply the generic update pattern, but because the AD App has its own PATCH operation and own model type which disconnects the generic getter from the generic setter, hence my code was quite hacky.  
But let me know if there is still a nice way to accomplish through the generic update.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
