### PR TITLE
[AKS] null out AAD profile on scale and upgrade

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1474,8 +1474,9 @@ def aks_scale(cmd, client, resource_group_name, name, node_count, no_wait=False)
     # TODO: change this approach when we support multiple agent pools.
     instance.agent_pool_profiles[0].count = int(node_count)  # pylint: disable=no-member
 
-    # null out the service principal because otherwise validation complains
+    # null out the SP and AAD profile because otherwise validation complains
     instance.service_principal_profile = None
+    instance.aad_profile = None
 
     return sdk_no_wait(no_wait, client.create_or_update, resource_group_name, name, instance)
 
@@ -1484,8 +1485,9 @@ def aks_upgrade(cmd, client, resource_group_name, name, kubernetes_version, no_w
     instance = client.get(resource_group_name, name)
     instance.kubernetes_version = kubernetes_version
 
-    # null out the service principal because otherwise validation complains
+    # null out the SP and AAD profile because otherwise validation complains
     instance.service_principal_profile = None
+    instance.aad_profile = None
 
     return sdk_no_wait(no_wait, client.create_or_update, resource_group_name, name, instance)
 


### PR DESCRIPTION
Fixes an error when scaling or upgrading an AAD-enabled cluster:

```
msrest.exceptions.ValidationError: Parameter 'ManagedClusterAADProfile.server_app_secret' can not be None.
```

cc: @amanohar 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
