### PR TITLE
stack: fix login failure caused by recent ADAL change

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -71,7 +71,9 @@ def _authentication_context_factory(cli_ctx, tenant, cache):
     import adal
     authority_url = cli_ctx.cloud.endpoints.active_directory
     is_adfs = bool(re.match('.+(/adfs|/adfs/)$', authority_url, re.I))
-    if not is_adfs:
+    if is_adfs:
+        authority_url = authority_url.rstrip('/')  # workaround: ADAL is known to reject auth urls with trailing /
+    else:
         authority_url = authority_url + '/' + (tenant or _COMMON_TENANT)
     return adal.AuthenticationContext(authority_url, cache=cache, api_version=None, validate_authority=(not is_adfs))
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1412,7 +1412,7 @@ class TestProfile(unittest.TestCase):
 
         # test w/ trailing slash
         r = profile.auth_ctx_factory(cli, 'common', None)
-        self.assertEqual(r.authority.url, adfs_url_1)
+        self.assertEqual(r.authority.url, adfs_url_1.rstrip('/'))
 
         # test w/o trailing slash
         adfs_url_2 = 'https://adfs.redmond.ext-u15f2402.masd.stbtest.microsoft.com/adfs'


### PR DESCRIPTION
It will be a while to sort out the plan to either absorb or revert the [ADAL change] (https://github.com/AzureAD/azure-activedirectory-library-for-python/pull/151/files#diff-03f44f824a1959ef23cc5f4861b150a5) . At the same time, I am submitting this change to get CI unblocked


- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
