### PR TITLE
login: check GUI is available before launch the browser

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -165,6 +165,13 @@ class Profile(object):
                                                      self.auth_ctx_factory,
                                                      self._creds_cache.adal_token_cache)
         if interactive:
+            if not use_device_code and ('SSH_CLIENT' in os.environ or
+                                        'SSH_TTY' in os.environ or
+                                        'SSH_CONNECTION' in os.environ or
+                                        in_cloud_console()):
+                logger.info('Detect we are in SSH or Cloud Shell, so fall back to device code')
+                use_device_code = True
+
             if not use_device_code:
                 try:
                     authority_url, _ = _get_authority_url(self.cli_ctx, tenant)

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -19,7 +19,7 @@ from knack.util import CLIError
 
 from azure.cli.core._environment import get_config_dir
 from azure.cli.core._session import ACCOUNT
-from azure.cli.core.util import get_file_json, in_cloud_console, open_page_in_browser
+from azure.cli.core.util import get_file_json, in_cloud_console, open_page_in_browser, has_gui
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
 
 logger = get_logger(__name__)
@@ -165,11 +165,8 @@ class Profile(object):
                                                      self.auth_ctx_factory,
                                                      self._creds_cache.adal_token_cache)
         if interactive:
-            if not use_device_code and ('SSH_CLIENT' in os.environ or
-                                        'SSH_TTY' in os.environ or
-                                        'SSH_CONNECTION' in os.environ or
-                                        in_cloud_console()):
-                logger.info('Detect we are in SSH or Cloud Shell, so fall back to device code')
+            if not use_device_code and (in_cloud_console() or not has_gui()):
+                logger.info('Detect we are in Cloud Shell or no GUI is available, so fall back to device code')
                 use_device_code = True
 
             if not use_device_code:

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -166,7 +166,7 @@ class Profile(object):
                                                      self._creds_cache.adal_token_cache)
         if interactive:
             if not use_device_code and (in_cloud_console() or not has_gui()):
-                logger.info('Detect we are in Cloud Shell or no GUI is available, so fall back to device code')
+                logger.info('Detect no GUI is available, so fall back to device code')
                 use_device_code = True
 
             if not use_device_code:

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -19,7 +19,7 @@ from knack.util import CLIError
 
 from azure.cli.core._environment import get_config_dir
 from azure.cli.core._session import ACCOUNT
-from azure.cli.core.util import get_file_json, in_cloud_console, open_page_in_browser, has_gui
+from azure.cli.core.util import get_file_json, in_cloud_console, open_page_in_browser, can_launch_browser
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
 
 logger = get_logger(__name__)
@@ -165,7 +165,7 @@ class Profile(object):
                                                      self.auth_ctx_factory,
                                                      self._creds_cache.adal_token_cache)
         if interactive:
-            if not use_device_code and (in_cloud_console() or not has_gui()):
+            if not use_device_code and (in_cloud_console() or not can_launch_browser()):
                 logger.info('Detect no GUI is available, so fall back to device code')
                 use_device_code = True
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -12,7 +12,8 @@ import tempfile
 from datetime import date, time, datetime
 
 from azure.cli.core.util import \
-    (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string, open_page_in_browser)
+    (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
+     open_page_in_browser, has_gui)
 
 
 class TestUtils(unittest.TestCase):
@@ -128,6 +129,26 @@ class TestUtils(unittest.TestCase):
             sunprocess_open_mock.assert_called_once_with(['open', 'http://foo'])
         else:
             webbrowser_open_mock.assert_called_once_with('http://foo', 2)
+
+    @mock.patch('azure.cli.core.util._get_platform_info', autospec=True)
+    def test_has_gui(self, get_platform_mock):
+        get_platform_mock.return_value = ('linux', '4.4.0-17134-microsoft')
+        result = has_gui()
+        self.assertTrue(result)
+
+        get_platform_mock.return_value = ('windows', '10')
+        result = has_gui()
+        self.assertTrue(result)
+
+        with mock.patch('os.environ', autospec=True) as env_mock:
+            get_platform_mock.return_value = ('linux', '4.15.0-1014-azure')
+            env_mock.get.return_value = None
+            result = has_gui()
+            self.assertFalse(result)
+
+            env_mock.get.return_value = 'foo'
+            result = has_gui()
+            self.assertTrue(result)
 
 
 class TestBase64ToHex(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -13,7 +13,7 @@ from datetime import date, time, datetime
 
 from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
-     open_page_in_browser, has_gui)
+     open_page_in_browser, can_launch_browser)
 
 
 class TestUtils(unittest.TestCase):
@@ -131,24 +131,45 @@ class TestUtils(unittest.TestCase):
             webbrowser_open_mock.assert_called_once_with('http://foo', 2)
 
     @mock.patch('azure.cli.core.util._get_platform_info', autospec=True)
-    def test_has_gui(self, get_platform_mock):
+    @mock.patch('webbrowser.get', autospec=True)
+    def test_can_launch_browser(self, webbrowser_get_mock, get_platform_mock):
+        # WSL is always fine
         get_platform_mock.return_value = ('linux', '4.4.0-17134-microsoft')
-        result = has_gui()
+        result = can_launch_browser()
         self.assertTrue(result)
 
+        # windows is always fine
         get_platform_mock.return_value = ('windows', '10')
-        result = has_gui()
+        result = can_launch_browser()
         self.assertTrue(result)
 
+        # osx is always fine
+        get_platform_mock.return_value = ('darwin', '10')
+        result = can_launch_browser()
+        self.assertTrue(result)
+
+        # now tests linux
         with mock.patch('os.environ', autospec=True) as env_mock:
+            # when no GUI, return false
             get_platform_mock.return_value = ('linux', '4.15.0-1014-azure')
             env_mock.get.return_value = None
-            result = has_gui()
+            result = can_launch_browser()
             self.assertFalse(result)
 
+            # when there is gui, and browser is a good one, return True
+            browser_mock = mock.MagicMock()
+            browser_mock.name = 'goodone'
             env_mock.get.return_value = 'foo'
-            result = has_gui()
+            result = can_launch_browser()
             self.assertTrue(result)
+
+            # when there is gui, but the browser is text mode, return False
+            browser_mock = mock.MagicMock()
+            browser_mock.name = 'www-browser'
+            webbrowser_get_mock.return_value = browser_mock
+            env_mock.get.return_value = 'foo'
+            result = can_launch_browser()
+            self.assertFalse(result)
 
 
 class TestBase64ToHex(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -293,6 +293,7 @@ def has_gui():
     if _is_wsl(platform_name, release) or platform_name != 'linux':
         return True
     # per https://unix.stackexchange.com/questions/46305/is-there-a-way-to-retrieve-the-name-of-the-desktop-environment
+    # and https://unix.stackexchange.com/questions/193827/what-is-display-0
     # we can check a few env vars
-    gui_env_vars = ['DESKTOP_SESSION', 'XDG_CURRENT_DESKTOP']
+    gui_env_vars = ['DESKTOP_SESSION', 'XDG_CURRENT_DESKTOP', 'DISPLAY']
     return any(os.getenv(v) for v in gui_env_vars)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -255,18 +255,11 @@ def sdk_no_wait(no_wait, func, *args, **kwargs):
 
 
 def open_page_in_browser(url):
-    import platform
     import subprocess
     import webbrowser
-    uname = platform.uname()
-    try:
-        platform_name = uname.system.lower()
-        release = uname.release.lower()
-    except AttributeError:
-        # python 2, `platform.uname()` returns: tuple(system, node, release, version, machine, processor)
-        platform_name = uname[0]
-        release = uname[2]
-    if platform_name == 'linux' and release.split('-')[-1] == 'microsoft':   # windows 10 linux subsystem
+    platform_name, release = _get_platform_info()
+
+    if _is_wsl(platform_name, release):   # windows 10 linux subsystem
         try:
             return subprocess.call(['cmd.exe', '/c', "start {}".format(url.replace('&', '^&'))])
         except FileNotFoundError:  # WSL might be too old
@@ -278,3 +271,28 @@ def open_page_in_browser(url):
         # b. Python 2.x can't sniff out the default browser
         return subprocess.Popen(['open', url])
     return webbrowser.open(url, new=2)  # 2 means: open in a new tab, if possible
+
+
+def _get_platform_info():
+    import platform
+    uname = platform.uname()
+    # python 2, `platform.uname()` returns: tuple(system, node, release, version, machine, processor)
+    platform_name = getattr(uname, 'system', None) or uname[0]
+    release = getattr(uname, 'release', None) or uname[2]
+    return platform_name.lower(), release.lower()
+
+
+def _is_wsl(platform_name, release):
+    platform_name, release = _get_platform_info()
+    return platform_name == 'linux' and release == 'microsoft'
+
+
+def has_gui():
+    import os
+    platform_name, release = _get_platform_info()
+    if _is_wsl(platform_name, release) or platform_name != 'linux':
+        return True
+    # per https://unix.stackexchange.com/questions/46305/is-there-a-way-to-retrieve-the-name-of-the-desktop-environment
+    # we can check a few env vars
+    gui_env_vars = ['DESKTOP_SESSION', 'XDG_CURRENT_DESKTOP']
+    return any(os.getenv(v) for v in gui_env_vars)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -287,8 +287,9 @@ def _is_wsl(platform_name, release):
     return platform_name == 'linux' and release.split('-')[-1] == 'microsoft'
 
 
-def has_gui():
+def can_launch_browser():
     import os
+    import webbrowser
     platform_name, release = _get_platform_info()
     if _is_wsl(platform_name, release) or platform_name != 'linux':
         return True
@@ -296,4 +297,16 @@ def has_gui():
     # and https://unix.stackexchange.com/questions/193827/what-is-display-0
     # we can check a few env vars
     gui_env_vars = ['DESKTOP_SESSION', 'XDG_CURRENT_DESKTOP', 'DISPLAY']
-    return any(os.getenv(v) for v in gui_env_vars)
+    result = True
+    if platform_name == 'linux':
+        if any(os.getenv(v) for v in gui_env_vars):
+            try:
+                default_browser = webbrowser.get()
+                if getattr(default_browser, 'name', None) == 'www-browser':  # text browser won't work
+                    result = False
+            except webbrowser.Error:
+                result = False
+        else:
+            result = False
+
+    return result

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -284,7 +284,7 @@ def _get_platform_info():
 
 def _is_wsl(platform_name, release):
     platform_name, release = _get_platform_info()
-    return platform_name == 'linux' and release == 'microsoft'
+    return platform_name == 'linux' and release.split('-')[-1] == 'microsoft'
 
 
 def has_gui():


### PR DESCRIPTION
This should address #6717. The existing logic would catch the exception and fallback to the device code, but for situations we know it would never work, this change would skip instead of even trying.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
