### PR TITLE
Break circular depdencies between core and testsdk

### DIFF
--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -1,0 +1,46 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core import AzCli
+
+
+class DummyCli(AzCli):
+    """A dummy CLI instance can be used to facilitate automation"""
+    def __init__(self, commands_loader_cls=None, **kwargs):
+        import os
+
+        from azure.cli.core import MainCommandsLoader
+        from azure.cli.core.commands import AzCliCommandInvoker
+        from azure.cli.core.azlogging import AzCliLogging
+        from azure.cli.core.cloud import get_active_cloud
+        from azure.cli.core.parser import AzCliCommandParser
+        from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
+        from azure.cli.core._help import AzCliHelp
+
+        from knack.completion import ARGCOMPLETE_ENV_NAME
+
+        super(DummyCli, self).__init__(
+            cli_name='az',
+            config_dir=GLOBAL_CONFIG_DIR,
+            config_env_var_prefix=ENV_VAR_PREFIX,
+            commands_loader_cls=commands_loader_cls or MainCommandsLoader,
+            parser_cls=AzCliCommandParser,
+            logging_cls=AzCliLogging,
+            help_cls=AzCliHelp,
+            invocation_cls=AzCliCommandInvoker)
+
+        self.data['headers'] = {}  # the x-ms-client-request-id is generated before a command is to execute
+        self.data['command'] = 'unknown'
+        self.data['completer_active'] = ARGCOMPLETE_ENV_NAME in os.environ
+        self.data['query_active'] = False
+
+        loader = self.commands_loader_cls(self)
+        setattr(self, 'commands_loader', loader)
+
+        self.cloud = get_active_cloud(self)
+
+    def get_cli_version(self):
+        from azure.cli.core import __version__ as cli_version
+        return cli_version

--- a/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
@@ -10,14 +10,14 @@ from azure.cli.core.profiles import (ResourceType, PROFILE_TYPE, CustomResourceT
                                      get_api_version, supported_api_version, register_resource_type)
 from azure.cli.core.profiles._shared import APIVersionException
 from azure.cli.core.cloud import Cloud
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 
 class TestAPIProfiles(unittest.TestCase):
 
     def test_get_api_version(self):
         # Can get correct resource type API version
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
@@ -25,7 +25,7 @@ class TestAPIProfiles(unittest.TestCase):
 
     def test_get_api_version_invalid_rt(self):
         # Resource Type not in profile
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
@@ -34,7 +34,7 @@ class TestAPIProfiles(unittest.TestCase):
 
     def test_get_api_version_invalid_active_profile(self):
         # The active profile is not in our profile dict
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='not-a-real-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
@@ -43,14 +43,14 @@ class TestAPIProfiles(unittest.TestCase):
 
     def test_supported_api_version_invalid_profile_name(self):
         # Invalid name for the profile name
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='not-a-real-profile')
         with self.assertRaises(ValueError):
             supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01')
 
     def test_get_api_version_invalid_rt_2(self):
         # None is not a valid resource type
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
@@ -59,67 +59,67 @@ class TestAPIProfiles(unittest.TestCase):
 
     def test_supported_api_profile_no_constraints(self):
         # At least a min or max version must be specified
-        cli = TestCli()
+        cli = DummyCli()
         with self.assertRaises(ValueError):
             supported_api_version(cli, PROFILE_TYPE)
 
     def test_supported_api_profile_min_constraint(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile')
         self.assertTrue(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01'))
 
     def test_supported_api_profile_min_constraint_not_supported(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile-preview')
         self.assertFalse(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-02'))
 
     def test_supported_api_profile_min_max_constraint(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile')
         self.assertTrue(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01', max_api='2000-01-01'))
 
     def test_supported_api_profile_max_constraint_not_supported(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile')
         self.assertFalse(supported_api_version(cli, PROFILE_TYPE, max_api='1999-12-30'))
 
     def test_supported_api_profile_preview_constraint(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile')
         self.assertTrue(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01-preview'))
 
     def test_supported_api_profile_preview_constraint_in_profile(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile-preview')
         self.assertFalse(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01'))
 
     def test_supported_api_profile_latest(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='latest')
         self.assertTrue(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01'))
 
     def test_supported_api_version_no_constraints(self):
         # At least a min or max version must be specified
-        cli = TestCli()
+        cli = DummyCli()
         with self.assertRaises(ValueError):
             supported_api_version(cli, ResourceType.MGMT_STORAGE)
 
     def test_supported_api_version_min_constraint(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertTrue(supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='2000-01-01'))
 
     def test_supported_api_version_max_constraint(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertTrue(supported_api_version(cli, ResourceType.MGMT_STORAGE, max_api='2021-01-01'))
 
     def test_supported_api_version_min_max_constraint(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
@@ -127,28 +127,28 @@ class TestAPIProfiles(unittest.TestCase):
                 supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='2020-01-01', max_api='2021-01-01'))
 
     def test_supported_api_version_max_constraint_not_supported(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertFalse(supported_api_version(cli, ResourceType.MGMT_STORAGE, max_api='2019-01-01'))
 
     def test_supported_api_version_min_constraint_not_supported(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertFalse(supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='2021-01-01'))
 
     def test_supported_api_version_preview_constraint(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10-preview'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertTrue(supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='2020-01-01'))
 
     def test_supported_api_version_invalid_rt_for_profile(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
         test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2020-10-10'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):

--- a/src/azure-cli-core/azure/cli/core/tests/test_application.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_application.py
@@ -13,18 +13,18 @@ from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import AzCliCommand
 from azure.cli.core.commands.validators import IterateAction
 
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 from knack.util import CLIError
 
 
 class TestApplication(unittest.TestCase):
     def test_client_request_id_is_not_assigned_when_application_is_created(self):
-        cli = TestCli()
+        cli = DummyCli()
         self.assertNotIn('x-ms-client-request-id', cli.data['headers'])
 
     def test_client_request_id_is_refreshed_correctly(self):
-        cli = TestCli()
+        cli = DummyCli()
         cli.refresh_request_id()
         self.assertIn('x-ms-client-request-id', cli.data['headers'])
 
@@ -45,7 +45,7 @@ class TestApplication(unittest.TestCase):
                 self.command_table = {'test': AzCliCommand(self, 'test', _handler)}
                 return self.command_table
 
-        cli = TestCli(commands_loader_cls=TestCommandsLoader)
+        cli = DummyCli(commands_loader_cls=TestCommandsLoader)
 
         cli.invoke(['test'])
         self.assertIn('x-ms-client-request-id', cli.data['headers'])
@@ -64,7 +64,7 @@ class TestApplication(unittest.TestCase):
         def other_handler(*args, **kwargs):
             self.assertEqual(kwargs['args'], 'secret sauce')
 
-        cli = TestCli()
+        cli = DummyCli()
 
         cli.raise_event('was_handler_called', args=handler_called)
         self.assertFalse(handler_called[0], "Raising event with no handlers registered somehow failed...")

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from azure.cli.core import AzCommandsLoader, MainCommandsLoader
 from azure.cli.core.commands import ExtensionCommandSource
 from azure.cli.core.extension import EXTENSIONS_MOD_PREFIX
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 from knack.arguments import CLICommandArgument, CLIArgumentType
 
@@ -77,7 +77,7 @@ class TestCommandRegistration(unittest.TestCase):
                 with self.argument_context('test register sample-vm-get') as c:
                     c.argument('vm_name', options_list=('--wonky-name', '-n'), metavar='VMNAME', help='Completely WONKY name...', required=False)
 
-        cli = TestCli(commands_loader_cls=TestCommandsLoader)
+        cli = DummyCli(commands_loader_cls=TestCommandsLoader)
         command = 'test register sample-vm-get'
         loader = _prepare_test_commands_loader(TestCommandsLoader, cli, command)
 
@@ -110,7 +110,7 @@ class TestCommandRegistration(unittest.TestCase):
                 with self.argument_context('test register sample-vm-get') as c:
                     c.argument('vm_name', options_list=('--wonky-name', '-n'), metavar='VMNAME', help='Completely WONKY name...', required=False)
 
-        cli = TestCli(commands_loader_cls=TestCommandsLoader)
+        cli = DummyCli(commands_loader_cls=TestCommandsLoader)
         command = 'test command sample-vm-get'
         loader = _prepare_test_commands_loader(TestCommandsLoader, cli, command)
 
@@ -206,7 +206,7 @@ class TestCommandRegistration(unittest.TestCase):
     def test_register_command_from_extension(self):
 
         from azure.cli.core.commands import _load_command_loader
-        cli = TestCli()
+        cli = DummyCli()
         main_loader = MainCommandsLoader(cli)
         cli.loader = main_loader
 
@@ -249,7 +249,7 @@ class TestCommandRegistration(unittest.TestCase):
                 with self.argument_context('test command vm-get-2') as c:
                     c.argument('vm_name', derived_vm_name_type, help='second modification')
 
-        cli = TestCli(commands_loader_cls=TestCommandsLoader)
+        cli = DummyCli(commands_loader_cls=TestCommandsLoader)
         loader = _prepare_test_commands_loader(TestCommandsLoader, cli, 'test vm-get')
         self.assertEqual(len(loader.command_table), 3,
                          'We expect exactly three commands in the command table')
@@ -279,7 +279,7 @@ class TestCommandRegistration(unittest.TestCase):
                 with self.argument_context('test command sample-vm-get') as c:
                     c.extra('added_param', options_list=['--added-param'], metavar='ADDED', help='Just added this right now!', required=True)
 
-        cli = TestCli(commands_loader_cls=TestCommandsLoader)
+        cli = DummyCli(commands_loader_cls=TestCommandsLoader)
         command = 'test command sample-vm-get'
         loader = _prepare_test_commands_loader(TestCommandsLoader, cli, command)
 
@@ -324,7 +324,7 @@ class TestCommandRegistration(unittest.TestCase):
         setattr(sys.modules[__name__], sample_sdk_method_with_weird_docstring.__name__,
                 sample_sdk_method_with_weird_docstring)  # pylint: disable=line-too-long
 
-        cli = TestCli(commands_loader_cls=TestCommandsLoader)
+        cli = DummyCli(commands_loader_cls=TestCommandsLoader)
         command = 'test command foo'
         loader = _prepare_test_commands_loader(TestCommandsLoader, cli, command)
 
@@ -384,7 +384,7 @@ class TestCommandRegistration(unittest.TestCase):
                                validator=test_validator_completer, completer=test_validator_completer)
 
         setattr(sys.modules[__name__], sample_sdk_method.__name__, sample_sdk_method)
-        cli = TestCli(commands_loader_cls=TestCommandsLoader)
+        cli = DummyCli(commands_loader_cls=TestCommandsLoader)
         command = 'override_using_register_cli_argument foo'
         loader = _prepare_test_commands_loader(TestCommandsLoader, cli, command)
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_with_configured_defaults.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_with_configured_defaults.py
@@ -13,7 +13,7 @@ import sys
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import AzCliCommand, CliCommandType
 
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 from knack.config import CLIConfig
 
@@ -54,7 +54,7 @@ class TestCommandWithConfiguredDefaults(unittest.TestCase):
                     c.argument('resource_group_name', options_list=['--resource-group-name', '-g'],
                                configured_default='group', required=required_arg)
                 self._update_command_definitions()  # pylint: disable=protected-access
-        return TestCli(commands_loader_cls=TestCommandsLoader)
+        return DummyCli(commands_loader_cls=TestCommandsLoader)
 
     @mock.patch.dict(os.environ, {'AZURE_DEFAULTS_GROUP': 'myRG'})
     def test_apply_configured_defaults_on_required_arg(self):

--- a/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
@@ -10,7 +10,7 @@ import sys
 from msrest.serialization import Model
 from azure.cli.core import AzCommandsLoader
 
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 from knack.util import CLIError
 
@@ -36,7 +36,7 @@ class ObjectTestObject(object):
         self.additional_properties = None
 
 
-class TestObject(Model):
+class ComplexTestObject(Model):
 
     def __init__(self):
         self.my_prop = 'my_value'
@@ -70,7 +70,7 @@ class TestObject(Model):
 
 def _prepare_test_loader():
 
-    my_obj = TestObject()
+    my_obj = ComplexTestObject()
 
     class GenericUpdateTestCommandsLoader(AzCommandsLoader):
 
@@ -104,7 +104,7 @@ class GenericUpdateTest(unittest.TestCase):
     def test_generic_update_scenario(self):  # pylint: disable=too-many-statements
 
         my_obj, loader_cls = _prepare_test_loader()
-        cli = TestCli(commands_loader_cls=loader_cls)
+        cli = DummyCli(commands_loader_cls=loader_cls)
 
         # Test simplest ways of setting properties
         cli.invoke('genupdate --set myProp=newValue'.split())
@@ -220,7 +220,7 @@ class GenericUpdateTest(unittest.TestCase):
     def test_generic_update_errors(self):  # pylint: disable=no-self-use
 
         my_obj, loader_cls = _prepare_test_loader()
-        cli = TestCli(commands_loader_cls=loader_cls)
+        cli = DummyCli(commands_loader_cls=loader_cls)
 
         def _execute_with_error(command, error, message):
             try:
@@ -297,7 +297,7 @@ class GenericUpdateTest(unittest.TestCase):
     def test_generic_update_empty_nodes(self):
 
         my_obj, loader_cls = _prepare_test_loader()
-        cli = TestCli(commands_loader_cls=loader_cls)
+        cli = DummyCli(commands_loader_cls=loader_cls)
 
         # add to prop
         cli.invoke('genupdate --add emptyProp a=b'.split())

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -9,7 +9,7 @@ import logging
 import unittest
 
 from azure.cli.core._help import ArgumentGroupRegistry, CliCommandHelpFile
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 from knack.help import HelpObject, GroupHelpFile, HelpAuthoringException
 
@@ -28,9 +28,9 @@ class HelpTest(unittest.TestCase):
         from azure.cli.core.commands.arm import add_id_parameters
         import knack.events as events
 
-        cli = TestCli()
+        cli = DummyCli()
         parser_dict = {}
-        cli = TestCli()
+        cli = DummyCli()
         help_ctx = cli.help_cls(cli)
         try:
             cli.invoke(['-h'])

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -12,7 +12,7 @@ from azure.cli.core import AzCommandsLoader, MainCommandsLoader
 from azure.cli.core.commands import AzCliCommand
 from azure.cli.core.parser import AzCliCommandParser
 
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 from knack.arguments import enum_choice_list
 
@@ -32,7 +32,7 @@ class TestParser(unittest.TestCase):
         def test_handler2():
             pass
 
-        cli = TestCli()
+        cli = DummyCli()
         cli.loader = mock.MagicMock()
         cli.loader.cli_ctx = cli
 
@@ -57,7 +57,7 @@ class TestParser(unittest.TestCase):
         def test_handler(args):  # pylint: disable=unused-argument
             pass
 
-        cli = TestCli()
+        cli = DummyCli()
         cli.loader = mock.MagicMock()
         cli.loader.cli_ctx = cli
 
@@ -80,7 +80,7 @@ class TestParser(unittest.TestCase):
         def test_handler():
             pass
 
-        cli = TestCli()
+        cli = DummyCli()
         cli.loader = mock.MagicMock()
         cli.loader.cli_ctx = cli
 
@@ -111,7 +111,7 @@ class TestParser(unittest.TestCase):
         def test_handler():
             pass
 
-        cli = TestCli()
+        cli = DummyCli()
         cli.loader = mock.MagicMock()
         cli.loader.cli_ctx = cli
 
@@ -196,7 +196,7 @@ class TestParser(unittest.TestCase):
     @mock.patch('azure.cli.core.extension.get_extension_modname', _mock_extension_modname)
     @mock.patch('azure.cli.core.extension.get_extensions', _mock_get_extensions)
     def test_parser_error_spellchecker(self):
-        cli = TestCli()
+        cli = DummyCli()
         main_loader = MainCommandsLoader(cli)
         cli.loader = main_loader
 

--- a/src/azure-cli-testsdk/HISTORY.rst
+++ b/src/azure-cli-testsdk/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.2.0
++++++
+* Removes dependency on azure-cli
+* Using explict import_module to import azure.cli.core components
+
 0.1.4
 ++++++
 * Minor fixes.

--- a/src/azure-cli-testsdk/azure/cli/testsdk/__init__.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/__init__.py
@@ -5,8 +5,6 @@
 
 from azure_devtools.scenario_tests import live_only, record_only, get_sha1_hash
 
-from azure.cli.core import AzCli
-
 from .base import ScenarioTest, LiveScenarioTest
 from .preparers import (StorageAccountPreparer, ResourceGroupPreparer, RoleBasedServicePrincipalPreparer,
                         KeyVaultPreparer)
@@ -14,52 +12,12 @@ from .exceptions import CliTestError
 from .checkers import (JMESPathCheck, JMESPathCheckExists, JMESPathCheckGreaterThan, NoneCheck, StringCheck,
                        StringContainCheck)
 from .decorators import api_version_constraint
-from .utilities import get_active_api_profile, create_random_name
+from .utilities import create_random_name
 
 __all__ = ['ScenarioTest', 'LiveScenarioTest', 'ResourceGroupPreparer', 'StorageAccountPreparer',
            'RoleBasedServicePrincipalPreparer', 'CliTestError', 'JMESPathCheck', 'JMESPathCheckExists', 'NoneCheck',
            'live_only', 'record_only', 'StringCheck', 'StringContainCheck', 'get_sha1_hash', 'KeyVaultPreparer',
-           'JMESPathCheckGreaterThan', 'api_version_constraint', 'get_active_api_profile', 'create_random_name']
-
-
-class TestCli(AzCli):
-
-    def __init__(self, commands_loader_cls=None, **kwargs):
-        import os
-
-        from azure.cli.core import MainCommandsLoader
-        from azure.cli.core.commands import AzCliCommandInvoker
-        from azure.cli.core.azlogging import AzCliLogging
-        from azure.cli.core.cloud import get_active_cloud
-        from azure.cli.core.parser import AzCliCommandParser
-        from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
-        from azure.cli.core._help import AzCliHelp
-
-        from knack.completion import ARGCOMPLETE_ENV_NAME
-
-        super(TestCli, self).__init__(
-            cli_name='az',
-            config_dir=GLOBAL_CONFIG_DIR,
-            config_env_var_prefix=ENV_VAR_PREFIX,
-            commands_loader_cls=commands_loader_cls or MainCommandsLoader,
-            parser_cls=AzCliCommandParser,
-            logging_cls=AzCliLogging,
-            help_cls=AzCliHelp,
-            invocation_cls=AzCliCommandInvoker)
-
-        self.data['headers'] = {}  # the x-ms-client-request-id is generated before a command is to execute
-        self.data['command'] = 'unknown'
-        self.data['completer_active'] = ARGCOMPLETE_ENV_NAME in os.environ
-        self.data['query_active'] = False
-
-        loader = self.commands_loader_cls(self)
-        setattr(self, 'commands_loader', loader)
-
-        self.cloud = get_active_cloud(self)
-
-    def get_cli_version(self):
-        from azure.cli.core import __version__ as cli_version
-        return cli_version
+           'JMESPathCheckGreaterThan', 'api_version_constraint', 'create_random_name']
 
 
 __version__ = '0.1.0'

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -22,6 +22,7 @@ from .patches import (patch_load_cached_subscriptions, patch_main_exception_hand
                       patch_progress_controller)
 from .exceptions import CliExecutionError
 from .utilities import find_recording_dir
+from .reverse_dependency import get_dummy_cli
 
 logger = logging.getLogger('azure.cli.testsdk')
 
@@ -73,8 +74,7 @@ class CheckerMixin(object):
 class ScenarioTest(ReplayableTest, CheckerMixin, unittest.TestCase):
     def __init__(self, method_name, config_file=None, recording_name=None,
                  recording_processors=None, replay_processors=None, recording_patches=None, replay_patches=None):
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        self.cli_ctx = get_dummy_cli()
         self.name_replacer = GeneralNameReplacer()
         self.kwargs = {}
         self.test_guid_count = 0
@@ -167,8 +167,7 @@ class LiveScenarioTest(IntegrationTestBase, CheckerMixin, unittest.TestCase):
 
     def __init__(self, method_name):
         super(LiveScenarioTest, self).__init__(method_name)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        self.cli_ctx = get_dummy_cli()
         self.kwargs = {}
 
     def cmd(self, command, checks=None, expect_failure=False):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/decorators.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/decorators.py
@@ -7,8 +7,7 @@ import unittest
 
 
 def api_version_constraint(resource_type, **kwargs):
-    from azure.cli.core.profiles import supported_api_version
-    from azure.cli.testsdk import TestCli
-    cli_ctx = TestCli()
-    return unittest.skipUnless(supported_api_version(cli_ctx, resource_type, **kwargs),
+    from .reverse_dependency import get_dummy_cli, get_support_api_version_func
+
+    return unittest.skipUnless(get_support_api_version_func()(get_dummy_cli(), resource_type, **kwargs),
                                "Test not supported by current profile.")

--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -10,6 +10,7 @@ from azure_devtools.scenario_tests import AbstractPreparer, SingleValueReplacer
 
 from .base import execute
 from .exceptions import CliTestError
+from .reverse_dependency import get_dummy_cli
 
 
 # Resource Group Preparer and its shorthand decorator
@@ -22,8 +23,7 @@ class ResourceGroupPreparer(AbstractPreparer, SingleValueReplacer):
                  dev_setting_location='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION',
                  random_name_length=75, key='rg'):
         super(ResourceGroupPreparer, self).__init__(name_prefix, random_name_length)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        self.cli_ctx = get_dummy_cli()
         self.location = location
         self.parameter_name = parameter_name
         self.parameter_name_for_location = parameter_name_for_location
@@ -60,8 +60,7 @@ class StorageAccountPreparer(AbstractPreparer, SingleValueReplacer):
                  resource_group_parameter_name='resource_group', skip_delete=True,
                  dev_setting_name='AZURE_CLI_TEST_DEV_STORAGE_ACCOUNT_NAME', key='sa'):
         super(StorageAccountPreparer, self).__init__(name_prefix, 24)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        self.cli_ctx = get_dummy_cli()
         self.location = location
         self.sku = sku
         self.resource_group_parameter_name = resource_group_parameter_name
@@ -106,8 +105,7 @@ class KeyVaultPreparer(AbstractPreparer, SingleValueReplacer):
                  resource_group_parameter_name='resource_group', skip_delete=True,
                  dev_setting_name='AZURE_CLI_TEST_DEV_KEY_VAULT_NAME', key='kv'):
         super(KeyVaultPreparer, self).__init__(name_prefix, 24)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        self.cli_ctx = get_dummy_cli()
         self.location = location
         self.sku = sku
         self.resource_group_parameter_name = resource_group_parameter_name
@@ -149,8 +147,7 @@ class RoleBasedServicePrincipalPreparer(AbstractPreparer, SingleValueReplacer):
                  dev_setting_sp_name='AZURE_CLI_TEST_DEV_SP_NAME',
                  dev_setting_sp_password='AZURE_CLI_TEST_DEV_SP_PASSWORD', key='sp'):
         super(RoleBasedServicePrincipalPreparer, self).__init__(name_prefix, 24)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        self.cli_ctx = get_dummy_cli()
         self.skip_assignment = skip_assignment
         self.result = {}
         self.parameter_name = parameter_name

--- a/src/azure-cli-testsdk/azure/cli/testsdk/reverse_dependency.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/reverse_dependency.py
@@ -1,0 +1,24 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from importlib import import_module
+
+DUMMY_CLI_TYPE = 'DummyCli'
+DUMMY_CLI_MODULE = 'azure.cli.core.mock'
+
+
+def get_dummy_cli(*args, **kwargs):
+    mod = import_module('azure.cli.core.mock')
+    return getattr(mod, 'DummyCli')(*args, **kwargs)
+
+
+def get_support_api_version_func():
+    mod = import_module('azure.cli.core.profiles')
+    return getattr(mod, 'supported_api_version')
+
+
+def get_commands_loggers():
+    mod = import_module('azure.cli.core.commands')
+    return getattr(mod, 'logger')

--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -18,17 +18,14 @@ def find_recording_dir(test_file):
     return os.path.join(os.path.dirname(test_file), 'recordings')
 
 
-def get_active_api_profile(cli_ctx):
-    from azure.cli.core.cloud import get_active_cloud
-    return get_active_cloud(cli_ctx).profile
-
-
 @contextmanager
 def force_progress_logging():
     from six import StringIO
     import logging
     from knack.log import get_logger
-    from azure.cli.core.commands import logger as cmd_logger
+    from .reverse_dependency import get_commands_loggers
+
+    cmd_logger = get_commands_loggers()
 
     # register a progress logger handler to get the content to verify
     test_io = StringIO()

--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.4"
+VERSION = "0.2.0"
 
 CLASSIFIERS = [
     'Development Status :: 3 - Alpha',
@@ -30,7 +30,6 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-cli',
     'jmespath',
     'mock',
     'vcrpy>=1.10.3',

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -27,7 +27,7 @@ from azure.cli.command_modules.acr._docker_utils import (
     get_login_credentials,
     get_access_credentials
 )
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 
 class AcrMockCommandsTests(unittest.TestCase):
@@ -37,7 +37,7 @@ class AcrMockCommandsTests(unittest.TestCase):
     @mock.patch('requests.request', autospec=True)
     def test_repository_list(self, mock_requests_get, mock_get_access_credentials, mock_get_registry_by_name):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         encoded_repositories = json.dumps({'repositories': ['testrepo1', 'testrepo2']}).encode()
 
         response = mock.MagicMock()
@@ -81,7 +81,7 @@ class AcrMockCommandsTests(unittest.TestCase):
     @mock.patch('requests.request', autospec=True)
     def test_repository_show_tags(self, mock_requests_get, mock_get_access_credentials, mock_get_registry_by_name):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         encoded_tags = json.dumps({'tags': ['testtag1', 'testtag2']}).encode()
         encoded_tags_detail = json.dumps({'tags': [
             {
@@ -138,7 +138,7 @@ class AcrMockCommandsTests(unittest.TestCase):
     @mock.patch('requests.request', autospec=True)
     def test_repository_show_manifests(self, mock_requests_get, mock_get_access_credentials, mock_get_registry_by_name):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         encoded_manifests = json.dumps({'manifests': [
             {
                 'digest': 'sha256:b972dda797ef258a7ea5738eb2109778c2bac6a99d1033e6c9f9bdb4fbd196e7',
@@ -192,7 +192,7 @@ class AcrMockCommandsTests(unittest.TestCase):
     @mock.patch('requests.request', autospec=True)
     def test_repository_show(self, mock_requests_get, mock_get_access_credentials, mock_get_registry_by_name):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         encoded_manifests = json.dumps({
             'registry': 'testregistry.azurecr.io',
             'imageName': 'testrepository'
@@ -249,7 +249,7 @@ class AcrMockCommandsTests(unittest.TestCase):
     @mock.patch('requests.get', autospec=True)
     def test_repository_delete(self, mock_requests_get, mock_requests_delete, mock_get_access_credentials, mock_get_registry_by_name):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
 
         get_response = mock.MagicMock()
         get_response.headers = {
@@ -365,7 +365,7 @@ class AcrMockCommandsTests(unittest.TestCase):
     @mock.patch('requests.get', autospec=True)
     def test_get_docker_credentials(self, mock_requests_get, mock_requests_post, mock_get_registry_by_name, mock_get_raw_token):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
 
         registry = Registry(location='westus', sku=Sku(name='Standard'))
         registry.login_server = 'testregistry.azurecr.io'

--- a/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/tests/latest/preparers.py
+++ b/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/tests/latest/preparers.py
@@ -18,8 +18,8 @@ class VaultPreparer(AbstractPreparer, SingleValueReplacer):
                  resource_group_parameter_name='resource_group',
                  dev_setting_name='AZURE_CLI_TEST_DEV_BACKUP_ACCT_NAME'):
         super(VaultPreparer, self).__init__(name_prefix, 24)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        from azure.cli.core.mock import DummyCli
+        self.cli_ctx = DummyCli()
         self.parameter_name = parameter_name
         self.resource_group = None
         self.resource_group_parameter_name = resource_group_parameter_name
@@ -76,8 +76,8 @@ class VMPreparer(AbstractPreparer, SingleValueReplacer):
                  resource_group_location_parameter_name='resource_group_location',
                  resource_group_parameter_name='resource_group', dev_setting_name='AZURE_CLI_TEST_DEV_BACKUP_VM_NAME'):
         super(VMPreparer, self).__init__(name_prefix, 15)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        from azure.cli.core.mock import DummyCli
+        self.cli_ctx = DummyCli()
         self.parameter_name = parameter_name
         self.resource_group = None
         self.resource_group_parameter_name = resource_group_parameter_name
@@ -126,8 +126,8 @@ class ItemPreparer(AbstractPreparer, SingleValueReplacer):
                  resource_group_parameter_name='resource_group',
                  dev_setting_name='AZURE_CLI_TEST_DEV_BACKUP_ITEM_NAME'):
         super(ItemPreparer, self).__init__(name_prefix, 24)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        from azure.cli.core.mock import DummyCli
+        self.cli_ctx = DummyCli()
         self.parameter_name = parameter_name
         self.vm_parameter_name = vm_parameter_name
         self.resource_group = None
@@ -184,8 +184,8 @@ class PolicyPreparer(AbstractPreparer, SingleValueReplacer):
                  resource_group_parameter_name='resource_group',
                  dev_setting_name='AZURE_CLI_TEST_DEV_BACKUP_POLICY_NAME'):
         super(PolicyPreparer, self).__init__(name_prefix, 24)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        from azure.cli.core.mock import DummyCli
+        self.cli_ctx = DummyCli()
         self.parameter_name = parameter_name
         self.resource_group = None
         self.resource_group_parameter_name = resource_group_parameter_name
@@ -237,8 +237,8 @@ class RPPreparer(AbstractPreparer, SingleValueReplacer):
                  vault_parameter_name='vault_name',
                  resource_group_parameter_name='resource_group', dev_setting_name='AZURE_CLI_TEST_DEV_BACKUP_RP_NAME'):
         super(RPPreparer, self).__init__(name_prefix, 24)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        from azure.cli.core.mock import DummyCli
+        self.cli_ctx = DummyCli()
         self.parameter_name = parameter_name
         self.vm_parameter_name = vm_parameter_name
         self.resource_group = None

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/latest/batch_preparers.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/latest/batch_preparers.py
@@ -14,8 +14,8 @@ class BatchAccountPreparer(AbstractPreparer, SingleValueReplacer):
                  resource_group_parameter_name='resource_group', skip_delete=True,
                  dev_setting_name='AZURE_CLI_TEST_DEV_BATCH_ACCT_NAME'):
         super(BatchAccountPreparer, self).__init__(name_prefix, 24)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        from azure.cli.core.mock import DummyCli
+        self.cli_ctx = DummyCli()
         self.parameter_name = parameter_name
         self.resource_group = None
         self.resource_group_parameter_name = resource_group_parameter_name

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/latest/test_batch_mgmt_commands.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/latest/test_batch_mgmt_commands.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 
 from knack.util import CLIError
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 from azure.cli.testsdk import (
     ScenarioTest, ResourceGroupPreparer, LiveScenarioTest)
 from .batch_preparers import BatchAccountPreparer, BatchScenarioMixin

--- a/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/tests/latest/test_batchai_custom.py
+++ b/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/tests/latest/test_batchai_custom.py
@@ -23,7 +23,7 @@ from azure.cli.command_modules.batchai.custom import (
     _add_setup_task,
     _get_effective_resource_parameters)
 from azure.cli.core.util import CLIError
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 from azure.mgmt.batchai.models import (
     Cluster, ClusterCreateParameters, UserAccountSettings, MountVolumes, NodeSetup, FileServer,
     FileServerCreateParameters, AzureFileShareReference, AzureBlobFileSystemReference, AzureStorageCredentialsInfo,
@@ -211,10 +211,10 @@ class TestBatchAICustom(unittest.TestCase):
                               admin_user_ssh_public_key=SSH_KEY))
 
     def test_batchai_patch_mount_volumes_no_volumes(self):
-        self.assertIsNone(_patch_mount_volumes(TestCli(), None))
+        self.assertIsNone(_patch_mount_volumes(DummyCli(), None))
 
     def test_batchai_patch_mount_volumes_empty_volumes(self):
-        self.assertEqual(MountVolumes(), _patch_mount_volumes(TestCli(), MountVolumes()))
+        self.assertEqual(MountVolumes(), _patch_mount_volumes(DummyCli(), MountVolumes()))
 
     def test_batchai_patch_mount_volumes_with_templates_via_command_line_args(self):
         # noinspection PyTypeChecker
@@ -248,7 +248,7 @@ class TestBatchAICustom(unittest.TestCase):
                 ),
             ]
         )
-        actual = _patch_mount_volumes(TestCli(), mount_volumes, 'account', 'key')
+        actual = _patch_mount_volumes(DummyCli(), mount_volumes, 'account', 'key')
         expected = MountVolumes(
             azure_file_shares=[
                 AzureFileShareReference(
@@ -315,7 +315,7 @@ class TestBatchAICustom(unittest.TestCase):
         )
         with _given_env_variable('AZURE_BATCHAI_STORAGE_ACCOUNT', 'account'):
             with _given_env_variable('AZURE_BATCHAI_STORAGE_KEY', 'key'):
-                actual = _patch_mount_volumes(TestCli(), mount_volumes)
+                actual = _patch_mount_volumes(DummyCli(), mount_volumes)
         expected = MountVolumes(
             azure_file_shares=[
                 AzureFileShareReference(
@@ -371,7 +371,7 @@ class TestBatchAICustom(unittest.TestCase):
         )
         get_storage_client.return_value = \
             _get_mock_storage_accounts_and_keys({'account1': 'key1', 'account2': 'key2'})
-        actual = _patch_mount_volumes(TestCli(), mount_volumes)
+        actual = _patch_mount_volumes(DummyCli(), mount_volumes)
         expected = MountVolumes(
             azure_file_shares=[
                 AzureFileShareReference(
@@ -407,7 +407,7 @@ class TestBatchAICustom(unittest.TestCase):
             ]
         )
         with self.assertRaisesRegexp(CLIError, 'Cannot find "account1" storage account'):
-            _patch_mount_volumes(TestCli(), mount_volumes)
+            _patch_mount_volumes(DummyCli(), mount_volumes)
 
     @patch('azure.cli.command_modules.batchai.custom._get_storage_management_client')
     def test_batchai_patch_mount_volumes_with_credentials_no_account_given(
@@ -426,7 +426,7 @@ class TestBatchAICustom(unittest.TestCase):
             ]
         )
         with self.assertRaisesRegexp(CLIError, 'Please configure Azure Storage account name'):
-            _patch_mount_volumes(TestCli(), mount_volumes)
+            _patch_mount_volumes(DummyCli(), mount_volumes)
 
     @patch('azure.cli.command_modules.batchai.custom._get_storage_management_client')
     def test_batchai_patch_mount_volumes_when_no_patching_required(
@@ -444,7 +444,7 @@ class TestBatchAICustom(unittest.TestCase):
                 )
             ]
         )
-        actual = _patch_mount_volumes(TestCli(), mount_volumes)
+        actual = _patch_mount_volumes(DummyCli(), mount_volumes)
         self.assertEquals(mount_volumes, actual)
 
     def test_batchai_patch_mount_volumes_no_azure_file_url(self):
@@ -460,7 +460,7 @@ class TestBatchAICustom(unittest.TestCase):
             ]
         )
         with self.assertRaisesRegexp(CLIError, 'Azure File URL cannot absent or be empty'):
-            _patch_mount_volumes(TestCli(), mount_volumes)
+            _patch_mount_volumes(DummyCli(), mount_volumes)
 
     def test_batchai_patch_mount_volumes_ill_formed_azure_file_url(self):
         # noinspection PyTypeChecker
@@ -475,7 +475,7 @@ class TestBatchAICustom(unittest.TestCase):
             ]
         )
         with self.assertRaisesRegexp(CLIError, 'Ill-formed Azure File URL'):
-            _patch_mount_volumes(TestCli(), mount_volumes)
+            _patch_mount_volumes(DummyCli(), mount_volumes)
 
     def test_batchai_add_nfs_to_mount_volumes_no_relative_mount_path(self):
         with self.assertRaisesRegexp(CLIError, 'File server relative mount path cannot be empty'):
@@ -503,11 +503,11 @@ class TestBatchAICustom(unittest.TestCase):
 
     def test_batchai_add_azure_file_share_to_mount_volumes_no_account_info(self):
         with self.assertRaisesRegexp(CLIError, 'Please configure Azure Storage account name'):
-            _add_azure_file_share_to_mount_volumes(TestCli(), MountVolumes(), 'share', 'relative_path')
+            _add_azure_file_share_to_mount_volumes(DummyCli(), MountVolumes(), 'share', 'relative_path')
 
     def test_batchai_add_azure_file_share_to_mount_volumes_no_relative_mount_path(self):
         with self.assertRaisesRegexp(CLIError, 'Azure File share relative mount path cannot be empty'):
-            _add_azure_file_share_to_mount_volumes(TestCli(), MountVolumes(), 'share', '')
+            _add_azure_file_share_to_mount_volumes(DummyCli(), MountVolumes(), 'share', '')
 
     @patch('azure.cli.command_modules.batchai.custom._get_storage_management_client')
     def test_batchai_add_azure_file_share_to_mount_volumes_account_and_key_via_env_variables(
@@ -515,7 +515,7 @@ class TestBatchAICustom(unittest.TestCase):
         get_storage_client.return_value = _get_mock_storage_accounts_and_keys({'account': 'key'})
         with _given_env_variable('AZURE_BATCHAI_STORAGE_ACCOUNT', 'account'):
             with _given_env_variable('AZURE_BATCHAI_STORAGE_KEY', 'key'):
-                actual = _add_azure_file_share_to_mount_volumes(TestCli(), MountVolumes(), 'share', 'relative_path')
+                actual = _add_azure_file_share_to_mount_volumes(DummyCli(), MountVolumes(), 'share', 'relative_path')
         expected = MountVolumes(azure_file_shares=[
             AzureFileShareReference(
                 account_name='account',
@@ -533,7 +533,7 @@ class TestBatchAICustom(unittest.TestCase):
             self, get_storage_client):
         get_storage_client.return_value = \
             _get_mock_storage_accounts_and_keys({'account': 'key'})
-        actual = _add_azure_file_share_to_mount_volumes(TestCli(), MountVolumes(), 'share', 'relative_path',
+        actual = _add_azure_file_share_to_mount_volumes(DummyCli(), MountVolumes(), 'share', 'relative_path',
                                                         'account', 'key')
         expected = MountVolumes(azure_file_shares=[
             AzureFileShareReference(
@@ -550,7 +550,7 @@ class TestBatchAICustom(unittest.TestCase):
     @patch('azure.cli.command_modules.batchai.custom._get_storage_management_client')
     def test_batchai_add_azure_file_share_to_mount_volumes_account_via_command_line_args(self, get_storage_client):
         get_storage_client.return_value = _get_mock_storage_accounts_and_keys({'account': 'key'})
-        actual = _add_azure_file_share_to_mount_volumes(TestCli(), MountVolumes(), 'share', 'relative_path', 'account')
+        actual = _add_azure_file_share_to_mount_volumes(DummyCli(), MountVolumes(), 'share', 'relative_path', 'account')
         expected = MountVolumes(azure_file_shares=[
             AzureFileShareReference(
                 account_name='account',
@@ -566,7 +566,7 @@ class TestBatchAICustom(unittest.TestCase):
     @patch('azure.cli.command_modules.batchai.custom._get_storage_management_client')
     def test_batchai_add_azure_file_share_to_absent_mount_volumes(self, get_storage_client):
         get_storage_client.return_value = _get_mock_storage_accounts_and_keys({'account': 'key'})
-        actual = _add_azure_file_share_to_mount_volumes(TestCli(), None, 'share', 'relative_path', 'account')
+        actual = _add_azure_file_share_to_mount_volumes(DummyCli(), None, 'share', 'relative_path', 'account')
         expected = MountVolumes(azure_file_shares=[
             AzureFileShareReference(
                 account_name='account',
@@ -581,16 +581,16 @@ class TestBatchAICustom(unittest.TestCase):
 
     def test_batchai_add_azure_container_mount_volumes_no_account(self):
         with self.assertRaisesRegexp(CLIError, 'Please configure Azure Storage account name'):
-            _add_azure_container_to_mount_volumes(TestCli(), MountVolumes(), 'container', 'relative_path')
+            _add_azure_container_to_mount_volumes(DummyCli(), MountVolumes(), 'container', 'relative_path')
 
     def test_batchai_add_azure_container_mount_volumes_no_relative_path(self):
         with self.assertRaisesRegexp(CLIError, 'Azure Storage Container relative mount path cannot be empty'):
-            _add_azure_container_to_mount_volumes(TestCli(), MountVolumes(), 'container', '')
+            _add_azure_container_to_mount_volumes(DummyCli(), MountVolumes(), 'container', '')
 
     def test_batchai_add_azure_container_to_absent_mount_volumes(self):
         with _given_env_variable('AZURE_BATCHAI_STORAGE_ACCOUNT', 'account'):
             with _given_env_variable('AZURE_BATCHAI_STORAGE_KEY', 'key'):
-                actual = _add_azure_container_to_mount_volumes(TestCli(), None, 'container', 'relative_path')
+                actual = _add_azure_container_to_mount_volumes(DummyCli(), None, 'container', 'relative_path')
         expected = MountVolumes(azure_blob_file_systems=[
             AzureBlobFileSystemReference(
                 account_name='account',
@@ -602,7 +602,7 @@ class TestBatchAICustom(unittest.TestCase):
     def test_batchai_add_azure_container_mount_volumes_account_and_key_via_env_variables(self):
         with _given_env_variable('AZURE_BATCHAI_STORAGE_ACCOUNT', 'account'):
             with _given_env_variable('AZURE_BATCHAI_STORAGE_KEY', 'key'):
-                actual = _add_azure_container_to_mount_volumes(TestCli(), MountVolumes(), 'container', 'relative_path')
+                actual = _add_azure_container_to_mount_volumes(DummyCli(), MountVolumes(), 'container', 'relative_path')
         expected = MountVolumes(azure_blob_file_systems=[
             AzureBlobFileSystemReference(
                 account_name='account',
@@ -613,7 +613,7 @@ class TestBatchAICustom(unittest.TestCase):
 
     def test_batchai_add_azure_container_mount_volumes_account_and_key_via_cmd_line_args(self):
         actual = _add_azure_container_to_mount_volumes(
-            TestCli(), MountVolumes(), 'container', 'relative_path', 'account', 'key')
+            DummyCli(), MountVolumes(), 'container', 'relative_path', 'account', 'key')
         expected = MountVolumes(azure_blob_file_systems=[
             AzureBlobFileSystemReference(
                 account_name='account',
@@ -626,7 +626,7 @@ class TestBatchAICustom(unittest.TestCase):
     def test_batchai_add_azure_container_mount_volumes_account_via_cmd_line_args(self, get_storage_client):
         get_storage_client.return_value = _get_mock_storage_accounts_and_keys({'account': 'key'})
         actual = _add_azure_container_to_mount_volumes(
-            TestCli(), MountVolumes(), 'container', 'relative_path', 'account')
+            DummyCli(), MountVolumes(), 'container', 'relative_path', 'account')
         expected = MountVolumes(azure_blob_file_systems=[
             AzureBlobFileSystemReference(
                 account_name='account',
@@ -844,7 +844,7 @@ class TestBatchAICustom(unittest.TestCase):
         self.assertFalse(_is_on_mount_point('afs', 'af'))
 
     def test_list_setup_task_files_for_cluster_when_no_node_setup(self):
-        self.assertEqual(_list_node_setup_files_for_cluster(TestCli(), Cluster(), '.', 60), [])
+        self.assertEqual(_list_node_setup_files_for_cluster(DummyCli(), Cluster(), '.', 60), [])
 
     def test_list_setup_task_files_for_cluster_when_output_not_on_mounts_root(self):
         with self.assertRaisesRegexp(CLIError, 'List files is supported only for clusters with startup task'):
@@ -853,7 +853,7 @@ class TestBatchAICustom(unittest.TestCase):
                     setup_task=SetupTask(
                         command_line='true',
                         std_out_err_path_prefix='/somewhere')))
-            _list_node_setup_files_for_cluster(TestCli(), cluster, '.', 60)
+            _list_node_setup_files_for_cluster(DummyCli(), cluster, '.', 60)
 
     def test_list_setup_task_files_for_cluster_when_cluster_doesnt_support_suffix(self):
         with self.assertRaisesRegexp(CLIError, 'List files is not supported for this cluster'):
@@ -862,7 +862,7 @@ class TestBatchAICustom(unittest.TestCase):
                     setup_task=SetupTask(
                         command_line='true',
                         std_out_err_path_prefix='$AZ_BATCHAI_MOUNT_ROOT/nfs')))
-            _list_node_setup_files_for_cluster(TestCli(), cluster, '.', 60)
+            _list_node_setup_files_for_cluster(DummyCli(), cluster, '.', 60)
 
     def test_list_setup_task_files_for_cluster_when_cluster_has_not_mount_volumes(self):
         with self.assertRaisesRegexp(CLIError, 'List files is supported only for clusters with startup task'):
@@ -872,7 +872,7 @@ class TestBatchAICustom(unittest.TestCase):
                         command_line='true',
                         std_out_err_path_prefix='$AZ_BATCHAI_MOUNT_ROOT/nfs')))
             cluster.node_setup.setup_task.std_out_err_path_suffix = 'path/segment'
-            _list_node_setup_files_for_cluster(TestCli(), cluster, '.', 60)
+            _list_node_setup_files_for_cluster(DummyCli(), cluster, '.', 60)
 
     def test_list_setup_task_files_for_cluster_when_output_not_on_afs_or_bfs(self):
         with self.assertRaisesRegexp(CLIError, 'List files is supported only for clusters with startup task'):
@@ -893,7 +893,7 @@ class TestBatchAICustom(unittest.TestCase):
                         )]
                 ))
             cluster.node_setup.setup_task.std_out_err_path_suffix = 'path/segment'
-            _list_node_setup_files_for_cluster(TestCli(), cluster, '.', 60)
+            _list_node_setup_files_for_cluster(DummyCli(), cluster, '.', 60)
 
     @patch('azure.cli.command_modules.batchai.custom._get_files_from_afs')
     def test_list_setup_task_files_for_cluster_when_output_on_afs(self, get_files_from_afs):
@@ -910,7 +910,7 @@ class TestBatchAICustom(unittest.TestCase):
                     account_name='some',
                     azure_file_url='some url',
                     credentials=None)])
-        cli_ctx = TestCli()
+        cli_ctx = DummyCli()
         _list_node_setup_files_for_cluster(cli_ctx, cluster, '.', 60)
         get_files_from_afs.assert_called_once_with(
             cli_ctx,
@@ -936,7 +936,7 @@ class TestBatchAICustom(unittest.TestCase):
                     account_name='some',
                     container_name='container',
                     credentials=None)])
-        cli_ctx = TestCli()
+        cli_ctx = DummyCli()
         _list_node_setup_files_for_cluster(cli_ctx, cluster, '.', 60)
         get_files_from_bfs.assert_called_once_with(
             cli_ctx,

--- a/src/command_modules/azure-cli-find/azure/cli/command_modules/find/tests/latest/test_find.py
+++ b/src/command_modules/azure-cli-find/azure/cli/command_modules/find/tests/latest/test_find.py
@@ -11,7 +11,7 @@ import six
 from six import StringIO
 
 from azure.cli.command_modules.find.custom import _purge, find
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 
 @contextlib.contextmanager
@@ -31,7 +31,7 @@ class SearchIndexTest(unittest.TestCase):
     def setUp(self):
         _purge()
         self.loader = mock.MagicMock()
-        self.loader.cli_ctx = TestCli()
+        self.loader.cli_ctx = DummyCli()
 
     def execute(self, args, reindex=False):
         with capture() as out:

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_completion.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_completion.py
@@ -7,7 +7,7 @@ import os
 import unittest
 import mock
 
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 from azure.cli.command_modules.interactive.azclishell.configuration import Configuration
 from azure.cli.command_modules.interactive.azclishell.app import AzInteractiveShell
 
@@ -22,7 +22,7 @@ class CompletionTest(unittest.TestCase):
         super(CompletionTest, self).__init__(methodName)
         with mock.patch.object(Configuration, 'get_help_files', lambda _: 'help_dump_test.json'):
             with mock.patch.object(Configuration, 'get_config_dir', lambda _: TEST_DIR):
-                shell_ctx = AzInteractiveShell(TestCli(), None)
+                shell_ctx = AzInteractiveShell(DummyCli(), None)
                 self.completer = shell_ctx.completer
                 self.shell_ctx = shell_ctx
 

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_feedback.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_feedback.py
@@ -35,10 +35,10 @@ class FeedbackTest(unittest.TestCase):
     """ tests the frequncy heuristic """
     def __init__(self, *args, **kwargs):
         super(FeedbackTest, self).__init__(*args, **kwargs)
-        from azure.cli.testsdk import TestCli
+        from azure.cli.core.mock import DummyCli
         from azure.cli.command_modules.interactive.azclishell.app import AzInteractiveShell
         self.norm_update = fh.update_frequency
-        self.shell_ctx = AzInteractiveShell(TestCli(), None)
+        self.shell_ctx = AzInteractiveShell(DummyCli(), None)
 
     def test_heuristic(self):
         # test the correct logging of time for frequency

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_query_injection.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_query_injection.py
@@ -28,9 +28,9 @@ class QueryInjection(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(QueryInjection, self).__init__(*args, **kwargs)
         from azure.cli.command_modules.interactive.azclishell.app import AzInteractiveShell
-        from azure.cli.testsdk import TestCli
+        from azure.cli.core.mock import DummyCli
         self.stream = six.StringIO()
-        self.shell = AzInteractiveShell(TestCli(), output_custom=self.stream)
+        self.shell = AzInteractiveShell(DummyCli(), output_custom=self.stream)
         self.shell.cli_execute = self._mock_execute
         self.shell.last = MockValues()
 

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_tree.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/latest/test_tree.py
@@ -8,7 +8,7 @@ import os
 import unittest
 import mock
 
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 from azure.cli.command_modules.interactive.azclishell.configuration import Configuration
 from azure.cli.command_modules.interactive.azclishell.app import AzInteractiveShell
 
@@ -22,7 +22,7 @@ class CommandTreeTest(unittest.TestCase):
     def init_tree(self):
         with mock.patch.object(Configuration, 'get_help_files', lambda _: 'help_dump_test.json'):
             with mock.patch.object(Configuration, 'get_config_dir', lambda _: TEST_DIR):
-                shell_ctx = AzInteractiveShell(TestCli(), None)
+                shell_ctx = AzInteractiveShell(DummyCli(), None)
                 self.command_tree = shell_ctx.completer.command_tree
 
     def test_in_tree(self):

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/latest/test_monitor_unittest.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/latest/test_monitor_unittest.py
@@ -41,10 +41,10 @@ class MonitorNameOrIdTest(unittest.TestCase):
     @mock.patch('azure.cli.core.commands.client_factory.get_subscription_id', _mock_get_subscription_id)
     def test_monitor_resource_id(self):
         from azure.cli.command_modules.monitor.validators import get_target_resource_validator
-        from azure.cli.testsdk import TestCli
+        from azure.cli.core.mock import DummyCli
 
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         validator = get_target_resource_validator('name_or_id', True)
 
         id = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Compute/' \

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -7,7 +7,7 @@ import unittest
 import mock
 
 from azure.cli.command_modules.profile.custom import list_subscriptions, get_access_token, login
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 
 class ProfileCommandTest(unittest.TestCase):
@@ -16,7 +16,7 @@ class ProfileCommandTest(unittest.TestCase):
     @mock.patch('azure.cli.command_modules.profile.custom.logger', autospec=True)
     def test_list_only_enabled_one(self, logger_mock, load_subscription_mock):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         sub1 = {'state': 'Enabled'}
         sub2 = {'state': 'Overdued'}
         load_subscription_mock.return_value = [sub1, sub2]
@@ -33,7 +33,7 @@ class ProfileCommandTest(unittest.TestCase):
     @mock.patch('azure.cli.core._profile.Profile.get_raw_token', autospec=True)
     def test_get_row_token(self, get_raw_token_mcok):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
 
         # arrange
         get_raw_token_mcok.return_value = (['bearer', 'token123', {'expiresOn': '2100-01-01'}], 'sub123', 'tenant123')

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
@@ -32,8 +32,8 @@ class ServerPreparer(AbstractPreparer, SingleValueReplacer):
                  resource_group_parameter_name='resource_group', skip_delete=True,
                  sku_name='GP_Gen5_2'):
         super(ServerPreparer, self).__init__(name_prefix, SERVER_NAME_MAX_LENGTH)
-        from azure.cli.testsdk import TestCli
-        self.cli_ctx = TestCli()
+        from azure.cli.core.mock import DummyCli
+        self.cli_ctx = DummyCli()
         self.engine_type = engine_type
         self.engine_parameter_name = engine_parameter_name
         self.location = location

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/2017_03_09_profile/test_api_check.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/2017_03_09_profile/test_api_check.py
@@ -51,8 +51,8 @@ class TestApiCheck(unittest.TestCase):
 
     def test_resolve_api_provider_backup(self):
         # Verifies provider is used as backup if api-version not specified.
-        from azure.cli.testsdk import TestCli
-        cli = TestCli()
+        from azure.cli.core.mock import DummyCli
+        cli = DummyCli()
         rcf = self._get_mock_client()
         res_utils = _ResourceUtils(cli, resource_type='Mock/test', resource_name='vnet1',
                                    resource_group_name='rg', rcf=rcf)
@@ -60,8 +60,8 @@ class TestApiCheck(unittest.TestCase):
 
     def test_resolve_api_provider_with_parent_backup(self):
         # Verifies provider (with parent) is used as backup if api-version not specified.
-        from azure.cli.testsdk import TestCli
-        cli = TestCli()
+        from azure.cli.core.mock import DummyCli
+        cli = DummyCli()
         rcf = self._get_mock_client()
         res_utils = _ResourceUtils(cli, parent_resource_path='foo/testfoo123', resource_group_name='rg',
                                    resource_provider_namespace='Mock', resource_type='test',
@@ -71,8 +71,8 @@ class TestApiCheck(unittest.TestCase):
 
     def test_resolve_api_all_previews(self):
         # Verifies most recent preview version returned only if there are no non-preview versions.
-        from azure.cli.testsdk import TestCli
-        cli = TestCli()
+        from azure.cli.core.mock import DummyCli
+        cli = DummyCli()
         rcf = self._get_mock_client()
         res_utils = _ResourceUtils(cli, resource_type='Mock/preview', resource_name='vnet1',
                                    resource_group_name='rg', rcf=rcf)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_api_check.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_api_check.py
@@ -51,8 +51,8 @@ class TestApiCheck(unittest.TestCase):
 
     def test_resolve_api_provider_backup(self):
         # Verifies provider is used as backup if api-version not specified.
-        from azure.cli.testsdk import TestCli
-        cli = TestCli()
+        from azure.cli.core.mock import DummyCli
+        cli = DummyCli()
         rcf = self._get_mock_client()
         res_utils = _ResourceUtils(cli, resource_type='Mock/test', resource_name='vnet1',
                                    resource_group_name='rg', rcf=rcf)
@@ -60,8 +60,8 @@ class TestApiCheck(unittest.TestCase):
 
     def test_resolve_api_provider_with_parent_backup(self):
         # Verifies provider (with parent) is used as backup if api-version not specified.
-        from azure.cli.testsdk import TestCli
-        cli = TestCli()
+        from azure.cli.core.mock import DummyCli
+        cli = DummyCli()
         rcf = self._get_mock_client()
         res_utils = _ResourceUtils(cli, parent_resource_path='foo/testfoo123', resource_group_name='rg',
                                    resource_provider_namespace='Mock', resource_type='test',
@@ -71,8 +71,8 @@ class TestApiCheck(unittest.TestCase):
 
     def test_resolve_api_all_previews(self):
         # Verifies most recent preview version returned only if there are no non-preview versions.
-        from azure.cli.testsdk import TestCli
-        cli = TestCli()
+        from azure.cli.core.mock import DummyCli
+        cli = DummyCli()
         rcf = self._get_mock_client()
         res_utils = _ResourceUtils(cli, resource_type='Mock/preview', resource_name='vnet1',
                                    resource_group_name='rg', rcf=rcf)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role_commands_thru_mock.py
@@ -9,7 +9,7 @@ import unittest
 import uuid
 import mock
 
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 from azure.mgmt.authorization.models import RoleDefinition, RoleAssignmentCreateParameters
 from azure.graphrbac.models import (Application, ServicePrincipal, GraphErrorException,
@@ -69,7 +69,7 @@ class TestRoleMocked(unittest.TestCase):
 
         # action
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         create_role_definition(cmd, role_definition_file)
 
         # assert
@@ -101,7 +101,7 @@ class TestRoleMocked(unittest.TestCase):
 
         # action
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         update_role_definition(cmd, role_definition_file)
 
         # assert
@@ -127,7 +127,7 @@ class TestRoleMocked(unittest.TestCase):
 
         # action
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         result = create_service_principal_for_rbac(cmd, name, test_pwd, 12, skip_assignment=True)
 
         # assert
@@ -168,7 +168,7 @@ class TestRoleMocked(unittest.TestCase):
 
         # action
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         result = create_service_principal_for_rbac(cmd, name, cert=cert, years=2, skip_assignment=True)
 
         # assert
@@ -195,7 +195,7 @@ class TestRoleMocked(unittest.TestCase):
         sp_object.app_id = 'app_id'
         app_object = mock.MagicMock()
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         app_object.object_id = test_object_id
 
         graph_client_mock.return_value = faked_graph_client
@@ -252,7 +252,7 @@ class TestRoleMocked(unittest.TestCase):
         key_cred = mock.MagicMock()
         key_cred.key_id = key_id_of_existing_cert
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
 
         graph_client_mock.return_value = faked_graph_client
         faked_graph_client.service_principals.list.return_value = [sp_object]
@@ -271,7 +271,7 @@ class TestRoleMocked(unittest.TestCase):
     @mock.patch('azure.cli.command_modules.role.custom._graph_client_factory', autospec=True)
     def test_create_for_rbac_failed_with_polished_error_if_due_to_permission(self, graph_client_mock, auth_client_mock):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         TestRoleMocked._common_rbac_err_polish_test_mock_setup(graph_client_mock, auth_client_mock,
                                                                'Insufficient privileges to complete the operation',
                                                                self.subscription_id)
@@ -287,7 +287,7 @@ class TestRoleMocked(unittest.TestCase):
     @mock.patch('azure.cli.command_modules.role.custom._graph_client_factory', autospec=True)
     def test_create_for_rbac_failed_with_regular_error(self, graph_client_mock, auth_client_mock):
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         TestRoleMocked._common_rbac_err_polish_test_mock_setup(graph_client_mock, auth_client_mock,
                                                                'something bad for you',
                                                                self.subscription_id)

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -9,6 +9,7 @@ import os
 from azure_devtools.scenario_tests import AllowLargeResponse
 
 from azure.cli.core.util import CLIError
+from azure.cli.core.mock import DummyCli
 from azure.cli.testsdk.base import execute
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk import (
@@ -19,7 +20,6 @@ from azure.cli.testsdk import (
     ResourceGroupPreparer,
     ScenarioTest,
     StorageAccountPreparer,
-    TestCli,
     LiveScenarioTest)
 from azure.cli.testsdk.preparers import (
     AbstractPreparer,
@@ -52,13 +52,13 @@ class SqlServerPreparer(AbstractPreparer, SingleValueReplacer):
     def create_resource(self, name, **kwargs):
         group = self._get_resource_group(**kwargs)
         template = 'az sql server create -l {} -g {} -n {} -u {} -p {}'
-        execute(TestCli(), template.format(self.location, group, name, self.admin_user, self.admin_password))
+        execute(DummyCli(), template.format(self.location, group, name, self.admin_user, self.admin_password))
         return {self.parameter_name: name}
 
     def remove_resource(self, name, **kwargs):
         if not self.skip_delete:
             group = self._get_resource_group(**kwargs)
-            execute(TestCli(), 'az sql server delete -g {} -n {} --yes --no-wait'.format(group, name))
+            execute(DummyCli(), 'az sql server delete -g {} -n {} --yes --no-wait'.format(group, name))
 
     def _get_resource_group(self, **kwargs):
         try:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -26,12 +26,12 @@ from azure.cli.command_modules.vm.disk_encryption import (encrypt_vm, decrypt_vm
                                                           encrypt_vmss, decrypt_vmss)
 from azure.cli.core.profiles import get_sdk, ResourceType
 
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 
 NetworkProfile, StorageProfile, DataDisk, OSDisk, OperatingSystemTypes, InstanceViewStatus, \
     VirtualMachineExtensionInstanceView, VirtualMachineExtension, ImageReference, DiskCreateOptionTypes, \
-    CachingTypes = get_sdk(TestCli(), ResourceType.MGMT_COMPUTE, 'NetworkProfile', 'StorageProfile', 'DataDisk', 'OSDisk',
+    CachingTypes = get_sdk(DummyCli(), ResourceType.MGMT_COMPUTE, 'NetworkProfile', 'StorageProfile', 'DataDisk', 'OSDisk',
                            'OperatingSystemTypes', 'InstanceViewStatus', 'VirtualMachineExtensionInstanceView',
                            'VirtualMachineExtension', 'ImageReference', 'DiskCreateOptionTypes',
                            'CachingTypes',
@@ -39,7 +39,7 @@ NetworkProfile, StorageProfile, DataDisk, OSDisk, OperatingSystemTypes, Instance
 
 
 def _get_test_cmd():
-    cli_ctx = TestCli()
+    cli_ctx = DummyCli()
     loader = AzCommandsLoader(cli_ctx, resource_type=ResourceType.MGMT_COMPUTE)
     cmd = AzCliCommand(loader, 'test', None)
     cmd.command_kwargs = {'resource_type': ResourceType.MGMT_COMPUTE, 'operation_group': 'virtual_machines'}

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -20,7 +20,7 @@ from azure.cli.command_modules.vm._validators import (validate_ssh_key,
                                                       _validate_vm_vmss_msi,
                                                       _validate_vm_vmss_accelerated_networking)
 from azure.cli.command_modules.vm._vm_utils import normalize_disk_info
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 from azure.mgmt.compute.models import CachingTypes
 from knack.util import CLIError
 
@@ -71,7 +71,7 @@ class TestActions(unittest.TestCase):
 
     def test_figure_out_storage_source(self):
         test_data = 'https://av123images.blob.core.windows.net/images/TDAZBET.vhd'
-        src_blob_uri, src_disk, src_snapshot = _figure_out_storage_source(TestCli(), 'tg1', test_data)
+        src_blob_uri, src_disk, src_snapshot = _figure_out_storage_source(DummyCli(), 'tg1', test_data)
         self.assertFalse(src_disk)
         self.assertFalse(src_snapshot)
         self.assertEqual(src_blob_uri, test_data)
@@ -85,7 +85,7 @@ class TestActions(unittest.TestCase):
     def test_source_storage_account_err_case(self):
         np = mock.MagicMock()
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         np._cmd = cmd
         np.source_storage_account_id = '/subscriptions/123/resourceGroups/ygsrc/providers/Microsoft.Storage/storageAccounts/s123'
         np.source = '/subscriptions/123/resourceGroups/yugangw/providers/Microsoft.Compute/disks/d2'
@@ -168,7 +168,7 @@ class TestActions(unittest.TestCase):
         compute_client = mock.MagicMock()
         image = mock.MagicMock()
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         image.plan.name = 'plan1'
         image.plan.product = 'product1'
         image.plan.publisher = 'publisher1'
@@ -195,7 +195,7 @@ class TestActions(unittest.TestCase):
         compute_client = mock.MagicMock()
         resp = mock.MagicMock()
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         resp.status_code = 404
         resp.text = '{"Message": "Not Found"}'
 
@@ -274,7 +274,7 @@ class TestActions(unittest.TestCase):
         # check throw on : az vm/vmss create --assign-identity --role reader --scope ""
         np_mock = mock.MagicMock()
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         np_mock.assign_identity = []
         np_mock.identity_scope = None
         np_mock.identity_role = 'reader'
@@ -316,7 +316,7 @@ class TestActions(unittest.TestCase):
         # check throw on : az vm/vmss assign-identity --role reader --scope ""
         np_mock = mock.MagicMock()
         cmd = mock.MagicMock()
-        cmd.cli_ctx = TestCli()
+        cmd.cli_ctx = DummyCli()
         np_mock.identity_scope = ''
         np_mock.identity_role = 'reader'
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_defaults.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_defaults.py
@@ -26,10 +26,10 @@ from azure.cli.command_modules.vm._validators import (_validate_vm_vmss_create_v
 
 
 def _get_test_cmd():
-    from azure.cli.testsdk import TestCli
+    from azure.cli.core.mock import DummyCli
     from azure.cli.core import AzCommandsLoader
     from azure.cli.core.commands import AzCliCommand
-    cli_ctx = TestCli()
+    cli_ctx = DummyCli()
     loader = AzCommandsLoader(cli_ctx, resource_type=ResourceType.MGMT_COMPUTE)
     cmd = AzCliCommand(loader, 'test', None)
     cmd.command_kwargs = {'resource_type': ResourceType.MGMT_COMPUTE}

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_image.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_image.py
@@ -8,17 +8,17 @@ import unittest
 import mock
 
 from azure.cli.core.cloud import CloudEndpointNotSetException
-from azure.cli.testsdk import TestCli
+from azure.cli.core.mock import DummyCli
 
 from knack.util import CLIError
 
 
 def _get_test_cmd():
-    from azure.cli.testsdk import TestCli
+    from azure.cli.core.mock import DummyCli
     from azure.cli.core import AzCommandsLoader
     from azure.cli.core.commands import AzCliCommand
     from azure.cli.core.profiles import ResourceType
-    cli_ctx = TestCli()
+    cli_ctx = DummyCli()
     loader = AzCommandsLoader(cli_ctx, resource_type=ResourceType.MGMT_COMPUTE)
     cmd = AzCliCommand(loader, 'test', None)
     cmd.command_kwargs = {'resource_type': ResourceType.MGMT_COMPUTE}
@@ -64,7 +64,7 @@ class TestVMImage(unittest.TestCase):
         type(mock_cloud.endpoints).vm_image_alias_doc = p
         mock_get_active_cloud.return_value = mock_cloud
         # assert
-        cli_ctx = TestCli()
+        cli_ctx = DummyCli()
         cli_ctx.cloud = mock_cloud
         with self.assertRaises(CLIError):
             load_images_from_aliases_doc(cli_ctx)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_parameters.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_parameters.py
@@ -11,11 +11,11 @@ except ImportError:
 
 
 def mock_echo_args(command_name, parameters):
-    from azure.cli.testsdk import TestCli
+    from azure.cli.core.mock import DummyCli
     try:
         # TODO: continue work on this...
         argv = ' '.join((command_name, parameters)).split()
-        cli = TestCli()
+        cli = DummyCli()
         cli.invoke(argv)
         command_table = cli.invocation.commands_loader.command_table
         prefunc = command_table[command_name].handler
@@ -39,11 +39,11 @@ class TestVMValidators(unittest.TestCase):
         from azure.cli.command_modules.vm._validators import _validate_vm_create_nics
 
         def _get_test_cmd():
-            from azure.cli.testsdk import TestCli
+            from azure.cli.core.mock import DummyCli
             from azure.cli.core import AzCommandsLoader
             from azure.cli.core.commands import AzCliCommand
             from azure.cli.core.profiles import ResourceType
-            cli_ctx = TestCli()
+            cli_ctx = DummyCli()
             loader = AzCommandsLoader(cli_ctx, resource_type=ResourceType.MGMT_COMPUTE)
             cmd = AzCliCommand(loader, 'test', None)
             cmd.command_kwargs = {'resource_type': ResourceType.MGMT_COMPUTE}


### PR DESCRIPTION
There is a circular dependency between `azure-cli-core` and `azure-cli-testsdk`. The dependency is broken in this PR by using explicit `import_module`.

This change prepares a broader move from nosetest to pytest.