### PR TITLE
Adding retry logic and use aka.ms url

### DIFF
--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/_index.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/_index.py
@@ -19,6 +19,7 @@ ERR_TMPL_BAD_JSON = '{}Response body does not contain valid json. Error detail: 
 ERR_UNABLE_TO_GET_EXTENSIONS = 'Unable to get extensions from index. Improper index format.'
 TRIES = 3
 
+
 # pylint: disable=inconsistent-return-statements
 def get_index(index_url=None):
     from azure.cli.core.util import should_disable_connection_verify

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/_index.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/_index.py
@@ -9,9 +9,7 @@ from knack.util import CLIError
 
 logger = get_logger(__name__)
 
-# "https://aka.ms/azure-cli-extension-index-v1" fails to redirect properly to the storage blob url below
-# a good portion of the time. Will replace back once fixed.
-DEFAULT_INDEX_URL = "https://azurecliextensionsync.blob.core.windows.net/index1/index.json"
+DEFAULT_INDEX_URL = "https://aka.ms/azure-cli-extension-index-v1"
 
 ERR_TMPL_EXT_INDEX = 'Unable to get extension index.\n'
 ERR_TMPL_NON_200 = '{}Server returned status code {{}} for {{}}'.format(ERR_TMPL_EXT_INDEX)
@@ -19,25 +17,31 @@ ERR_TMPL_NO_NETWORK = '{}Please ensure you have network connection. Error detail
 ERR_TMPL_BAD_JSON = '{}Response body does not contain valid json. Error detail: {{}}'.format(ERR_TMPL_EXT_INDEX)
 
 ERR_UNABLE_TO_GET_EXTENSIONS = 'Unable to get extensions from index. Improper index format.'
-
+TRIES = 3
 
 # pylint: disable=inconsistent-return-statements
 def get_index(index_url=None):
     from azure.cli.core.util import should_disable_connection_verify
     index_url = index_url or DEFAULT_INDEX_URL
-    try:
-        response = requests.get(index_url, verify=(not should_disable_connection_verify()))
-        if response.status_code == 200:
-            return response.json()
-        else:
+
+    for try_number in range(TRIES):
+        try:
+            response = requests.get(index_url, verify=(not should_disable_connection_verify()))
+            if response.status_code == 200:
+                return response.json()
             msg = ERR_TMPL_NON_200.format(response.status_code, index_url)
             raise CLIError(msg)
-    except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError) as err:
-        msg = ERR_TMPL_NO_NETWORK.format(str(err))
-        raise CLIError(msg)
-    except ValueError as err:
-        msg = ERR_TMPL_BAD_JSON.format(str(err))
-        raise CLIError(msg)
+        except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError) as err:
+            msg = ERR_TMPL_NO_NETWORK.format(str(err))
+            raise CLIError(msg)
+        except ValueError as err:
+            # Indicates that url is not redirecting properly to intended index url, we stop retrying after TRIES calls
+            if try_number == TRIES - 1:
+                msg = ERR_TMPL_BAD_JSON.format(str(err))
+                raise CLIError(msg)
+            import time
+            time.sleep(0.5)
+            continue
 
 
 def get_index_extensions(index_url=None):


### PR DESCRIPTION
---
-"https://aka.ms/azure-cli-extension-index-v1" seems to be more consistent, so adding back
-will work with all CLI versions in case we need to change the underlying blob url/storage account
-added retry logic in case reliability drops again
