### PR TITLE
Fix `vnet check-ip-address` help

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -851,6 +851,9 @@ def load_arguments(self, _):
         c.argument('ddos_protection_plan', help='Name or ID of a DDoS protection plan to associate with the VNet.', min_api='2018-02-01', validator=validate_ddos_name_or_id)
         c.argument('vm_protection', arg_type=get_three_state_flag(), help='Enable VM protection for all subnets in the VNet.', min_api='2017-09-01')
 
+    with self.argument_context('network vnet check-ip-address') as c:
+        c.argument('ip_address', required=True)
+
     with self.argument_context('network vnet create') as c:
         c.argument('location', get_location_type(self.cli_ctx))
         c.argument('subnet_name', help='Name of a new subnet to create within the VNet.')


### PR DESCRIPTION
Fixes #6654.  `--ip-address` is required, but due to reflection on the SDK which has a default of None, it appeared as optional. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
