### PR TITLE
auth: remove adal dependencies from cli and rely on msrestazure instead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-adal==0.5.0
 argcomplete==1.8.0
 colorama==0.3.9
 humanfriendly==4.7

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -50,7 +50,6 @@ CLASSIFIERS = [
 
 # TODO These dependencies should be updated to reflect only what this package needs
 DEPENDENCIES = [
-    'adal>=0.4.7',
     'applicationinsights>=0.11.1',
     'argcomplete>=1.8.0',
     'colorama>=0.3.9',

--- a/src/command_modules/azure-cli-batchai/HISTORY.rst
+++ b/src/command_modules/azure-cli-batchai/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+0.2.3
++++++
+* minor changes
 
 0.2.2
 +++++

--- a/src/command_modules/azure-cli-batchai/setup.py
+++ b/src/command_modules/azure-cli-batchai/setup.py
@@ -33,7 +33,6 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-mgmt-batchai==1.0.0',
     'azure-cli-core',
-    'adal>=0.4.3',
     'mock>=2.0.0'
 ]
 

--- a/src/command_modules/azure-cli-batchai/setup.py
+++ b/src/command_modules/azure-cli-batchai/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.2.2"
+VERSION = "0.2.3"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+2.0.25
+++++++
+* minor changes
+
 2.0.24
 ++++++
 * `disk create`: fix a bug that source detection is not accurate

--- a/src/command_modules/azure-cli-profile/setup.py
+++ b/src/command_modules/azure-cli-profile/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.24"
+VERSION = "2.0.25"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-profile/setup.py
+++ b/src/command_modules/azure-cli-profile/setup.py
@@ -30,7 +30,6 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'adal>=0.4.7',
     'azure-cli-core',
 ]
 


### PR DESCRIPTION
msrestazure already depends on adal, so I will rely on msrest to do the right thing. This is to avoid random CI break caused by version out-of-sync when a new ADAL gets released.

//cc: @lmazuel 

- [na] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [na] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
