### PR TITLE
Add version constraint of paramiko

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.43
+++++++
+* Minor fixes
+
 2.0.42
 ++++++
 * login: support browser based login in WSL bash window

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 from __future__ import print_function
 
-__version__ = "2.0.42"
+__version__ = "2.0.43"
 
 import os
 import sys

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.42"
+VERSION = "2.0.43"
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -58,7 +58,7 @@ DEPENDENCIES = [
     'knack==0.4.1',
     'msrest>=0.4.4',
     'msrestazure>=0.4.25',
-    'paramiko',
+    'paramiko>=2.0.8',
     'pip',
     'pygments',
     'PyJWT',

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.43
+++++++
+* Minor fixes
+
 2.0.42
 ++++++
 * Minor fixes

--- a/src/azure-cli/azure/cli/__init__.py
+++ b/src/azure-cli/azure/cli/__init__.py
@@ -11,4 +11,4 @@ import pkg_resources
 pkg_resources.declare_namespace(__name__)
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "2.0.42"
+__version__ = "2.0.43"

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.42"
+VERSION = "2.0.43"
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.2.1
++++++
+* Depdendency update: paramiko >= 2.0.8
+
 2.2.0
 +++++
 * BREAKING CHANGE: 'show' commands log error message and fail with exit code of 3 upon a missing resource.

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.2.0"
+VERSION = "2.2.1"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -35,7 +35,7 @@ DEPENDENCIES = [
     'azure-mgmt-containerservice==4.1.0',
     'azure-graphrbac==0.40.0',
     'azure-cli-core',
-    'paramiko',
+    'paramiko>=2.0.8',
     'pyyaml~=4.2b4',
     'six',
     'scp',


### PR DESCRIPTION
The current release package already pin paramiko at 2.4.1. This change
merely ensure user who PIP installed CLI can avoid vulnerability.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
