### PR TITLE
vm create:remove `--write-accelerator` from `vm create`

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,8 @@ Release History
 ===============
 2.0.32
 ++++++
+* BREAKING CHANGE: remove `--write-accelerator` from `vm create`. The same support
+                   can be accessed through `vm update` or `vm disk attach`
 * vm/vmss extension: fix an incorrect extension image matching logic
 * vm create: expose `--boot-diagnostics-storage` to capture boot log
 * vm/vmss update: expose `--license-type`

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -153,8 +153,6 @@ def load_arguments(self, _):
         c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none.', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
-        c.argument('write_accelerator', nargs='*', min_api='2017-12-01', arg_group='Storage',
-                   help="enable/disable disk write accelerator. Use singular value 'true/false' to apply across, or specify individual disks, e.g.'os=true 1=true 2=true' for os disk and data disks with lun of 1 & 2")
         c.argument('boot_diagnostics_storage',
                    help='pre-existing storage account name or its blob uri to capture boot diagnostics. Its sku should be one of Standard_GRS, Standard_LRS and Standard_RAGRS')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -428,7 +428,7 @@ def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):
         namespace.os_type = 'windows' if 'windows' in namespace.os_offer.lower() else 'linux'
 
     from ._vm_utils import normalize_disk_info
-    #attach_data_disks are not exposed yet for VMSS, so use 'getattr' to avoid crash
+    # attach_data_disks are not exposed yet for VMSS, so use 'getattr' to avoid crash
     namespace.disk_info = normalize_disk_info(image_data_disks=image_data_disks,
                                               data_disk_sizes_gb=namespace.data_disk_sizes_gb,
                                               attach_data_disks=getattr(namespace, 'attach_data_disks', []),

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -428,15 +428,13 @@ def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):
         namespace.os_type = 'windows' if 'windows' in namespace.os_offer.lower() else 'linux'
 
     from ._vm_utils import normalize_disk_info
-    # accelnet and attach_data_disks are not exposed yet for VMSS, so use 'getattr' to avoid crash
-    write_accelerator_settings = getattr(namespace, 'write_accelerator', None)
+    #attach_data_disks are not exposed yet for VMSS, so use 'getattr' to avoid crash
     namespace.disk_info = normalize_disk_info(image_data_disks=image_data_disks,
                                               data_disk_sizes_gb=namespace.data_disk_sizes_gb,
                                               attach_data_disks=getattr(namespace, 'attach_data_disks', []),
                                               storage_sku=namespace.storage_sku,
                                               os_disk_caching=namespace.os_caching,
-                                              data_disk_cachings=namespace.data_caching,
-                                              write_accelerator_settings=write_accelerator_settings)
+                                              data_disk_cachings=namespace.data_caching)
 
 
 def _validate_vm_create_storage_account(cmd, namespace):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -127,7 +127,7 @@ def list_sku_info(cli_ctx, location=None):
 
 
 def normalize_disk_info(image_data_disks=None, data_disk_sizes_gb=None, attach_data_disks=None, storage_sku=None,
-                        os_disk_caching=None, data_disk_cachings=None, write_accelerator_settings=None):
+                        os_disk_caching=None, data_disk_cachings=None):
     # we should return a dictionary with info like below and will emoit when see conflictions
     # {
     #   'os': { caching: 'Read', write_accelerator: None},
@@ -174,19 +174,11 @@ def normalize_disk_info(image_data_disks=None, data_disk_sizes_gb=None, attach_d
     if data_disk_cachings:
         update_disk_caching(info, data_disk_cachings)
 
-    # fill in write accelerators
-    if write_accelerator_settings:
-        update_write_accelerator_settings(info, write_accelerator_settings)
-
     # default os disk caching to 'ReadWrite' unless set otherwise
     if os_disk_caching:
         info['os']['caching'] = os_disk_caching
     else:
-        if info['os'].get('writeAcceleratorEnabled'):
-            info['os']['caching'] = 'None'
-        else:
-            info['os']['caching'] = 'ReadWrite'
-
+        info['os']['caching'] = 'ReadWrite'
     return info
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -494,7 +494,7 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
               public_ip_address_dns_name=None, public_ip_sku=None, os_disk_name=None, os_type=None,
               storage_account=None, os_caching=None, data_caching=None, storage_container_name=None, storage_sku=None,
               use_unmanaged_disk=False, attach_os_disk=None, os_disk_size_gb=None, attach_data_disks=None,
-              data_disk_sizes_gb=None, write_accelerator=None, disk_info=None,
+              data_disk_sizes_gb=None, disk_info=None,
               vnet_name=None, vnet_address_prefix='10.0.0.0/16', subnet=None, subnet_address_prefix='10.0.0.0/24',
               storage_profile=None, os_publisher=None, os_offer=None, os_sku=None, os_version=None,
               storage_account_type=None, vnet_type=None, nsg_type=None, public_ip_address_type=None, nic_type=None,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_write_accelerator_e2e.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_write_accelerator_e2e.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"location": "westus2", "tags": {"date": "2018-04-13T15:39:23Z", "cause":
+    body: '{"location": "westus2", "tags": {"date": "2018-05-16T17:05:06Z", "cause":
       "automation", "product": "azurecli"}}'
     headers:
       Accept: [application/json]
@@ -9,19 +9,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['111']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001","name":"cli_vm_write_accel000001","location":"westus2","tags":{"date":"2018-04-13T15:39:23Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001","name":"cli_vm_write_accel000001","location":"westus2","tags":{"date":"2018-05-16T17:05:06Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['385']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:39:26 GMT']
+      date: ['Wed, 16 May 2018 17:05:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -36,19 +36,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001","name":"cli_vm_write_accel000001","location":"westus2","tags":{"date":"2018-04-13T15:39:23Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001","name":"cli_vm_write_accel000001","location":"westus2","tags":{"date":"2018-05-16T17:05:06Z","cause":"automation","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['385']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:39:27 GMT']
+      date: ['Wed, 16 May 2018 17:05:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -108,9 +108,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline'; sandbox]
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:39:27 GMT']
+      date: ['Wed, 16 May 2018 17:05:11 GMT']
       etag: ['"60d07919b4224266adafb81340896eea100dc887"']
-      expires: ['Fri, 13 Apr 2018 15:44:27 GMT']
+      expires: ['Wed, 16 May 2018 17:10:11 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -118,12 +118,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [a698b088274cef0ae1d2cf23b5e6e11f9b3cda4b]
+      x-fastly-request-id: [f11cb6fcacb120d30501146120327dd0cc1c28d5]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['7254:8B63:9B50A0:A4D550:5AD0CF2F']
-      x-served-by: [cache-sea1047-SEA]
-      x-timer: ['S1523633968.832839,VS0,VE98']
+      x-github-request-id: ['2F4E:6410:1D7805:1F601F:5AFC64C6']
+      x-served-by: [cache-sea1023-SEA]
+      x-timer: ['S1526490311.977342,VS0,VE92']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -134,9 +134,9 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-01-01
@@ -146,7 +146,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:39:28 GMT']
+      date: ['Wed, 16 May 2018 17:05:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -154,61 +154,60 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"mode": "Incremental", "template": {"contentVersion":
-      "1.0.0.0", "variables": {}, "resources": [{"name": "vm1VNET", "location": "westus2",
-      "dependsOn": [], "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
-      "subnets": [{"name": "vm1Subnet", "properties": {"addressPrefix": "10.0.0.0/24"}}]},
-      "apiVersion": "2015-06-15", "type": "Microsoft.Network/virtualNetworks", "tags":
-      {}}, {"name": "vm1NSG", "dependsOn": [], "location": "westus2", "properties":
-      {"securityRules": [{"name": "default-allow-ssh", "properties": {"direction":
-      "Inbound", "sourceAddressPrefix": "*", "sourcePortRange": "*", "destinationAddressPrefix":
-      "*", "priority": 1000, "destinationPortRange": "22", "access": "Allow", "protocol":
-      "Tcp"}}]}, "apiVersion": "2015-06-15", "type": "Microsoft.Network/networkSecurityGroups",
-      "tags": {}}, {"name": "vm1PublicIP", "dependsOn": [], "location": "westus2",
-      "properties": {"publicIPAllocationMethod": null}, "apiVersion": "2018-01-01",
-      "type": "Microsoft.Network/publicIPAddresses", "tags": {}}, {"name": "vm1VMNic",
+    body: 'b''{"properties": {"template": {"contentVersion": "1.0.0.0", "$schema":
+      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "outputs": {}, "parameters": {}, "variables": {}, "resources": [{"location":
+      "westus2", "name": "vm1VNET", "type": "Microsoft.Network/virtualNetworks", "dependsOn":
+      [], "apiVersion": "2015-06-15", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "subnets": [{"name": "vm1Subnet", "properties": {"addressPrefix":
+      "10.0.0.0/24"}}]}}, {"location": "westus2", "name": "vm1NSG", "type": "Microsoft.Network/networkSecurityGroups",
+      "dependsOn": [], "apiVersion": "2015-06-15", "tags": {}, "properties": {"securityRules":
+      [{"name": "default-allow-ssh", "properties": {"direction": "Inbound", "sourcePortRange":
+      "*", "protocol": "Tcp", "priority": 1000, "destinationPortRange": "22", "sourceAddressPrefix":
+      "*", "access": "Allow", "destinationAddressPrefix": "*"}}]}}, {"location": "westus2",
+      "name": "vm1PublicIP", "type": "Microsoft.Network/publicIPAddresses", "dependsOn":
+      [], "apiVersion": "2018-01-01", "tags": {}, "properties": {"publicIPAllocationMethod":
+      null}}, {"location": "westus2", "name": "vm1VMNic", "type": "Microsoft.Network/networkInterfaces",
       "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET", "Microsoft.Network/networkSecurityGroups/vm1NSG",
-      "Microsoft.Network/publicIpAddresses/vm1PublicIP"], "location": "westus2", "properties":
-      {"networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
-      "ipConfigurations": [{"name": "ipconfigvm1", "properties": {"subnet": {"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}}}]},
-      "apiVersion": "2015-06-15", "type": "Microsoft.Network/networkInterfaces", "tags":
-      {}}, {"name": "vm1", "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"],
-      "location": "westus2", "properties": {"storageProfile": {"imageReference": {"sku":
-      "7.3", "publisher": "OpenLogic", "offer": "CentOS", "version": "latest"}, "osDisk":
-      {"name": null, "caching": "ReadWrite", "createOption": "fromImage", "managedDisk":
-      {"storageAccountType": null}}, "dataDisks": [{"writeAcceleratorEnabled": true,
-      "diskSizeGB": 1, "createOption": "empty", "lun": 0, "managedDisk": {"storageAccountType":
-      null}}]}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "osProfile": {"computerName": "vm1", "linuxConfiguration": {"ssh": {"publicKeys":
-      [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n", "path": "/home/yugangw/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
-      true}, "adminUsername": "yugangw"}, "hardwareProfile": {"vmSize": "Standard_M64ms"}},
-      "apiVersion": "2017-12-01", "type": "Microsoft.Compute/virtualMachines", "tags":
-      {}}], "parameters": {}, "outputs": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
-      "parameters": {}}}'''
+      "Microsoft.Network/publicIpAddresses/vm1PublicIP"], "apiVersion": "2015-06-15",
+      "tags": {}, "properties": {"ipConfigurations": [{"name": "ipconfigvm1", "properties":
+      {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
+      "privateIPAllocationMethod": "Dynamic"}}], "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"}}},
+      {"location": "westus2", "name": "vm1", "type": "Microsoft.Compute/virtualMachines",
+      "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"], "apiVersion":
+      "2017-12-01", "tags": {}, "properties": {"networkProfile": {"networkInterfaces":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "osProfile": {"computerName": "vm1", "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n", "path": "/home/clitester/.ssh/authorized_keys"}]}}, "adminUsername":
+      "clitester"}, "hardwareProfile": {"vmSize": "Standard_M64ms"}, "storageProfile":
+      {"dataDisks": [{"managedDisk": {"storageAccountType": null}, "lun": 0, "diskSizeGB":
+      1, "createOption": "empty"}], "imageReference": {"offer": "CentOS", "sku": "7.3",
+      "publisher": "OpenLogic", "version": "latest"}, "osDisk": {"name": null, "caching":
+      "ReadWrite", "managedDisk": {"storageAccountType": null}, "createOption": "fromImage"}}}}]},
+      "mode": "Incremental", "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm create]
       Connection: [keep-alive]
-      Content-Length: ['3813']
+      Content-Length: ['3784']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/vm_deploy_KX4zWtBADgQOmSoZLiqbypnIjb6vNiaw","name":"vm_deploy_KX4zWtBADgQOmSoZLiqbypnIjb6vNiaw","properties":{"templateHash":"16730608298103251324","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-04-13T15:39:30.3859505Z","duration":"PT0.5568244S","correlationId":"e932e7e6-4993-44ae-84df-d6b6e4a318cd","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"networkSecurityGroups","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"networkInterfaces","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/vm_deploy_vYB2ZT1Ecxz2w3l2B2na4rfz34yeqFtf","name":"vm_deploy_vYB2ZT1Ecxz2w3l2B2na4rfz34yeqFtf","properties":{"templateHash":"4226258672239180572","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2018-05-16T17:05:13.5654637Z","duration":"PT0.5951885S","correlationId":"cb291f29-aede-4190-82b8-08e5c84d7237","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"networkSecurityGroups","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"networkInterfaces","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/vm_deploy_KX4zWtBADgQOmSoZLiqbypnIjb6vNiaw/operationStatuses/08586779729156484958?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/vm_deploy_vYB2ZT1Ecxz2w3l2B2na4rfz34yeqFtf/operationStatuses/08586751165725073537?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['2707']
+      content-length: ['2706']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:39:30 GMT']
+      date: ['Wed, 16 May 2018 17:05:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -223,19 +222,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:40:00 GMT']
+      date: ['Wed, 16 May 2018 17:05:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -250,19 +249,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:40:30 GMT']
+      date: ['Wed, 16 May 2018 17:06:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -277,19 +276,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:41:00 GMT']
+      date: ['Wed, 16 May 2018 17:06:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -304,19 +303,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:41:30 GMT']
+      date: ['Wed, 16 May 2018 17:07:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -331,19 +330,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:42:01 GMT']
+      date: ['Wed, 16 May 2018 17:07:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -358,19 +357,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:42:30 GMT']
+      date: ['Wed, 16 May 2018 17:08:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -385,19 +384,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:43:01 GMT']
+      date: ['Wed, 16 May 2018 17:08:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -412,19 +411,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:43:31 GMT']
+      date: ['Wed, 16 May 2018 17:09:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -439,19 +438,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:44:02 GMT']
+      date: ['Wed, 16 May 2018 17:09:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -466,181 +465,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:44:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:45:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:45:32 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:46:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:46:32 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:47:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vm create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586779729156484958?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586751165725073537?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:47:33 GMT']
+      date: ['Wed, 16 May 2018 17:10:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -655,19 +492,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/vm_deploy_KX4zWtBADgQOmSoZLiqbypnIjb6vNiaw","name":"vm_deploy_KX4zWtBADgQOmSoZLiqbypnIjb6vNiaw","properties":{"templateHash":"16730608298103251324","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-04-13T15:47:06.934789Z","duration":"PT7M37.1056629S","correlationId":"e932e7e6-4993-44ae-84df-d6b6e4a318cd","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"networkSecurityGroups","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"networkInterfaces","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Resources/deployments/vm_deploy_vYB2ZT1Ecxz2w3l2B2na4rfz34yeqFtf","name":"vm_deploy_vYB2ZT1Ecxz2w3l2B2na4rfz34yeqFtf","properties":{"templateHash":"4226258672239180572","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2018-05-16T17:10:05.7474173Z","duration":"PT4M52.7771421S","correlationId":"cb291f29-aede-4190-82b8-08e5c84d7237","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"networkSecurityGroups","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"networkInterfaces","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['3773']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:47:33 GMT']
+      date: ['Wed, 16 May 2018 17:10:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -682,36 +519,35 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"None\"\
-        ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
-        : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        ,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"\
+        Premium_LRS\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -722,21 +558,21 @@ interactions:
         \            \"code\": \"ProvisioningState/succeeded\",\r\n            \"\
         level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n      \
         \      \"message\": \"Guest Agent is running\",\r\n            \"time\": \"\
-        2018-04-13T15:47:31+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\"\
+        2018-05-16T17:10:15+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\"\
         : []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n          \"statuses\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n          \"statuses\"\
         : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2018-04-13T15:40:02.5288256+00:00\"\
+        : \"Provisioning succeeded\",\r\n              \"time\": \"2018-05-16T17:05:43.6778071+00:00\"\
         \r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"\
-        name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\",\r\n          \"statuses\"\
+        name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\",\r\n          \"statuses\"\
         : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2018-04-13T15:40:02.5288256+00:00\"\
+        : \"Provisioning succeeded\",\r\n              \"time\": \"2018-05-16T17:05:43.6778071+00:00\"\
         \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"statuses\"\
         : [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\
         \n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2018-04-13T15:46:53.0472041+00:00\"\
+        \ succeeded\",\r\n          \"time\": \"2018-05-16T17:09:54.4557874+00:00\"\
         \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
@@ -744,9 +580,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['4506']
+      content-length: ['4466']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:47:33 GMT']
+      date: ['Wed, 16 May 2018 17:10:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -754,7 +590,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4194,Microsoft.Compute/LowCostGet30Min;33594']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4194,Microsoft.Compute/LowCostGet30Min;33593']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -764,20 +600,20 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"33011f64-103c-4a56-8d26-8baa04124549\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"416ac3d5-28b2-4010-81dc-4f696632abaf\\\"\",\r\n \
         \ \"location\": \"westus2\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1b6e3758-f634-4dba-ad93-c8a52a81bc40\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"293dc1b7-b6d5-4a76-a2ff-5d1dbac7abce\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"33011f64-103c-4a56-8d26-8baa04124549\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"416ac3d5-28b2-4010-81dc-4f696632abaf\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -787,8 +623,8 @@ interactions:
         : \"IPv4\",\r\n          \"isInUseWithService\": false\r\n        }\r\n  \
         \    }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n\
         \      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"\
-        q5rhys2q45tedc2xdol22kiiuh.xx.internal.cloudapp.net\"\r\n    },\r\n    \"\
-        macAddress\": \"00-0D-3A-F7-6F-40\",\r\n    \"enableAcceleratedNetworking\"\
+        lhbohflxf3rurh001b14dipg3g.xx.internal.cloudapp.net\"\r\n    },\r\n    \"\
+        macAddress\": \"00-0D-3A-06-85-DC\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -799,8 +635,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2597']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:47:34 GMT']
-      etag: [W/"33011f64-103c-4a56-8d26-8baa04124549"]
+      date: ['Wed, 16 May 2018 17:10:16 GMT']
+      etag: [W/"416ac3d5-28b2-4010-81dc-4f696632abaf"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -817,18 +653,18 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 networkmanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP?api-version=2018-01-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"61b2714f-d1b4-45f0-af57-f13f85bcc43e\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"4376897a-51e6-4e81-8992-adfe211184e0\\\"\",\r\n \
         \ \"location\": \"westus2\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"4ba3a44a-6a4b-4b49-b0e2-e12b9f3a28c5\"\
-        ,\r\n    \"ipAddress\": \"40.125.67.5\",\r\n    \"publicIPAddressVersion\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"31490016-0f95-4c52-97b6-08bd75f381b7\"\
+        ,\r\n    \"ipAddress\": \"13.66.152.104\",\r\n    \"publicIPAddressVersion\"\
         : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
         : 4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
@@ -837,10 +673,10 @@ interactions:
         \n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1021']
+      content-length: ['1023']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:47:34 GMT']
-      etag: [W/"61b2714f-d1b4-45f0-af57-f13f85bcc43e"]
+      date: ['Wed, 16 May 2018 17:10:16 GMT']
+      etag: [W/"4376897a-51e6-4e81-8992-adfe211184e0"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -857,36 +693,35 @@ interactions:
       CommandName: [vm show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"None\"\
-        ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
-        : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        ,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"\
+        Premium_LRS\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -896,9 +731,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2885']
+      content-length: ['2845']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:47:45 GMT']
+      date: ['Wed, 16 May 2018 17:10:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -906,7 +741,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4193,Microsoft.Compute/LowCostGet30Min;33593']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4193,Microsoft.Compute/LowCostGet30Min;33592']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -916,36 +751,35 @@ interactions:
       CommandName: [vm update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"None\"\
-        ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
-        : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        ,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"\
+        Premium_LRS\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -955,9 +789,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2885']
+      content-length: ['2845']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:47:57 GMT']
+      date: ['Wed, 16 May 2018 17:10:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -965,61 +799,60 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4192,Microsoft.Compute/LowCostGet30Min;33592']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4192,Microsoft.Compute/LowCostGet30Min;33591']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"tags": {}, "location": "westus2", "properties": {"storageProfile":
-      {"imageReference": {"sku": "7.3", "publisher": "OpenLogic", "offer": "CentOS",
-      "version": "latest"}, "osDisk": {"name": "vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774",
-      "diskSizeGB": 30, "caching": "ReadOnly", "osType": "Linux", "writeAcceleratorEnabled":
-      true, "createOption": "FromImage", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774",
-      "storageAccountType": "Premium_LRS"}}, "dataDisks": [{"name": "vm1_disk2_56b004ae0de448389f70125ff2100f08",
-      "diskSizeGB": 1, "caching": "ReadOnly", "lun": 0, "writeAcceleratorEnabled":
-      true, "createOption": "Empty", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08",
-      "storageAccountType": "Premium_LRS"}}]}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "osProfile": {"computerName": "vm1", "linuxConfiguration": {"ssh": {"publicKeys":
-      [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n", "path": "/home/yugangw/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
-      true}, "secrets": [], "adminUsername": "yugangw"}, "hardwareProfile": {"vmSize":
-      "Standard_M64ms"}}}'''
+    body: 'b''{"tags": {}, "location": "westus2", "properties": {"networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "osProfile": {"computerName": "vm1", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n", "path": "/home/clitester/.ssh/authorized_keys"}]}}, "adminUsername":
+      "clitester"}, "hardwareProfile": {"vmSize": "Standard_M64ms"}, "storageProfile":
+      {"dataDisks": [{"lun": 0, "caching": "ReadOnly", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa",
+      "storageAccountType": "Premium_LRS"}, "writeAcceleratorEnabled": true, "createOption":
+      "Empty", "diskSizeGB": 1, "name": "vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa"}],
+      "imageReference": {"offer": "CentOS", "sku": "7.3", "publisher": "OpenLogic",
+      "version": "latest"}, "osDisk": {"osType": "Linux", "name": "vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d",
+      "caching": "ReadOnly", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d",
+      "storageAccountType": "Premium_LRS"}, "writeAcceleratorEnabled": true, "diskSizeGB":
+      30, "createOption": "FromImage"}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      Content-Length: ['2042']
+      Content-Length: ['2046']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : true,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -1028,11 +861,11 @@ interactions:
         \ \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01']
       cache-control: [no-cache]
-      content-length: ['2929']
+      content-length: ['2933']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:47:58 GMT']
+      date: ['Wed, 16 May 2018 17:10:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1050,20 +883,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:48:28 GMT']
+      date: ['Wed, 16 May 2018 17:11:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1071,7 +904,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29947']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29967']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1080,20 +913,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:49:01 GMT']
+      date: ['Wed, 16 May 2018 17:11:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1101,7 +934,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29944']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29964']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1110,20 +943,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:49:33 GMT']
+      date: ['Wed, 16 May 2018 17:12:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1131,7 +964,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14991,Microsoft.Compute/GetOperation30Min;29941']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29961']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1140,20 +973,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:50:04 GMT']
+      date: ['Wed, 16 May 2018 17:12:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1161,7 +994,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29938']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29958']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1170,20 +1003,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:50:35 GMT']
+      date: ['Wed, 16 May 2018 17:13:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1191,7 +1024,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29935']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29955']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1200,20 +1033,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:51:07 GMT']
+      date: ['Wed, 16 May 2018 17:13:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1221,7 +1054,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29932']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29952']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1230,20 +1063,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:51:38 GMT']
+      date: ['Wed, 16 May 2018 17:14:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1251,7 +1084,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29929']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29949']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1260,20 +1093,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:52:09 GMT']
+      date: ['Wed, 16 May 2018 17:14:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1281,7 +1114,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29926']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29946']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1290,20 +1123,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:52:41 GMT']
+      date: ['Wed, 16 May 2018 17:15:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1311,7 +1144,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29923']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29943']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1320,20 +1153,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/24fcd845-eaea-4641-9b57-e66529df44c2?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f5692369-0a5e-41cd-9c3b-ce3291c612ef?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:47:58.8449197+00:00\",\r\
-        \n  \"endTime\": \"2018-04-13T15:52:56.431335+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"24fcd845-eaea-4641-9b57-e66529df44c2\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:10:41.8506641+00:00\",\r\
+        \n  \"endTime\": \"2018-05-16T17:15:29.1420832+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"f5692369-0a5e-41cd-9c3b-ce3291c612ef\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['183']
+      content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:53:11 GMT']
+      date: ['Wed, 16 May 2018 17:15:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1341,7 +1174,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29920']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29941']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1350,35 +1183,35 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : true,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -1388,9 +1221,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2930']
+      content-length: ['2934']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:53:11 GMT']
+      date: ['Wed, 16 May 2018 17:15:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1398,7 +1231,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4198,Microsoft.Compute/LowCostGet30Min;33590']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33586']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1408,36 +1241,36 @@ interactions:
       CommandName: [vm show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : true,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -1447,9 +1280,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2930']
+      content-length: ['2934']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:53:12 GMT']
+      date: ['Wed, 16 May 2018 17:15:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1457,7 +1290,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4196,Microsoft.Compute/LowCostGet30Min;33588']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4194,Microsoft.Compute/LowCostGet30Min;33585']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1467,36 +1300,36 @@ interactions:
       CommandName: [vm disk attach]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : true,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -1506,9 +1339,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2930']
+      content-length: ['2934']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:53:23 GMT']
+      date: ['Wed, 16 May 2018 17:16:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1516,66 +1349,66 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33587']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4193,Microsoft.Compute/LowCostGet30Min;33584']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"tags": {}, "location": "westus2", "properties": {"storageProfile":
-      {"imageReference": {"sku": "7.3", "publisher": "OpenLogic", "offer": "CentOS",
-      "version": "latest"}, "osDisk": {"name": "vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774",
-      "diskSizeGB": 30, "caching": "ReadOnly", "osType": "Linux", "writeAcceleratorEnabled":
-      true, "createOption": "FromImage", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774",
-      "storageAccountType": "Premium_LRS"}}, "dataDisks": [{"name": "vm1_disk2_56b004ae0de448389f70125ff2100f08",
-      "diskSizeGB": 1, "caching": "ReadOnly", "lun": 0, "writeAcceleratorEnabled":
-      true, "createOption": "Empty", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08",
-      "storageAccountType": "Premium_LRS"}}, {"name": "d1", "diskSizeGB": 1, "lun":
-      1, "writeAcceleratorEnabled": true, "createOption": "Empty", "managedDisk":
-      {}}]}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "osProfile": {"computerName": "vm1", "linuxConfiguration": {"ssh": {"publicKeys":
-      [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n", "path": "/home/yugangw/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
-      true}, "secrets": [], "adminUsername": "yugangw"}, "hardwareProfile": {"vmSize":
-      "Standard_M64ms"}}}'''
+    body: 'b''{"tags": {}, "location": "westus2", "properties": {"networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "osProfile": {"computerName": "vm1", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n", "path": "/home/clitester/.ssh/authorized_keys"}]}}, "adminUsername":
+      "clitester"}, "hardwareProfile": {"vmSize": "Standard_M64ms"}, "storageProfile":
+      {"dataDisks": [{"lun": 0, "caching": "ReadOnly", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa",
+      "storageAccountType": "Premium_LRS"}, "writeAcceleratorEnabled": true, "createOption":
+      "Empty", "diskSizeGB": 1, "name": "vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa"},
+      {"lun": 1, "name": "d1", "managedDisk": {}, "writeAcceleratorEnabled": true,
+      "diskSizeGB": 1, "createOption": "Empty"}], "imageReference": {"offer": "CentOS",
+      "sku": "7.3", "publisher": "OpenLogic", "version": "latest"}, "osDisk": {"osType":
+      "Linux", "name": "vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d", "caching":
+      "ReadOnly", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d",
+      "storageAccountType": "Premium_LRS"}, "writeAcceleratorEnabled": true, "diskSizeGB":
+      30, "createOption": "FromImage"}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      Content-Length: ['2162']
+      Content-Length: ['2166']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : true,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        },\r\n        {\r\
         \n          \"lun\": 1,\r\n          \"name\": \"d1\",\r\n          \"createOption\"\
         : \"Empty\",\r\n          \"caching\": \"None\",\r\n          \"writeAcceleratorEnabled\"\
         : true,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\"\
         : \"Premium_LRS\"\r\n          },\r\n          \"diskSizeGB\": 1\r\n     \
         \   }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"vm1\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"vm1\",\r\n      \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\"\
         : {\r\n          \"publicKeys\": [\r\n            {\r\n              \"path\"\
-        : \"/home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"\
-        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        : \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -1584,11 +1417,11 @@ interactions:
         \ \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01']
       cache-control: [no-cache]
-      content-length: ['3226']
+      content-length: ['3230']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:53:24 GMT']
+      date: ['Wed, 16 May 2018 17:16:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1606,20 +1439,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:53:55 GMT']
+      date: ['Wed, 16 May 2018 17:16:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1627,7 +1460,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29918']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29939']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1636,20 +1469,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:54:25 GMT']
+      date: ['Wed, 16 May 2018 17:17:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1657,7 +1490,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29915']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29936']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1666,20 +1499,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:54:57 GMT']
+      date: ['Wed, 16 May 2018 17:17:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1687,7 +1520,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29912']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29933']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1696,20 +1529,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:55:30 GMT']
+      date: ['Wed, 16 May 2018 17:18:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1717,7 +1550,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29909']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29930']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1726,20 +1559,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:56:04 GMT']
+      date: ['Wed, 16 May 2018 17:18:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1747,7 +1580,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29906']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29927']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1756,20 +1589,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:56:35 GMT']
+      date: ['Wed, 16 May 2018 17:19:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1777,7 +1610,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29903']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29924']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1786,20 +1619,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:57:07 GMT']
+      date: ['Wed, 16 May 2018 17:19:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1807,7 +1640,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29900']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29921']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1816,20 +1649,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:57:38 GMT']
+      date: ['Wed, 16 May 2018 17:20:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1837,7 +1670,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29897']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29918']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1846,20 +1679,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:58:09 GMT']
+      date: ['Wed, 16 May 2018 17:20:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1867,7 +1700,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29894']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29915']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1876,20 +1709,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1b49961d-5067-4828-9d3f-e7ae17d63c8e?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2afb4c2b-a49e-4434-b73c-ce3e642f5dd5?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:53:25.2914654+00:00\",\r\
-        \n  \"endTime\": \"2018-04-13T15:58:22.8927156+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"1b49961d-5067-4828-9d3f-e7ae17d63c8e\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:16:11.0798699+00:00\",\r\
+        \n  \"endTime\": \"2018-05-16T17:21:04.3510475+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"2afb4c2b-a49e-4434-b73c-ce3e642f5dd5\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:58:39 GMT']
+      date: ['Wed, 16 May 2018 17:21:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1897,7 +1730,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29891']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29913']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1906,28 +1739,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm disk attach]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : true,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        },\r\n        {\r\
         \n          \"lun\": 1,\r\n          \"name\": \"d1\",\r\n          \"createOption\"\
         : \"Empty\",\r\n          \"caching\": \"None\",\r\n          \"writeAcceleratorEnabled\"\
@@ -1935,11 +1768,11 @@ interactions:
         : \"Premium_LRS\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/d1\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -1949,9 +1782,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3429']
+      content-length: ['3433']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:58:39 GMT']
+      date: ['Wed, 16 May 2018 17:21:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1959,7 +1792,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4198,Microsoft.Compute/LowCostGet30Min;33583']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4195,Microsoft.Compute/LowCostGet30Min;33579']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1969,29 +1802,29 @@ interactions:
       CommandName: [vm update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : true,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        },\r\n        {\r\
         \n          \"lun\": 1,\r\n          \"name\": \"d1\",\r\n          \"createOption\"\
         : \"Empty\",\r\n          \"caching\": \"None\",\r\n          \"writeAcceleratorEnabled\"\
@@ -1999,11 +1832,11 @@ interactions:
         : \"Premium_LRS\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/d1\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -2013,9 +1846,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3429']
+      content-length: ['3433']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:58:41 GMT']
+      date: ['Wed, 16 May 2018 17:21:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2023,57 +1856,56 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4197,Microsoft.Compute/LowCostGet30Min;33582']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4194,Microsoft.Compute/LowCostGet30Min;33578']
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"tags": {}, "location": "westus2", "properties": {"storageProfile":
-      {"imageReference": {"sku": "7.3", "publisher": "OpenLogic", "offer": "CentOS",
-      "version": "latest"}, "osDisk": {"name": "vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774",
-      "diskSizeGB": 30, "caching": "ReadOnly", "osType": "Linux", "writeAcceleratorEnabled":
-      false, "createOption": "FromImage", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774",
-      "storageAccountType": "Premium_LRS"}}, "dataDisks": [{"name": "vm1_disk2_56b004ae0de448389f70125ff2100f08",
-      "diskSizeGB": 1, "caching": "ReadOnly", "lun": 0, "writeAcceleratorEnabled":
-      true, "createOption": "Empty", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08",
-      "storageAccountType": "Premium_LRS"}}, {"name": "d1", "diskSizeGB": 1, "caching":
-      "None", "lun": 1, "writeAcceleratorEnabled": false, "createOption": "Empty",
-      "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/d1",
-      "storageAccountType": "Premium_LRS"}}]}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "osProfile": {"computerName": "vm1", "linuxConfiguration": {"ssh": {"publicKeys":
-      [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
-      yugangw@YUGANGW1\\n", "path": "/home/yugangw/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
-      true}, "secrets": [], "adminUsername": "yugangw"}, "hardwareProfile": {"vmSize":
-      "Standard_M64ms"}}}'''
+    body: 'b''{"tags": {}, "location": "westus2", "properties": {"networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "osProfile": {"computerName": "vm1", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH
+      yugangw@YUGANGW1\\n", "path": "/home/clitester/.ssh/authorized_keys"}]}}, "adminUsername":
+      "clitester"}, "hardwareProfile": {"vmSize": "Standard_M64ms"}, "storageProfile":
+      {"dataDisks": [{"lun": 0, "caching": "ReadOnly", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa",
+      "storageAccountType": "Premium_LRS"}, "writeAcceleratorEnabled": true, "createOption":
+      "Empty", "diskSizeGB": 1, "name": "vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa"},
+      {"lun": 1, "caching": "None", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/d1",
+      "storageAccountType": "Premium_LRS"}, "writeAcceleratorEnabled": false, "createOption":
+      "Empty", "diskSizeGB": 1, "name": "d1"}], "imageReference": {"offer": "CentOS",
+      "sku": "7.3", "publisher": "OpenLogic", "version": "latest"}, "osDisk": {"osType":
+      "Linux", "name": "vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d", "caching":
+      "ReadOnly", "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d",
+      "storageAccountType": "Premium_LRS"}, "writeAcceleratorEnabled": false, "diskSizeGB":
+      30, "createOption": "FromImage"}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      Content-Length: ['2407']
+      Content-Length: ['2411']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : false,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        },\r\n        {\r\
         \n          \"lun\": 1,\r\n          \"name\": \"d1\",\r\n          \"createOption\"\
         : \"Empty\",\r\n          \"caching\": \"None\",\r\n          \"writeAcceleratorEnabled\"\
@@ -2081,11 +1913,11 @@ interactions:
         : \"Premium_LRS\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/d1\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -2094,11 +1926,11 @@ interactions:
         \ \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01']
       cache-control: [no-cache]
-      content-length: ['3430']
+      content-length: ['3434']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:58:41 GMT']
+      date: ['Wed, 16 May 2018 17:21:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2116,20 +1948,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:59:11 GMT']
+      date: ['Wed, 16 May 2018 17:22:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2137,7 +1969,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29889']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29911']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2146,20 +1978,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 15:59:42 GMT']
+      date: ['Wed, 16 May 2018 17:22:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2167,7 +1999,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29886']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29908']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2176,20 +2008,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:00:12 GMT']
+      date: ['Wed, 16 May 2018 17:23:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2197,7 +2029,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29883']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29905']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2206,20 +2038,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:00:48 GMT']
+      date: ['Wed, 16 May 2018 17:23:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2227,7 +2059,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29880']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29902']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2236,20 +2068,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:01:19 GMT']
+      date: ['Wed, 16 May 2018 17:24:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2257,7 +2089,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29877']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2266,20 +2098,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:01:52 GMT']
+      date: ['Wed, 16 May 2018 17:24:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2287,7 +2119,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29874']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29896']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2296,20 +2128,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:02:25 GMT']
+      date: ['Wed, 16 May 2018 17:25:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2317,7 +2149,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29871']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29893']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2326,20 +2158,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:02:59 GMT']
+      date: ['Wed, 16 May 2018 17:25:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2347,7 +2179,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29868']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29890']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2356,20 +2188,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:03:31 GMT']
+      date: ['Wed, 16 May 2018 17:26:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2377,7 +2209,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29865']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29887']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2386,20 +2218,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/8f6768a0-4d11-427c-8a8a-eaaed68d5b39?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/51722f3b-aeaf-42e2-b044-0459d2396486?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-04-13T15:58:41.6900708+00:00\",\r\
-        \n  \"endTime\": \"2018-04-13T16:03:44.5619256+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"8f6768a0-4d11-427c-8a8a-eaaed68d5b39\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-05-16T17:21:33.5543522+00:00\",\r\
+        \n  \"endTime\": \"2018-05-16T17:26:37.7748512+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"51722f3b-aeaf-42e2-b044-0459d2396486\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:04:02 GMT']
+      date: ['Wed, 16 May 2018 17:26:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2407,7 +2239,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29862']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29884']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2416,28 +2248,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm update]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : false,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        },\r\n        {\r\
         \n          \"lun\": 1,\r\n          \"name\": \"d1\",\r\n          \"createOption\"\
         : \"Empty\",\r\n          \"caching\": \"None\",\r\n          \"writeAcceleratorEnabled\"\
@@ -2445,11 +2277,11 @@ interactions:
         : \"Premium_LRS\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/d1\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -2459,9 +2291,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3431']
+      content-length: ['3435']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:04:02 GMT']
+      date: ['Wed, 16 May 2018 17:26:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2469,7 +2301,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4198,Microsoft.Compute/LowCostGet30Min;33577']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4198,Microsoft.Compute/LowCostGet30Min;33576']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2479,29 +2311,29 @@ interactions:
       CommandName: [vm show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 computemanagementclient/4.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 computemanagementclient/4.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-12-01
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"916ee01e-c285-4149-b6f4-0d24546e4e76\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"12da3596-b36f-43a0-b3b7-ccd330ab30f3\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_M64ms\"\r\n\
         \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
         \      \"publisher\": \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n\
         \        \"sku\": \"7.3\",\r\n        \"version\": \"latest\"\r\n      },\r\
         \n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadOnly\",\r\n        \"writeAcceleratorEnabled\"\
         : false,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\"\
-        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_035cdf6c33f24d18bfc58699c03d7774\"\
+        : \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_40b1535722c04a6b992a75d0f4f5079d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
-        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        : [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         ,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadOnly\"\
         ,\r\n          \"writeAcceleratorEnabled\": true,\r\n          \"managedDisk\"\
         : {\r\n            \"storageAccountType\": \"Premium_LRS\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_56b004ae0de448389f70125ff2100f08\"\
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/vm1_disk2_386ef0739b7948a9aeb191d1c81b28aa\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        },\r\n        {\r\
         \n          \"lun\": 1,\r\n          \"name\": \"d1\",\r\n          \"createOption\"\
         : \"Empty\",\r\n          \"caching\": \"None\",\r\n          \"writeAcceleratorEnabled\"\
@@ -2509,11 +2341,11 @@ interactions:
         : \"Premium_LRS\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Compute/disks/d1\"\
         \r\n          },\r\n          \"diskSizeGB\": 1\r\n        }\r\n      ]\r\n\
         \    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n  \
-        \    \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n\
-        \        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n\
-        \          \"publicKeys\": [\r\n            {\r\n              \"path\": \"\
-        /home/yugangw/.ssh/authorized_keys\",\r\n              \"keyData\": \"ssh-rsa\
-        \ AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
+        \    \"adminUsername\": \"clitester\",\r\n      \"linuxConfiguration\": {\r\
+        \n        \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\
+        \n          \"publicKeys\": [\r\n            {\r\n              \"path\":\
+        \ \"/home/clitester/.ssh/authorized_keys\",\r\n              \"keyData\":\
+        \ \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaQ1KLeMgSuB7YfE9J8CIFBgyXuaUTjh2mcJL8F8PKS+ad3czClma99lDBSmXaIrdPcdyn/A5RfauijgTKPNbC64FgnbtNjTWjyb4NSJyXKP9BlbGqvz8xxO+CPOTvNe7GOPi9l0pZZLq8uXB1D4G6h54BBaEqpLIWGNDusllfRyy2Z9zIOCSuVmpss+zq1nWmiB3mrDTm36DO1jQFnOaytYYBrluulJ6fAn6vHI3vW/mDugwCb5KzT0hcKT2UeuM75odM/OS8I4YneDxdCz0Gu456o4izTHchGXWZURxJlSUD1znIMMJDJmxHbD+bhnfcZ8Xu5KxNDPhUCTYeN/oH\
         \ yugangw@YUGANGW1\\n\"\r\n            }\r\n          ]\r\n        }\r\n \
         \     },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"\
         networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vm_write_accel000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
@@ -2523,9 +2355,9 @@ interactions:
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3431']
+      content-length: ['3435']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 13 Apr 2018 16:04:02 GMT']
+      date: ['Wed, 16 May 2018 17:26:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2533,7 +2365,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4197,Microsoft.Compute/LowCostGet30Min;33576']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4196,Microsoft.Compute/LowCostGet30Min;33574']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2544,9 +2376,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.32]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.29 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.33]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vm_write_accel000001?api-version=2017-05-10
@@ -2555,12 +2387,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 13 Apr 2018 16:04:03 GMT']
+      date: ['Wed, 16 May 2018 17:26:49 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZWTTo1RldSSVRFOjVGQUNDRUxDUU5KRTZXN1hIVTRaNDNJNU9TRlVPRXxEMTE0REE1RTY1MjQ2NzI4LVdFU1RVUzIiLCJqb2JMb2NhdGlvbiI6Indlc3R1czIifQ?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZWTTo1RldSSVRFOjVGQUNDRUxBQ0tFSU9DUUlESUpJUFpaREdERlhEUHwyODNDNkJDQjYyNDBDQTRDLVdFU1RVUzIiLCJqb2JMb2NhdGlvbiI6Indlc3R1czIifQ?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -369,27 +369,6 @@ class TestActions(unittest.TestCase):
             normalize_disk_info(data_disk_cachings=['0=None', '1=foo'])
         self.assertTrue("data disk with lun of '0' doesn't exist" in str(err.exception))
 
-        # verify write accelerator configuring; also, when it is enabled, caching will be set to None
-
-        r = normalize_disk_info(write_accelerator_settings=['true'])
-        self.assertEqual(r['os']['caching'], CachingTypes.none.value)
-
-        r = normalize_disk_info(data_disk_sizes_gb=[1, 2], write_accelerator_settings=['true'])
-        self.assertEqual(r['os']['writeAcceleratorEnabled'], True)
-        self.assertEqual(r[0]['writeAcceleratorEnabled'], True)
-        self.assertEqual(r[1]['writeAcceleratorEnabled'], True)
-
-        r = normalize_disk_info(data_disk_sizes_gb=[1, 2], write_accelerator_settings=['0=true'])
-        self.assertEqual(r['os'].get('writeAcceleratorEnabled'), None)
-        self.assertEqual(r['os']['caching'], CachingTypes.read_write.value)
-        self.assertEqual(r[0]['writeAcceleratorEnabled'], True)
-        self.assertEqual(r[1].get('writeAcceleratorEnabled'), None)
-
-        # error on configuring non-existing disks
-        with self.assertRaises(CLIError) as err:
-            normalize_disk_info(write_accelerator_settings=['0=true'])
-        self.assertTrue("data disk with lun of '0' doesn't exist" in str(err.exception))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -599,11 +599,10 @@ class VMWriteAcceleratorScenarioTest(ScenarioTest):
         self.kwargs.update({
             'vm': 'vm1'
         })
-        self.cmd('vm create -g {rg} -n {vm} --write-accelerator 0=true --data-disk-sizes-gb 1 --image centos --size Standard_M64ms --admin-username clitester')
+        self.cmd('vm create -g {rg} -n {vm} --data-disk-sizes-gb 1 --image centos --size Standard_M64ms --admin-username clitester --generate-ssh-keys')
         self.cmd('vm show -g {rg} -n {vm}', checks=[
             self.check('storageProfile.osDisk.writeAcceleratorEnabled', None),
-            self.check('storageProfile.dataDisks[0].writeAcceleratorEnabled', True),
-            self.check('storageProfile.dataDisks[1].writeAcceleratorEnabled', None)
+            self.check('storageProfile.dataDisks[0].writeAcceleratorEnabled', None)
         ])
         self.cmd('vm update -g {rg} -n {vm} --write-accelerator true --disk-caching readonly')
         self.cmd('vm show -g {rg} -n {vm}', checks=[


### PR DESCRIPTION
The goal is to control the complexity of `vm create` by not exposing something which few people will need, say this accelerator flag which requires 64+ cores VM. This command argument was introduced in the last sprint, and but was too late to revert. CRP team was fine with the change, and the telemetry data shows no usage since release, so it is fine to pull it out.


- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
