### PR TITLE
Reverted check for bad short options in parser and added linter rule

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -172,10 +172,6 @@ class AzCliCommandParser(CLICommandParser):
         options_list = arg.options_list
         argparse_options = {name: value for name, value in arg.options.items() if name in ARGPARSE_SUPPORTED_KWARGS}
         if options_list:
-            for opt in options_list:
-                if not opt.startswith('--') and len(opt) != 2:
-                    raise CLIError("command authoring error: multi-character short option '{}' is not allowed. "
-                                   "Use a single character or convert to a long-option.".format(opt))
             return obj.add_argument(*options_list, **argparse_options)
         else:
             if 'required' in argparse_options:

--- a/tools/automation/cli_linter/linter.py
+++ b/tools/automation/cli_linter/linter.py
@@ -56,8 +56,8 @@ class Linter(object):
         return [param_help.get('name', None) for param_help in \
             self._all_yaml_help.get(entry_name).get('parameters', [])]
 
-    def is_valid_parameter_help_name(self, entry_name, param_name):
-        return param_name in [param.name for param in self._loaded_help.get(entry_name).parameters]
+    def is_valid_parameter_help_name(self, entry_name, param_help_name):
+        return param_help_name in [param.name for param in self._loaded_help.get(entry_name).parameters]
 
     def get_command_help(self, command_name):
         return self._get_loaded_help_description(command_name)
@@ -65,8 +65,11 @@ class Linter(object):
     def get_command_group_help(self, command_group_name):
         return self._get_loaded_help_description(command_group_name)
 
+    def get_parameter_options(self, command_name, parameter_name):
+        return self._command_table.get(command_name).arguments.get(parameter_name).type.settings.get('options_list')
+
     def get_parameter_help(self, command_name, parameter_name):
-        options = self._command_table.get(command_name).arguments.get(parameter_name).type.settings.get('options_list')
+        options = self.get_parameter_options(command_name, parameter_name)
         parameter_helps = self._loaded_help.get(command_name).parameters
         param_help = next((param for param in parameter_helps if share_element(options, param.name.split())), None)
         # workaround for --ids which is not does not generate doc help (BUG)

--- a/tools/automation/cli_linter/rules/parameter_rules.py
+++ b/tools/automation/cli_linter/rules/parameter_rules.py
@@ -20,4 +20,5 @@ def bad_short_option_rule(linter, command_name, parameter_name):
             bad_options.append(option)
 
     if bad_options:
-        raise RuleError('Found multi-character short options: {}'.format(' | '.join(bad_options)))
+        raise RuleError('Found multi-character short options: {}. Use a single character or '
+        				'convert to a long-option.'.format(' | '.join(bad_options)))

--- a/tools/automation/cli_linter/rules/parameter_rules.py
+++ b/tools/automation/cli_linter/rules/parameter_rules.py
@@ -11,3 +11,13 @@ from ..linter import RuleError
 def missing_parameter_help_rule(linter, command_name, parameter_name):
     if not linter.get_parameter_help(command_name, parameter_name):
         raise RuleError('Missing help')
+
+@parameter_rule
+def bad_short_option_rule(linter, command_name, parameter_name):
+    bad_options = []
+    for option in linter.get_parameter_options(command_name, parameter_name):
+        if not option.startswith('--') and len(option) != 2:
+            bad_options.append(option)
+
+    if bad_options:
+        raise RuleError('Found multi-character short options: {}'.format(' | '.join(bad_options)))


### PR DESCRIPTION
---
This broke the [iot extension](https://github.com/Azure/azure-iot-cli-extension)

This checklist is used to make sure that common guidelines for a pull request are followed.
