### PR TITLE
setup: ensure trim pyc except pip

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -18,11 +18,14 @@ if "%CLI_VERSION%"=="" (
 :: Set up the output directory and temp. directories
 echo Cleaning previous build artifacts...
 
+:: find the root window installer script folder
+for %%i in ("%~dp0..") do set "WIN_SCRIPT_FOLDER=%%~fi"
+
 set OUTPUT_DIR=%~dp0..\out
 if exist %OUTPUT_DIR% rmdir /s /q %OUTPUT_DIR%
 mkdir %OUTPUT_DIR%
 
-set ARTIFACTS_DIR=%~dp0..\artifacts
+set ARTIFACTS_DIR=%WIN_SCRIPT_FOLDER%\artifacts
 mkdir %ARTIFACTS_DIR%
 
 set TEMP_SCRATCH_FOLDER=%ARTIFACTS_DIR%\cli_scratch
@@ -171,7 +174,7 @@ for /f %%a in ('dir /b /s *_py3.*.pyc') do (
 popd
 
 :: Remove .py and only deploy .pyc files
-pushd %BUILDING_DIR%\Lib\site-packages\azure
+pushd %BUILDING_DIR%\Lib\site-packages
 for /f %%f in ('dir /b /s *.pyc') do (
     set PARENT_DIR=%%~df%%~pf..
     echo !PARENT_DIR! | findstr /C:"!BUILDING_DIR!\Lib\site-packages\pip" 1>nul


### PR DESCRIPTION
@troydai , there is a out-of-sync between 2 commits we made on the same file recently, which caused non `pip` 3rd party libs' `.py` files are not trimmed, hence we have 2000+ more files in the installer.
This PR corrects it.  It is your call to take it or leave it. IMO, I suggest we trim .py on libs owned by us, and trim `pyc` files on 3rd party ones'


- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
