### PR TITLE
Added linter rule for catching show commands with no exception handler for 404 missing resource.

### DIFF
--- a/tools/automation/cli_linter/linter.py
+++ b/tools/automation/cli_linter/linter.py
@@ -161,6 +161,8 @@ class LinterManager(object):
         if not self.exit_code:
             print(os.linesep + 'No violations found.')
         colorama.deinit()
+        from .rules.command_rules import counter
+        print(counter)
         return self.exit_code
 
     def _run_rules(self, rule_group):

--- a/tools/automation/cli_linter/linter.py
+++ b/tools/automation/cli_linter/linter.py
@@ -77,6 +77,9 @@ class Linter(object):
     def _get_loaded_help_description(self, entry):
         return self._loaded_help.get(entry).short_summary or self._loaded_help.get(entry).long_summary
 
+    def get_exception_handler(self, command_name):
+        return self._command_table.get(command_name).exception_handler
+
 
 class LinterManager(object):
     def __init__(self, command_table=None, help_file_entries=None, loaded_help=None, exclusions=None,

--- a/tools/automation/cli_linter/rules/command_rules.py
+++ b/tools/automation/cli_linter/rules/command_rules.py
@@ -27,6 +27,7 @@ def no_404_handler_for_show_commands_rule(linter, command_name):
         return
     exception_handler = linter.get_exception_handler(command_name)
     if not exception_handler:
+        counter['No'] += 1
         raise RuleError('Show command is missing exception handler and should resolve a 404.')
 
     # create a CloudError to test exception handler
@@ -37,4 +38,8 @@ def no_404_handler_for_show_commands_rule(linter, command_name):
     try:
         exception_handler(error)
     except Exception:
+        counter['Handler'] += 1
         raise RuleError('Show command has exception handler %s, but did not handle 404 CloudError.' % exception_handler)
+    counter['Yes'] += 1
+
+counter = {'Yes':0, 'No':0, 'Handler':0}

--- a/tools/automation/cli_linter/rules/command_rules.py
+++ b/tools/automation/cli_linter/rules/command_rules.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from requests.models import Response
+from msrestazure.azure_exceptions import CloudError
 from ..rule_decorators import command_rule
 from ..linter import RuleError
 
@@ -17,3 +19,22 @@ def missing_command_help_rule(linter, command_name):
 def no_ids_for_list_commands_rule(linter, command_name):
     if command_name.split()[-1] == 'list' and 'ids' in linter.get_command_parameters(command_name):
         raise RuleError('List commands should not expose --ids argument')
+
+
+@command_rule
+def no_404_handler_for_show_commands_rule(linter, command_name):
+    if not command_name.split()[-1] == 'show':
+        return
+    exception_handler = linter.get_exception_handler(command_name)
+    if not exception_handler:
+        raise RuleError('Show command is missing exception handler and should resolve a 404.')
+
+    # create a CloudError to test exception handler
+    response = Response()
+    response.status_code = 404
+    error = CloudError(response)
+
+    try:
+        exception_handler(error)
+    except Exception:
+        raise RuleError('Show command has exception handler %s, but did not handle 404 CloudError.' % exception_handler)


### PR DESCRIPTION
---
Fixes: https://github.com/Azure/azure-cli/issues/6391
-Added a counter and print in second commit, which will be removed

@yugangw-msft you can run `azdev cli-lint --rule no_404_handler_for_show_commands_rule` to just run the new rule.

This checklist is used to make sure that common guidelines for a pull request are followed.

