### PR TITLE
[Resource] Suppress "deployment" commands on Stack profile

### DIFF
--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * `group deployment delete`: Add `--no-wait` support.
 * `deployment delete`: Add `--no-wait` support.
 * Added `deployment wait` command.
+* Fix issue where the subscription-level `az deployment` commands erroneously appeared for profile 2017-03-09-profile.
 
 2.0.32
 ++++++

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -219,8 +219,8 @@ def load_command_table(self, _):
         g.command('list', 'list')
         g.custom_command('show', 'get_deployment_operations', client_factory=cf_deployment_operations, exception_handler=empty_on_404)
 
-    with self.command_group('deployment', resource_deployment_sdk) as g:
-        g.command('list', 'list_at_subscription_scope', table_transformer=transform_deployments_list, min_api='2018-05-01')
+    with self.command_group('deployment', resource_deployment_sdk, min_api='2018-05-01', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES) as g:
+        g.command('list', 'list_at_subscription_scope', table_transformer=transform_deployments_list)
         g.command('show', 'get_at_subscription_scope', exception_handler=empty_on_404)
         g.command('delete', 'delete_at_subscription_scope', supports_no_wait=True)
         g.custom_command('validate', 'validate_arm_template_at_subscription_scope', table_transformer=deployment_validate_table_format, exception_handler=handle_template_based_exception)
@@ -228,7 +228,7 @@ def load_command_table(self, _):
         g.custom_command('export', 'export_subscription_deployment_template')
         g.generic_wait_command('wait', getter_name='get_at_subscription_scope')
 
-    with self.command_group('deployment operation', resource_deployment_operation_sdk) as g:
+    with self.command_group('deployment operation', resource_deployment_operation_sdk, min_api='2018-05-01', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES) as g:
         g.command('list', 'list_at_subscription_scope')
         g.custom_command('show', 'get_deployment_operations_at_subscription_scope', client_factory=cf_deployment_operations, exception_handler=empty_on_404)
 


### PR DESCRIPTION
Closes #6720.

The subscription-level deployment commands are only supported on the 2018-05-01 API version or higher. They should not appear on the stack profile at all.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
