### PR TITLE
Allow one "bubble" in the perf script.

### DIFF
--- a/tools/automation/verify/verify_module_load_times.py
+++ b/tools/automation/verify/verify_module_load_times.py
@@ -20,7 +20,6 @@ THRESHOLDS = {
     'vm': 25,
     'batch': 25,
     'storage': 50,
-    'servicefabric': 30,
     TOTAL: 300
 }
 
@@ -94,6 +93,7 @@ def run_verifications(args):
         failed_mods = {}
 
         mods = sorted(results.keys())
+        bubble_found = False
         for mod in mods:
             val = results[mod]
             mean_val = mean(val)
@@ -106,7 +106,13 @@ def run_verifications(args):
                 'values': val
             }
             if mean_val > threshold:
-                failed_mods[mod] = statistics
+                if not bubble_found and mean_val < 30:
+                    # This temporary measure allows one floating performance
+                    # failure up to 30 ms. See issue #6224 and #6218.
+                    bubble_found = True
+                    passed_mods[mod] = statistics
+                else:
+                    failed_mods[mod] = statistics
             else:
                 passed_mods[mod] = statistics
 


### PR DESCRIPTION
See issue #6224, #6218 and PR #6426.

We have a "perf bubble" in the CLI that, depending on the PR, moves between modules. Rather than chasing it by changing the threshold, this script allows one small bubble (<30 ms load time) to still pass, regardless of which module it is in. The second detected bubble will fail the script. 

This should be a more stable workaround until the underlying cause is identified.

---


This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [N/A] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
