### PR TITLE
Prevent multi-character short options

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -172,6 +172,10 @@ class AzCliCommandParser(CLICommandParser):
         options_list = arg.options_list
         argparse_options = {name: value for name, value in arg.options.items() if name in ARGPARSE_SUPPORTED_KWARGS}
         if options_list:
+            for opt in options_list:
+                if not opt.startswith('--') and len(opt) != 2:
+                    raise CLIError("command authoring error: multi-character short option '{}' is not allowed. "
+                                   "Use a single character or convert to a long-option.".format(opt))
             return obj.add_argument(*options_list, **argparse_options)
         else:
             if 'required' in argparse_options:


### PR DESCRIPTION
Throws a command authoring error if the developer attempts to use a multi-character short option.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
