### PR TITLE
Fix extension version

### DIFF
--- a/doc/extensions/README.md
+++ b/doc/extensions/README.md
@@ -12,8 +12,6 @@ What is an Extension?
 - Currently, we support one extension type, a [Python Wheel](http://pythonwheels.com/).
 - All extension documentation here refers to this type of extension.
 
-> Extensions should be built with wheel `0.29.0` or `0.30.0` until [#6441](https://github.com/Azure/azure-cli/issues/6441) is resolved
-
 
 What an Extension is not
 ------------------------

--- a/src/azure-cli-core/azure/cli/core/extension.py
+++ b/src/azure-cli-core/azure/cli/core/extension.py
@@ -17,7 +17,7 @@ EXTENSIONS_DIR = os.path.expanduser(_CUSTOM_EXT_DIR) if _CUSTOM_EXT_DIR else os.
                                                                                           'cliextensions')
 EXTENSIONS_MOD_PREFIX = 'azext_'
 
-WHL_METADATA_FILENAME = 'metadata.json'
+WHL_METADATA_FILENAME = 'METADATA'
 AZEXT_METADATA_FILENAME = 'azext_metadata.json'
 
 EXT_METADATA_MINCLICOREVERSION = 'azext.minCliCoreVersion'
@@ -102,6 +102,7 @@ class WheelExtension(Extension):
         return self.metadata.get('version')
 
     def get_metadata(self):
+        from wheel.metadata import pkginfo_to_dict
         from wheel.install import WHEEL_INFO_RE
         if not extension_exists(self.name):
             return None
@@ -116,8 +117,8 @@ class WheelExtension(Extension):
             if parsed_dist_info_dir and parsed_dist_info_dir.groupdict().get('name') == self.name.replace('-', '_'):
                 whl_metadata_filepath = os.path.join(ext_dir, dist_info_dirname, WHL_METADATA_FILENAME)
                 if os.path.isfile(whl_metadata_filepath):
-                    with open(whl_metadata_filepath) as f:
-                        metadata.update(json.load(f))
+                    whl_dict = pkginfo_to_dict(whl_metadata_filepath)
+                    metadata.update(whl_dict)
         return metadata
 
     @staticmethod


### PR DESCRIPTION
Fixes #6441 by pulling from METADATA instead of metadata.json, which was removed in https://github.com/pypa/wheel/issues/195

[PEP 427](https://www.python.org/dev/peps/pep-0427/) defines METADATA, so this change should be safe for all versions of `wheel`

This allows extension authors to use the latest version of `wheel` and still have their version / metadata visible in `az extension list` and `az extension show`

This is an internal-only change and does not modify any user-facing input/output formats