### PR TITLE
Extension list-available will only list extensions available for CLI version

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension.py
+++ b/src/azure-cli-core/azure/cli/core/extension.py
@@ -160,8 +160,6 @@ def ext_compat_with_cli(azext_metadata):
             is_compatible = False
         elif max_required and parsed_cli_version > parse_version(max_required):
             is_compatible = False
-        else:
-            is_compatible = True
     return is_compatible, core_version, min_required, max_required
 
 

--- a/src/command_modules/azure-cli-extension/HISTORY.rst
+++ b/src/command_modules/azure-cli-extension/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.16
+++++++
+* `extension list-available` will only show extensions compatible with CLI version.
+
 0.0.15
 ++++++
 * Minor fixes

--- a/src/command_modules/azure-cli-extension/HISTORY.rst
+++ b/src/command_modules/azure-cli-extension/HISTORY.rst
@@ -3,8 +3,8 @@
 Release History
 ===============
 
-0.0.16
-++++++
+0.1.0
++++++
 * `extension list-available` will only show extensions compatible with CLI version.
 
 0.0.15

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
@@ -283,7 +283,12 @@ def list_available_extensions(index_url=None, show_details=False):
     installed_extension_names = [e.name for e in installed_extensions]
     results = []
     for name, items in OrderedDict(sorted(index_data.items())).items():
-        latest = sorted(items, key=lambda c: parse_version(c['metadata']['version']), reverse=True)[0]
+        # exclude extensions/versions incompatible with current CLI version
+        items = [item for item in items if ext_compat_with_cli(item['metadata'])]
+        if not items:
+            continue
+
+        latest = sorted(items, key=lambda c: parse_version(c['metadata']['version']))[-1]
         installed = False
         if name in installed_extension_names:
             installed = True

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
@@ -284,7 +284,7 @@ def list_available_extensions(index_url=None, show_details=False):
     results = []
     for name, items in OrderedDict(sorted(index_data.items())).items():
         # exclude extensions/versions incompatible with current CLI version
-        items = [item for item in items if ext_compat_with_cli(item['metadata'])]
+        items = [item for item in items if ext_compat_with_cli(item['metadata'])[0]]
         if not items:
             continue
 

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
@@ -288,7 +288,7 @@ def list_available_extensions(index_url=None, show_details=False):
         if not items:
             continue
 
-        latest = sorted(items, key=lambda c: parse_version(c['metadata']['version']))[-1]
+        latest = max(items, key=lambda c: parse_version(c['metadata']['version']))
         installed = False
         if name in installed_extension_names:
             installed = True

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
@@ -274,6 +274,21 @@ class TestExtensionCommands(unittest.TestCase):
             self.assertEqual(res[0]['version'], '0.1.0')
             self.assertEqual(res[0]['preview'], False)
 
+    def test_list_available_extensions_incompatible_cli_version(self):
+        sample_index_extensions = {
+            'test_sample_extension1': [{
+                'metadata': {
+                    "azext.maxCliCoreVersion": "0.0.0",
+                    'name': 'test_sample_extension1',
+                    'summary': 'my summary',
+                    'version': '0.1.0'
+                }}]
+        }
+        with mock.patch('azure.cli.command_modules.extension.custom.get_index_extensions', return_value=sample_index_extensions):
+            res = list_available_extensions()
+            self.assertIsInstance(res, list)
+            self.assertEqual(len(res), 0)
+
     def test_add_list_show_remove_extension_extra_index_url(self):
         """
         Tests extension addition while specifying --extra-index-url parameter.

--- a/src/command_modules/azure-cli-extension/setup.py
+++ b/src/command_modules/azure-cli-extension/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.15"
+VERSION = "0.0.16"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',

--- a/src/command_modules/azure-cli-extension/setup.py
+++ b/src/command_modules/azure-cli-extension/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.0.16"
+VERSION = "0.1.0"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
---
`extension list-available` will only show extensions compatible with the version of the CLI being used.

Closes: https://github.com/Azure/azure-cli-extensions/issues/187
Closes: https://github.com/Azure/azure-cli/issues/6419

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
