### PR TITLE
Allow SemVer APIVersion

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -166,6 +166,7 @@ def get_api_version(api_profile, resource_type, as_sdk_profile=False):
     except KeyError:
         raise APIVersionException(resource_type, api_profile)
 
+
 @total_ordering
 class _SemVerAPIFormat(object):
     """Basic semver x.y.z API format.
@@ -240,13 +241,16 @@ class _DateAPIFormat(object):
                         return True
         return False
 
+
 def _cross_api_format_lt(api_version, other):
     """LT strategy that supports if types are different.
 
     For now, let's assume that any Semver is higher than any DateAPI
     This fits KeyVault, if later we have a counter-example we'll update
     """
-    is_semver = lambda x: "." in x # Keep it stupid and simple
+    def is_semver(version):
+        # Keep it stupid and simple
+        return "." in version
 
     api_version = _SemVerAPIFormat(api_version) if is_semver(api_version) else _DateAPIFormat(api_version)
     other = _SemVerAPIFormat(other) if is_semver(other) else _DateAPIFormat(other)
@@ -256,6 +260,7 @@ def _cross_api_format_lt(api_version, other):
     elif isinstance(api_version, _DateAPIFormat) and isinstance(other, _SemVerAPIFormat):
         return True
     return False
+
 
 def _validate_api_version(api_version_str, min_api=None, max_api=None):
     """Validate if api_version is inside the interval min_api/max_api.

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -242,18 +242,24 @@ class _DateAPIFormat(object):
         return False
 
 
+def _parse_api_version(api_version):
+    """Will try to parse it as a date, and if not working
+    as semver, and if still not working raise.
+    """
+    try:
+        return _DateAPIFormat(api_version)
+    except ValueError:
+        return _SemVerAPIFormat(api_version)
+
+
 def _cross_api_format_lt(api_version, other):
     """LT strategy that supports if types are different.
 
     For now, let's assume that any Semver is higher than any DateAPI
     This fits KeyVault, if later we have a counter-example we'll update
     """
-    def is_semver(version):
-        # Keep it stupid and simple
-        return "." in version
-
-    api_version = _SemVerAPIFormat(api_version) if is_semver(api_version) else _DateAPIFormat(api_version)
-    other = _SemVerAPIFormat(other) if is_semver(other) else _DateAPIFormat(other)
+    api_version = _parse_api_version(api_version)
+    other = _parse_api_version(other)
 
     if type(api_version) is type(other):
         return api_version < other

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -166,6 +166,31 @@ def get_api_version(api_profile, resource_type, as_sdk_profile=False):
     except KeyError:
         raise APIVersionException(resource_type, api_profile)
 
+@total_ordering
+class _SemVerAPIFormat(object):
+    """Basic semver x.y.z API format.
+    Supports x, or x.y, or x.y.z
+    """
+
+    def __init__(self, api_version_str):
+        try:
+            parts = api_version_str.split('.')
+            parts += [0, 0]  # At worst never read, at best minor/patch
+            self.major = int(parts[0])
+            self.minor = int(parts[1])
+            self.patch = int(parts[2])
+        except (ValueError, TypeError):
+            raise ValueError('The API version {} is not in a '
+                             'semver format'.format(api_version_str))
+
+    def __eq__(self, other):
+        return (self.major, self.minor, self.patch) == (other.major, other.minor, other.patch)
+
+    def __lt__(self, other):
+        return self.major < other.major or \
+            (self.major == other.major and self.minor < other.minor) or \
+            (self.major == other.major and self.minor == other.minor and self.patch < other.patch)
+
 
 @total_ordering  # pylint: disable=too-few-public-methods
 class _DateAPIFormat(object):
@@ -215,12 +240,29 @@ class _DateAPIFormat(object):
                         return True
         return False
 
+def _cross_api_format_lt(api_version, other):
+    """LT strategy that supports if types are different.
+
+    For now, let's assume that any Semver is higher than any DateAPI
+    This fits KeyVault, if later we have a counter-example we'll update
+    """
+    is_semver = lambda x: "." in x # Keep it stupid and simple
+
+    api_version = _SemVerAPIFormat(api_version) if is_semver(api_version) else _DateAPIFormat(api_version)
+    other = _SemVerAPIFormat(other) if is_semver(other) else _DateAPIFormat(other)
+
+    if type(api_version) is type(other):
+        return api_version < other
+    elif isinstance(api_version, _DateAPIFormat) and isinstance(other, _SemVerAPIFormat):
+        return True
+    return False
 
 def _validate_api_version(api_version_str, min_api=None, max_api=None):
-    api_version = _DateAPIFormat(api_version_str)
-    if min_api and api_version < _DateAPIFormat(min_api):
+    """Validate if api_version is inside the interval min_api/max_api.
+    """
+    if min_api and _cross_api_format_lt(api_version_str, min_api):
         return False
-    if max_api and api_version > _DateAPIFormat(max_api):
+    if max_api and _cross_api_format_lt(max_api, api_version_str):
         return False
     return True
 
@@ -270,13 +312,14 @@ def get_versioned_sdk_path(api_profile, resource_type, operation_group=None):
         resource type in question.
         e.g. Converts azure.mgmt.storage.operations.storage_accounts_operations to
                       azure.mgmt.storage.v2016_12_01.operations.storage_accounts_operations
+                      azure.keyvault.v7_0.models.KeyVault
     """
     api_version = get_api_version(api_profile, resource_type)
     if isinstance(api_version, _ApiVersions):
         if operation_group is None:
             raise ValueError("operation_group is required for resource type '{}'".format(resource_type))
         api_version = getattr(api_version, operation_group)
-    return '{}.v{}'.format(resource_type.import_prefix, api_version.replace('-', '_'))
+    return '{}.v{}'.format(resource_type.import_prefix, api_version.replace('-', '_').replace('.', '_'))
 
 
 def get_versioned_sdk(api_profile, resource_type, *attr_args, **kwargs):

--- a/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
@@ -27,9 +27,9 @@ class TestAPIProfiles(unittest.TestCase):
         # Can get correct resource type API version if semver used
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
-        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '7.0'}}
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '7.0'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
-            self.assertEqual(get_api_version(cli, ResourceType.MGMT_STORAGE), '7.0')
+            self.assertEqual(get_api_version(cli, ResourceType.MGMT_KEYVAULT), '7.0')
 
     def test_get_api_version_invalid_rt(self):
         # Resource Type not in profile
@@ -122,16 +122,16 @@ class TestAPIProfiles(unittest.TestCase):
     def test_supported_api_version_min_constraint_semver(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
-        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '7.0'}}
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '7.0'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
-            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='6.0'))
+            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_KEYVAULT, min_api='6.0'))
 
     def test_supported_api_version_min_constraint_mixed_type(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
-        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '7.0'}}
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '7.0'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
-            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='2016-06-04'))
+            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_KEYVAULT, min_api='2016-06-04'))
 
     def test_supported_api_version_max_constraint(self):
         cli = DummyCli()
@@ -143,16 +143,16 @@ class TestAPIProfiles(unittest.TestCase):
     def test_supported_api_version_max_constraint_semver(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
-        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '7.0'}}
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '7.0'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
-            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_STORAGE, max_api='8.0'))
+            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_KEYVAULT, max_api='8.0'))
 
     def test_supported_api_version_max_constraint_mixed_type(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
-        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '2016-06-04'}}
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '2016-06-04'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
-            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_STORAGE, max_api='8.0'))
+            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_KEYVAULT, max_api='8.0'))
 
     def test_supported_api_version_min_max_constraint(self):
         cli = DummyCli()
@@ -165,10 +165,10 @@ class TestAPIProfiles(unittest.TestCase):
     def test_supported_api_version_min_max_constraint_semver(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
-        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '7.0'}}
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '7.0'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertTrue(
-                supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='6.0', max_api='8.0'))
+                supported_api_version(cli, ResourceType.MGMT_KEYVAULT, min_api='6.0', max_api='8.0'))
 
     def test_supported_api_version_max_constraint_not_supported(self):
         cli = DummyCli()
@@ -180,16 +180,16 @@ class TestAPIProfiles(unittest.TestCase):
     def test_supported_api_version_max_constraint_not_supported_semver(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
-        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '7.0'}}
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '7.0'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
-            self.assertFalse(supported_api_version(cli, ResourceType.MGMT_STORAGE, max_api='6.0'))
+            self.assertFalse(supported_api_version(cli, ResourceType.MGMT_KEYVAULT, max_api='6.0'))
 
     def test_supported_api_version_max_constraint_not_supported_mixed_type(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
-        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '7.0'}}
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '7.0'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
-            self.assertFalse(supported_api_version(cli, ResourceType.MGMT_STORAGE, max_api='2016-07-01'))
+            self.assertFalse(supported_api_version(cli, ResourceType.MGMT_KEYVAULT, max_api='2016-07-01'))
 
     def test_supported_api_version_min_constraint_not_supported(self):
         cli = DummyCli()
@@ -201,9 +201,9 @@ class TestAPIProfiles(unittest.TestCase):
     def test_supported_api_version_min_constraint_not_supported_semver(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
-        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: '7.0'}}
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '7.0'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
-            self.assertFalse(supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='8.0'))
+            self.assertFalse(supported_api_version(cli, ResourceType.MGMT_KEYVAULT, min_api='8.0'))
 
     def test_supported_api_version_min_constraint_not_supported_mixed_type(self):
         cli = DummyCli()
@@ -264,11 +264,11 @@ class TestAPIProfiles(unittest.TestCase):
             )
 
     def test_get_versioned_sdk_path_semver(self):
-        test_profile = {'latest': {ResourceType.MGMT_STORAGE: '7.0'}}
+        test_profile = {'latest': {ResourceType.DATA_KEYVAULT: '7.0'}}
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertEqual(
-                get_versioned_sdk_path('latest', ResourceType.MGMT_STORAGE),
-                "azure.mgmt.storage.v7_0"
+                get_versioned_sdk_path('latest', ResourceType.DATA_KEYVAULT),
+                "azure.keyvault.v7_0"
             )
 
 


### PR DESCRIPTION
KeyVault data-plane latest API version is "7.0", which won't work in the Profile package right now, because every API versions used to discriminate are supposed to be date (e.g. "2018-06-01").

This introduces:
- The ability to get models from an API version that uses semver
- Ordering of semver
- Ordering of semver against date. This is subtle, we have no reason to consider 7.0 against 2016-07-01 as one older than the other. For now, *I consider date API Version are always older than SemVer*. This fits the KeyVault scenario, and if one day we have another service team that says the opposite, we could add a flag or something in the profile definition. I tend by default to reduce technical debt and not try to solve an hypothetic problem, so didn't add that flag today :).