### PR TITLE
setup: scripts to run tests against installed msi

### DIFF
--- a/build_scripts/windows/scripts/verify_msi.cmd
+++ b/build_scripts/windows/scripts/verify_msi.cmd
@@ -1,0 +1,29 @@
+echo OFF
+SetLocal EnableDelayedExpansion
+
+echo This script will run all tests on installed Azure CLI under "ProgramFiles(x86)" folder.
+echo You must create a virtual-env with python 3.6.5 and activate it before invoke this script 
+
+set REPO_DIR=%~dp0..\..\..\
+
+pip install -e %REPO_DIR%\tools
+pip install -e %REPO_DIR%\src\azure-cli-testsdk
+
+set PYTHONPATH=%ProgramFiles(x86)%\Microsoft SDKs\Azure\CLI2\Lib\site-packages
+
+for /D %%i in (%REPO_DIR%\src\command_modules\*) do (
+    set m=%%~ni
+    set module=!m:~10!
+    azdev test !module!
+	if !errorlevel! neq 0 goto ERROR
+)
+azdev test core
+if %errorlevel% neq 0 goto ERROR
+goto END
+:ERROR
+echo Error occurred, please check the output for details.
+exit /b 1
+
+:END
+exit /b 0
+popd

--- a/build_scripts/windows/scripts/verify_msi.cmd
+++ b/build_scripts/windows/scripts/verify_msi.cmd
@@ -10,20 +10,12 @@ pip install -e %REPO_DIR%\tools
 pip install -e %REPO_DIR%\src\azure-cli-testsdk
 
 set PYTHONPATH=%ProgramFiles(x86)%\Microsoft SDKs\Azure\CLI2\Lib\site-packages
-
 for /D %%i in (%REPO_DIR%\src\command_modules\*) do (
     set m=%%~ni
     set module=!m:~10!
     azdev test !module!
-	if !errorlevel! neq 0 goto ERROR
+	if !errorlevel! neq 0 set ERR_MODULES=!ERR_MODULES!;!module!
 )
 azdev test core
-if %errorlevel% neq 0 goto ERROR
-goto END
-:ERROR
-echo Error occurred, please check the output for details.
-exit /b 1
-
-:END
-exit /b 0
-popd
+if %errorlevel% neq 0 set ERR_MODULES=%ERR_MODULES%;core
+echo Module with test errors: %ERR_MODULES%

--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -30,7 +30,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-cli',
+    # 'azure-cli',
     'jmespath',
     'mock',
     'vcrpy>=1.10.3',

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -32,7 +32,7 @@ DEPENDENCIES = [
     'readme_renderer>=17.2',
     'requests',
     'pyyaml',
-    'knack',
+    #'knack',
     'six>=1.10.0',
     'tabulate>=0.7.7',
     'colorama>=0.3.7'
@@ -53,7 +53,12 @@ setup(
         'automation.tests',
         'automation.setup',
         'automation.coverage',
-        'automation.verify'
+        'automation.verify',
+        'automation.utilities',
+        'automation.clibuild',
+        'automation.cli_linter',
+        'automation.setup',
+        'automation.clipublish'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
@troydai, a prototype in case it helps for other related verification work

Three main notes:
1. set `PYTHONPATH` to installed `site_packages` folder
2. Ensure test package of  `azure-cli-dev-tools` and `azure-cli-sdk` not to install any CLI/SDK modules which is available through the first step.
3. The python used to run test should match the python included in the installer, which is 3.6.5 for windows msi, this is to make sure the .pyc can be loaded by test

Overall, this is not a 100% clean functional test, but pretty close with minimum tweaks.

- [na] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [na] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
