### PR TITLE
Add `--force-string` flag to generic update.

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 2.0.42
 ++++++
 * login: support browser based login in WSL bash window
+* Adds `--force-string` flag to all generic update commands.
 
 2.0.41
 ++++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-04-02T15:05:05Z"}}'
+      "date": "2018-07-06T20:20:13Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -9,24 +9,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vnet_test000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001","name":"cli_vnet_test000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-04-02T15:05:05Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001","name":"cli_vnet_test000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-07-06T20:20:13Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:07 GMT']
+      date: ['Fri, 06 Jul 2018 20:20:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -36,19 +36,19 @@ interactions:
       CommandName: [network vnet create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vnet_test000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001","name":"cli_vnet_test000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-04-02T15:05:05Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001","name":"cli_vnet_test000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-07-06T20:20:13Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:08 GMT']
+      date: ['Fri, 06 Jul 2018 20:20:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -66,39 +66,39 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['205']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"416ae1eb-476f-421c-8ad6-1c00b20b129d\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"fea60cd6-d308-4e5c-a6d2-399ef220388d\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"default\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"416ae1eb-476f-421c-8ad6-1c00b20b129d\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"fea60cd6-d308-4e5c-a6d2-399ef220388d\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f63fb2d1-c3d7-45d4-8a20-f4cd7f2dfe21?api-version=2018-02-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ca7a7255-bfd0-4261-8fe9-755ec338b4b1?api-version=2018-02-01']
       cache-control: [no-cache]
       content-length: ['1230']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:08 GMT']
+      date: ['Fri, 06 Jul 2018 20:20:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -107,18 +107,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet create]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f63fb2d1-c3d7-45d4-8a20-f4cd7f2dfe21?api-version=2018-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ca7a7255-bfd0-4261-8fe9-755ec338b4b1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:11 GMT']
+      date: ['Fri, 06 Jul 2018 20:20:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -134,18 +134,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet create]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f63fb2d1-c3d7-45d4-8a20-f4cd7f2dfe21?api-version=2018-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ca7a7255-bfd0-4261-8fe9-755ec338b4b1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:23 GMT']
+      date: ['Fri, 06 Jul 2018 20:20:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -161,22 +161,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet create]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"default\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
@@ -185,8 +185,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1232']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:23 GMT']
-      etag: [W/"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee"]
+      date: ['Fri, 06 Jul 2018 20:20:51 GMT']
+      etag: [W/"fc0be9b7-8756-42f6-a213-c0292afff2dc"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -203,9 +203,9 @@ interactions:
       CommandName: [network vnet check-ip-address]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/CheckIPAddressAvailability?ipAddress=10.0.0.50&api-version=2018-02-01
@@ -215,7 +215,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['25']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:23 GMT']
+      date: ['Fri, 06 Jul 2018 20:20:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -232,9 +232,9 @@ interactions:
       CommandName: [network vnet check-ip-address]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/CheckIPAddressAvailability?ipAddress=10.0.0.0&api-version=2018-02-01
@@ -246,7 +246,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['145']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:24 GMT']
+      date: ['Fri, 06 Jul 2018 20:20:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -263,27 +263,26 @@ interactions:
       CommandName: [network vnet list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/virtualNetworks?api-version=2018-02-01
   response:
-    body: {string: '{"value":[{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation014whdssyvw7jfnoexwuyhiqyqsndnjgnj5naa27jcghah5uoqumtrmojy6lwa/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"420ee8b1-2baf-49fb-b7b9-429e4bb07f47\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"50ecd32a-2b4c-4a57-a7ca-587d84eb0101"},"properties":{"provisioningState":"Succeeded","resourceGuid":"51fa6bd4-6d1e-4f27-a9d0-ad709b15f168","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation014whdssyvw7jfnoexwuyhiqyqsndnjgnj5naa27jcghah5uoqumtrmojy6lwa/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"420ee8b1-2baf-49fb-b7b9-429e4bb07f47\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01ofs4jum5pgipgviiyt3rz6dfx6jphkwzwxtb7ztjus4mrvurxauwow5oi2ip/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"2c1371ca-58be-4423-9089-df8b3974fdc4\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"5bc73e05-2ff8-48e7-a062-0aa2611b619a"},"properties":{"provisioningState":"Succeeded","resourceGuid":"e385fe7d-a39c-4d74-b47b-ceab91137000","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01ofs4jum5pgipgviiyt3rz6dfx6jphkwzwxtb7ztjus4mrvurxauwow5oi2ip/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"2c1371ca-58be-4423-9089-df8b3974fdc4\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01uaic4wwniigwe6n5bmni4ch3mzqlplsgiwalrlnfznoigmt5ah3fyj7ay5jf/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"f80f8639-87dc-4437-a645-e716b24b861f\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9ec9b5da-c8a8-46cf-ba85-8a0775b50545"},"properties":{"provisioningState":"Succeeded","resourceGuid":"688e38a8-37de-4d36-8231-a26c150290aa","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01uaic4wwniigwe6n5bmni4ch3mzqlplsgiwalrlnfznoigmt5ah3fyj7ay5jf/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"f80f8639-87dc-4437-a645-e716b24b861f\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01vrhbspwox2r4xyvnrvowmlzxq6jr6fl7fpaa6qi7heb4bvrlg7rei72b22gw/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"2e02267a-66fa-4ab7-898b-7ef2ac6e95e1\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"c9a3b57d-40b0-4162-b9c5-0f4502787198"},"properties":{"provisioningState":"Succeeded","resourceGuid":"0fb6ce19-c538-459c-b071-f3a0e3c06655","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01vrhbspwox2r4xyvnrvowmlzxq6jr6fl7fpaa6qi7heb4bvrlg7rei72b22gw/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"2e02267a-66fa-4ab7-898b-7ef2ac6e95e1\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01x2ivwmgy7h7xlhxsucwcey6t3oqntveobkjypkl4l2qhrsxs5yzrlkt43pwg/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"c76f2f7b-9940-4d2d-a1b8-11c118423c1f\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"302eea7f-56dc-4c33-aff9-e9f2024be2d3"},"properties":{"provisioningState":"Succeeded","resourceGuid":"95ed3f13-4709-460a-877a-0e8001b4684a","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01x2ivwmgy7h7xlhxsucwcey6t3oqntveobkjypkl4l2qhrsxs5yzrlkt43pwg/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"c76f2f7b-9940-4d2d-a1b8-11c118423c1f\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation2uaupk3gjn62bq6xovmzmkfiau5ckzltzzg23wipgtikelknor4mttwch5lzg6/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"bec13427-27a7-43a9-9034-aa540f53241b\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"b09e8b1d-3820-425b-b20f-65fb736722c0"},"properties":{"provisioningState":"Succeeded","resourceGuid":"8c949909-a3ad-43b0-94c4-302fe813197a","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation2uaupk3gjn62bq6xovmzmkfiau5ckzltzzg23wipgtikelknor4mttwch5lzg6/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"bec13427-27a7-43a9-9034-aa540f53241b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation5bhuubklmix25cgxkmdnru4a4my626erp5ekt72ictql2e3whesn6yn5dxxz4j/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"6c103208-887b-434e-a3cc-692d0330c59e\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"fbad0d12-1a47-4697-ba6a-df2746357de0"},"properties":{"provisioningState":"Succeeded","resourceGuid":"6dc8628b-01aa-4abd-af3a-9edeede21106","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation5bhuubklmix25cgxkmdnru4a4my626erp5ekt72ictql2e3whesn6yn5dxxz4j/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"6c103208-887b-434e-a3cc-692d0330c59e\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation5d5s7t6ltceqo5tg4dxvxtspxhl2xcmhfgyhpecowralnvufqlaywvytovn6v3/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"b3ac3911-40a1-4848-9af3-a165012e8338\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"f7794a12-90f3-45c7-aeee-898076fd4674"},"properties":{"provisioningState":"Succeeded","resourceGuid":"0c0eed03-0653-4fe2-b803-bc28ccbc3014","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation5d5s7t6ltceqo5tg4dxvxtspxhl2xcmhfgyhpecowralnvufqlaywvytovn6v3/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"b3ac3911-40a1-4848-9af3-a165012e8338\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomationqykn64bzakkymrnxrjj5epxgcwrtjuv3bril5nwr6g674dsmrnjkbdslhvv6be/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"4a83974b-907a-4333-ad32-94ff5a28d5cf\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"8fa27b18-063d-4372-9af0-93a5b5cc9f39"},"properties":{"provisioningState":"Succeeded","resourceGuid":"7aa26de7-fdfd-408e-bf32-9579baed6496","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomationqykn64bzakkymrnxrjj5epxgcwrtjuv3bril5nwr6g674dsmrnjkbdslhvv6be/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"4a83974b-907a-4333-ad32-94ff5a28d5cf\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomationyfwfjfweexioxkx2y3zmbmgodchnm3uetmvqsaexybtsrwkd47lsvrp5zmdzlr/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"cc19a467-7729-48b5-aea7-967f1dfc4e0b\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"c330e530-d621-4aa9-8b49-64a36cf75e02"},"properties":{"provisioningState":"Succeeded","resourceGuid":"0798d69d-ebe7-4796-ab7d-fd40b97e8d27","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomationyfwfjfweexioxkx2y3zmbmgodchnm3uetmvqsaexybtsrwkd47lsvrp5zmdzlr/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"cc19a467-7729-48b5-aea7-967f1dfc4e0b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connectiongu2mmqc5mzrhhtncoabte6idy5hw/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"dd2edb9d-0b84-4409-b163-9f8e3621c73a\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b2d26296-b8d1-4095-abcb-fdb7488db350","addressSpace":{"addressPrefixes":["10.11.0.0/16","10.12.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connectiongu2mmqc5mzrhhtncoabte6idy5hw/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/GatewaySubnet","etag":"W/\"dd2edb9d-0b84-4409-b163-9f8e3621c73a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.12.255.0/27","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connectiongu2mmqc5mzrhhtncoabte6idy5hw/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/vnetGatewayConfig0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connectiongu2mmqc5mzrhhtncoabte6idy5hw/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/vnetGatewayConfig1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection46zph2pifrtxnbv7ok2sjo4tpj4bc2fh/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"fd935b9c-6243-4a27-8841-aaa1d83514d3\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e8dfab6a-5b83-4079-9551-cd77aa5d6750","addressSpace":{"addressPrefixes":["10.21.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection46zph2pifrtxnbv7ok2sjo4tpj4bc2fh/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/GatewaySubnet","etag":"W/\"fd935b9c-6243-4a27-8841-aaa1d83514d3\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.21.255.0/27","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection46zph2pifrtxnbv7ok2sjo4tpj4bc2fh/providers/Microsoft.Network/virtualNetworkGateways/vgw1/ipConfigurations/vnetGatewayConfig0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection46zph2pifrtxnbv7ok2sjo4tpj4bc2fh/providers/Microsoft.Network/virtualNetworkGateways/vgw1/ipConfigurations/vnetGatewayConfig1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection46zph2pifrtxnbv7ok2sjo4tpj4bc2fh/providers/Microsoft.Network/virtualNetworks/vnet2","etag":"W/\"71c578ab-9b7c-4793-a702-c6c8ed89d273\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"86f81448-7b3a-4a64-96cf-e891778e0b7a","addressSpace":{"addressPrefixes":["10.22.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection46zph2pifrtxnbv7ok2sjo4tpj4bc2fh/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/GatewaySubnet","etag":"W/\"71c578ab-9b7c-4793-a702-c6c8ed89d273\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.22.255.0/27","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection46zph2pifrtxnbv7ok2sjo4tpj4bc2fh/providers/Microsoft.Network/virtualNetworkGateways/vgw2/ipConfigurations/vnetGatewayConfig0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_vnet_vnet_connection46zph2pifrtxnbv7ok2sjo4tpj4bc2fh/providers/Microsoft.Network/virtualNetworkGateways/vgw2/ipConfigurations/vnetGatewayConfig1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_existing_subnetckw5xmvytvmy3zt7cz7hwnef7iojlu4k4bg4zwxwnm3rfzau/providers/Microsoft.Network/virtualNetworks/vnet2","etag":"W/\"3324129e-14c6-4dcb-912a-06807cd0d864\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"dd81bf4d-fe70-443f-9b5a-a525633bf97a","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_existing_subnetckw5xmvytvmy3zt7cz7hwnef7iojlu4k4bg4zwxwnm3rfzau/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/subnet1","etag":"W/\"3324129e-14c6-4dcb-912a-06807cd0d864\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_existing_subnetckw5xmvytvmy3zt7cz7hwnef7iojlu4k4bg4zwxwnm3rfzau/providers/Microsoft.Network/applicationGateways/ag2/frontendIPConfigurations/appGatewayFrontendIP"}],"applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_existing_subnetckw5xmvytvmy3zt7cz7hwnef7iojlu4k4bg4zwxwnm3rfzau/providers/Microsoft.Network/applicationGateways/ag2/gatewayIPConfigurations/appGatewayFrontendIP"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_privatewelu7ndzzczq5draitlc3des3fy3h77eytzckmm7lv43/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"3c7aa5e3-5ef5-4b9c-872d-fd5a151be2ea\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f4929c61-a400-4777-b6d5-3a36700c3796","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_privatewelu7ndzzczq5draitlc3des3fy3h77eytzckmm7lv43/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1","etag":"W/\"3c7aa5e3-5ef5-4b9c-872d-fd5a151be2ea\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_privatewelu7ndzzczq5draitlc3des3fy3h77eytzckmm7lv43/providers/Microsoft.Network/applicationGateways/ag1/gatewayIPConfigurations/appGatewayFrontendIP"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"ag1Vnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public4mbxi2iksfn5npwlnmtbhxzfi25aclhjw2nq3ubveg5dp/providers/Microsoft.Network/virtualNetworks/ag1Vnet","etag":"W/\"482aa3f7-8759-407b-9aef-8b61dc761e37\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"223aaa0a-cf3f-4f91-8047-5528997b782f","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public4mbxi2iksfn5npwlnmtbhxzfi25aclhjw2nq3ubveg5dp/providers/Microsoft.Network/virtualNetworks/ag1Vnet/subnets/default","etag":"W/\"482aa3f7-8759-407b-9aef-8b61dc761e37\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public4mbxi2iksfn5npwlnmtbhxzfi25aclhjw2nq3ubveg5dp/providers/Microsoft.Network/applicationGateways/ag1/frontendIPConfigurations/appGatewayFrontendIP"}],"applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_frontend_ip_public4mbxi2iksfn5npwlnmtbhxzfi25aclhjw2nq3ubveg5dp/providers/Microsoft.Network/applicationGateways/ag1/gatewayIPConfigurations/appGatewayFrontendIP"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"ag1Vnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_settingsquedf6sf74pdz3jvvvsq2uea7zeefygrcakkyuaoav673ztad2/providers/Microsoft.Network/virtualNetworks/ag1Vnet","etag":"W/\"1369d1dc-2a1e-441f-86d2-b098415193a4\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"9d483637-c555-451a-8f48-3491a5406f91","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_http_settingsquedf6sf74pdz3jvvvsq2uea7zeefygrcakkyuaoav673ztad2/providers/Microsoft.Network/virtualNetworks/ag1Vnet/subnets/default","etag":"W/\"1369d1dc-2a1e-441f-86d2-b098415193a4\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"ag1Vnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe3owo7iz5ahzxavztjkqggiym4e3wxoby2ut6wzuo7f5yo7pcyczp4ye7tb/providers/Microsoft.Network/virtualNetworks/ag1Vnet","etag":"W/\"f1a5f241-11f6-4fa3-afe2-6469bb0bbd1d\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e630bc3a-e7fd-42f2-8244-78e532eda3db","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe3owo7iz5ahzxavztjkqggiym4e3wxoby2ut6wzuo7f5yo7pcyczp4ye7tb/providers/Microsoft.Network/virtualNetworks/ag1Vnet/subnets/default","etag":"W/\"f1a5f241-11f6-4fa3-afe2-6469bb0bbd1d\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe3owo7iz5ahzxavztjkqggiym4e3wxoby2ut6wzuo7f5yo7pcyczp4ye7tb/providers/Microsoft.Network/applicationGateways/ag1/frontendIPConfigurations/appGatewayFrontendIP"}],"applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_probe3owo7iz5ahzxavztjkqggiym4e3wxoby2ut6wzuo7f5yo7pcyczp4ye7tb/providers/Microsoft.Network/applicationGateways/ag1/gatewayIPConfigurations/appGatewayFrontendIP"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"ag1Vnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rulem3kjwlzsij67o7xauwxfc57zspjkrqhbivpne5sohg7ty7hyxjrua763d5d/providers/Microsoft.Network/virtualNetworks/ag1Vnet","etag":"W/\"ca6b1637-c1df-4d18-986e-e582b4ac1b0f\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f65ad0c3-5d64-4c6e-9a69-4fdaee2776a2","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rulem3kjwlzsij67o7xauwxfc57zspjkrqhbivpne5sohg7ty7hyxjrua763d5d/providers/Microsoft.Network/virtualNetworks/ag1Vnet/subnets/default","etag":"W/\"ca6b1637-c1df-4d18-986e-e582b4ac1b0f\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rulem3kjwlzsij67o7xauwxfc57zspjkrqhbivpne5sohg7ty7hyxjrua763d5d/providers/Microsoft.Network/applicationGateways/ag1/frontendIPConfigurations/appGatewayFrontendIP"}],"applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rulem3kjwlzsij67o7xauwxfc57zspjkrqhbivpne5sohg7ty7hyxjrua763d5d/providers/Microsoft.Network/applicationGateways/ag1/gatewayIPConfigurations/appGatewayFrontendIP"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"myvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenarioojthyrjalird37tbcqfe5iszqhrqufqrntjekj372k6qcssr2uhhn3/providers/Microsoft.Network/virtualNetworks/myvnet","etag":"W/\"f646c68b-6117-4340-bdd9-0b3346e4e721\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f5525c23-b62a-4bc8-a4f3-20d0b86cf636","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"mysubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenarioojthyrjalird37tbcqfe5iszqhrqufqrntjekj372k6qcssr2uhhn3/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet","etag":"W/\"f646c68b-6117-4340-bdd9-0b3346e4e721\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenarioojthyrjalird37tbcqfe5iszqhrqufqrntjekj372k6qcssr2uhhn3/providers/Microsoft.Network/networkInterfaces/cli-test-nic/ipConfigurations/ipconfig1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresourcevoyewtel6bm4bvxsqiga65cq75bbmchd63md4mmk6s4fzs4c5bp/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"aeea221c-1052-431b-813e-6f97d96d0726\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5137aa79-6cb4-4fd1-947f-aa22070d7a9e","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresourcevoyewtel6bm4bvxsqiga65cq75bbmchd63md4mmk6s4fzs4c5bp/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1","etag":"W/\"aeea221c-1052-431b-813e-6f97d96d0726\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresourcevoyewtel6bm4bvxsqiga65cq75bbmchd63md4mmk6s4fzs4c5bp/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresourcevoyewtel6bm4bvxsqiga65cq75bbmchd63md4mmk6s4fzs4c5bp/providers/Microsoft.Network/virtualNetworks/vnet2","etag":"W/\"97aeaeeb-577f-439a-9976-ce0195345b2e\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"64206d95-c6fc-47a3-bae8-0d54e6a13264","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_subresourcevoyewtel6bm4bvxsqiga65cq75bbmchd63md4mmk6s4fzs4c5bp/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/subnet2","etag":"W/\"97aeaeeb-577f-439a-9976-ce0195345b2e\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vrfvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_optionsqvxrdmiyxwvwtk4yhmzrlxtm2ipfuuvlxta5nd/providers/Microsoft.Network/virtualNetworks/vrfvnet","etag":"W/\"67f2b0c8-0f3b-4015-88f8-e7ea21ba58ee\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5ddc2fa6-0aad-46de-855a-5616f08639a6","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"vrfsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_optionsqvxrdmiyxwvwtk4yhmzrlxtm2ipfuuvlxta5nd/providers/Microsoft.Network/virtualNetworks/vrfvnet/subnets/vrfsubnet","etag":"W/\"67f2b0c8-0f3b-4015-88f8-e7ea21ba58ee\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vmss1VNET","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_w_ipswhabnb3i4j76ybtihqun23mwv6k4c4a7sgmvmmj6hlyq5gju6/providers/Microsoft.Network/virtualNetworks/vmss1VNET","etag":"W/\"b1814f7f-a0c4-485c-99e3-9355f4398c48\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Updating","resourceGuid":"2541d3b5-54b0-4a74-9daa-c384ee95f956","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"vmss1Subnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_w_ipswhabnb3i4j76ybtihqun23mwv6k4c4a7sgmvmmj6hlyq5gju6/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet","etag":"W/\"b1814f7f-a0c4-485c-99e3-9355f4398c48\"","properties":{"provisioningState":"Updating","addressPrefix":"10.0.0.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vmss1VNET","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_rolling_update6krjywbnpgp3djddevx4fndfrwgjctt2uuzldizpvfgyezo/providers/Microsoft.Network/virtualNetworks/vmss1VNET","etag":"W/\"bf9fe451-6d7a-45eb-af37-9fd72ccc970b\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"35d8ed98-79b1-4744-aad2-a309929338d6","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"vmss1Subnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_rolling_update6krjywbnpgp3djddevx4fndfrwgjctt2uuzldizpvfgyezo/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet","etag":"W/\"bf9fe451-6d7a-45eb-af37-9fd72ccc970b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_rolling_update6krjywbnpgp3djddevx4fndfrwgjctt2uuzldizpvfgyezo/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss1b7f9Nic/ipConfigurations/vmss1b7f9IPConfig"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_rolling_update6krjywbnpgp3djddevx4fndfrwgjctt2uuzldizpvfgyezo/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss1b7f9Nic/ipConfigurations/vmss1b7f9IPConfig"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vm1VNET","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_lb_integration7soe65lgt5wmxtkl5sgsuxijsw5rrndu6bzu6qmwpyw5agkse/providers/Microsoft.Network/virtualNetworks/vm1VNET","etag":"W/\"da688201-5e77-4d2f-a399-24b9f1b8b021\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"295457af-1c6d-4f0c-8cab-f9652b57928a","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"vm1Subnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_lb_integration7soe65lgt5wmxtkl5sgsuxijsw5rrndu6bzu6qmwpyw5agkse/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet","etag":"W/\"da688201-5e77-4d2f-a399-24b9f1b8b021\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_lb_integration7soe65lgt5wmxtkl5sgsuxijsw5rrndu6bzu6qmwpyw5agkse/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_lb_integration7soe65lgt5wmxtkl5sgsuxijsw5rrndu6bzu6qmwpyw5agkse/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering2bfvlvaspbufggzhj2qg2i2gtnl3n44v5et5pu6v6gq4kzhhq4hk3n/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"540d2d87-54c8-44c1-a750-9e360d017d1b\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"0cd1a1e9-e763-4348-8639-6883b80963f5","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering2bfvlvaspbufggzhj2qg2i2gtnl3n44v5et5pu6v6gq4kzhhq4hk3n/providers/Microsoft.Network/virtualNetworks/vnet2","etag":"W/\"4f66aad0-462c-46b5-9793-e53d060f8a0a\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"c97001cb-e3db-4dae-81ad-258f26445759","addressSpace":{"addressPrefixes":["11.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering2bfvlvaspbufggzhj2qg2i2gtnl3n44v5et5pu6v6gq4kzhhq4hk3n/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/GatewaySubnet","etag":"W/\"4f66aad0-462c-46b5-9793-e53d060f8a0a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"11.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering2bfvlvaspbufggzhj2qg2i2gtnl3n44v5et5pu6v6gq4kzhhq4hk3n/providers/Microsoft.Network/virtualNetworkGateways/gateway1/ipConfigurations/vnetGatewayConfig0"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_client_packagedqo7smopgebf6agdpwkfbilr2sa42g2ezhwz73axwz7oibe5/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"174ecc38-e057-40b7-b49a-2757d64fe46e\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Updating","resourceGuid":"dd8a21a3-cd18-4973-96c9-051a0520bd59","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vpn_client_packagedqo7smopgebf6agdpwkfbilr2sa42g2ezhwz73axwz7oibe5/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/GatewaySubnet","etag":"W/\"174ecc38-e057-40b7-b49a-2757d64fe46e\"","properties":{"provisioningState":"Updating","addressPrefix":"10.0.0.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"051c9746-8127-4593-b5dd-b686d571a72b","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default","etag":"W/\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"net06626","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg07815/providers/Microsoft.Network/virtualNetworks/net06626","etag":"W/\"2489fe62-9157-4c02-b940-03fbf95e6745\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"07481348-5c08-4203-818f-c89917f33f4f","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg07815/providers/Microsoft.Network/virtualNetworks/net06626/subnets/subnet1","etag":"W/\"2489fe62-9157-4c02-b940-03fbf95e6745\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/29","networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg07815/providers/Microsoft.Network/networkSecurityGroups/nsg55109"},"ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg07815/providers/Microsoft.Network/networkInterfaces/nic5784105c44b/ipConfigurations/primary"}]}},{"name":"subnet2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg07815/providers/Microsoft.Network/virtualNetworks/net06626/subnets/subnet2","etag":"W/\"2489fe62-9157-4c02-b940-03fbf95e6745\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.8/29"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnetb6e59266308d","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg07815/providers/Microsoft.Network/virtualNetworks/vnetb6e59266308d","etag":"W/\"57060c75-a005-4efc-9c7a-e2966e14b061\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3650bacb-f1f6-4b10-939a-bfe54c2840e4","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg07815/providers/Microsoft.Network/virtualNetworks/vnetb6e59266308d/subnets/subnet1","etag":"W/\"57060c75-a005-4efc-9c7a-e2966e14b061\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg07815/providers/Microsoft.Network/networkInterfaces/ni33894/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"net033298","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg10479/providers/Microsoft.Network/virtualNetworks/net033298","etag":"W/\"c29f230d-19e1-4b44-8500-5a80f20db5dc\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"98f5de75-f5d7-4d67-9601-f18d37c6d25b","addressSpace":{"addressPrefixes":["192.168.0.0/16","10.254.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg10479/providers/Microsoft.Network/virtualNetworks/net033298/subnets/GatewaySubnet","etag":"W/\"c29f230d-19e1-4b44-8500-5a80f20db5dc\"","properties":{"provisioningState":"Succeeded","addressPrefix":"192.168.200.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg10479/providers/Microsoft.Network/virtualNetworkGateways/vngw99206/ipConfigurations/ipcfg44909"}]}},{"name":"FrontEnd","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg10479/providers/Microsoft.Network/virtualNetworks/net033298/subnets/FrontEnd","etag":"W/\"c29f230d-19e1-4b44-8500-5a80f20db5dc\"","properties":{"provisioningState":"Succeeded","addressPrefix":"192.168.1.0/24"}},{"name":"BackEnd","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg10479/providers/Microsoft.Network/virtualNetworks/net033298/subnets/BackEnd","etag":"W/\"c29f230d-19e1-4b44-8500-5a80f20db5dc\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.254.1.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet91182","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg22662/providers/Microsoft.Network/virtualNetworks/vnet91182","etag":"W/\"147160f4-1e8c-4dd6-ba58-f6badf85c80a\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f1651014-f287-46eb-9113-4bdd414fe2c0","addressSpace":{"addressPrefixes":["10.0.0.0/25"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg22662/providers/Microsoft.Network/virtualNetworks/vnet91182/subnets/GatewaySubnet","etag":"W/\"147160f4-1e8c-4dd6-ba58-f6badf85c80a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/27","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg22662/providers/Microsoft.Network/virtualNetworkGateways/vngw16740/ipConfigurations/ipcfg52799"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet20567","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg27424/providers/Microsoft.Network/virtualNetworks/vnet20567","etag":"W/\"14e08faf-7b2d-4f17-9c0a-dd16c783b546\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"26e60cbe-318b-4348-aad6-1b23149ff21d","addressSpace":{"addressPrefixes":["10.41.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg27424/providers/Microsoft.Network/virtualNetworks/vnet20567/subnets/GatewaySubnet","etag":"W/\"14e08faf-7b2d-4f17-9c0a-dd16c783b546\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.41.255.0/27","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg27424/providers/Microsoft.Network/virtualNetworkGateways/vngw289927/ipConfigurations/ipcfg38991"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet79749","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg27424/providers/Microsoft.Network/virtualNetworks/vnet79749","etag":"W/\"bd759e33-4523-4826-9000-dd6d804a1503\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"2afaed1a-f568-42be-8939-466c3392114f","addressSpace":{"addressPrefixes":["10.11.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg27424/providers/Microsoft.Network/virtualNetworks/vnet79749/subnets/GatewaySubnet","etag":"W/\"bd759e33-4523-4826-9000-dd6d804a1503\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.11.255.0/27","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg27424/providers/Microsoft.Network/virtualNetworkGateways/vngw77353/ipConfigurations/ipcfg22457"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet28089","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg30815/providers/Microsoft.Network/virtualNetworks/vnet28089","etag":"W/\"8520d097-3f0b-4416-8354-9881ec047f59\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"aed78b25-7767-4937-a959-667bae789f4f","addressSpace":{"addressPrefixes":["10.0.0.0/25"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg30815/providers/Microsoft.Network/virtualNetworks/vnet28089/subnets/GatewaySubnet","etag":"W/\"8520d097-3f0b-4416-8354-9881ec047f59\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/27","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg30815/providers/Microsoft.Network/virtualNetworkGateways/vngw77116/ipConfigurations/ipcfg02010"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet67790","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg94432/providers/Microsoft.Network/virtualNetworks/vnet67790","etag":"W/\"292dbca9-dac0-4406-b581-547fcec8fba1\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"0f19af1f-f2de-4d4f-945d-ff2dd49aecd7","addressSpace":{"addressPrefixes":["10.41.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg94432/providers/Microsoft.Network/virtualNetworks/vnet67790/subnets/GatewaySubnet","etag":"W/\"292dbca9-dac0-4406-b581-547fcec8fba1\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.41.255.0/27","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg94432/providers/Microsoft.Network/virtualNetworkGateways/vngw482712/ipConfigurations/ipcfg61900"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet68879","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg94432/providers/Microsoft.Network/virtualNetworks/vnet68879","etag":"W/\"cf49be5a-e8ca-46b7-8a8e-7509c61e7e8e\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"12328e92-4c8b-41d2-89e8-5a24f2973f4f","addressSpace":{"addressPrefixes":["10.11.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"GatewaySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg94432/providers/Microsoft.Network/virtualNetworks/vnet68879/subnets/GatewaySubnet","etag":"W/\"cf49be5a-e8ca-46b7-8a8e-7509c61e7e8e\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.11.255.0/27","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg94432/providers/Microsoft.Network/virtualNetworkGateways/vngw48271/ipConfigurations/ipcfg84795"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"yg-1VNET","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yg/providers/Microsoft.Network/virtualNetworks/yg-1VNET","etag":"W/\"63fcc85d-bc72-43ee-9a8d-129f27b47f20\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"a0715ab8-c636-43a7-b1de-6db43b5ee99e","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"yg-1Subnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yg/providers/Microsoft.Network/virtualNetworks/yg-1VNET/subnets/yg-1Subnet","etag":"W/\"63fcc85d-bc72-43ee-9a8d-129f27b47f20\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yg/providers/Microsoft.Network/networkInterfaces/yg-1VMNic/ipConfigurations/ipconfigyg-1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnetaf5557253d32","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/abc4333group/providers/Microsoft.Network/virtualNetworks/vnetaf5557253d32","etag":"W/\"b0db070f-18eb-4d27-a73d-6a76198e9112\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5a7beeb3-9745-4d07-b710-c545687a3754","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/abc4333group/providers/Microsoft.Network/virtualNetworks/vnetaf5557253d32/subnets/subnet1","etag":"W/\"b0db070f-18eb-4d27-a73d-6a76198e9112\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/abc4333group/providers/Microsoft.Network/networkInterfaces/nicvm579338d636759/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet77535365dcbd","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/abc6592group/providers/Microsoft.Network/virtualNetworks/vnet77535365dcbd","etag":"W/\"23df020c-4b08-4433-947f-1bc1da2c905b\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"752bb9a6-b109-42a1-abd8-bcd4bcd2fc5b","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/abc6592group/providers/Microsoft.Network/virtualNetworks/vnet77535365dcbd/subnets/subnet1","etag":"W/\"23df020c-4b08-4433-947f-1bc1da2c905b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/abc6592group/providers/Microsoft.Network/networkInterfaces/nicvm8134a9a571812/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vmssvnet2228","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg359/providers/Microsoft.Network/virtualNetworks/vmssvnet2228","etag":"W/\"b9e8db0e-9e02-48ba-a381-0186b895043f\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"160bac45-2e65-4617-84fa-f09839b13ac0","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg359/providers/Microsoft.Network/virtualNetworks/vmssvnet2228/subnets/subnet1","etag":"W/\"b9e8db0e-9e02-48ba-a381-0186b895043f\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg359/providers/Microsoft.Compute/virtualMachineScaleSets/vmss5146/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg359/providers/Microsoft.Compute/virtualMachineScaleSets/vmss5146/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vmssvnet1101","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg3893/providers/Microsoft.Network/virtualNetworks/vmssvnet1101","etag":"W/\"f0c00200-477f-433c-a533-11fed0261e44\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"c2a7b5d4-35ad-49ae-b55e-ec4d6e63b416","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg3893/providers/Microsoft.Network/virtualNetworks/vmssvnet1101/subnets/subnet1","etag":"W/\"f0c00200-477f-433c-a533-11fed0261e44\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg3893/providers/Microsoft.Compute/virtualMachineScaleSets/vmss5111/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg3893/providers/Microsoft.Compute/virtualMachineScaleSets/vmss5111/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg3893/providers/Microsoft.Compute/virtualMachineScaleSets/vmss5111/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vmssvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg5351/providers/Microsoft.Network/virtualNetworks/vmssvnet","etag":"W/\"a44b5884-9838-41b4-8dd9-b9928e60fb0f\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"00f34fe6-9e29-48f5-86a0-ac5658a78d0a","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg5351/providers/Microsoft.Network/virtualNetworks/vmssvnet/subnets/subnet1","etag":"W/\"a44b5884-9838-41b4-8dd9-b9928e60fb0f\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg5351/providers/Microsoft.Compute/virtualMachineScaleSets/vmss4233/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg5351/providers/Microsoft.Compute/virtualMachineScaleSets/vmss4233/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg5351/providers/Microsoft.Network/loadBalancers/InternalLb1-5185/frontendIPConfigurations/InternalLb1-5185-FE1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vmssvnet9056","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg8693/providers/Microsoft.Network/virtualNetworks/vmssvnet9056","etag":"W/\"33f75160-e842-4d9a-ba6f-eefe22eae25c\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f687deb1-b6d7-41e6-af4e-62774f173fa3","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg8693/providers/Microsoft.Network/virtualNetworks/vmssvnet9056/subnets/subnet1","etag":"W/\"33f75160-e842-4d9a-ba6f-eefe22eae25c\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg8693/providers/Microsoft.Compute/virtualMachineScaleSets/vmss8425/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg8693/providers/Microsoft.Compute/virtualMachineScaleSets/vmss8425/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet87451","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/virtualNetworks/vnet87451","etag":"W/\"05167c1a-6739-4662-bfae-f83e6193bf74\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"38566165-7fbf-4874-9e1e-f2691d6f5bd0","addressSpace":{"addressPrefixes":["10.0.0.0/24"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/virtualNetworks/vnet87451/subnets/default","etag":"W/\"05167c1a-6739-4662-bfae-f83e6193bf74\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/25","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/applicationGateways/agdf0863705/frontendIPConfigurations/frontend77216"}],"applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/applicationGateways/agdf0863705/gatewayIPConfigurations/ipcfg92023"}]}},{"name":"apps","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/virtualNetworks/vnet87451/subnets/apps","etag":"W/\"05167c1a-6739-4662-bfae-f83e6193bf74\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.128/25"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet87966","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/virtualNetworks/vnet87966","etag":"W/\"6ad0bb6f-8ed3-475a-968c-4f81e2385dbb\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"9a2a4dc3-0b3a-4460-8941-105b74c9258c","addressSpace":{"addressPrefixes":["10.0.0.0/24"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/virtualNetworks/vnet87966/subnets/default","etag":"W/\"6ad0bb6f-8ed3-475a-968c-4f81e2385dbb\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/25","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/applicationGateways/agd3c82747d/frontendIPConfigurations/frontend33631"}],"applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/applicationGateways/agd3c82747d/gatewayIPConfigurations/ipcfg96099"}]}},{"name":"apps","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg076564656/providers/Microsoft.Network/virtualNetworks/vnet87966/subnets/apps","etag":"W/\"6ad0bb6f-8ed3-475a-968c-4f81e2385dbb\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.128/25"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet03327","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg455/providers/Microsoft.Network/virtualNetworks/vnet03327","etag":"W/\"ff60949f-1bcc-4d9a-9e9e-6c50c0b8e5cd\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b41d5b4e-6bb2-481a-b726-9c7161155efe","addressSpace":{"addressPrefixes":["10.0.0.0/24"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg455/providers/Microsoft.Network/virtualNetworks/vnet03327/subnets/default","etag":"W/\"ff60949f-1bcc-4d9a-9e9e-6c50c0b8e5cd\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/25"}},{"name":"apps","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg455/providers/Microsoft.Network/virtualNetworks/vnet03327/subnets/apps","etag":"W/\"ff60949f-1bcc-4d9a-9e9e-6c50c0b8e5cd\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.128/25"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet46396","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6736/providers/Microsoft.Network/virtualNetworks/vnet46396","etag":"W/\"a75ace72-8d1b-4c1f-851b-ad3549372f02\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"190263e5-e37c-453a-b839-9ab915032a30","addressSpace":{"addressPrefixes":["10.0.0.0/24"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6736/providers/Microsoft.Network/virtualNetworks/vnet46396/subnets/default","etag":"W/\"a75ace72-8d1b-4c1f-851b-ad3549372f02\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/25","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6736/providers/Microsoft.Network/applicationGateways/ag6736/frontendIPConfigurations/frontend63197"}],"applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6736/providers/Microsoft.Network/applicationGateways/ag6736/gatewayIPConfigurations/ipcfg20835"}]}},{"name":"apps","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6736/providers/Microsoft.Network/virtualNetworks/vnet46396/subnets/apps","etag":"W/\"a75ace72-8d1b-4c1f-851b-ad3549372f02\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.128/25"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet07315650ad7c","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest1809/providers/Microsoft.Network/virtualNetworks/vnet07315650ad7c","etag":"W/\"d6c721aa-49c5-4cd4-b628-e58f701a4989\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"749e2c74-ec1d-422c-8f79-fb69bc458feb","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest1809/providers/Microsoft.Network/virtualNetworks/vnet07315650ad7c/subnets/subnet1","etag":"W/\"d6c721aa-49c5-4cd4-b628-e58f701a4989\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest1809/providers/Microsoft.Network/networkInterfaces/nicjavavm2cc88200a/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnetb305487435bf","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest2442/providers/Microsoft.Network/virtualNetworks/vnetb305487435bf","etag":"W/\"812be6cf-3ec2-420e-983d-ea1aa59eceb4\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"87cc70b2-aee4-4b64-a8c4-2e5353d3e788","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest2442/providers/Microsoft.Network/virtualNetworks/vnetb305487435bf/subnets/subnet1","etag":"W/\"812be6cf-3ec2-420e-983d-ea1aa59eceb4\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest2442/providers/Microsoft.Network/networkInterfaces/nicjavavm7e0958540/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnetfd950922d4a0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest2953/providers/Microsoft.Network/virtualNetworks/vnetfd950922d4a0","etag":"W/\"64d462f4-a3f5-4270-a854-eff356ba57f1\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"7ccb682d-81d7-4a48-aecd-76b3699852bb","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest2953/providers/Microsoft.Network/virtualNetworks/vnetfd950922d4a0/subnets/subnet1","etag":"W/\"64d462f4-a3f5-4270-a854-eff356ba57f1\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest2953/providers/Microsoft.Network/networkInterfaces/nicjavavmdf353464f/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet3b5263484153","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5281/providers/Microsoft.Network/virtualNetworks/vnet3b5263484153","etag":"W/\"a2be8f06-1d56-487d-84b9-95b23a64d574\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b3e976bd-87c3-4d28-aa0d-36bd19aa9d33","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5281/providers/Microsoft.Network/virtualNetworks/vnet3b5263484153/subnets/subnet1","etag":"W/\"a2be8f06-1d56-487d-84b9-95b23a64d574\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5281/providers/Microsoft.Network/networkInterfaces/nicjavavm3b3063136/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet04c79453576a","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5283/providers/Microsoft.Network/virtualNetworks/vnet04c79453576a","etag":"W/\"104f8335-72bd-4f8f-86e2-c56cdd5a3363\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"05ebc2d8-7c7a-4724-bebd-19757e86f3d6","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5283/providers/Microsoft.Network/virtualNetworks/vnet04c79453576a/subnets/subnet1","etag":"W/\"104f8335-72bd-4f8f-86e2-c56cdd5a3363\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5283/providers/Microsoft.Network/networkInterfaces/nicjavavm4f413973b/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet5c4480282fae","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5634/providers/Microsoft.Network/virtualNetworks/vnet5c4480282fae","etag":"W/\"a39a6ce7-2779-4057-a899-fcd860163888\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3da82564-8493-4909-bf35-55cfe8fde87c","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5634/providers/Microsoft.Network/virtualNetworks/vnet5c4480282fae/subnets/subnet1","etag":"W/\"a39a6ce7-2779-4057-a899-fcd860163888\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5634/providers/Microsoft.Network/networkInterfaces/nicjavavm3c2908708/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vneta2e843446aa7","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5634/providers/Microsoft.Network/virtualNetworks/vneta2e843446aa7","etag":"W/\"e2c376c9-55d8-46f6-b978-daa4f258ae80\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"2bcca612-e84f-46d4-80a3-61a7e04fdb51","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5634/providers/Microsoft.Network/virtualNetworks/vneta2e843446aa7/subnets/subnet1","etag":"W/\"e2c376c9-55d8-46f6-b978-daa4f258ae80\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest5634/providers/Microsoft.Network/networkInterfaces/nicjavavmac327777b/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet220860201493","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest7413/providers/Microsoft.Network/virtualNetworks/vnet220860201493","etag":"W/\"0a065039-86ce-46a8-951d-81ce3f25a7cd\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"6b7925d0-1a6f-4c17-82db-e0a9429d462f","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest7413/providers/Microsoft.Network/virtualNetworks/vnet220860201493/subnets/subnet1","etag":"W/\"0a065039-86ce-46a8-951d-81ce3f25a7cd\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest7413/providers/Microsoft.Network/networkInterfaces/nicjavavm97e337431/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet2b8256387227","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest7463/providers/Microsoft.Network/virtualNetworks/vnet2b8256387227","etag":"W/\"ebd58297-6af4-4351-bbcc-58cfd4a1f9cd\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"a9d2fc57-0c81-4eca-9277-f66814541f20","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest7463/providers/Microsoft.Network/virtualNetworks/vnet2b8256387227/subnets/subnet1","etag":"W/\"ebd58297-6af4-4351-bbcc-58cfd4a1f9cd\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmbdtest7463/providers/Microsoft.Network/networkInterfaces/nicjavavma4879094b/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnete796634911c9","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest2194/providers/Microsoft.Network/virtualNetworks/vnete796634911c9","etag":"W/\"e257668c-affb-42d1-9f25-09ccd1962110\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3e471f74-d602-4d4a-9127-daba2923c7da","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest2194/providers/Microsoft.Network/virtualNetworks/vnete796634911c9/subnets/subnet1","etag":"W/\"e257668c-affb-42d1-9f25-09ccd1962110\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest2194/providers/Microsoft.Network/networkInterfaces/nicjavavm47847202b/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet41a12941fec0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest3147/providers/Microsoft.Network/virtualNetworks/vnet41a12941fec0","etag":"W/\"8e74952f-7680-4c21-8b5d-10f65d166572\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"8b2a79ba-2d26-4fe6-9540-a22eda44a7d9","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest3147/providers/Microsoft.Network/virtualNetworks/vnet41a12941fec0/subnets/subnet1","etag":"W/\"8e74952f-7680-4c21-8b5d-10f65d166572\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest3147/providers/Microsoft.Network/networkInterfaces/nicjavavm95b105476/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnetacf13415a07b","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest4297/providers/Microsoft.Network/virtualNetworks/vnetacf13415a07b","etag":"W/\"f8a1d42a-3a8f-4294-a0fc-b842ebe15700\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"8e3bedb0-e81d-45dc-9bde-4727f232d3b9","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest4297/providers/Microsoft.Network/virtualNetworks/vnetacf13415a07b/subnets/subnet1","etag":"W/\"f8a1d42a-3a8f-4294-a0fc-b842ebe15700\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest4297/providers/Microsoft.Network/networkInterfaces/nicjavavme70130843/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet6c5423956","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg12195b/providers/Microsoft.Network/virtualNetworks/vnet6c5423956","etag":"W/\"8cfdeecb-eb84-4b1c-bd58-2ad5da97a8fa\"","type":"Microsoft.Network/virtualNetworks","location":"westeurope","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"7c13ad28-e750-45f2-b771-fb4d0ebf4103","addressSpace":{"addressPrefixes":["192.168.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"MySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg12195b/providers/Microsoft.Network/virtualNetworks/vnet6c5423956/subnets/MySubnet","etag":"W/\"8cfdeecb-eb84-4b1c-bd58-2ad5da97a8fa\"","properties":{"provisioningState":"Succeeded","addressPrefix":"192.168.200.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet3c1813992","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg375651/providers/Microsoft.Network/virtualNetworks/vnet3c1813992","etag":"W/\"88c8bfcf-030e-4d19-8923-3c9c75edc51c\"","type":"Microsoft.Network/virtualNetworks","location":"westeurope","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e5ec4822-5fd5-4dbd-8a19-3c83fe0df3e5","addressSpace":{"addressPrefixes":["192.168.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"MySubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg375651/providers/Microsoft.Network/virtualNetworks/vnet3c1813992/subnets/MySubnet","etag":"W/\"88c8bfcf-030e-4d19-8923-3c9c75edc51c\"","properties":{"provisioningState":"Succeeded","addressPrefix":"192.168.200.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet34a494669e09","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgfluentchash-7095/providers/Microsoft.Network/virtualNetworks/vnet34a494669e09","etag":"W/\"df932185-5b9f-4b14-92f5-2ec0a7ca580f\"","type":"Microsoft.Network/virtualNetworks","location":"southcentralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5a9cd347-94e7-47ff-8ac9-88318fc49f85","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgfluentchash-7095/providers/Microsoft.Network/virtualNetworks/vnet34a494669e09/subnets/subnet1","etag":"W/\"df932185-5b9f-4b14-92f5-2ec0a7ca580f\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgfluentchash-7095/providers/Microsoft.Network/networkInterfaces/nicchashvm088305696/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet69209432cfaa","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgfluentchash-7095/providers/Microsoft.Network/virtualNetworks/vnet69209432cfaa","etag":"W/\"2c96c87f-d8c4-4534-8971-b78d8d0eb095\"","type":"Microsoft.Network/virtualNetworks","location":"southcentralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"40b03299-3789-4509-a82a-f6e9abe0e58e","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgfluentchash-7095/providers/Microsoft.Network/virtualNetworks/vnet69209432cfaa/subnets/subnet1","etag":"W/\"2c96c87f-d8c4-4534-8971-b78d8d0eb095\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgfluentchash-7095/providers/Microsoft.Network/networkInterfaces/nicchashvma0948593b/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet35d41063da2f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg401/providers/Microsoft.Network/virtualNetworks/vnet35d41063da2f","etag":"W/\"8ce1c3c7-fa54-42f8-9059-ba220fe38e2d\"","type":"Microsoft.Network/virtualNetworks","location":"eastus2","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"a2bebebc-fe7d-4d08-8c60-38758db888da","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg401/providers/Microsoft.Network/virtualNetworks/vnet35d41063da2f/subnets/subnet1","etag":"W/\"8ce1c3c7-fa54-42f8-9059-ba220fe38e2d\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg401/providers/Microsoft.Network/networkInterfaces/nicextvm37451ab37381/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}}]}'}
+    body: {string: '{"value":[{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01p6iszzzx4aw67ogvpe3mha4vbctvd7pujeyehkxs5dgwiwjyhxndtrv7o3sp/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"1f80ea5f-ac1c-4ad7-9568-db7924341887\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"e972888e-997e-479f-a56d-730873826c8d"},"properties":{"provisioningState":"Succeeded","resourceGuid":"c4e025f6-73e3-4c65-8218-d7744ce552c1","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01p6iszzzx4aw67ogvpe3mha4vbctvd7pujeyehkxs5dgwiwjyhxndtrv7o3sp/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"1f80ea5f-ac1c-4ad7-9568-db7924341887\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"Dtlcliautomationlab","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomationm3utrrbx7ntvb356eqynqiauhjpfhvyicagolw3vzmsiek54rhgowr6eudkv2e/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab","etag":"W/\"ea3a6a3d-bfef-4f83-bf96-c06588daec8b\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"fe2a2bc9-d45c-4efa-8558-355d25e26350"},"properties":{"provisioningState":"Succeeded","resourceGuid":"2d79a1b6-6905-4057-b55e-07325dfc058f","addressSpace":{"addressPrefixes":["10.0.0.0/20"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"DtlcliautomationlabSubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomationm3utrrbx7ntvb356eqynqiauhjpfhvyicagolw3vzmsiek54rhgowr6eudkv2e/providers/Microsoft.Network/virtualNetworks/Dtlcliautomationlab/subnets/DtlcliautomationlabSubnet","etag":"W/\"ea3a6a3d-bfef-4f83-bf96-c06588daec8b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/20"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"ag1Vnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basiclvyzlean5fx4g46qlmcyabvd2ejuwlbrmcjqlwwbubotbue7rkgvwk3i53/providers/Microsoft.Network/virtualNetworks/ag1Vnet","etag":"W/\"c89669ed-f7ac-46b2-ba46-0d6910c2873f\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"57614f1c-6050-4854-8cdc-90a4081bd5bf","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basiclvyzlean5fx4g46qlmcyabvd2ejuwlbrmcjqlwwbubotbue7rkgvwk3i53/providers/Microsoft.Network/virtualNetworks/ag1Vnet/subnets/default","etag":"W/\"c89669ed-f7ac-46b2-ba46-0d6910c2873f\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basiclvyzlean5fx4g46qlmcyabvd2ejuwlbrmcjqlwwbubotbue7rkgvwk3i53/providers/Microsoft.Network/applicationGateways/ag1/frontendIPConfigurations/appGatewayFrontendIP"}],"applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_basiclvyzlean5fx4g46qlmcyabvd2ejuwlbrmcjqlwwbubotbue7rkgvwk3i53/providers/Microsoft.Network/applicationGateways/ag1/gatewayIPConfigurations/appGatewayFrontendIP"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"ag3Vnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ipsda5vkhqjdq23wtmuycu7bkiig7imzbvlqu4etlga2ixemk6gqql2/providers/Microsoft.Network/virtualNetworks/ag3Vnet","etag":"W/\"7e1a5b8b-321c-4431-84c2-b44033f9aecd\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"656244a5-009d-4bc9-9e4f-7bb32741165e","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ipsda5vkhqjdq23wtmuycu7bkiig7imzbvlqu4etlga2ixemk6gqql2/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1","etag":"W/\"7e1a5b8b-321c-4431-84c2-b44033f9aecd\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ipsda5vkhqjdq23wtmuycu7bkiig7imzbvlqu4etlga2ixemk6gqql2/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP"}],"applicationGatewayIPConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ipsda5vkhqjdq23wtmuycu7bkiig7imzbvlqu4etlga2ixemk6gqql2/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayFrontendIP"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"cli.lock.rsrc2o3hho4gobe7jw525","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cannotdelete_resource_lockgzfvhhyaaogl2ecqeng6egpkx3t4bi4hq22xh2lv/providers/Microsoft.Network/virtualNetworks/cli.lock.rsrc2o3hho4gobe7jw525","etag":"W/\"4cf95868-3989-4cb0-842b-a8b2377e4477\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"819e45fd-c61a-498a-9e02-a2380dd91e1f","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"cli-lock-vneths6oqchfkapqwxsn5","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_commands_with_idsq55o53elttaoyujpkwkurlhw733zaq4nhedsrgbueuit/providers/Microsoft.Network/virtualNetworks/cli-lock-vneths6oqchfkapqwxsn5","etag":"W/\"eed85389-16ed-42b6-af55-0e9f5139647d\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3b3476a7-7367-44c8-aeae-4a789baa8ca9","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"cli-lock-subnetwicxn6q7i4quydt","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_commands_with_idsq55o53elttaoyujpkwkurlhw733zaq4nhedsrgbueuit/providers/Microsoft.Network/virtualNetworks/cli-lock-vneths6oqchfkapqwxsn5/subnets/cli-lock-subnetwicxn6q7i4quydt","etag":"W/\"eed85389-16ed-42b6-af55-0e9f5139647d\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/16"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"cli-lock-vnets3pz4yhbseuttt3pr","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_idtrjul2bka2fiu44yy3sitaglg7x5eqfjmr4jbscoob4vp/providers/Microsoft.Network/virtualNetworks/cli-lock-vnets3pz4yhbseuttt3pr","etag":"W/\"be416c8f-e6f2-4433-bad6-5571270ed316\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"dda7592b-2b8c-4a83-a130-662bb352e62a","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"cli-lock-subnetzzyasf2i5xmf2df","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_lock_with_resource_idtrjul2bka2fiu44yy3sitaglg7x5eqfjmr4jbscoob4vp/providers/Microsoft.Network/virtualNetworks/cli-lock-vnets3pz4yhbseuttt3pr/subnets/cli-lock-subnetzzyasf2i5xmf2df","etag":"W/\"be416c8f-e6f2-4433-bad6-5571270ed316\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/16"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"cli.lock.rsrcxdnfikzuiynni4y5g","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_readonly_resource_lock2z2vuwt2gdobutsgjbkdf6f2lwjlih7tpotoqpoc6jtv/providers/Microsoft.Network/virtualNetworks/cli.lock.rsrcxdnfikzuiynni4y5g","etag":"W/\"d27a57f5-5c01-4ae3-be76-bdab8491dda7\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"da9fc41a-a059-417c-827c-acb441ff7112","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"cli.lock.rsrc5tzpqyyjbzoccq6tt","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_lockxf25y5etotzyp3ixnzbgpkso4yywlxprn7hclefrbxkmqha7k3iog/providers/Microsoft.Network/virtualNetworks/cli.lock.rsrc5tzpqyyjbzoccq6tt","etag":"W/\"a2c24aa4-ca21-4c61-9842-a92f316e06c7\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"6df61cb1-dda6-4d4e-aa94-1beeaeecb9dc","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"fc0be9b7-8756-42f6-a213-c0292afff2dc\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"146d8581-9c27-4dee-98b6-2af8d5f07993","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default","etag":"W/\"fc0be9b7-8756-42f6-a213-c0292afff2dc\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24"}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vm1VNET","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-rg/providers/Microsoft.Network/virtualNetworks/vm1VNET","etag":"W/\"3e5f5275-1e7e-4344-a4b9-e597cb9aa6dc\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5b081b08-5d1b-43e9-90c7-602f9ae35049","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"vm1Subnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-rg/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet","etag":"W/\"3e5f5275-1e7e-4344-a4b9-e597cb9aa6dc\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-rg/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"vnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-rg/providers/Microsoft.Network/virtualNetworks/vnet1","etag":"W/\"5413a8cd-3512-4ea2-802f-164f7df38b49\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"90090959-8964-49ef-a33f-d5d8cadfb12f","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"yugangw2-1VNET","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw2/providers/Microsoft.Network/virtualNetworks/yugangw2-1VNET","etag":"W/\"9f1df93f-deec-4572-946b-c6a281a75b9a\"","type":"Microsoft.Network/virtualNetworks","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f9c7de71-378c-4e90-b581-6cefaf044790","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"yugangw2-1Subnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw2/providers/Microsoft.Network/virtualNetworks/yugangw2-1VNET/subnets/yugangw2-1Subnet","etag":"W/\"9f1df93f-deec-4572-946b-c6a281a75b9a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw2/providers/Microsoft.Network/networkInterfaces/yugangw2-1VMNic/ipConfigurations/ipconfigyugangw2-1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"nete9082831d8","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg605582365a/providers/Microsoft.Network/virtualNetworks/nete9082831d8","etag":"W/\"e8aa30c0-5ead-484f-8ecb-452f5e603238\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f330adf8-5bb2-4478-9c7f-a90805e4805e","addressSpace":{"addressPrefixes":["10.0.0.0/28"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"subnet1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg605582365a/providers/Microsoft.Network/virtualNetworks/nete9082831d8/subnets/subnet1","etag":"W/\"e8aa30c0-5ead-484f-8ecb-452f5e603238\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/28","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg605582365a/providers/Microsoft.Network/networkInterfaces/nic198293c4c4f/ipConfigurations/primary"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"mccancel01-vnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mccancel01/providers/Microsoft.Network/virtualNetworks/mccancel01-vnet","etag":"W/\"568f28a8-2113-4dc0-ae8a-ac05914d5d11\"","type":"Microsoft.Network/virtualNetworks","location":"westcentralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e664dd29-cfe9-4260-bda2-7f5964542a68","addressSpace":{"addressPrefixes":["172.18.0.0/24"]},"subnets":[{"name":"default","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mccancel01/providers/Microsoft.Network/virtualNetworks/mccancel01-vnet/subnets/default","etag":"W/\"568f28a8-2113-4dc0-ae8a-ac05914d5d11\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.18.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mccancel01/providers/Microsoft.Network/networkInterfaces/mccancel01548/ipConfigurations/ipconfig1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"sr1VNET","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sr/providers/Microsoft.Network/virtualNetworks/sr1VNET","etag":"W/\"35e58411-3478-430f-b638-edef24dc387a\"","type":"Microsoft.Network/virtualNetworks","location":"westcentralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3c3d14df-cb17-4a4d-9f61-b4a234d86c76","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"sr1Subnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sr/providers/Microsoft.Network/virtualNetworks/sr1VNET/subnets/sr1Subnet","etag":"W/\"35e58411-3478-430f-b638-edef24dc387a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sr/providers/Microsoft.Network/networkInterfaces/sr1VMNic/ipConfigurations/ipconfigsr1"}]}}],"virtualNetworkPeerings":[],"enableDdosProtection":false,"enableVmProtection":false}},{"name":"yg-vnet-2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yg/providers/Microsoft.Network/virtualNetworks/yg-vnet-2","etag":"W/\"719de86b-de11-4e11-af3b-6d0fc8a3728c\"","type":"Microsoft.Network/virtualNetworks","location":"westus2","tags":{},"properties":{"provisioningState":"Failed","resourceGuid":"9bfbc831-5e91-4712-9b66-6f92fe8abe64","addressSpace":{"addressPrefixes":["20.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[],"virtualNetworkPeerings":[{"name":"yg-peering2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yg/providers/Microsoft.Network/virtualNetworks/yg-vnet-2/virtualNetworkPeerings/yg-peering2","etag":"W/\"719de86b-de11-4e11-af3b-6d0fc8a3728c\"","properties":{"provisioningState":"Failed","peeringState":"Initiated","remoteVirtualNetwork":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet"},"allowVirtualNetworkAccess":false,"allowForwardedTraffic":true,"allowGatewayTransit":false,"useRemoteGateways":false,"remoteAddressSpace":{"addressPrefixes":["99.0.0.0/16"]},"routeServiceVips":{}}}],"enableDdosProtection":false,"enableVmProtection":false}}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['80552']
+      content-length: ['17531']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:24 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-original-request-ids: [e8979246-ac56-4223-a5f2-cb8a53146da4, ee60496d-6e7e-4b08-ba1b-4e4f693fa7a9,
-        5dacf9ba-a51f-4305-9da2-05840877ffd7, 3999ec20-9158-40bb-a9b0-a7265feb95a7,
-        0c0d9230-2c9a-4834-be79-75ba97078247]
+      x-ms-original-request-ids: [7fa36f85-cc41-437b-a5b5-ace2c755e3e6, 34384659-d48c-44a8-a0b1-0391e1e52e3e,
+        652e73e2-ea49-421d-85e5-ac3354eb42b6, b2a3d5fc-cd64-4ee8-ba48-c3498a4ebfa1]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -293,25 +292,25 @@ interactions:
       CommandName: [network vnet list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vnet1\",\r\n\
         \      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n      \"etag\": \"W/\\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"dhcpOptions\"\
         : {\r\n          \"dnsServers\": []\r\n        },\r\n        \"subnets\":\
         \ [\r\n          {\r\n            \"name\": \"default\",\r\n            \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n            \"etag\": \"W/\\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\\"\
+        ,\r\n            \"etag\": \"W/\\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\"\r\n \
         \           }\r\n          }\r\n        ],\r\n        \"virtualNetworkPeerings\"\
@@ -321,7 +320,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1393']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:24 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -338,23 +337,23 @@ interactions:
       CommandName: [network vnet show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"default\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
@@ -363,8 +362,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1232']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:25 GMT']
-      etag: [W/"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee"]
+      date: ['Fri, 06 Jul 2018 20:21:08 GMT']
+      etag: [W/"fc0be9b7-8756-42f6-a213-c0292afff2dc"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -381,23 +380,23 @@ interactions:
       CommandName: [network vnet update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"default\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
@@ -406,8 +405,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1232']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:26 GMT']
-      etag: [W/"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee"]
+      date: ['Fri, 06 Jul 2018 20:21:11 GMT']
+      etag: [W/"fc0be9b7-8756-42f6-a213-c0292afff2dc"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -422,10 +421,10 @@ interactions:
       ["20.0.0.0/16", "10.0.0.0/16"]}, "dhcpOptions": {"dnsServers": ["1.2.3.4"]},
       "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default",
       "properties": {"addressPrefix": "10.0.0.0/24", "provisioningState": "Succeeded"},
-      "name": "default", "etag": "W/\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\""}],
-      "virtualNetworkPeerings": [], "resourceGuid": "051c9746-8127-4593-b5dd-b686d571a72b",
+      "name": "default", "etag": "W/\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\""}],
+      "virtualNetworkPeerings": [], "resourceGuid": "146d8581-9c27-4dee-98b6-2af8d5f07993",
       "provisioningState": "Succeeded", "enableDdosProtection": false, "enableVmProtection":
-      false}, "etag": "W/\\"5e7f826a-1ebd-4ae6-a387-3e68a768a8ee\\""}'''
+      false}, "etag": "W/\\"fc0be9b7-8756-42f6-a213-c0292afff2dc\\""}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -433,34 +432,34 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['987']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"86b1ff10-03b6-4b1e-938e-6499b553773c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"028cd20b-b20d-42b4-8088-d089fffb46de\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         20.0.0.0/16\",\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\"\
         : {\r\n      \"dnsServers\": [\r\n        \"1.2.3.4\"\r\n      ]\r\n    },\r\
         \n    \"subnets\": [\r\n      {\r\n        \"name\": \"default\",\r\n    \
         \    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"86b1ff10-03b6-4b1e-938e-6499b553773c\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"028cd20b-b20d-42b4-8088-d089fffb46de\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6b2f67f3-04f0-46f7-8c4f-d44033610a9e?api-version=2018-02-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/96f5b3cf-c882-44db-b63a-38aed9d48ab1?api-version=2018-02-01']
       cache-control: [no-cache]
       content-length: ['1281']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:26 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -468,7 +467,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -477,18 +476,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet update]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6b2f67f3-04f0-46f7-8c4f-d44033610a9e?api-version=2018-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/96f5b3cf-c882-44db-b63a-38aed9d48ab1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:29 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -504,23 +503,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet update]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"bc8e2cb4-5f86-42b6-9322-fc50956b6546\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"eacab60f-176b-417e-9c40-8ccb4b5cb43e\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         20.0.0.0/16\",\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\"\
         : {\r\n      \"dnsServers\": [\r\n        \"1.2.3.4\"\r\n      ]\r\n    },\r\
         \n    \"subnets\": [\r\n      {\r\n        \"name\": \"default\",\r\n    \
         \    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"bc8e2cb4-5f86-42b6-9322-fc50956b6546\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"eacab60f-176b-417e-9c40-8ccb4b5cb43e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
@@ -529,8 +528,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1283']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:30 GMT']
-      etag: [W/"bc8e2cb4-5f86-42b6-9322-fc50956b6546"]
+      date: ['Fri, 06 Jul 2018 20:21:19 GMT']
+      etag: [W/"eacab60f-176b-417e-9c40-8ccb4b5cb43e"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -547,24 +546,24 @@ interactions:
       CommandName: [network vnet update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"bc8e2cb4-5f86-42b6-9322-fc50956b6546\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"eacab60f-176b-417e-9c40-8ccb4b5cb43e\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         20.0.0.0/16\",\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\"\
         : {\r\n      \"dnsServers\": [\r\n        \"1.2.3.4\"\r\n      ]\r\n    },\r\
         \n    \"subnets\": [\r\n      {\r\n        \"name\": \"default\",\r\n    \
         \    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"bc8e2cb4-5f86-42b6-9322-fc50956b6546\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"eacab60f-176b-417e-9c40-8ccb4b5cb43e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
@@ -573,8 +572,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1283']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:30 GMT']
-      etag: [W/"bc8e2cb4-5f86-42b6-9322-fc50956b6546"]
+      date: ['Fri, 06 Jul 2018 20:21:23 GMT']
+      etag: [W/"eacab60f-176b-417e-9c40-8ccb4b5cb43e"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -588,10 +587,10 @@ interactions:
       "location": "westus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["20.0.0.0/16", "10.0.0.0/16"]}, "dhcpOptions": {}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default",
       "properties": {"addressPrefix": "10.0.0.0/24", "provisioningState": "Succeeded"},
-      "name": "default", "etag": "W/\\"bc8e2cb4-5f86-42b6-9322-fc50956b6546\\""}],
-      "virtualNetworkPeerings": [], "resourceGuid": "051c9746-8127-4593-b5dd-b686d571a72b",
+      "name": "default", "etag": "W/\\"eacab60f-176b-417e-9c40-8ccb4b5cb43e\\""}],
+      "virtualNetworkPeerings": [], "resourceGuid": "146d8581-9c27-4dee-98b6-2af8d5f07993",
       "provisioningState": "Succeeded", "enableDdosProtection": false, "enableVmProtection":
-      false}, "etag": "W/\\"bc8e2cb4-5f86-42b6-9322-fc50956b6546\\""}'''
+      false}, "etag": "W/\\"eacab60f-176b-417e-9c40-8ccb4b5cb43e\\""}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -599,33 +598,33 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['962']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"b73ed2bb-30b3-4752-b0d7-54a5be597d00\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"78c5f8cd-2d81-4c60-a3db-b5d24b313d75\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         20.0.0.0/16\",\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\"\
         : {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\
         \n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"b73ed2bb-30b3-4752-b0d7-54a5be597d00\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"78c5f8cd-2d81-4c60-a3db-b5d24b313d75\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/d66ab0f5-4253-4da9-8b95-c99763b0103e?api-version=2018-02-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f80e5b96-87c3-4dcd-a0aa-b341d3c2e832?api-version=2018-02-01']
       cache-control: [no-cache]
       content-length: ['1254']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:30 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -633,7 +632,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -642,18 +641,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet update]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/d66ab0f5-4253-4da9-8b95-c99763b0103e?api-version=2018-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f80e5b96-87c3-4dcd-a0aa-b341d3c2e832?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:34 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -669,22 +668,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet update]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"a8e046b7-e912-4d4d-a22e-e907052fa76c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"b7d81a87-6173-4f00-956f-16d451ab21b2\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         20.0.0.0/16\",\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\"\
         : {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\
         \n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"a8e046b7-e912-4d4d-a22e-e907052fa76c\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b7d81a87-6173-4f00-956f-16d451ab21b2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
@@ -693,8 +692,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1256']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:34 GMT']
-      etag: [W/"a8e046b7-e912-4d4d-a22e-e907052fa76c"]
+      date: ['Fri, 06 Jul 2018 20:21:30 GMT']
+      etag: [W/"b7d81a87-6173-4f00-956f-16d451ab21b2"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -711,23 +710,23 @@ interactions:
       CommandName: [network vnet update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"a8e046b7-e912-4d4d-a22e-e907052fa76c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"b7d81a87-6173-4f00-956f-16d451ab21b2\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         20.0.0.0/16\",\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\"\
         : {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\
         \n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"a8e046b7-e912-4d4d-a22e-e907052fa76c\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b7d81a87-6173-4f00-956f-16d451ab21b2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
@@ -736,8 +735,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1256']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:35 GMT']
-      etag: [W/"a8e046b7-e912-4d4d-a22e-e907052fa76c"]
+      date: ['Fri, 06 Jul 2018 20:21:32 GMT']
+      etag: [W/"b7d81a87-6173-4f00-956f-16d451ab21b2"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -752,10 +751,10 @@ interactions:
       ["20.0.0.0/24", "10.0.0.0/16"]}, "dhcpOptions": {"dnsServers": []}, "subnets":
       [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default",
       "properties": {"addressPrefix": "10.0.0.0/24", "provisioningState": "Succeeded"},
-      "name": "default", "etag": "W/\\"a8e046b7-e912-4d4d-a22e-e907052fa76c\\""}],
-      "virtualNetworkPeerings": [], "resourceGuid": "051c9746-8127-4593-b5dd-b686d571a72b",
+      "name": "default", "etag": "W/\\"b7d81a87-6173-4f00-956f-16d451ab21b2\\""}],
+      "virtualNetworkPeerings": [], "resourceGuid": "146d8581-9c27-4dee-98b6-2af8d5f07993",
       "provisioningState": "Succeeded", "enableDdosProtection": false, "enableVmProtection":
-      false}, "etag": "W/\\"a8e046b7-e912-4d4d-a22e-e907052fa76c\\""}'''
+      false}, "etag": "W/\\"b7d81a87-6173-4f00-956f-16d451ab21b2\\""}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -763,33 +762,33 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['978']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"77f97eb8-3492-4103-bea5-24e37e852d65\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"b18368cd-eea1-4743-8c47-b17a221a8d02\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         20.0.0.0/24\",\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\"\
         : {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\
         \n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"77f97eb8-3492-4103-bea5-24e37e852d65\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b18368cd-eea1-4743-8c47-b17a221a8d02\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/47cb7244-b1d7-4087-95a9-8b0b762cea86?api-version=2018-02-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f610bf1e-dabe-4ac7-bc33-d79b2d4cc515?api-version=2018-02-01']
       cache-control: [no-cache]
       content-length: ['1254']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:35 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -797,7 +796,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -806,18 +805,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet update]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/47cb7244-b1d7-4087-95a9-8b0b762cea86?api-version=2018-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f610bf1e-dabe-4ac7-bc33-d79b2d4cc515?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:39 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -833,22 +832,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet update]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"b953708a-2593-420e-b56a-756cb9dd3b79\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"ffde5246-9951-4a42-af9e-5c2dc2f7245e\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         20.0.0.0/24\",\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\"\
         : {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\
         \n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n        \"etag\": \"W/\\\"b953708a-2593-420e-b56a-756cb9dd3b79\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"ffde5246-9951-4a42-af9e-5c2dc2f7245e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
@@ -857,8 +856,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1256']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:39 GMT']
-      etag: [W/"b953708a-2593-420e-b56a-756cb9dd3b79"]
+      date: ['Fri, 06 Jul 2018 20:21:40 GMT']
+      etag: [W/"ffde5246-9951-4a42-af9e-5c2dc2f7245e"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -876,29 +875,29 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['67']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"subnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"817d7ccf-fcc2-4e84-b926-9bd440cb4ea7\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"92dd92a4-dbea-43c1-a2e8-12ba0c7a1671\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         addressPrefix\": \"20.0.0.0/24\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9f82cb83-ce02-4b2c-8031-e9f70ac20f36?api-version=2018-02-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2428a797-83d3-4a14-8382-3f1a58d5d110?api-version=2018-02-01']
       cache-control: [no-cache]
       content-length: ['402']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:40 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -907,18 +906,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet subnet create]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9f82cb83-ce02-4b2c-8031-e9f70ac20f36?api-version=2018-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2428a797-83d3-4a14-8382-3f1a58d5d110?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:43 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -934,22 +933,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet subnet create]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"subnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"3a2bda87-b301-485b-9690-ec948798049c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"c0cd40fb-0d5a-47c5-9885-60dfb22f3fa2\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         addressPrefix\": \"20.0.0.0/24\"\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['403']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:44 GMT']
-      etag: [W/"3a2bda87-b301-485b-9690-ec948798049c"]
+      date: ['Fri, 06 Jul 2018 20:21:49 GMT']
+      etag: [W/"c0cd40fb-0d5a-47c5-9885-60dfb22f3fa2"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -966,20 +965,20 @@ interactions:
       CommandName: [network vnet subnet list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"default\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n      \"etag\": \"W/\\\"3a2bda87-b301-485b-9690-ec948798049c\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"c0cd40fb-0d5a-47c5-9885-60dfb22f3fa2\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"addressPrefix\": \"10.0.0.0/24\"\r\n      }\r\n    },\r\n \
         \   {\r\n      \"name\": \"subnet1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"\
-        ,\r\n      \"etag\": \"W/\\\"3a2bda87-b301-485b-9690-ec948798049c\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"c0cd40fb-0d5a-47c5-9885-60dfb22f3fa2\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"addressPrefix\": \"20.0.0.0/24\"\r\n      }\r\n    }\r\n  ]\r\
         \n}"}
@@ -987,7 +986,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['906']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:45 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1004,23 +1003,23 @@ interactions:
       CommandName: [network vnet subnet show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"name\": \"subnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"3a2bda87-b301-485b-9690-ec948798049c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"c0cd40fb-0d5a-47c5-9885-60dfb22f3fa2\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         addressPrefix\": \"20.0.0.0/24\"\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['403']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:45 GMT']
-      etag: [W/"3a2bda87-b301-485b-9690-ec948798049c"]
+      date: ['Fri, 06 Jul 2018 20:21:55 GMT']
+      etag: [W/"c0cd40fb-0d5a-47c5-9885-60dfb22f3fa2"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1038,26 +1037,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1?api-version=2018-02-01
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6b414533-f88a-453e-93d2-74cc2a30d2ea?api-version=2018-02-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8877b606-4244-47cd-8ddb-615a1e954bf2?api-version=2018-02-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 02 Apr 2018 15:05:46 GMT']
+      date: ['Fri, 06 Jul 2018 20:21:59 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/6b414533-f88a-453e-93d2-74cc2a30d2ea?api-version=2018-02-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/8877b606-4244-47cd-8ddb-615a1e954bf2?api-version=2018-02-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1066,18 +1065,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet subnet delete]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6b414533-f88a-453e-93d2-74cc2a30d2ea?api-version=2018-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8877b606-4244-47cd-8ddb-615a1e954bf2?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:56 GMT']
+      date: ['Fri, 06 Jul 2018 20:22:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1094,16 +1093,16 @@ interactions:
       CommandName: [network vnet subnet list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"default\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n      \"etag\": \"W/\\\"9b08a71c-7c6b-4172-bb20-8bc6a9117371\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"3fbc07fd-c4ae-4db6-ae9d-f2c85474eee7\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"addressPrefix\": \"10.0.0.0/24\"\r\n      }\r\n    }\r\n  ]\r\
         \n}"}
@@ -1111,7 +1110,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['464']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:57 GMT']
+      date: ['Fri, 06 Jul 2018 20:22:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1128,25 +1127,25 @@ interactions:
       CommandName: [network vnet list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vnet1\",\r\n\
         \      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n      \"etag\": \"W/\\\"9b08a71c-7c6b-4172-bb20-8bc6a9117371\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"3fbc07fd-c4ae-4db6-ae9d-f2c85474eee7\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"051c9746-8127-4593-b5dd-b686d571a72b\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"146d8581-9c27-4dee-98b6-2af8d5f07993\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"20.0.0.0/24\",\r\n            \"10.0.0.0/16\"\r\n          ]\r\
         \n        },\r\n        \"dhcpOptions\": {\r\n          \"dnsServers\": []\r\
         \n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\"\
         : \"default\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default\"\
-        ,\r\n            \"etag\": \"W/\\\"9b08a71c-7c6b-4172-bb20-8bc6a9117371\\\"\
+        ,\r\n            \"etag\": \"W/\\\"3fbc07fd-c4ae-4db6-ae9d-f2c85474eee7\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\"\r\n \
         \           }\r\n          }\r\n        ],\r\n        \"virtualNetworkPeerings\"\
@@ -1156,7 +1155,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1421']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:05:58 GMT']
+      date: ['Fri, 06 Jul 2018 20:22:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1174,26 +1173,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-02-01
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/93a490a5-aea7-4a1b-9b5f-9bfb08a73b31?api-version=2018-02-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eda36226-9111-4ded-ac51-738ed3c96489?api-version=2018-02-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 02 Apr 2018 15:05:58 GMT']
+      date: ['Fri, 06 Jul 2018 20:22:19 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/93a490a5-aea7-4a1b-9b5f-9bfb08a73b31?api-version=2018-02-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/eda36226-9111-4ded-ac51-738ed3c96489?api-version=2018-02-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1202,18 +1201,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet delete]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/93a490a5-aea7-4a1b-9b5f-9bfb08a73b31?api-version=2018-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eda36226-9111-4ded-ac51-738ed3c96489?api-version=2018-02-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:06:08 GMT']
+      date: ['Fri, 06 Jul 2018 20:22:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1230,9 +1229,9 @@ interactions:
       CommandName: [network vnet list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 networkmanagementclient/2.0.0rc1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 networkmanagementclient/2.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_vnet_test000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-02-01
@@ -1242,7 +1241,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 02 Apr 2018 15:06:10 GMT']
+      date: ['Fri, 06 Jul 2018 20:22:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1258,9 +1257,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.31]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_vnet_test000001?api-version=2018-05-01
@@ -1269,12 +1268,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 02 Apr 2018 15:06:11 GMT']
+      date: ['Fri, 06 Jul 2018 20:22:37 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZWTkVUOjVGVEVTVDNEWkFPM0ZaRjNYQjVSQVRMTVE0R1Y3NElTSTJNTnxCOUI2RTk2MkNFNEU2NDEzLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZWTkVUOjVGVEVTVEpIM08zM1BBT08zT1VQTFIyVzZINEhGUEZBUk1ZWXwxMkI2NzM4MjIzMDFFNTdCLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -153,7 +153,7 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_resource_groups', table_transformer=transform_resource_group_list)
         g.custom_command('create', 'create_resource_group')
         g.custom_command('export', 'export_group_as_template')
-        g.generic_update_command('update')
+        g.generic_update_command('update', custom_func_name='update_resource_group', custom_func_type=resource_custom)
         g.generic_wait_command('wait')
 
     with self.command_group('group lock', resource_type=ResourceType.MGMT_RESOURCE_LOCKS) as g:

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -488,6 +488,14 @@ def create_resource_group(cmd, rg_name, location, tags=None):
     return rcf.resource_groups.create_or_update(rg_name, parameters)
 
 
+def update_resource_group(instance, tags=None):
+
+    if tags is not None:
+        instance.tags = tags
+
+    return instance
+
+
 def export_group_as_template(
         cmd, resource_group_name, include_comments=False, include_parameter_default_value=False):
     """Captures a resource group as a template.

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/recordings/test_resource_group.yaml
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/recordings/test_resource_group.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-06-12T23:18:40Z"}}'
+      "date": "2018-07-06T20:29:45Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -9,24 +9,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rg_scenario000001","name":"cli_test_rg_scenario000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-06-12T23:18:40Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rg_scenario000001","name":"cli_test_rg_scenario000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-07-06T20:29:45Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 12 Jun 2018 23:18:40 GMT']
+      date: ['Fri, 06 Jul 2018 20:29:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -37,9 +37,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
@@ -48,9 +48,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Tue, 12 Jun 2018 23:18:41 GMT']
+      date: ['Fri, 06 Jul 2018 20:29:55 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT0xPTTRUTjVKQkU2Q0pHREJaWVFQNnxDMUUyRDc0Q0Y5N0UxRUFDLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT042MkFFNTVLRUdBV0tNN0VRNUNLVnxFNjlBRDAyNkRBNUQ5MjcwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
@@ -63,19 +63,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [group delete]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT0xPTTRUTjVKQkU2Q0pHREJaWVFQNnxDMUUyRDc0Q0Y5N0UxRUFDLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT042MkFFNTVLRUdBV0tNN0VRNUNLVnxFNjlBRDAyNkRBNUQ5MjcwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01
   response:
     body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Tue, 12 Jun 2018 23:18:55 GMT']
+      date: ['Fri, 06 Jul 2018 20:30:10 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT0xPTTRUTjVKQkU2Q0pHREJaWVFQNnxDMUUyRDc0Q0Y5N0UxRUFDLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT042MkFFNTVLRUdBV0tNN0VRNUNLVnxFNjlBRDAyNkRBNUQ5MjcwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
@@ -87,19 +87,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [group delete]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT0xPTTRUTjVKQkU2Q0pHREJaWVFQNnxDMUUyRDc0Q0Y5N0UxRUFDLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT042MkFFNTVLRUdBV0tNN0VRNUNLVnxFNjlBRDAyNkRBNUQ5MjcwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01
   response:
     body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Tue, 12 Jun 2018 23:19:10 GMT']
+      date: ['Fri, 06 Jul 2018 20:30:24 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT0xPTTRUTjVKQkU2Q0pHREJaWVFQNnxDMUUyRDc0Q0Y5N0UxRUFDLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT042MkFFNTVLRUdBV0tNN0VRNUNLVnxFNjlBRDAyNkRBNUQ5MjcwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
@@ -111,17 +111,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [group delete]
       Connection: [keep-alive]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT0xPTTRUTjVKQkU2Q0pHREJaWVFQNnxDMUUyRDc0Q0Y5N0UxRUFDLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT042MkFFNTVLRUdBV0tNN0VRNUNLVnxFNjlBRDAyNkRBNUQ5MjcwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01
   response:
     body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Tue, 12 Jun 2018 23:19:26 GMT']
+      date: ['Fri, 06 Jul 2018 20:30:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -135,9 +135,9 @@ interactions:
       CommandName: [group exists]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
@@ -147,7 +147,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['167']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 12 Jun 2018 23:19:27 GMT']
+      date: ['Fri, 06 Jul 2018 20:30:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -163,9 +163,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['51']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
@@ -175,7 +175,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['327']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 12 Jun 2018 23:19:27 GMT']
+      date: ['Fri, 06 Jul 2018 20:30:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -190,9 +190,9 @@ interactions:
       CommandName: [group exists]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
@@ -201,7 +201,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Tue, 12 Jun 2018 23:19:27 GMT']
+      date: ['Fri, 06 Jul 2018 20:30:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -215,9 +215,9 @@ interactions:
       CommandName: [group show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
@@ -227,7 +227,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['327']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 12 Jun 2018 23:19:27 GMT']
+      date: ['Fri, 06 Jul 2018 20:30:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -242,9 +242,9 @@ interactions:
       CommandName: [group list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups?$filter=tagname%20eq%20%27a%27%20and%20tagvalue%20eq%20%27b%27&api-version=2018-05-01
@@ -254,7 +254,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['339']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 12 Jun 2018 23:19:28 GMT']
+      date: ['Fri, 06 Jul 2018 20:30:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -266,13 +266,190 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [group update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rg_scenario000001","name":"cli_test_rg_scenario000001","location":"westus","tags":{"a":"b","c":""},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['327']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 06 Jul 2018 20:30:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"name": "cli_test_rg_scenario000001", "properties": {}, "location":
+      "westus", "tags": {}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group update]
+      Connection: [keep-alive]
+      Content-Length: ['139']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rg_scenario000001","name":"cli_test_rg_scenario000001","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['313']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 06 Jul 2018 20:30:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rg_scenario000001","name":"cli_test_rg_scenario000001","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['313']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 06 Jul 2018 20:30:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"name": "cli_test_rg_scenario000001", "properties": {}, "location":
+      "westus", "tags": {"a": "{\''k\'': \''v\''}"}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group update]
+      Connection: [keep-alive]
+      Content-Length: ['156']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rg_scenario000001","name":"cli_test_rg_scenario000001","location":"westus","tags":{"a":"{''k'':
+        ''v''}"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['329']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 06 Jul 2018 20:30:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group update]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rg_scenario000001","name":"cli_test_rg_scenario000001","location":"westus","tags":{"a":"{''k'':
+        ''v''}"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['329']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 06 Jul 2018 20:30:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"name": "cli_test_rg_scenario000001", "properties": {}, "location":
+      "westus", "tags": {"a": "{\''k\'': \''v\''}", "b": "{\\"k\\":\\"v\\"}"}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group update]
+      Connection: [keep-alive]
+      Content-Length: ['178']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
+          AZURECLI/2.0.42]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rg_scenario000001","name":"cli_test_rg_scenario000001","location":"westus","tags":{"a":"{''k'':
+        ''v''}","b":"{\"k\":\"v\"}"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['349']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 06 Jul 2018 20:30:54 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
       CommandName: [group delete]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17134-SP0) requests/2.18.4 msrest/0.4.29
           msrest_azure/0.4.31 resourcemanagementclient/2.0.0rc2 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
+          AZURECLI/2.0.42]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_rg_scenario000001?api-version=2018-05-01
@@ -281,9 +458,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Tue, 12 Jun 2018 23:19:28 GMT']
+      date: ['Fri, 06 Jul 2018 20:30:54 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT0xPTTRUTjVKQkU2Q0pHREJaWVFQNnxDMUUyRDc0Q0Y5N0UxRUFDLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGUkc6NUZTQ0VOQVJJT042MkFFNTVLRUdBV0tNN0VRNUNLVnxFNjlBRDAyNkRBNUQ5MjcwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -36,6 +36,14 @@ class ResourceGroupScenarioTest(ScenarioTest):
             self.check('[0].name', '{rg}'),
             self.check('[0].tags', {'a': 'b', 'c': ''})
         ])
+        # test --force-string
+        self.kwargs.update({'tag': "\"{\\\"k\\\":\\\"v\\\"}\""})
+        self.cmd('group update -g {rg} --tags ""',
+                 checks=self.check('tags', {}))
+        self.cmd('group update -g {rg} --set tags.a={tag}',
+                 checks=self.check('tags.a', "{{'k': 'v'}}"))
+        self.cmd('group update -g {rg} --set tags.b={tag} --force-string',
+                 checks=self.check('tags.b', '{{\"k\":\"v\"}}'))
 
 
 class ResourceGroupNoWaitScenarioTest(ScenarioTest):


### PR DESCRIPTION
Adds support for the `--tags` convenience argument to `group update`. Also, adds global support to generic update for `--force-string` which signals the code to not try and evaluate the contents of a supplied string, but simply to treat the input as a string.  Fixes #6605.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
