### PR TITLE
[AKS] handle monitoring solution through its subscription ID

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
@@ -19,8 +19,9 @@ def cf_managed_clusters(cli_ctx, *_):
     return get_container_service_client(cli_ctx).managed_clusters
 
 
-def cf_resource_groups(cli_ctx, *_):
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES).resource_groups
+def cf_resource_groups(cli_ctx, *_, subscription_id=None):
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,
+                                   subscription_id=subscription_id).resource_groups
 
 
 def get_auth_management_client(cli_ctx, scope=None, **_):

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
@@ -19,7 +19,7 @@ def cf_managed_clusters(cli_ctx, *_):
     return get_container_service_client(cli_ctx).managed_clusters
 
 
-def cf_resource_groups(cli_ctx, *_, subscription_id=None):
+def cf_resource_groups(cli_ctx, subscription_id=None):
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,
                                    subscription_id=subscription_id).resource_groups
 

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1586,10 +1586,14 @@ def _update_addons(instance, addons, enable, workspace_resource_id=None, no_wait
         addon = ADDONS[addon_arg]
         if enable:
             # add new addons or update existing ones and enable them
-            addon_profile = addon_profiles.get(addon, ManagedClusterAddonProfile(enabled=True))
+            addon_profile = addon_profiles.get(addon, ManagedClusterAddonProfile(enabled=False))
             # special config handling for certain addons
-            if addon == 'omsagent' and workspace_resource_id:
-                addon_profile.config = {'logAnalyticsWorkspaceResourceID': workspace_resource_id}
+            if addon == 'omsgagent':
+                if addon_profile.enabled:
+                    raise CLIError('The monitoring addon is already enabled for this managed cluster.\n'
+                                   'To change monitoring configuration, run "az aks disable-addons -monitoring" before enabling it again.')
+                elif workspace_resource_id:
+                    addon_profile.config = {'logAnalyticsWorkspaceResourceID': workspace_resource_id}
             addon_profiles[addon] = addon_profile
         else:
             if addon not in addon_profiles:

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -903,12 +903,12 @@ def load_service_principals(config_path):
         return None
 
 
-def _invoke_deployment(cli_ctx, resource_group_name, deployment_name, template, parameters, validate, no_wait):
+def _invoke_deployment(cli_ctx, resource_group_name, deployment_name, template, parameters, validate, no_wait, subscription_id=None):
     from azure.mgmt.resource.resources import ResourceManagementClient
     from azure.mgmt.resource.resources.models import DeploymentProperties
 
     properties = DeploymentProperties(template=template, parameters=parameters, mode='incremental')
-    smc = get_mgmt_service_client(cli_ctx, ResourceManagementClient).deployments
+    smc = get_mgmt_service_client(cli_ctx, ResourceManagementClient, subscription_id=subscription_id).deployments
     if validate:
         logger.info('==== BEGIN TEMPLATE ====')
         logger.info(json.dumps(template, indent=2))
@@ -1773,7 +1773,7 @@ def _ensure_container_insights_for_monitoring(cmd, addon):
 
     # publish the Container Insights solution to the Log Analytics workspace
     return _invoke_deployment(cmd.cli_ctx, resource_group, deployment_name, template, params,
-                              validate=False, no_wait=False)
+                              validate=False, no_wait=False, subscription_id=subscription_id)
 
 
 def _ensure_aks_service_principal(cli_ctx,

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1588,7 +1588,7 @@ def _update_addons(instance, addons, enable, workspace_resource_id=None, no_wait
             # add new addons or update existing ones and enable them
             addon_profile = addon_profiles.get(addon, ManagedClusterAddonProfile(enabled=False))
             # special config handling for certain addons
-            if addon == 'omsgagent':
+            if addon == 'omsagent':
                 if addon_profile.enabled:
                     raise CLIError('The monitoring addon is already enabled for this managed cluster.\n'
                                    'To change monitoring configuration, run "az aks disable-addons -monitoring" before enabling it again.')

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1693,14 +1693,15 @@ def _ensure_container_insights_for_monitoring(cmd, addon):
     if not workspace_resource_id.startswith('/'):
         workspace_resource_id = '/' + workspace_resource_id
 
-    # extract resource group from workspace_resource_id URL
+    # extract subscription ID and resource group from workspace_resource_id URL
     try:
+        subscription_id = workspace_resource_id.split('/')[2]
         resource_group = workspace_resource_id.split('/')[4]
     except IndexError:
         raise CLIError('Could not locate resource group in workspace-resource-id URL.')
 
     # find the location from the resource group
-    location = _get_rg_location(cmd.cli_ctx, resource_group)
+    location = _get_rg_location(cmd.cli_ctx, resource_group, subscription_id)
 
     # pylint: disable=line-too-long
     template = {
@@ -1851,8 +1852,8 @@ def _ensure_service_principal(cli_ctx,
     return load_acs_service_principal(subscription_id)
 
 
-def _get_rg_location(ctx, resource_group_name):
-    groups = cf_resource_groups(ctx)
+def _get_rg_location(ctx, resource_group_name, subscription_id=None):
+    groups = cf_resource_groups(ctx, subscription_id=subscription_id)
     # Just do the get, we don't need the result, it will error out if the group doesn't exist.
     rg = groups.get(resource_group_name)
     return rg.location

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -903,7 +903,8 @@ def load_service_principals(config_path):
         return None
 
 
-def _invoke_deployment(cli_ctx, resource_group_name, deployment_name, template, parameters, validate, no_wait, subscription_id=None):
+def _invoke_deployment(cli_ctx, resource_group_name, deployment_name, template, parameters, validate, no_wait,
+                       subscription_id=None):
     from azure.mgmt.resource.resources import ResourceManagementClient
     from azure.mgmt.resource.resources.models import DeploymentProperties
 
@@ -1591,7 +1592,8 @@ def _update_addons(instance, addons, enable, workspace_resource_id=None, no_wait
             if addon == 'omsagent':
                 if addon_profile.enabled:
                     raise CLIError('The monitoring addon is already enabled for this managed cluster.\n'
-                                   'To change monitoring configuration, run "az aks disable-addons -monitoring" before enabling it again.')
+                                   'To change monitoring configuration, run "az aks disable-addons -monitoring"'
+                                   'before enabling it again.')
                 elif workspace_resource_id:
                     addon_profile.config = {'logAnalyticsWorkspaceResourceID': workspace_resource_id}
             addon_profiles[addon] = addon_profile

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -17,7 +17,8 @@ from azure.cli.command_modules.acs._params import (regions_in_preview,
                                                    regions_in_prod)
 from azure.cli.command_modules.acs.custom import (merge_kubernetes_configurations, list_acs_locations,
                                                   _acs_browse_internal, _add_role_assignment, _get_default_dns_prefix,
-                                                  create_application, _update_addons)
+                                                  create_application, _update_addons,
+                                                  _ensure_container_insights_for_monitoring)
 from azure.mgmt.containerservice.models import (ContainerServiceOrchestratorTypes,
                                                 ContainerService,
                                                 ContainerServiceOrchestratorProfile)
@@ -449,3 +450,24 @@ class AcsCustomCommandTest(unittest.TestCase):
         routing_addon_profile = instance.addon_profiles['httpApplicationRouting']
         self.assertTrue(routing_addon_profile.enabled)
         self.assertEqual(sorted(list(instance.addon_profiles)), ['httpApplicationRouting', 'omsagent'])
+
+        # monitoring enabled and then enabled again should error
+        instance = mock.Mock()
+        instance.addon_profiles = None
+        instance = _update_addons(instance, 'monitoring', enable=True)
+        with self.assertRaises(CLIError):
+            instance = _update_addons(instance, 'monitoring', enable=True)
+
+    @mock.patch('azure.cli.command_modules.acs.custom._get_rg_location')
+    @mock.patch('azure.cli.command_modules.acs.custom._invoke_deployment')
+    def test_ensure_container_insights_for_monitoring(self, invoke_def, rg_def):
+        cmd = mock.Mock()
+        addon = mock.Mock()
+        wsID = "/subscriptions/1234abcd-cad5-417b-1234-aec62ffa6fe7/resourcegroups/mbdev/providers/microsoft.operationalinsights/workspaces/mbdev"
+        addon.config = {
+            'logAnalyticsWorkspaceResourceID': wsID
+        }
+        self.assertTrue(_ensure_container_insights_for_monitoring(cmd, addon))
+        args, kwargs = invoke_def.call_args
+        self.assertEqual(args[3]['resources'][0]['type'], "Microsoft.Resources/deployments")
+        self.assertEqual(args[4]['workspaceResourceId']['value'], wsID)


### PR DESCRIPTION
The Log Analytics workspace is often in a different subscription from the AKS cluster it connects to. This changes those API calls to use the subscription ID embedded in the --workspace-resource-id argument, which fixes this use case.

Also raises an error when the user enables monitoring when it's already enabled, since changing the config this way doesn't work yet. We can remove this error catching when the behavior is fixed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
