### PR TITLE
Fix MSI for msrestazure 0.4.34

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -927,6 +927,8 @@ class TestProfile(unittest.TestCase):
                 self.token = None
                 self.client_id = kwargs.get('client_id')
                 self.object_id = kwargs.get('object_id')
+                # since msrestazure 0.4.34, set_token in init
+                self.set_token()
 
             def set_token(self):
                 # here we will reject the 1st sniffing of trying with client_id and then acccept the 2nd


### PR DESCRIPTION
FYI @troydai @williexu 

I got a issue from customer that KV and MSI didn't work anymore since azure-keyvault 1.0.0. Turned out this was two bugs:
- MSIAuthentication should get the token in the `__init__` and not in `signed_session`. That's the contract of msrestazure that KV expects to do some credentials magic. It was working in azure-keyvault 0.3.7 by chance. https://github.com/Azure/msrestazure-for-python/issues/106
- MSIAuthentication should support set `resource`, in order for KV magic to work. This was broken by the IMDS work. https://github.com/Azure/msrestazure-for-python/issues/109

Bug 1 is fixed in msrestazure 0.4.34, but CLI was built on the incorrect behavior that `set_token` was a required call. This PR simplifies the code according to the expected behavior.

Bug 2 is in a PR and works. Will be released soon. Will not create CLI changes.

Note that in order to support `azure-keyvault` 1.0.0, this is required. And is backward compatible with everything.