### PR TITLE
To omit the error - 'ascii' codec can't decode byte 0xe2 in position …

### DIFF
--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -216,7 +216,7 @@ def _default_rc_file_creation_step():
 
 def _find_line_in_file(file_path, search_pattern):
     try:
-        with open(file_path, 'r') as search_file:
+        with open(file_path, 'r', encoding="utf-8") as search_file:
             for line in search_file:
                 if search_pattern in line:
                     return True
@@ -226,7 +226,7 @@ def _find_line_in_file(file_path, search_pattern):
 
 def _modify_rc(rc_file_path, line_to_add):
     if not _find_line_in_file(rc_file_path, line_to_add):
-        with open(rc_file_path, 'a') as rc_file:
+        with open(rc_file_path, 'a', encoding="utf-8") as rc_file:
             rc_file.write('\n'+line_to_add+'\n')
 
 def create_tab_completion_file(filename):


### PR DESCRIPTION
…3256 - when running the install script, the .bashrc file should be read in UTF-8 mode

There are no user facing changes, so there is no HISTORY.rst

```
diff -Nrup azure-cli_old/scripts/curl_install_pypi/install.py azure-cli/scripts/curl_install_pypi/install.py
--- azure-cli_old/scripts/curl_install_pypi/install.py	2018-05-30 14:46:27.327346600 +0200
+++ azure-cli/scripts/curl_install_pypi/install.py	2018-05-30 14:48:26.010331300 +0200
@@ -216,7 +216,7 @@ def _default_rc_file_creation_step():
 
 def _find_line_in_file(file_path, search_pattern):
     try:
-        with open(file_path, 'r') as search_file:
+        with open(file_path, 'r', encoding="utf-8") as search_file:
             for line in search_file:
                 if search_pattern in line:
                     return True
@@ -226,7 +226,7 @@ def _find_line_in_file(file_path, search
 
 def _modify_rc(rc_file_path, line_to_add):
     if not _find_line_in_file(rc_file_path, line_to_add):
-        with open(rc_file_path, 'a') as rc_file:
+        with open(rc_file_path, 'a', encoding="utf-8") as rc_file:
             rc_file.write('\n'+line_to_add+'\n')
 
 def create_tab_completion_file(filename):
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
