### PR TITLE
setup: deploy pyc files only

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -160,14 +160,13 @@ popd
 :: Remove .py and only deploy .pyc files
 pushd %BUILDING_DIR%\Lib\site-packages
 for /f %%f in ('dir /b /s *.pyc') do (
-    : echo %%~f
     set PARENT_DIR=%%~df%%~pf..
     set FILENAME=%%~nf
-	set BASE_FILENAME=!FILENAME:~0,-11!
-	set pyc=!BASE_FILENAME!.pyc
-	del !PARENT_DIR!\!BASE_FILENAME!.py
-	copy %%~f !PARENT_DIR!\!pyc! >nul
-	del %%~f 
+    set BASE_FILENAME=!FILENAME:~0,-11!
+    set pyc=!BASE_FILENAME!.pyc
+    del !PARENT_DIR!\!BASE_FILENAME!.py
+    copy %%~f !PARENT_DIR!\!pyc! >nul
+    del %%~f 
 )
 popd
 

--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -144,14 +144,30 @@ rmdir /s /q %BUILDING_DIR%\Scripts
 for /f %%a in ('dir %BUILDING_DIR%\Lib\site-packages\*.egg-info /b /s /a:d') do (
     rmdir /s /q %%a
 )
-for /d /r %BUILDING_DIR%\Lib\site-packages %%d in (__pycache__) do (
-    if exist %%d rmdir /s /q "%%d"
-)
+
 :: Use universal files and remove Py3 only files
 pushd %BUILDING_DIR%\Lib\site-packages\azure\mgmt
 for /f %%a in ('dir /b /s *_py3.py') do (
     set PY3_FILE=%%a
     if exist !PY3_FILE! del !PY3_FILE!
+)
+for /f %%a in ('dir /b /s *_py3.*.pyc') do (
+    set PY3_FILE=%%a
+    if exist !PY3_FILE! del !PY3_FILE!
+)
+popd
+
+:: Remove .py and only deploy .pyc files
+pushd %BUILDING_DIR%\Lib\site-packages
+for /f %%f in ('dir /b /s *.pyc') do (
+    : echo %%~f
+    set PARENT_DIR=%%~df%%~pf..
+    set FILENAME=%%~nf
+	set BASE_FILENAME=!FILENAME:~0,-11!
+	set pyc=!BASE_FILENAME!.pyc
+	del !PARENT_DIR!\!BASE_FILENAME!.py
+	copy %%~f !PARENT_DIR!\!pyc! >nul
+	del %%~f 
 )
 popd
 


### PR DESCRIPTION
Based on [pep-3147](https://www.python.org/dev/peps/pep-3147/), I rearranged the pyc files. Done a few testing, saw nothing broken. 

- [na] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [na] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
