### PR TITLE
Use 'az monitor autoscale list' instead

### DIFF
--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
@@ -491,11 +491,11 @@ helps['monitor autoscale rule delete'] = """
 """
 
 
-helps['monitor autoscale-settings'] = """
+helps['monitor autoscale'] = """
             type: group
             short-summary: (DEPRECATED) Manage autoscale settings.
             """
-helps['monitor autoscale-settings update'] = """
+helps['monitor autoscale update'] = """
             type: command
             short-summary: Updates an autoscale setting.
             """


### PR DESCRIPTION
```
DaveVoyles@Dave-MacBook-Pro  ~  az monitor autoscale-settings list
This command is deprecating and will be removed in future releases. Use 'az monitor autoscale list' instead.
```

Removed ```settings```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
