### PR TITLE
check notifications before enumeration

### DIFF
--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/autoscale_settings.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/autoscale_settings.py
@@ -123,29 +123,31 @@ def autoscale_update(instance, count=None, min_count=None, max_count=None, tags=
             profile.capacity.minimum = min_count
             profile.capacity.maximum = max_count
 
-    if instance.notifications:
-        notification = next(x for x in instance.notifications if x.operation.lower() == 'scale')
+    if not instance.notifications:
+        return instance
 
-        # process removals
-        if remove_actions is not None:
-            removed_emails, removed_webhooks = _parse_action_removals(remove_actions)
-            notification.email.custom_emails = \
-                [x for x in notification.email.custom_emails if x not in removed_emails]
-            notification.webhooks = \
-                [x for x in notification.webhooks if x.service_uri not in removed_webhooks]
+    notification = next(x for x in instance.notifications if x.operation.lower() == 'scale')
 
-        # process additions
-        for action in add_actions or []:
-            if isinstance(action, EmailNotification):
-                for email in action.custom_emails:
-                    notification.email.custom_emails.append(email)
-            elif isinstance(action, WebhookNotification):
-                notification.webhooks.append(action)
+    # process removals
+    if remove_actions is not None:
+        removed_emails, removed_webhooks = _parse_action_removals(remove_actions)
+        notification.email.custom_emails = \
+            [x for x in notification.email.custom_emails if x not in removed_emails]
+        notification.webhooks = \
+            [x for x in notification.webhooks if x.service_uri not in removed_webhooks]
 
-        if email_administrator is not None:
-            notification.email.send_to_subscription_administrator = email_administrator
-        if email_coadministrators is not None:
-            notification.email.send_to_subscription_co_administrators = email_coadministrators
+    # process additions
+    for action in add_actions or []:
+        if isinstance(action, EmailNotification):
+            for email in action.custom_emails:
+                notification.email.custom_emails.append(email)
+        elif isinstance(action, WebhookNotification):
+            notification.webhooks.append(action)
+
+    if email_administrator is not None:
+        notification.email.send_to_subscription_administrator = email_administrator
+    if email_coadministrators is not None:
+        notification.email.send_to_subscription_co_administrators = email_coadministrators
 
     return instance
 

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/autoscale_settings.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/autoscale_settings.py
@@ -122,7 +122,7 @@ def autoscale_update(instance, count=None, min_count=None, max_count=None, tags=
             profile.capacity.default = count
             profile.capacity.minimum = min_count
             profile.capacity.maximum = max_count
-            
+
     if instance.notifications:
         notification = next(x for x in instance.notifications if x.operation.lower() == 'scale')
 

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/autoscale_settings.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/autoscale_settings.py
@@ -122,29 +122,30 @@ def autoscale_update(instance, count=None, min_count=None, max_count=None, tags=
             profile.capacity.default = count
             profile.capacity.minimum = min_count
             profile.capacity.maximum = max_count
+            
+    if instance.notifications:
+        notification = next(x for x in instance.notifications if x.operation.lower() == 'scale')
 
-    notification = next(x for x in instance.notifications if x.operation.lower() == 'scale')
+        # process removals
+        if remove_actions is not None:
+            removed_emails, removed_webhooks = _parse_action_removals(remove_actions)
+            notification.email.custom_emails = \
+                [x for x in notification.email.custom_emails if x not in removed_emails]
+            notification.webhooks = \
+                [x for x in notification.webhooks if x.service_uri not in removed_webhooks]
 
-    # process removals
-    if remove_actions is not None:
-        removed_emails, removed_webhooks = _parse_action_removals(remove_actions)
-        notification.email.custom_emails = \
-            [x for x in notification.email.custom_emails if x not in removed_emails]
-        notification.webhooks = \
-            [x for x in notification.webhooks if x.service_uri not in removed_webhooks]
+        # process additions
+        for action in add_actions or []:
+            if isinstance(action, EmailNotification):
+                for email in action.custom_emails:
+                    notification.email.custom_emails.append(email)
+            elif isinstance(action, WebhookNotification):
+                notification.webhooks.append(action)
 
-    # process additions
-    for action in add_actions or []:
-        if isinstance(action, EmailNotification):
-            for email in action.custom_emails:
-                notification.email.custom_emails.append(email)
-        elif isinstance(action, WebhookNotification):
-            notification.webhooks.append(action)
-
-    if email_administrator is not None:
-        notification.email.send_to_subscription_administrator = email_administrator
-    if email_coadministrators is not None:
-        notification.email.send_to_subscription_co_administrators = email_coadministrators
+        if email_administrator is not None:
+            notification.email.send_to_subscription_administrator = email_administrator
+        if email_coadministrators is not None:
+            notification.email.send_to_subscription_co_administrators = email_coadministrators
 
     return instance
 


### PR DESCRIPTION

not all VMSS autoscale settings has notifications, we need to verify before iteration to avoid StopIteration exception

without the change, following command will hit StopIteration exception

az monitor autoscale update --resource-group vmssRgName --name AutoScaleName --count 5

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
