### PR TITLE
Add encryption params to create vm command

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 2.0.36
 ++++++
+* `vm create`: add params '--disk-encryption-key', '--disk-encryption-keyvault', '--key-encryption-key', '--key-encryption-keyvault'. The params are useful when building VMs out of custom images that were encrypted with Azure Disk Encryption (az vm encryption).
 * `vm/vmss extension set/delete`: Added `--no-wait` support.
 * Added `vm extension wait`.
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -429,10 +429,10 @@ def load_arguments(self, _):
 
     for scope in ['vm create']:
         with self.argument_context(scope) as c:
-            c.argument('disk_encryption_key_url', help='The location of the disk encryption key')
-            c.argument('disk_encryption_key_vault_id', help='The resource ID of the Key Vault containing the disk encryption key')
-            c.argument('key_encryption_key_url', help='The location of the key encryption key')
-            c.argument('key_encryption_key_vault_id', help='The resource ID of the Key Vault containing the key encryption key')
+            c.argument('disk_encryption_key', help='The URL of the disk encryption key')
+            c.argument('disk_encryption_keyvault', help='The resource ID or name of the Key Vault containing the disk encryption key')
+            c.argument('key_encryption_key', help='The URL or name of the key encryption key')
+            c.argument('key_encryption_keyvault', help='The resource ID or name of the Key Vault containing the key encryption key')
 
     for scope in ['vm create', 'vmss create', 'vm identity assign', 'vmss identity assign']:
         with self.argument_context(scope) as c:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -427,6 +427,13 @@ def load_arguments(self, _):
             c.argument('plan_publisher', help='plan publisher')
             c.argument('plan_promotion_code', help='plan promotion code')
 
+    for scope in ['vm create']:
+        with self.argument_context(scope) as c:
+            c.argument('disk_encryption_key_url', help='The location of the disk encryption key')
+            c.argument('disk_encryption_key_vault_id', help='The resource ID of the Key Vault containing the disk encryption key')
+            c.argument('key_encryption_key_url', help='The location of the key encryption key')
+            c.argument('key_encryption_key_vault_id', help='The resource ID of the Key Vault containing the key encryption key')
+
     for scope in ['vm create', 'vmss create', 'vm identity assign', 'vmss identity assign']:
         with self.argument_context(scope) as c:
             arg_group = 'Managed Service Identity' if scope.split()[-1] == 'create' else None

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -296,7 +296,7 @@ def build_vm_resource(  # pylint: disable=too-many-locals
             }
             if key_encryption_key_url:
                 encryption_settings['keyEncryptionKey'] = {
-                    'secretUrl': key_encryption_key_url,
+                    'keyUrl': key_encryption_key_url,
                     'sourceVault': {
                         'id': key_encryption_key_vault_id
                     }

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -312,17 +312,17 @@ def _validate_location(cmd, namespace, zone_info, size_info):
 def _validate_vm_encryption_settings(cmd, namespace):
     #if there is no disk_encryption* parameter then none of the encryption params should be provided
     required = []
-    forbidden = ['disk_encryption_key_url', 'disk_encryption_key_vault_id', 'key_encryption_key_url', 'key_encryption_key_vault_id']
+    forbidden = ['disk_encryption_key', 'disk_encryption_keyvault', 'key_encryption_key', 'key_encryption_keyvault']
 
-    # if disk_encryption_key_url or disk_encryption_key_vault_id are present. They should both be required.
-    if getattr(namespace, 'disk_encryption_key_url', None) or getattr(namespace, 'disk_encryption_key_vault_id', None):
-        required = ['disk_encryption_key_url', 'disk_encryption_key_vault_id']
-        forbidden = ['key_encryption_key_url', 'key_encryption_key_vault_id']
+    # if disk_encryption_key or disk_encryption_keyvault are present. They should both be required.
+    if getattr(namespace, 'disk_encryption_key', None) or getattr(namespace, 'disk_encryption_keyvault', None):
+        required = ['disk_encryption_key', 'disk_encryption_keyvault']
+        forbidden = ['key_encryption_key', 'key_encryption_keyvault']
 
-    if getattr(namespace, 'key_encryption_key_url', None) or getattr(namespace, 'key_encryption_key_vault_id', None):
+    if getattr(namespace, 'key_encryption_key', None) or getattr(namespace, 'key_encryption_keyvault', None):
         # if any key_encryption_key stuff is present, then both params are required
         # else they are both forbidden
-        required = ['disk_encryption_key_url', 'disk_encryption_key_vault_id', 'key_encryption_key_url', 'key_encryption_key_vault_id']
+        required = ['disk_encryption_key', 'disk_encryption_keyvault', 'key_encryption_key', 'key_encryption_keyvault']
         forbidden = []
 
     # Now verify that the status of required and forbidden parameters
@@ -330,6 +330,15 @@ def _validate_vm_encryption_settings(cmd, namespace):
         namespace, required, forbidden,
         description='storage profile: {}:'.format(_get_storage_profile_description(namespace.storage_profile)))
 
+    if getattr(namespace, 'disk_encryption_keyvault', None):
+        namespace.disk_encryption_keyvault = _get_resource_id(cmd.cli_ctx, namespace.disk_encryption_keyvault,
+                                                              namespace.resource_group_name,
+                                                              'vaults', 'Microsoft.KeyVault')
+
+    if getattr(namespace, 'key_encryption_keyvault', None):
+        namespace.key_encryption_keyvault = _get_resource_id(cmd.cli_ctx, namespace.key_encryption_keyvault,
+                                                             namespace.resource_group_name,
+                                                             'vaults', 'Microsoft.KeyVault')
 
 # pylint: disable=too-many-branches, too-many-statements
 def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -310,7 +310,7 @@ def _validate_location(cmd, namespace, zone_info, size_info):
 
 
 def _validate_vm_encryption_settings(cmd, namespace):
-    #if there is no disk_encryption* parameter then none of the encryption params should be provided
+    # if there is no disk_encryption* parameter then none of the encryption params should be provided
     required = []
     forbidden = ['disk_encryption_key', 'disk_encryption_keyvault', 'key_encryption_key', 'key_encryption_keyvault']
 
@@ -339,6 +339,7 @@ def _validate_vm_encryption_settings(cmd, namespace):
         namespace.key_encryption_keyvault = _get_resource_id(cmd.cli_ctx, namespace.key_encryption_keyvault,
                                                              namespace.resource_group_name,
                                                              'vaults', 'Microsoft.KeyVault')
+
 
 # pylint: disable=too-many-branches, too-many-statements
 def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -112,6 +112,10 @@ def get_key_vault_base_url(cli_ctx, vault_name):
     suffix = cli_ctx.cloud.suffixes.keyvault_dns
     return 'https://{}{}'.format(vault_name, suffix)
 
+def get_keyvault_key_url(cli_ctx, keyvault_name, key_name):
+    client = create_keyvault_data_plane_client(cli_ctx)
+    result = client.get_key(get_key_vault_base_url(cli_ctx, keyvault_name), key_name, '')
+    return result.key.kid  # pylint: disable=no-member
 
 def list_sku_info(cli_ctx, location=None):
     from ._client_factory import _compute_client_factory

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -112,10 +112,12 @@ def get_key_vault_base_url(cli_ctx, vault_name):
     suffix = cli_ctx.cloud.suffixes.keyvault_dns
     return 'https://{}{}'.format(vault_name, suffix)
 
+
 def get_keyvault_key_url(cli_ctx, keyvault_name, key_name):
     client = create_keyvault_data_plane_client(cli_ctx)
     result = client.get_key(get_key_vault_base_url(cli_ctx, keyvault_name), key_name, '')
     return result.key.kid  # pylint: disable=no-member
+
 
 def list_sku_info(cli_ctx, location=None):
     from ._client_factory import _compute_client_factory

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -501,7 +501,8 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
               validate=False, custom_data=None, secrets=None, plan_name=None, plan_product=None, plan_publisher=None,
               plan_promotion_code=None, license_type=None, assign_identity=None, identity_scope=None,
               identity_role='Contributor', identity_role_id=None, application_security_groups=None, zone=None,
-              boot_diagnostics_storage=None):
+              boot_diagnostics_storage=None, disk_encryption_key_url=None, disk_encryption_key_vault_id=None,
+              key_encryption_key_url=None, key_encryption_key_vault_id=None):
     from azure.cli.core.commands.client_factory import get_subscription_id
     from azure.cli.core.util import random_string, hash_string
     from azure.cli.core.commands.arm import ArmTemplateBuilder
@@ -618,7 +619,9 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
         os_publisher=os_publisher, os_offer=os_offer, os_sku=os_sku, os_version=os_version, os_vhd_uri=os_vhd_uri,
         attach_os_disk=attach_os_disk, os_disk_size_gb=os_disk_size_gb, custom_data=custom_data, secrets=secrets,
         license_type=license_type, zone=zone, disk_info=disk_info,
-        boot_diagnostics_storage_uri=boot_diagnostics_storage)
+        boot_diagnostics_storage_uri=boot_diagnostics_storage, disk_encryption_key_url=disk_encryption_key_url,
+        disk_encryption_key_vault_id=disk_encryption_key_vault_id, key_encryption_key_url=key_encryption_key_url,
+        key_encryption_key_vault_id=key_encryption_key_vault_id)
     vm_resource['dependsOn'] = vm_dependencies
 
     if plan_name:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -506,13 +506,12 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
     from azure.cli.core.commands.client_factory import get_subscription_id
     from azure.cli.core.util import random_string, hash_string
     from azure.cli.core.commands.arm import ArmTemplateBuilder
-    from azure.cli.command_modules.vm._vm_utils import get_keyvault_key_url
     from azure.cli.command_modules.vm._template_builder import (build_vm_resource,
                                                                 build_storage_account_resource, build_nic_resource,
                                                                 build_vnet_resource, build_nsg_resource,
                                                                 build_public_ip_resource, StorageProfile,
                                                                 build_msi_role_assignment)
-    from msrestazure.tools import resource_id, is_valid_resource_id, parse_resource_id
+    from msrestazure.tools import resource_id, is_valid_resource_id
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
     network_id_template = resource_id(
@@ -611,12 +610,6 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
 
     if secrets:
         secrets = _merge_secrets([validate_file_or_dict(secret) for secret in secrets])
-
-    if key_encryption_key:
-        key_encryption_keyvault = key_encryption_keyvault
-        if '://' not in key_encryption_key:  # appears a key name
-            key_encryption_key = get_keyvault_key_url(
-                cmd.cli_ctx, (parse_resource_id(key_encryption_keyvault))['name'], key_encryption_key)
 
     vm_resource = build_vm_resource(
         cmd=cmd, name=vm_name, location=location, tags=tags, size=size, storage_profile=storage_profile, nics=nics,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -10,7 +10,7 @@ from knack.log import get_logger
 from azure.cli.core.commands import LongRunningOperation
 
 from azure.cli.command_modules.vm.custom import set_vm, _compute_client_factory, _is_linux_os
-from azure.cli.command_modules.vm._vm_utils import get_key_vault_base_url, create_keyvault_data_plane_client
+from azure.cli.command_modules.vm._vm_utils import get_key_vault_base_url, get_keyvault_key_url
 
 _DATA_VOLUME_TYPE = 'DATA'
 _ALL_VOLUME_TYPE = 'ALL'
@@ -118,7 +118,7 @@ def encrypt_vm(cmd, resource_group_name, vm_name,  # pylint: disable=too-many-lo
     if key_encryption_key:
         key_encryption_keyvault = key_encryption_keyvault or disk_encryption_keyvault
         if '://' not in key_encryption_key:  # appears a key name
-            key_encryption_key = _get_keyvault_key_url(
+            key_encryption_key = get_keyvault_key_url(
                 cmd.cli_ctx, (parse_resource_id(key_encryption_keyvault))['name'], key_encryption_key)
 
     # 2. we are ready to provision/update the disk encryption extensions
@@ -362,11 +362,6 @@ def show_vm_encryption_status(cmd, resource_group_name, vm_name):
     return encryption_status
 
 
-def _get_keyvault_key_url(cli_ctx, keyvault_name, key_name):
-    client = create_keyvault_data_plane_client(cli_ctx)
-    result = client.get_key(get_key_vault_base_url(cli_ctx, keyvault_name), key_name, '')
-    return result.key.kid  # pylint: disable=no-member
-
 
 def _check_encrypt_is_supported(image_reference, volume_type):
     offer = getattr(image_reference, 'offer', None)
@@ -467,7 +462,7 @@ def encrypt_vmss(cmd, resource_group_name, vmss_name,  # pylint: disable=too-man
     if key_encryption_key:
         key_encryption_keyvault = key_encryption_keyvault or disk_encryption_keyvault
         if '://' not in key_encryption_key:  # appears a key name
-            key_encryption_key = _get_keyvault_key_url(
+            key_encryption_key = get_keyvault_key_url(
                 cmd.cli_ctx, (parse_resource_id(key_encryption_keyvault))['name'], key_encryption_key)
 
     #  to avoid bad server errors, ensure the vault has the right configurations

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -362,7 +362,6 @@ def show_vm_encryption_status(cmd, resource_group_name, vm_name):
     return encryption_status
 
 
-
 def _check_encrypt_is_supported(image_reference, volume_type):
     offer = getattr(image_reference, 'offer', None)
     publisher = getattr(image_reference, 'publisher', None)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -240,7 +240,7 @@ class TestVmCustom(unittest.TestCase):
 
     # pylint: disable=line-too-long
     @mock.patch('azure.cli.command_modules.vm.disk_encryption._compute_client_factory', autospec=True)
-    @mock.patch('azure.cli.command_modules.vm.disk_encryption._get_keyvault_key_url', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm._vm_utils.get_keyvault_key_url', autospec=True)
     def test_enable_encryption_error_cases_handling(self, mock_get_keyvault_key_url, mock_compute_client_factory):
         faked_keyvault = '/subscriptions/01234567-1bf0-4dda-aec3-cb9272f09590/resourceGroups/rg1/providers/Microsoft.KeyVault/vaults/v1'
         os_disk = OSDisk(create_option=None, os_type=OperatingSystemTypes.linux)


### PR DESCRIPTION
---
The encryption parameters are added to the create VM command in case user wants to create a vm from an already encrypted custom image. 
In this scenario the user will have to supply the encryption key URL and Key Vault which was used to encrypt the source VM of the custom image. 

---
This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
