### PR TITLE
[Network] Deprecate `--ids` on certain list commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -260,8 +260,7 @@ class AzCliCommandInvoker(CommandInvoker):
         self.commands_loader.command_table = self.commands_loader.command_table  # update with the truncated table
         self.commands_loader.command_name = command
         self.commands_loader.load_arguments(command)
-        self.cli_ctx.raise_event(EVENT_INVOKER_POST_CMD_TBL_CREATE, cmd_tbl=self.commands_loader.command_table,
-                                 commands_loader=self.commands_loader)
+        self.cli_ctx.raise_event(EVENT_INVOKER_POST_CMD_TBL_CREATE, commands_loader=self.commands_loader)
         self.parser.cli_ctx = self.cli_ctx
         self.parser.load_command_table(self.commands_loader)
 

--- a/src/azure-cli-core/azure/cli/core/file_util.py
+++ b/src/azure-cli-core/azure/cli/core/file_util.py
@@ -43,11 +43,11 @@ def create_invoker_and_load_cmds_and_args(cli_ctx):
     invoker = cli_ctx.invocation_cls(cli_ctx=cli_ctx, commands_loader_cls=cli_ctx.commands_loader_cls,
                                      parser_cls=cli_ctx.parser_cls, help_cls=cli_ctx.help_cls)
     cli_ctx.invocation = invoker
-    cmd_table = invoker.commands_loader.load_command_table(None)
-    for command in cmd_table:
+    invoker.commands_loader.load_command_table(None)
+    for command in invoker.commands_loader.command_table:
         invoker.commands_loader.load_arguments(command)
     invoker.parser.load_command_table(invoker.commands_loader)
-    add_id_parameters(None, cmd_tbl=cmd_table)
+    add_id_parameters(None, commands_loader=invoker.commands_loader)
 
 
 def _store_parsers(parser, parser_keys, parser_values, sub_parser_keys, sub_parser_values):

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -44,7 +44,7 @@ class HelpTest(unittest.TestCase):
                 cmd_tbl[cmd].loader.load_arguments(cmd)
             except KeyError:
                 pass
-        cli.register_event(events.EVENT_INVOKER_CMD_TBL_LOADED, add_id_parameters)
+        cli.register_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, add_id_parameters)
         cli.raise_event(events.EVENT_INVOKER_CMD_TBL_LOADED, command_table=cmd_tbl)
         cli.invocation.parser.load_command_table(cli.invocation.commands_loader)
         _store_parsers(cli.invocation.parser, parser_dict)

--- a/src/azure-cli-testsdk/azure/cli/testsdk/__init__.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/__init__.py
@@ -58,8 +58,8 @@ class TestCli(AzCli):
         self.cloud = get_active_cloud(self)
 
     def get_cli_version(self):
-        from azure.cli.core.util import get_az_version_string
-        return get_az_version_string()
+        from azure.cli.core import __version__ as cli_version
+        return cli_version
 
 
 __version__ = '0.1.0'

--- a/src/command_modules/azure-cli-interactive/HISTORY.rst
+++ b/src/command_modules/azure-cli-interactive/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.3.26
+++++++
+* Minor fixes
+
 0.3.25
 ++++++
 * Update PyYAML dependency to 4.2b4

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/_dump_commands.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/_dump_commands.py
@@ -84,7 +84,7 @@ class FreshTable(object):
 
         main_loader.load_command_table(None)
         main_loader.load_arguments(None)
-        add_id_parameters(None, cmd_tbl=main_loader.command_table)
+        add_id_parameters(None, commands_loader=main_loader)
         cmd_table = main_loader.command_table
 
         cmd_table_data = {}

--- a/src/command_modules/azure-cli-interactive/setup.py
+++ b/src/command_modules/azure-cli-interactive/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     cmdclass = {}
 
 # Version is also defined in azclishell.__init__.py.
-VERSION = "0.3.25"
+VERSION = "0.3.26"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -7,6 +7,8 @@ Release History
 +++++
 * `network nic create/update/delete`: Add `--no-wait` support.
 * Added `network nic wait`.
+* `network vnet subnet list`: Argument `--ids` is deprecated.
+* `network vnet peering list`: Argument `--ids` is deprecated.
 
 2.1.5
 ++++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -882,6 +882,10 @@ def load_arguments(self, _):
         c.argument('route_table', help='Name or ID of a route table to associate with the subnet.')
         c.argument('service_endpoints', nargs='+', min_api='2017-06-01')
 
+    for scope in ['network vnet subnet list', 'network vnet peering list']:
+        with self.argument_context(scope) as c:
+            c.argument('ids', deprecate_info=c.deprecate(hide=True, expiration='2.1.0'))
+
     # endregion
 
     # region VirtualNetworkGateways


### PR DESCRIPTION
Closes #6062.

Also, fixes a logic bug in the global subscription ID parameter.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
