### PR TITLE
Better Non Dockerhub Registry Access - Container Instances

### DIFF
--- a/src/command_modules/azure-cli-container/HISTORY.rst
+++ b/src/command_modules/azure-cli-container/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 0.2.2
 +++++
+* Remove the requirement for username and password for non dockerhub registries
 * Fix error when creating container groups from yaml file
 
 0.2.1

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/custom.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/custom.py
@@ -41,6 +41,7 @@ from ._client_factory import cf_container_groups, cf_container, cf_log_analytics
 logger = get_logger(__name__)
 WINDOWS_NAME = 'Windows'
 SERVER_DELIMITER = '.'
+ACR_SERVER_DELIMITER = '.azurecr.io'
 AZURE_FILE_VOLUME_NAME = 'azurefile'
 SECRETS_VOLUME_NAME = 'secrets'
 GITREPO_VOLUME_NAME = 'gitrepo'
@@ -273,7 +274,7 @@ def _create_image_registry_credentials(registry_login_server, registry_username,
         image_registry_credentials = [ImageRegistryCredential(server=registry_login_server,
                                                               username=registry_username,
                                                               password=registry_password)]
-    elif SERVER_DELIMITER in image.split("/")[0]:
+    elif ACR_SERVER_DELIMITER in image.split("/")[0]:
         if not registry_username:
             try:
                 registry_username = prompt(msg='Image registry username: ')
@@ -290,9 +291,15 @@ def _create_image_registry_credentials(registry_login_server, registry_username,
         if acr_server:
             image_registry_credentials = [ImageRegistryCredential(server=acr_server,
                                                                   username=registry_username,
+                                                                  password=registry_password)]                                           
+    elif registry_username and registry_password and SERVER_DELIMITER in image.split("/")[0]:
+        login_server = image.split("/")[0] if image.split("/") else None
+        if login_server:
+            image_registry_credentials = [ImageRegistryCredential(server=login_server,
+                                                                  username=registry_username,
                                                                   password=registry_password)]
         else:
-            raise CLIError('Failed to parse ACR server from image name; please explicitly specify --registry-server.')
+            raise CLIError('Failed to parse login server from image name; please explicitly specify --registry-server.')
 
     return image_registry_credentials
 


### PR DESCRIPTION
Remove requirement for username and password for non dockerhub repositories

fixes #6744 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
