### PR TITLE
fix the wrong help

### DIFF
--- a/src/command_modules/azure-cli-eventhubs/azure/cli/command_modules/eventhubs/_help.py
+++ b/src/command_modules/azure-cli-eventhubs/azure/cli/command_modules/eventhubs/_help.py
@@ -75,7 +75,7 @@ helps['eventhubs namespace create'] = """
     examples:
         - name: Creates a new namespace.
           text: az eventhubs namespace create --resource-group myresourcegroup --name mynamespace --location westus
-           --tags tag1=value1 tag2=value2 --sku-name Standard --sku-tier Standard --is-auto-inflate-enabled False --maximum-throughput-units 30
+           --tags tag1=value1 tag2=value2 --sku Standard --is-auto-inflate-enabled False --maximum-throughput-units 30
 """
 
 helps['eventhubs namespace update'] = """


### PR DESCRIPTION
According to the other help, it might be right.

This pull request is the fix of this issue. 

https://github.com/Azure/azure-cli/issues/6674

This pull request is only for help text.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
