### PR TITLE
Add global `--subscription` argument

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.0.37
 ++++++
-* Minor fixes
+* Add global support for `--subscription` to most commands.
 
 2.0.35
 ++++++

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -31,7 +31,7 @@ class AzCli(CLI):
     def __init__(self, **kwargs):
         super(AzCli, self).__init__(**kwargs)
 
-        from azure.cli.core.commands.arm import add_id_parameters
+        from azure.cli.core.commands.arm import add_id_parameters, register_global_subscription_parameter
         from azure.cli.core.cloud import get_active_cloud
         from azure.cli.core.extensions import register_extensions
         from azure.cli.core._session import ACCOUNT, CONFIG, SESSION
@@ -55,6 +55,7 @@ class AzCli(CLI):
 
         register_extensions(self)
         self.register_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, add_id_parameters)
+        register_global_subscription_parameter(self)
 
         self.progress_controller = None
 

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -417,12 +417,16 @@ class Profile(object):
             not subscription and x.get(_IS_DEFAULT_SUBSCRIPTION) or
             subscription and subscription.lower() in [x[_SUBSCRIPTION_ID].lower(), x[
                 _SUBSCRIPTION_NAME].lower()])]
-        if len(result) != 1:
-            raise CLIError("Please run 'az account set' to select active account.")
+        if not result and subscription:
+            raise CLIError("Subscription '{}' not found. Check the spelling and casing and try again.".format(subscription))
+        elif not result and not subscription:
+            raise CLIError("No subscription found. Run 'az account set' to select a subscription.")
+        elif len(result) > 1:
+            raise CLIError("Multiple subscriptions with the name '{}' found. Specify the subscription ID.".format(subscription))
         return result[0]
 
-    def get_subscription_id(self):
-        return self.get_subscription()[_SUBSCRIPTION_ID]
+    def get_subscription_id(self, subscription=None):  # take id or name
+        return self.get_subscription(subscription)[_SUBSCRIPTION_ID]
 
     def get_access_token_for_resource(self, username, tenant, resource):
         tenant = tenant or 'common'

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -418,11 +418,13 @@ class Profile(object):
             subscription and subscription.lower() in [x[_SUBSCRIPTION_ID].lower(), x[
                 _SUBSCRIPTION_NAME].lower()])]
         if not result and subscription:
-            raise CLIError("Subscription '{}' not found. Check the spelling and casing and try again.".format(subscription))
+            raise CLIError("Subscription '{}' not found. "
+                           "Check the spelling and casing and try again.".format(subscription))
         elif not result and not subscription:
             raise CLIError("No subscription found. Run 'az account set' to select a subscription.")
         elif len(result) > 1:
-            raise CLIError("Multiple subscriptions with the name '{}' found. Specify the subscription ID.".format(subscription))
+            raise CLIError("Multiple subscriptions with the name '{}' found. "
+                           "Specify the subscription ID.".format(subscription))
         return result[0]
 
     def get_subscription_id(self, subscription=None):  # take id or name

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -249,7 +249,8 @@ class AzCliCommandInvoker(CommandInvoker):
         self.commands_loader.command_table = self.commands_loader.command_table  # update with the truncated table
         self.commands_loader.command_name = command
         self.commands_loader.load_arguments(command)
-        self.cli_ctx.raise_event(EVENT_INVOKER_POST_CMD_TBL_CREATE, cmd_tbl=self.commands_loader.command_table)
+        self.cli_ctx.raise_event(EVENT_INVOKER_POST_CMD_TBL_CREATE, cmd_tbl=self.commands_loader.command_table,
+                                 commands_loader=self.commands_loader)
         self.parser.cli_ctx = self.cli_ctx
         self.parser.load_command_table(self.commands_loader.command_table)
 

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -297,8 +297,10 @@ def register_global_subscription_parameter(cli_ctx):
         commands_loader._update_command_definitions()  # pylint: disable=protected-access
 
     def parse_subscription_parameter(cli_ctx, args, **kwargs):  # pylint: disable=unused-argument
-        subscription_id = getattr(args, '_subscription', None)
-        if subscription_id:
+        subscription = getattr(args, '_subscription', None)
+        if subscription:
+            from azure.cli.core._profile import Profile
+            subscription_id = Profile(cli_ctx=cli_ctx).get_subscription_id(subscription)
             cli_ctx.data['subscription_id'] = subscription_id
 
     cli_ctx.register_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, add_subscription_parameter)

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -278,6 +278,20 @@ def add_id_parameters(_, **kwargs):  # pylint: disable=unused-argument
         command_loaded_handler(command)
 
 
+def register_global_subscription_parameter(cli_ctx):
+    import knack.events as events
+
+    def add_subscription_parameter(_, arg_group):
+        arg_group.add_argument('--subscription', dest='_subscription', help='Subscription ID.')
+
+    def parse_subscription_parameter(cli_ctx, args, **kwargs):
+        subscription_id = getattr(args, '_subscription', None)
+        cli_ctx.data['subscription_id'] = subscription_id
+
+    cli_ctx.register_event(events.EVENT_PARSER_GLOBAL_CREATE, add_subscription_parameter)
+    cli_ctx.register_event(events.EVENT_INVOKER_POST_PARSE_ARGS, parse_subscription_parameter)
+
+
 add_usage = '--add property.listProperty <key=value, string or JSON string>'
 set_usage = '--set property1.property2=<value>'
 remove_usage = '--remove property.list <indexToRemove> OR --remove propertyToRemove'

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -280,16 +280,21 @@ def add_id_parameters(_, **kwargs):  # pylint: disable=unused-argument
 
 
 def register_global_subscription_parameter(cli_ctx):
+
     import knack.events as events
     from knack.util import CLIError
 
     def add_subscription_parameter(_, **kwargs):
+        from azure.cli.command_modules.profile._completers import get_subscription_id_list
+
         commands_loader = kwargs['commands_loader']
         cmd_tbl = kwargs['cmd_tbl']
         for command_name, cmd in cmd_tbl.items():
             if 'subscription' not in cmd.arguments:
                 commands_loader.extra_argument_registry[command_name]['_subscription'] = CLICommandArgument(
-                    '_subscription', options_list=['--subscription'], help='Subscription ID.', arg_group='Global')
+                    '_subscription', options_list=['--subscription'],
+                    help='Name or ID of subscription. You can configure the default subscription using `az account set -s NAME_OR_ID`"',
+                    completer=get_subscription_id_list, arg_group='Global', configured_default='subscription')
         commands_loader._update_command_definitions()
 
     def parse_subscription_parameter(cli_ctx, args, **kwargs):

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -49,8 +49,6 @@ def get_mgmt_service_client(cli_ctx, client_or_resource_type, subscription_id=No
      :params subscription_id: the current account's subscription
      :param aux_subscriptions: mainly for cross tenant scenarios, say vnet peering.
     """
-                            **kwargs):
-
     if not subscription_id and 'subscription_id' in cli_ctx.data:
         subscription_id = cli_ctx.data['subscription_id']
 

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -49,6 +49,11 @@ def get_mgmt_service_client(cli_ctx, client_or_resource_type, subscription_id=No
      :params subscription_id: the current account's subscription
      :param aux_subscriptions: mainly for cross tenant scenarios, say vnet peering.
     """
+                            **kwargs):
+
+    if not subscription_id and 'subscription_id' in cli_ctx.data:
+        subscription_id = cli_ctx.data['subscription_id']
+
     sdk_profile = None
     if isinstance(client_or_resource_type, (ResourceType, CustomResourceType)):
         # Get the versioned client
@@ -166,7 +171,10 @@ def get_data_service_client(cli_ctx, service_type, account_name, account_key, co
 
 def get_subscription_id(cli_ctx):
     from azure.cli.core._profile import Profile
-    _, subscription_id, _ = Profile(cli_ctx=cli_ctx).get_login_credentials()
+    if 'subscription_id' in cli_ctx.data:
+        subscription_id = cli_ctx.data['subscription_id']
+    else:
+        _, subscription_id, _ = Profile(cli_ctx=cli_ctx).get_login_credentials()
     return subscription_id
 
 

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -172,7 +172,7 @@ def get_subscription_id(cli_ctx):
     if 'subscription_id' in cli_ctx.data:
         subscription_id = cli_ctx.data['subscription_id']
     else:
-        _, subscription_id, _ = Profile(cli_ctx=cli_ctx).get_login_credentials()
+        subscription_id = Profile(cli_ctx=cli_ctx).get_subscription_id()
     return subscription_id
 
 

--- a/src/command_modules/azure-cli-cloud/HISTORY.rst
+++ b/src/command_modules/azure-cli-cloud/HISTORY.rst
@@ -3,9 +3,12 @@
 Release History
 ===============
 
+2.0.14
+++++++
+* Minor fixes
+
 2.0.13
 ++++++
-
 * `sdist` is now compatible with wheel 0.31.0
 
 2.0.12

--- a/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/__init__.py
+++ b/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/__init__.py
@@ -56,6 +56,7 @@ class CloudCommandsLoader(AzCommandsLoader):
             c.argument('suffix_keyvault_dns', help='The Key Vault service dns suffix')
             c.argument('suffix_azure_datalake_store_file_system_endpoint', help='The Data Lake store filesystem service dns suffix')
             c.argument('suffix_azure_datalake_analytics_catalog_and_job_endpoint', help='The Data Lake analytics job and catalog service dns suffix')
+            c.ignore('_subscription')  # hide global subscription param
 
         with self.argument_context('cloud show') as c:
             c.argument('cloud_name', help='Name of a registered cloud.', default=active_cloud_name)

--- a/src/command_modules/azure-cli-cloud/setup.py
+++ b/src/command_modules/azure-cli-cloud/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.13"
+VERSION = "2.0.14"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-configure/HISTORY.rst
+++ b/src/command_modules/azure-cli-configure/HISTORY.rst
@@ -3,9 +3,12 @@
 Release History
 ===============
 
+2.0.16
+++++++
+* Minor fixes.
+
 2.0.15
 ++++++
-
 * `sdist` is now compatible with wheel 0.31.0
 
 2.0.14

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
@@ -27,6 +27,7 @@ class ConfigureCommandsLoader(AzCommandsLoader):
 
         with self.argument_context('configure') as c:
             c.argument('defaults', nargs='+', options_list=('--defaults', '-d'))
+            c.ignore('_subscription')  # ignore the global subscription param
 
 
 COMMAND_LOADER_CLS = ConfigureCommandsLoader

--- a/src/command_modules/azure-cli-configure/setup.py
+++ b/src/command_modules/azure-cli-configure/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.15"
+VERSION = "2.0.16"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-extension/HISTORY.rst
+++ b/src/command_modules/azure-cli-extension/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.15
+++++++
+* Minor fixes
+
 0.0.14
 ++++++
 * Be more resilient to system error when removing an extension.

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/__init__.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/__init__.py
@@ -61,9 +61,9 @@ class ExtensionCommandsLoader(AzCommandsLoader):
             c.argument('pip_proxy', options_list=['--pip-proxy'],
                        help='Proxy for pip to use for extension dependencies in the form of [user:passwd@]proxy.server:port',
                        arg_group='Experimental Pip')
-
             c.argument('pip_extra_index_urls', options_list=['--pip-extra-index-urls'], nargs='+',
                        help='Space-separated list of extra URLs of package indexes to use. This should point to a repository compliant with PEP 503 (the simple repository API) or a local directory laid out in the same format.', arg_group='Experimental Pip')
+            c.ignore('_subscription')  # hide global subscription param
 
         with self.argument_context('extension add') as c:
             c.argument('extension_name', completer=extension_name_from_index_completion_list)

--- a/src/command_modules/azure-cli-extension/setup.py
+++ b/src/command_modules/azure-cli-extension/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.14"
+VERSION = "0.0.15"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',

--- a/src/command_modules/azure-cli-feedback/HISTORY.rst
+++ b/src/command_modules/azure-cli-feedback/HISTORY.rst
@@ -3,9 +3,12 @@
 Release History
 ===============
 
+2.1.2
+++++++
+* Minor fixes
+
 2.1.1
 +++++
-
 * `sdist` is now compatible with wheel 0.31.0
 
 2.1.0

--- a/src/command_modules/azure-cli-feedback/azure/cli/command_modules/feedback/__init__.py
+++ b/src/command_modules/azure-cli-feedback/azure/cli/command_modules/feedback/__init__.py
@@ -22,5 +22,9 @@ class FeedbackCommandsLoader(AzCommandsLoader):
 
         return self.command_table
 
+    def load_arguments(self, command):
+        with self.argument_context('feedback') as c:
+            c.ignore('_subscription')  # hide global subscription param
+
 
 COMMAND_LOADER_CLS = FeedbackCommandsLoader

--- a/src/command_modules/azure-cli-feedback/setup.py
+++ b/src/command_modules/azure-cli-feedback/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.1.1"
+VERSION = "2.1.2"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-find/HISTORY.rst
+++ b/src/command_modules/azure-cli-find/HISTORY.rst
@@ -3,9 +3,12 @@
 Release History
 ===============
 
+0.2.10
+++++++
+* Minor fixes
+
 0.2.9
 ++++++
-
 * `sdist` is now compatible with wheel 0.31.0
 
 0.2.8

--- a/src/command_modules/azure-cli-find/azure/cli/command_modules/find/__init__.py
+++ b/src/command_modules/azure-cli-find/azure/cli/command_modules/find/__init__.py
@@ -22,6 +22,8 @@ class FindCommandsLoader(AzCommandsLoader):
 
     def load_arguments(self, command):
         from azure.cli.command_modules.find._params import load_arguments
+        with self.argument_context('find') as c:
+            c.ignore('_subscription')  # hide global subscription param
         load_arguments(self, command)
 
 

--- a/src/command_modules/azure-cli-find/setup.py
+++ b/src/command_modules/azure-cli-find/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.2.9"
+VERSION = "0.2.10"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-interactive/HISTORY.rst
+++ b/src/command_modules/azure-cli-interactive/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.3.23
+++++++
+* Minor fixes
+
 0.3.22
 ++++++
 * Cap the dependencies

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/__init__.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/__init__.py
@@ -39,6 +39,7 @@ class InteractiveCommandsLoader(AzCommandsLoader):
         with self.argument_context('interactive') as c:
             c.argument('style', options_list=['--style', '-s'], help='The colors of the shell.',
                        choices=style_options())
+            c.ignore('_subscription')  # hide global subscription param
 
 
 COMMAND_LOADER_CLS = InteractiveCommandsLoader

--- a/src/command_modules/azure-cli-interactive/setup.py
+++ b/src/command_modules/azure-cli-interactive/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     cmdclass = {}
 
 # Version is also defined in azclishell.__init__.py.
-VERSION = "0.3.22"
+VERSION = "0.3.23"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,9 +2,14 @@
 
 Release History
 ===============
+
+2.0.26
+++++++
+* Minor fixes
+
 2.0.25
 ++++++
-* minor changes
+* Minor fixes
 
 2.0.24
 ++++++

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
@@ -40,25 +40,25 @@ class ProfileCommandsLoader(AzCommandsLoader):
     def load_arguments(self, command):
 
         with self.argument_context('login') as c:
-            c.argument('password', options_list=('--password', '-p'), help="Credentials like user password, or for a service principal, provide client secret or a pem file with key and public certificate. Will prompt if not given.")
+            c.argument('password', options_list=['--password', '-p'], help="Credentials like user password, or for a service principal, provide client secret or a pem file with key and public certificate. Will prompt if not given.")
             c.argument('service_principal', action='store_true', help='The credential representing a service principal.')
-            c.argument('username', options_list=('--username', '-u'), help='user name, service principal, or managed service identity ID')
-            c.argument('tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
+            c.argument('username', options_list=['--username', '-u'], help='user name, service principal, or managed service identity ID')
+            c.argument('tenant', options_list=['--tenant', '-t'], help='The AAD tenant, must provide when using service principals.')
             c.argument('allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
-            c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
+            c.argument('identity', options_list=['-i', '--identity'], action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
 
         with self.argument_context('logout') as c:
             c.argument('username', help='account user, if missing, logout the current active account')
 
         with self.argument_context('account') as c:
-            c.argument('subscription', options_list=('--subscription', '-s'), arg_group='', help='Name or ID of subscription.', completer=get_subscription_id_list)
+            c.argument('subscription', options_list=['--subscription', '-s'], arg_group='', help='Name or ID of subscription.', completer=get_subscription_id_list)
 
         with self.argument_context('account list') as c:
             c.argument('all', help="List all subscriptions, rather just 'Enabled' ones", action='store_true')
             c.argument('refresh', help="retrieve up-to-date subscriptions from server", action='store_true')
 
         with self.argument_context('account show') as c:
-            c.argument('show_auth_for_sdk', options_list=('--sdk-auth',), action='store_true', help='output result in compatible with Azure SDK auth file')
+            c.argument('show_auth_for_sdk', options_list=['--sdk-auth'], action='store_true', help='output result in compatible with Azure SDK auth file')
 
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
@@ -51,7 +51,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('username', help='account user, if missing, logout the current active account')
 
         with self.argument_context('account') as c:
-            c.argument('subscription', options_list=('--subscription', '-s'), help='Name or ID of subscription.', completer=get_subscription_id_list)
+            c.argument('subscription', options_list=('--subscription', '-s'), arg_group='', help='Name or ID of subscription.', completer=get_subscription_id_list)
 
         with self.argument_context('account list') as c:
             c.argument('all', help="List all subscriptions, rather just 'Enabled' ones", action='store_true')

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
@@ -46,6 +46,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('tenant', options_list=['--tenant', '-t'], help='The AAD tenant, must provide when using service principals.')
             c.argument('allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
             c.argument('identity', options_list=['-i', '--identity'], action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
+            c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('logout') as c:
             c.argument('username', help='account user, if missing, logout the current active account')
@@ -56,6 +57,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
         with self.argument_context('account list') as c:
             c.argument('all', help="List all subscriptions, rather just 'Enabled' ones", action='store_true')
             c.argument('refresh', help="retrieve up-to-date subscriptions from server", action='store_true')
+            c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account show') as c:
             c.argument('show_auth_for_sdk', options_list=['--sdk-auth'], action='store_true', help='output result in compatible with Azure SDK auth file')

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -10,7 +10,6 @@ from knack.prompting import prompt_pass, NoTTYException
 from knack.util import CLIError
 
 from azure.cli.core._profile import Profile
-from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.util import in_cloud_console
 
 logger = get_logger(__name__)

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -10,6 +10,7 @@ from knack.prompting import prompt_pass, NoTTYException
 from knack.util import CLIError
 
 from azure.cli.core._profile import Profile
+from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.util import in_cloud_console
 
 logger = get_logger(__name__)
@@ -46,9 +47,10 @@ def list_subscriptions(cmd, all=False, refresh=False):  # pylint: disable=redefi
 
 
 # pylint: disable=inconsistent-return-statements
-def show_subscription(cmd, subscription=None, show_auth_for_sdk=None):
+def show_subscription(cmd, show_auth_for_sdk=None):
     import json
     profile = Profile(cli_ctx=cmd.cli_ctx)
+    subscription = get_subscription_id(cmd.cli_ctx)
     if not show_auth_for_sdk:
         return profile.get_subscription(subscription)
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -47,10 +47,9 @@ def list_subscriptions(cmd, all=False, refresh=False):  # pylint: disable=redefi
 
 
 # pylint: disable=inconsistent-return-statements
-def show_subscription(cmd, show_auth_for_sdk=None):
+def show_subscription(cmd, subscription=None, show_auth_for_sdk=None):
     import json
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    subscription = get_subscription_id(cmd.cli_ctx)
     if not show_auth_for_sdk:
         return profile.get_subscription(subscription)
 

--- a/src/command_modules/azure-cli-profile/setup.py
+++ b/src/command_modules/azure-cli-profile/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.25"
+VERSION = "2.0.26"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.31
+++++++
+* Minor fixes
+
 2.0.30
 ++++++
 *  add `account management-group` commands.

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -215,6 +215,7 @@ def load_arguments(self, _):
 
     with self.argument_context('account management-group') as c:
         c.argument('group_name', options_list=['--name', '-n'])
+        c.ignore('_subscription')  # hide global subscription parameter
 
     with self.argument_context('account management-group show') as c:
         c.argument('expand', options_list=['--expand', '-e'], action='store_true')

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.30"
+VERSION = "2.0.31"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -7,10 +7,6 @@ Release History
 * ad: remove stack traces from graph exceptions before surface to users
 * ad sp create: do not throw if CLI can't resolve app id
 
-2.0.25
-++++++
-* Minor fixes
-
 2.0.24
 ++++++
 * ad app update: add generic update support

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -7,6 +7,10 @@ Release History
 * ad: remove stack traces from graph exceptions before surface to users
 * ad sp create: do not throw if CLI can't resolve app id
 
+2.0.25
+++++++
+* Minor fixes
+
 2.0.24
 ++++++
 * ad app update: add generic update support

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -18,6 +18,9 @@ name_arg_type = CLIArgumentType(options_list=('--name', '-n'), metavar='NAME')
 
 # pylint: disable=too-many-statements
 def load_arguments(self, _):
+    with self.argument_context('ad') as c:
+        c.argument('_subscription')  # hide global subscription param
+
     with self.argument_context('ad app') as c:
         c.argument('app_id', help='application id')
         c.argument('application_object_id', options_list=('--object-id',))


### PR DESCRIPTION
Closes #5665. Closes #807.

Adds `--subscription` for most commands. Selectively omits it from N/A commands. Commands that already have `--subscription` will continue to use their customized version.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
