### PR TITLE
Fix Auth_url for AAD env (stack)

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -74,7 +74,7 @@ def _authentication_context_factory(cli_ctx, tenant, cache):
     if is_adfs:
         authority_url = authority_url.rstrip('/')  # workaround: ADAL is known to reject auth urls with trailing /
     else:
-        authority_url = authority_url + '/' + (tenant or _COMMON_TENANT)
+        authority_url = authority_url.rstrip('/') + '/' + (tenant or _COMMON_TENANT)
     return adal.AuthenticationContext(authority_url, cache=cache, api_version=None, validate_authority=(not is_adfs))
 
 


### PR DESCRIPTION



AzureStack AAD login fails with 

> The authority url must be of the format https://login.microsoftonline.com/your_tenant


This is because AzureStack ARM returns loginEndpoint with a trailing slash “/” for metadata endpoint query:

"loginEndpoint":"https://login.windows.net/”

And [this ](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/_profile.py#L77)line adds another trailing slash which causes the auth_url look like this: 

> https://login.windows.net//tenant_id

 and fails the validation. This can be fixed if we strip the trailing slash before adding another one like this:
```
is_adfs = bool(re.match('.+(/adfs|/adfs/)$', authority_url, re.I)) 
if is_adfs: 
authority_url = authority_url.rstrip('/') # workaround: ADAL is known to reject auth urls with trailing / 
else: 
authority_url = authority_url.rstrip('/') + '/' + (tenant or _COMMON_TENANT)

```

---
This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
