### PR TITLE
Add wheel version note for extension developers

### DIFF
--- a/doc/extensions/README.md
+++ b/doc/extensions/README.md
@@ -12,6 +12,8 @@ What is an Extension?
 - Currently, we support one extension type, a [Python Wheel](http://pythonwheels.com/).
 - All extension documentation here refers to this type of extension.
 
+> Extensions should be built with wheel `0.29.0` or `0.30.0` until [#6441](https://github.com/Azure/azure-cli/issues/6441) is resolved
+
 
 What an Extension is not
 ------------------------


### PR DESCRIPTION
This change adds help text for extension developers so that they know to use wheel 0.29.0 or 0.30.0 to package their extension, per the comment in #6441

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
