### PR TITLE
Update ADL to latest

### DIFF
--- a/src/command_modules/azure-cli-dls/HISTORY.rst
+++ b/src/command_modules/azure-cli-dls/HISTORY.rst
@@ -3,9 +3,12 @@
 Release History
 ===============
 
+0.0.22
+++++++
+* Updated the ADLS version to latest.
+
 0.0.21
 ++++++
-
 * `sdist` is now compatible with wheel 0.31.0
 
 0.0.20

--- a/src/command_modules/azure-cli-dls/setup.py
+++ b/src/command_modules/azure-cli-dls/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.0.21"
+VERSION = "0.0.22"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [
@@ -35,7 +35,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-mgmt-datalake-store==0.2.0',
-    'azure-datalake-store==0.0.19',
+    'azure-datalake-store==0.0.22',
     'azure-cli-core',
 ]
 


### PR DESCRIPTION
Updating ADL versions to latest to fix a "msrest" dependency problem. CLI should not be impacted.

FYI @milanchandna 