### PR TITLE
Support for extension filtering when running linter

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -55,7 +55,7 @@ class AzCliHelp(CLIHelp):
     def _print_extensions_msg(help_file):
         if help_file.type != 'command':
             return
-        if help_file.command_source and isinstance(help_file.command_source, ExtensionCommandSource):
+        if isinstance(help_file.command_source, ExtensionCommandSource):
             logger.warning(help_file.command_source.get_command_warn_msg())
             if help_file.command_source.preview:
                 logger.warning(help_file.command_source.get_preview_warn_msg())

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -17,6 +17,7 @@ from knack.util import CLIError
 
 import azure.cli.core.telemetry as telemetry
 from azure.cli.core.extension import get_extension
+from azure.cli.core.commands import ExtensionCommandSource
 from azure.cli.core.commands.events import EVENT_INVOKER_ON_TAB_COMPLETION
 
 logger = get_logger(__name__)
@@ -125,15 +126,17 @@ class AzCliCommandParser(CLICommandParser):
 
     def format_help(self):
         extension_version = None
+        extension_name = None
         try:
-            if self.command_source:
+            if isinstance(self.command_source, ExtensionCommandSource):
+                extension_name = self.command_source.extension_name
                 extension_version = get_extension(self.command_source.extension_name).version
         except Exception:  # pylint: disable=broad-except
             pass
 
         telemetry.set_command_details(
             command=self.prog[3:],
-            extension_name=self.command_source.extension_name if self.command_source else None,
+            extension_name=extension_name,
             extension_version=extension_version)
         telemetry.set_success(summary='show help')
         super(AzCliCommandParser, self).format_help()

--- a/tools/automation/cli_linter/__init__.py
+++ b/tools/automation/cli_linter/__init__.py
@@ -67,7 +67,6 @@ def main(args):
         command_table, help_file_entries = include_commands(
             command_table, help_file_entries, module_inclusions=args.modules, extensions=args.extensions)
 
-
     # Instantiate and run Linter
     linter_manager = LinterManager(command_table=command_table,
                                    help_file_entries=help_file_entries,

--- a/tools/automation/cli_linter/__init__.py
+++ b/tools/automation/cli_linter/__init__.py
@@ -22,6 +22,7 @@ def define_arguments(parser):
     parser.add_argument('--help-file-entries', dest='rule_types_to_run', action='append_const', const='help_entries',
                         help='Run linter on help-file-entries.')
     parser.add_argument('--modules', dest='modules', nargs='+', help='The modules on which the linter should run.')
+    parser.add_argument('--extensions', dest='extensions', nargs='+', help='The extensions on which the linter should run.')
     parser.add_argument('--rules', dest='rules', nargs='+', help='The rules which the linter should run.')
 
 
@@ -60,10 +61,11 @@ def main(args):
             mod_exclusions = yaml.load(open(exclusion_path))
             exclusions.update(mod_exclusions)
 
-    # only run linter on modules specified
-    if args.modules:
-        from .util import include_mods
-        command_table, help_file_entries = include_mods(command_table, help_file_entries, args.modules)
+    # only run linter on modules and extensions specified
+    if args.modules or args.extensions:
+        from .util import include_commands
+        command_table, help_file_entries = include_commands(
+            command_table, help_file_entries, module_inclusions=args.modules, extensions=args.extensions)
 
 
     # Instantiate and run Linter

--- a/tools/automation/cli_linter/linter.py
+++ b/tools/automation/cli_linter/linter.py
@@ -10,7 +10,7 @@ from importlib import import_module
 from pkgutil import iter_modules
 import yaml
 import colorama
-from .util import get_command_groups, share_element, exclude_mods
+from .util import get_command_groups, share_element, exclude_commands
 
 
 class Linter(object):
@@ -106,8 +106,8 @@ class LinterManager(object):
             def get_linter():
                 if rule_name in self._ci_exclusions and self._ci:
                     mod_exclusions = self._ci_exclusions[rule_name]
-                    command_table, help_file_entries = exclude_mods(self._command_table, self._help_file_entries,
-                                                                    mod_exclusions)
+                    command_table, help_file_entries = exclude_commands(self._command_table, self._help_file_entries,
+                                                                        mod_exclusions)
                     return Linter(command_table=command_table, help_file_entries=help_file_entries,
                                   loaded_help=self._loaded_help)
                 return self.linter

--- a/tools/automation/cli_linter/linter.py
+++ b/tools/automation/cli_linter/linter.py
@@ -10,7 +10,7 @@ from importlib import import_module
 from pkgutil import iter_modules
 import yaml
 import colorama
-from .util import get_command_groups, share_element, exclude_commands
+from .util import get_command_groups, share_element, exclude_commands, LinterError
 
 
 class Linter(object):
@@ -140,7 +140,7 @@ class LinterManager(object):
             for rule_name, add_to_linter_func in functions:
                 if hasattr(add_to_linter_func, 'linter_rule'):
                     if rule_name in found_rules:
-                        raise Exception('Multiple rules found with the same name: %s' % rule_name)
+                        raise LinterError('Multiple rules found with the same name: %s' % rule_name)
                     found_rules.add(rule_name)
                     add_to_linter_func(self)
 

--- a/tools/automation/cli_linter/tests/linter_exclusions.yml
+++ b/tools/automation/cli_linter/tests/linter_exclusions.yml
@@ -1,0 +1,5 @@
+---
+foo command_1:
+    rule_exclusions:
+    - fail_for_every_command_rule
+...

--- a/tools/automation/cli_linter/tests/test_linter.py
+++ b/tools/automation/cli_linter/tests/test_linter.py
@@ -1,0 +1,122 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import os
+import unittest
+import argparse
+import mock
+from automation.cli_linter import main
+from automation.cli_linter.linter import LinterScope, RuleError
+from azure.cli.core.commands import AzCliCommand, ExtensionCommandSource
+
+
+class TestExtensionsBase(unittest.TestCase):
+    def setUp(self):
+        def create_invoker_and_load_cmds_and_args(cli):
+            cli.invocation = mock.MagicMock()
+            cli.invocation.commands_loader = mock.MagicMock()
+            cli.invocation.commands_loader.command_table = self.cmd_table = {}
+            for cmd in ['foo command_1', 'foo command_2', 'bar command_1', 'bar command_2', 'foobar']:
+                self.cmd_table[cmd] = AzCliCommand(cli.invocation.commands_loader, cmd, lambda: None)
+            for cmd in ['bar command_1', 'bar command_2']:
+                self.cmd_table[cmd].command_source = ExtensionCommandSource(extension_name='bar')
+                self.cmd_table[cmd].command_source.extension_name = 'bar'
+            for cmd in ['foo command_1', 'foo command_2']:
+                self.cmd_table[cmd].command_source = mock.MagicMock()
+                self.cmd_table[cmd].command_source = 'foo'
+
+        def get_command_modules_paths(**_):
+            return [(mod, os.path.dirname(__file__)) for mod in ('foo', 'drool')]
+
+        def get_all_help(_):
+            for cmd in self.cmd_table:
+                cmd_help = mock.MagicMock()
+                cmd_help.command = cmd
+                yield cmd_help
+
+        self.patches = []
+        self.patches.append(mock.patch('azure.cli.core.get_default_cli', mock.MagicMock))
+        self.patches.append(mock.patch('azure.cli.core.file_util.get_all_help', get_all_help))
+        self.patches.append(mock.patch('azure.cli.core.file_util.create_invoker_and_load_cmds_and_args',
+                                       create_invoker_and_load_cmds_and_args))
+        self.patches.append(mock.patch('automation.utilities.path.get_command_modules_paths',
+                                       get_command_modules_paths))
+        self.patches.append(mock.patch('knack.cli.CLI', mock.MagicMock))
+        self.patches.append(mock.patch('sys.exit', lambda _: None))
+
+        for patch in self.patches:
+            patch.start()
+
+    def tearDown(self):
+        for patch in self.patches:
+            patch.stop()
+
+    def test_module_extension_inclusion(self):
+        args = argparse.Namespace(ci=False, func=main, modules=None, extensions=None, rule_types_to_run=None,
+                                  rules=None)
+        expected_cmds = []
+        expected_cmd_table_size = 0
+
+        def check_cmd_table(manager, **_):
+            command_table = manager._command_table
+            self.assertEqual(len(command_table), expected_cmd_table_size)
+            for command_name in expected_cmds:
+                self.assertIn(command_name, command_table)
+
+        with mock.patch('automation.cli_linter.linter.LinterManager.run', check_cmd_table):
+            # all extensions/modules loaded if no specific extensions or modules specified
+            expected_cmd_table_size = 5
+            main(args)
+
+            # check only extensions are included
+            args.extensions = ['bar']
+            expected_cmd_table_size = 2
+            expected_cmds = ['bar command_1', 'bar command_2']
+            main(args)
+
+            # check only foo module included
+            args.extensions = None
+            args.modules = ['foo']
+            expected_cmd_table_size = 2
+            expected_cmds = ['foo command_1', 'foo command_2']
+            main(args)
+
+            # check both 'bar' extension and 'foo' module are included
+            args.extensions = ['bar']
+            expected_cmd_table_size = 4
+            expected_cmds = ['foo command_1', 'foo command_2', 'bar command_1', 'bar command_2']
+            main(args)
+
+    def test_rule_exclusion(self):
+        from automation.cli_linter.rule_decorators import command_rule
+
+        violations = []
+
+        @command_rule
+        def fail_for_every_command_rule(linter, command_name):
+            raise RuleError('Failed command.')
+
+        def run(manager, **kwargs):
+            # adds the rule to be run
+            fail_for_every_command_rule(manager)
+
+            # run the rule
+            for (rule_func, linter_callable) in manager._rules.get('commands').values():
+                # use new linter if needed
+                with LinterScope(manager, linter_callable):
+                    violations.extend(sorted(rule_func()) or [])
+
+        # run the rule, `foo command_1` should be excluded from being linted
+        with mock.patch('automation.cli_linter.linter.LinterManager.run', run):
+            args = argparse.Namespace(ci=False, func=main, modules=None, extensions=None, rule_types_to_run=None,
+                                      rules=None)
+            main(args)
+            self.assertAlmostEqual(len(violations), 4)
+            for msg in violations:
+                self.assertNotIn('foo command_1', msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/automation/cli_linter/util.py
+++ b/tools/automation/cli_linter/util.py
@@ -12,16 +12,19 @@ import inspect
 _LOADER_CLS_RE = re.compile('.*azure/cli/command_modules/(?P<module>[^/]*)/__init__.*')
 
 
-def exclude_mods(command_table, help_file_entries, module_exclusions):
-    return _filter_mods(command_table, help_file_entries, module_exclusions, True)
+def exclude_commands(command_table, help_file_entries, module_exclusions=None, extensions=None):
+    return _filter_mods(command_table, help_file_entries, modules=module_exclusions, extensions=extensions,
+                        exclude=True)
 
 
-def include_mods(command_table, help_file_entries, module_inclusions):
-    return _filter_mods(command_table, help_file_entries, module_inclusions, False)
+def include_commands(command_table, help_file_entries, module_inclusions=None, extensions=None):
+    return _filter_mods(command_table, help_file_entries, modules=module_inclusions, extensions=extensions)
 
 
-def _filter_mods(command_table, help_file_entries, modules, exclude):
+def _filter_mods(command_table, help_file_entries, modules=None, extensions=None, exclude=False):
     from ..utilities.path import get_command_modules_paths
+    modules = modules or []
+    extensions = extensions or []
 
     command_modules_paths = get_command_modules_paths()
     filtered_module_names = {mod for mod, path in command_modules_paths if mod in modules}
@@ -31,12 +34,14 @@ def _filter_mods(command_table, help_file_entries, modules, exclude):
 
     for command_name in list(command_table.keys()):
         try:
-            mod_name = _get_command_module(command_name, command_table)
+            source_name, is_extension = _get_command_source(command_name, command_table)
         except LinterError as ex:
             print(ex)
             continue
-        if (mod_name in filtered_module_names) == exclude:
-            # brute force method of clearing traces of a module
+
+        is_specified = source_name in extensions if is_extension else source_name in filtered_module_names
+        if is_specified == exclude:
+            # brute force method of ignoring commands from a module or extension
             del command_table[command_name]
             help_file_entries.pop(command_name, None)
             for group_name in get_command_groups(command_name):
@@ -57,20 +62,23 @@ def get_command_groups(command_name):
             yield ' '.join(command_args)
 
 
-def _get_command_module(command_name, command_table):
-    # hacky way to get a command's module
+def _get_command_source(command_name, command_table):
     command = command_table.get(command_name)
+    # see if command is an extension
+    if command.command_source:
+        return command.command_source.extension_name, True
+
+    # hacky way to get a command's module
     loader_cls = command.loader.__class__
     loader_file_path = inspect.getfile(loader_cls)
     # normalize os path to '/' for regex
     loader_file_path = '/'.join(loader_file_path.split(os.path.sep))
     match = _LOADER_CLS_RE.match(loader_file_path)
     # loader class path is consistent due to convention, throw error if no match
-    # this will likely throw error for extensions
     if not match:
         raise LinterError('`{}`\'s loader class path does not match regex pattern: {}' \
             .format(command_name, _LOADER_CLS_RE.pattern))
-    return match.groupdict().get('module')
+    return match.groupdict().get('module'), False
 
 
 class LinterError(Exception):

--- a/tools/automation/tests/__init__.py
+++ b/tools/automation/tests/__init__.py
@@ -40,8 +40,7 @@ def execute(args):
     if args.ci:
         # CI Mode runs specific modules
         output('Running in CI Mode')
-        selected_modules = [
-                            # ('All modules', 'azure.cli', 'azure.cli'),
+        selected_modules = [('All modules', 'azure.cli', 'azure.cli'),
                             ('CLI Linter', 'automation.cli_linter', 'automation.cli_linter')]
     elif not (args.tests or args.src_file):
         # Default is to run with modules (possibly via environment variable)

--- a/tools/automation/tests/__init__.py
+++ b/tools/automation/tests/__init__.py
@@ -39,7 +39,10 @@ def execute(args):
 
     if args.ci:
         # CI Mode runs specific modules
-        selected_modules = [('CI mode', 'azure.cli', 'azure.cli')]
+        output('Running in CI Mode')
+        selected_modules = [
+                            # ('All modules', 'azure.cli', 'azure.cli'),
+                            ('CLI Linter', 'automation.cli_linter', 'automation.cli_linter')]
     elif not (args.tests or args.src_file):
         # Default is to run with modules (possibly via environment variable)
         if os.environ.get('AZURE_CLI_TEST_MODULES', None):


### PR DESCRIPTION
---
-`cmd.command_source` also used to persist command module source for non-extension commands
-added basic testing for linter for mod/ext filtering and rule exclusion

This checklist is used to make sure that common guidelines for a pull request are followed.

