### PR TITLE
[ACR] Add record only flag to import and build-task tests

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/latest/test_acr_commands.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/latest/test_acr_commands.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer
+from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, record_only
 
 
 class AcrCommandsTests(ScenarioTest):
@@ -269,6 +269,7 @@ class AcrCommandsTests(ScenarioTest):
         self.cmd('acr delete -n {registry_name} -g {rg}')
 
     @ResourceGroupPreparer()
+    @record_only()
     def test_acr_create_build_task(self, resource_group, resource_group_location):
         self.kwargs.update({
             'registry_name': self.create_random_name('clireg', 20),
@@ -402,6 +403,7 @@ class AcrCommandsTests(ScenarioTest):
         self.cmd('acr delete -n {registry_name} -g {rg}')
 
     @ResourceGroupPreparer()
+    @record_only()
     def test_acr_image_import(self, resource_group):
         '''There are six test cases in the function.
         Case 1: Import image from a regsitry in a different subscription from the current one


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
