### PR TITLE
validate_max_pods must calculate min # of pods

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
@@ -6,6 +6,7 @@
 import os
 import os.path
 import re
+from math import ceil
 
 from knack.log import get_logger
 
@@ -113,5 +114,9 @@ def validate_linux_host_name(namespace):
 
 def validate_max_pods(namespace):
     """Validates that max_pods is set to a reasonable minimum number."""
-    if namespace.max_pods != 0 and namespace.max_pods < 5:
-        raise CLIError('--max-pods must be at least 5 for a managed Kubernetes cluster to function.')
+    # kube-proxy and kube-svc reside each nodes,
+    # 2 kube-proxy pods, 1 azureproxy/heapster/dashboard/tunnelfront are in kube-system
+    minimum_pods_required = ceil((namespace.node_count * 2 + 6 + 1) / namespace.node_count)
+    if namespace.max_pods != 0 and namespace.max_pods < minimum_pods_required:
+        raise CLIError('--max-pods must be at least {} for a managed Kubernetes cluster to function.'
+                       .format(minimum_pods_required))


### PR DESCRIPTION
Added the calculation of minimum number of pods based on node_count to enable at least 1 pod in default namespace for --max-pods.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
