### PR TITLE
Add `--no-wait` support to various commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ jobs:
       python: 3.6
     - stage: verify
       env: PURPOSE='Automation'
-      script: travis_wait 30 ./scripts/ci/test_automation.sh
+      script: travis_wait 45 ./scripts/ci/test_automation.sh
       python: 3.6
     - stage: verify
       env: PURPOSE='Automation'
-      script: travis_wait 30 ./scripts/ci/test_automation.sh
+      script: travis_wait 45 ./scripts/ci/test_automation.sh
       python: 2.7
     - stage: verify
       script: ./scripts/ci/test_static.sh

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -5,7 +5,8 @@ Release History
 
 2.1.6
 +++++
-* Minor fixes
+* `network nic create/update/delete`: Add `--no-wait` support.
+* Added `network nic wait`.
 
 2.1.5
 ++++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
@@ -115,6 +115,7 @@ def transform_traffic_manager_create_output(result):
 def transform_nic_create_output(result):
     if result:
         return {'NewNIC': result.result()}
+    return None
 
 
 def transform_nsg_create_output(result):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
@@ -113,7 +113,8 @@ def transform_traffic_manager_create_output(result):
 
 
 def transform_nic_create_output(result):
-    return {'NewNIC': result.result()}
+    if result:
+        return {'NewNIC': result.result()}
 
 
 def transform_nsg_create_output(result):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -2445,6 +2445,14 @@ helps['network nic show'] = """
           text: az network nic show -g MyResourceGroup -n MyNic --query "dnsSettings.internalDomainNameSuffix"
 """
 
+helps['network nic wait'] = """
+    type: command
+    short-summary: Place the CLI in a waiting state until a condition of the network interface is met.
+    examples:
+        - name: Pause CLI until the network interface is created.
+          text: az network nic wait -g MyResourceGroup -n MyNic --created
+"""
+
 helps['network nic show-effective-route-table'] = """
     type: command
     short-summary: Show the effective route table applied to a network interface.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -451,13 +451,14 @@ def load_command_table(self, _):
     # region NetworkInterfaces: (NIC)
 
     with self.command_group('network nic', network_nic_sdk) as g:
-        g.custom_command('create', 'create_nic', transform=transform_nic_create_output, validator=process_nic_create_namespace)
-        g.command('delete', 'delete')
+        g.custom_command('create', 'create_nic', transform=transform_nic_create_output, validator=process_nic_create_namespace, supports_no_wait=True)
+        g.command('delete', 'delete', supports_no_wait=True)
         g.command('show', 'get', exception_handler=empty_on_404)
         g.custom_command('list', 'list_nics')
         g.command('show-effective-route-table', 'get_effective_route_table', min_api='2016-09-01')
         g.command('list-effective-nsg', 'list_effective_network_security_groups', min_api='2016-09-01')
-        g.generic_update_command('update', custom_func_name='update_nic')
+        g.generic_update_command('update', custom_func_name='update_nic', supports_no_wait=True)
+        g.generic_wait_command('wait')
 
     resource = 'network_interfaces'
     subresource = 'ip_configurations'

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1940,7 +1940,7 @@ def create_nic(cmd, resource_group_name, network_interface_name, subnet, locatio
                load_balancer_name=None, network_security_group=None,
                private_ip_address=None, private_ip_address_version=None,
                public_ip_address=None, virtual_network_name=None, enable_accelerated_networking=None,
-               application_security_groups=None):
+               application_security_groups=None, no_wait=False):
     client = network_client_factory(cmd.cli_ctx).network_interfaces
     (NetworkInterface, NetworkInterfaceDnsSettings, NetworkInterfaceIPConfiguration, NetworkSecurityGroup,
      PublicIPAddress, Subnet) = cmd.get_models(
@@ -1975,7 +1975,7 @@ def create_nic(cmd, resource_group_name, network_interface_name, subnet, locatio
     if public_ip_address:
         ip_config.public_ip_address = PublicIPAddress(id=public_ip_address)
     nic.ip_configurations = [ip_config]
-    return client.create_or_update(resource_group_name, network_interface_name, nic)
+    return sdk_no_wait(no_wait, client.create_or_update, resource_group_name, network_interface_name, nic)
 
 
 def update_nic(cmd, instance, network_security_group=None, enable_ip_forwarding=None,

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -5,7 +5,8 @@ Release History
 
 2.0.33
 ++++++
-* Minor fixes
+* `group deployment delete`: Add `--no-wait` support.
+* `deployment delete`: Add `--no-wait` support.
 
 2.0.32
 ++++++

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -7,6 +7,7 @@ Release History
 ++++++
 * `group deployment delete`: Add `--no-wait` support.
 * `deployment delete`: Add `--no-wait` support.
+* Added `deployment wait` command.
 
 2.0.32
 ++++++

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -710,6 +710,10 @@ helps['deployment validate'] = """
             Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
             It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
 """
+helps['deployment wait'] = """
+    type: command
+    short-summary: Place the CLI in a waiting state until a deployment condition is met.
+"""
 helps['deployment operation'] = """
     type: group
     short-summary: Manage deployment operations.

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -210,7 +210,7 @@ def load_command_table(self, _):
         g.command('list', 'list_by_resource_group', table_transformer=transform_deployments_list, min_api='2017-05-10')
         g.command('list', 'list', table_transformer=transform_deployments_list, max_api='2016-09-01')
         g.command('show', 'get', exception_handler=empty_on_404)
-        g.command('delete', 'delete')
+        g.command('delete', 'delete', supports_no_wait=True)
         g.custom_command('validate', 'validate_arm_template', table_transformer=deployment_validate_table_format, exception_handler=handle_template_based_exception)
         g.custom_command('export', 'export_deployment_as_template')
         g.generic_wait_command('wait')
@@ -222,7 +222,7 @@ def load_command_table(self, _):
     with self.command_group('deployment', resource_deployment_sdk) as g:
         g.command('list', 'list_at_subscription_scope', table_transformer=transform_deployments_list, min_api='2018-05-01')
         g.command('show', 'get_at_subscription_scope', exception_handler=empty_on_404)
-        g.command('delete', 'delete_at_subscription_scope')
+        g.command('delete', 'delete_at_subscription_scope', supports_no_wait=True)
         g.custom_command('validate', 'validate_arm_template_at_subscription_scope', table_transformer=deployment_validate_table_format, exception_handler=handle_template_based_exception)
         g.custom_command('create', 'deploy_arm_template_at_subscription_scope', supports_no_wait=True, validator=process_deployment_create_namespace, exception_handler=handle_template_based_exception)
         g.custom_command('export', 'export_subscription_deployment_template')

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -226,6 +226,7 @@ def load_command_table(self, _):
         g.custom_command('validate', 'validate_arm_template_at_subscription_scope', table_transformer=deployment_validate_table_format, exception_handler=handle_template_based_exception)
         g.custom_command('create', 'deploy_arm_template_at_subscription_scope', supports_no_wait=True, validator=process_deployment_create_namespace, exception_handler=handle_template_based_exception)
         g.custom_command('export', 'export_subscription_deployment_template')
+        g.generic_wait_command('wait', getter_name='get_at_subscription_scope')
 
     with self.command_group('deployment operation', resource_deployment_operation_sdk) as g:
         g.command('list', 'list_at_subscription_scope')

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -5,7 +5,8 @@ Release History
 
 2.0.36
 ++++++
-* Minor fixes
+* `vm/vmss extension set/delete`: Added `--no-wait` support.
+* Added `vm extension wait`.
 
 2.0.35
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -222,6 +222,11 @@ helps['vm extension set'] = """
                 --protected-settings '{"username":"user1", "ssh_key":"ssh_rsa ..."}'
 """
 
+helps['vm extension wait'] = """
+    type: command
+    short-summary: Place the CLI in a waiting state until a condition of a virtual machine extension is met.
+"""
+
 helps['vm availability-set delete'] = """
     type: command
     short-summary: Delete an availability set.

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -215,10 +215,11 @@ def load_command_table(self, _):
         g.custom_command('show', 'show_vm_encryption_status', exception_handler=empty_on_404)
 
     with self.command_group('vm extension', compute_vm_extension_sdk) as g:
-        g.command('delete', 'delete')
+        g.command('delete', 'delete', supports_no_wait=True)
         g.command('show', 'get', exception_handler=empty_on_404, table_transformer=transform_extension_show_table_output)
-        g.custom_command('set', 'set_extension')
+        g.custom_command('set', 'set_extension', supports_no_wait=True)
         g.custom_command('list', 'list_extensions', table_transformer='[].' + transform_extension_show_table_output)
+        g.generic_wait_command('wait')
 
     with self.command_group('vm extension image', compute_vm_extension_image_sdk) as g:
         g.command('show', 'get', exception_handler=empty_on_404)
@@ -301,9 +302,9 @@ def load_command_table(self, _):
         g.custom_command('show', 'show_vmss_encryption_status', exception_handler=empty_on_404)
 
     with self.command_group('vmss extension', compute_vmss_sdk) as g:
-        g.custom_command('delete', 'delete_vmss_extension')
+        g.custom_command('delete', 'delete_vmss_extension', supports_no_wait=True)
         g.custom_command('show', 'get_vmss_extension', exception_handler=empty_on_404)
-        g.custom_command('set', 'set_vmss_extension')
+        g.custom_command('set', 'set_vmss_extension', supports_no_wait=True)
         g.custom_command('list', 'list_vmss_extensions')
 
     with self.command_group('vmss extension image', compute_vm_extension_image_sdk) as g:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1186,8 +1186,8 @@ def list_extensions(cmd, resource_group_name, vm_name):
     return result
 
 
-def set_extension(cmd, resource_group_name, vm_name, vm_extension_name, publisher,
-                  version=None, settings=None, protected_settings=None, no_auto_upgrade=False, force_update=False):
+def set_extension(cmd, resource_group_name, vm_name, vm_extension_name, publisher, version=None, settings=None,
+                  protected_settings=None, no_auto_upgrade=False, force_update=False, no_wait=False):
     vm = get_vm(cmd, resource_group_name, vm_name, 'instanceView')
     client = _compute_client_factory(cmd.cli_ctx)
 
@@ -1203,7 +1203,7 @@ def set_extension(cmd, resource_group_name, vm_name, vm_extension_name, publishe
                                   auto_upgrade_minor_version=(not no_auto_upgrade))
     if force_update:
         ext.force_update_tag = str(_gen_guid())
-    return client.virtual_machine_extensions.create_or_update(resource_group_name, vm_name, instance_name, ext)
+    return sdk_no_wait(no_wait, client.virtual_machine_extensions.create_or_update, resource_group_name, vm_name, instance_name, ext)
 # endregion
 
 
@@ -2361,7 +2361,8 @@ def list_vmss_extensions(cmd, resource_group_name, vmss_name):
 
 
 def set_vmss_extension(cmd, resource_group_name, vmss_name, extension_name, publisher, version=None,
-                       settings=None, protected_settings=None, no_auto_upgrade=False, force_update=False):
+                       settings=None, protected_settings=None, no_auto_upgrade=False, force_update=False,
+                       no_wait=True):
     client = _compute_client_factory(cmd.cli_ctx)
     vmss = client.virtual_machine_scale_sets.get(resource_group_name, vmss_name)
     VirtualMachineScaleSetExtension, VirtualMachineScaleSetExtensionProfile = cmd.get_models(
@@ -2390,7 +2391,7 @@ def set_vmss_extension(cmd, resource_group_name, vmss_name, extension_name, publ
         vmss.virtual_machine_profile.extension_profile = VirtualMachineScaleSetExtensionProfile(extensions=[])
     vmss.virtual_machine_profile.extension_profile.extensions.append(ext)
 
-    return client.virtual_machine_scale_sets.create_or_update(resource_group_name, vmss_name, vmss)
+    return sdk_no_wait(no_wait, client.virtual_machine_scale_sets.create_or_update, resource_group_name, vmss_name, vmss)
 # endregion
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1203,7 +1203,8 @@ def set_extension(cmd, resource_group_name, vm_name, vm_extension_name, publishe
                                   auto_upgrade_minor_version=(not no_auto_upgrade))
     if force_update:
         ext.force_update_tag = str(_gen_guid())
-    return sdk_no_wait(no_wait, client.virtual_machine_extensions.create_or_update, resource_group_name, vm_name, instance_name, ext)
+    return sdk_no_wait(no_wait, client.virtual_machine_extensions.create_or_update,
+                       resource_group_name, vm_name, instance_name, ext)
 # endregion
 
 
@@ -2362,7 +2363,7 @@ def list_vmss_extensions(cmd, resource_group_name, vmss_name):
 
 def set_vmss_extension(cmd, resource_group_name, vmss_name, extension_name, publisher, version=None,
                        settings=None, protected_settings=None, no_auto_upgrade=False, force_update=False,
-                       no_wait=True):
+                       no_wait=False):
     client = _compute_client_factory(cmd.cli_ctx)
     vmss = client.virtual_machine_scale_sets.get(resource_group_name, vmss_name)
     VirtualMachineScaleSetExtension, VirtualMachineScaleSetExtensionProfile = cmd.get_models(
@@ -2391,7 +2392,8 @@ def set_vmss_extension(cmd, resource_group_name, vmss_name, extension_name, publ
         vmss.virtual_machine_profile.extension_profile = VirtualMachineScaleSetExtensionProfile(extensions=[])
     vmss.virtual_machine_profile.extension_profile.extensions.append(ext)
 
-    return sdk_no_wait(no_wait, client.virtual_machine_scale_sets.create_or_update, resource_group_name, vmss_name, vmss)
+    return sdk_no_wait(no_wait, client.virtual_machine_scale_sets.create_or_update,
+                       resource_group_name, vmss_name, vmss)
 # endregion
 
 


### PR DESCRIPTION
Adds `--no-wait` support to various VM and VMSS extension, NIC and Deployment commands. Adds some `wait` commands where not previously supported (except VMSS extension, which did not work with generic wait).

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
