### PR TITLE
Support specific port for k8s dashboard

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.1.2
+++++++
+* Updated options for `az aks browse` command. Added `--listen-port` support.
+
 2.1.1
 ++++++
 * Updated options of `az aks use-dev-spaces` command. Added `--update` support.

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -134,6 +134,10 @@ helps['aks browse'] = """
           type: bool
           short-summary: Don't launch a web browser after establishing port-forwarding.
           long-summary: Add this argument when launching a web browser manually, or for automated testing.
+        - name: --listen-port
+          type: string
+          short-summary: The listening port for the dashboard.
+          long-sumarry: Add this argument when the default listening port is used by another process or unavailable.
 """
 
 helps['aks create'] = """

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -135,7 +135,6 @@ helps['aks browse'] = """
           short-summary: Don't launch a web browser after establishing port-forwarding.
           long-summary: Add this argument when launching a web browser manually, or for automated testing.
         - name: --listen-port
-          type: string
           short-summary: The listening port for the dashboard.
           long-sumarry: Add this argument when the default listening port is used by another process or unavailable.
 """

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1288,14 +1288,14 @@ def _update_dict(dict1, dict2):
     return cp
 
 
-def aks_browse(cmd, client, resource_group_name, name, disable_browser=False):
+def aks_browse(cmd, client, resource_group_name, name, disable_browser=False, listen_port='8001'):
     if in_cloud_console():
         raise CLIError('This command requires a web browser, which is not supported in Azure Cloud Shell.')
 
     if not which('kubectl'):
         raise CLIError('Can not find kubectl executable in PATH')
 
-    proxy_url = 'http://127.0.0.1:8001/'
+    proxy_url = 'http://127.0.0.1:{0}/'.format(listen_port)
     _, browse_path = tempfile.mkstemp()
     # TODO: need to add an --admin option?
     aks_get_credentials(cmd, client, resource_group_name, name, admin=False, path=browse_path)
@@ -1318,7 +1318,7 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False):
     if not disable_browser:
         wait_then_open_async(proxy_url)
     subprocess.call(["kubectl", "--kubeconfig", browse_path, "--namespace", "kube-system",
-                     "port-forward", dashboard_pod, "8001:9090"])
+                     "port-forward", dashboard_pod, "{0}:9090".format(listen_port)])
 
 
 def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint: disable=too-many-locals,too-many-statements

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.1.1"
+VERSION = "2.1.2"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
The idea for this pull request is to support customized local port for kubernetes dashboard in case the default port is used or unavailable.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
