### PR TITLE
Bump version to 2.0.37

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.37
+++++++
+* Minor fixes
+
 2.0.35
 ++++++
 * Minor fixes

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 from __future__ import print_function
 
-__version__ = "2.0.35"
+__version__ = "2.0.37"
 
 import os
 import sys

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.35"
+VERSION = "2.0.37"
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.37
+++++++
+* Minor fixes
+
 2.0.35
 ++++++
 * Minor fixes

--- a/src/azure-cli/azure/cli/__init__.py
+++ b/src/azure-cli/azure/cli/__init__.py
@@ -11,4 +11,4 @@ import pkg_resources
 pkg_resources.declare_namespace(__name__)
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "2.0.35"
+__version__ = "2.0.37"

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.35"
+VERSION = "2.0.37"
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:


### PR DESCRIPTION
We reserved `2.0.36` for the intermediate before next normal release cycle.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
