### PR TITLE
Create load balancer: argument "--vnet-name"

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1958,7 +1958,7 @@ helps['network lb create'] = """
             Create a standard zone flavored public-facing load balancer, through provisioning a
             zonal frontend ip configuration and Vnet.
           text: >
-            az network lb create -g MyResourceGroup -n MyLb --sku Standard --frontend-ip-zone 1 -vnet-name MyVnet --subnet MySubnet
+            az network lb create -g MyResourceGroup -n MyLb --sku Standard --frontend-ip-zone 1 --vnet-name MyVnet --subnet MySubnet
 """
 
 helps['network lb delete'] = """


### PR DESCRIPTION
Argument is keyed with a single "-" instead of two. Correct syntax is "--vnet-name".

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
