### PR TITLE
[AKS] handle [Ctrl+C] gracefully in "az aks browse"

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 2.2.2
 +++++
+* Return 0 (success) when ending `az aks browse` by pressing [Ctrl+C]
 * changes for consuming multi api azure.mgmt.authorization package
 
 2.2.1

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1316,8 +1316,12 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False, li
     logger.warning('Press CTRL+C to close the tunnel...')
     if not disable_browser:
         wait_then_open_async(proxy_url)
-    subprocess.call(["kubectl", "--kubeconfig", browse_path, "--namespace", "kube-system",
-                     "port-forward", dashboard_pod, "{0}:9090".format(listen_port)])
+    try:
+        subprocess.call(["kubectl", "--kubeconfig", browse_path, "--namespace", "kube-system",
+                         "port-forward", dashboard_pod, "{0}:9090".format(listen_port)])
+    except KeyboardInterrupt:
+        # Let command processing finish gracefully after the user presses [Ctrl+C]
+        return
 
 
 def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint: disable=too-many-locals


### PR DESCRIPTION
Closes #6737. 

This also changes the return code from a non-interactive `az aks browse` command from 1 (error) to 0 (success). Since the command itself instructs the user to press [Ctrl+C], it seems incorrect to return an error code on `KeyboardInterrupt`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
