### PR TITLE
Move azure-mgmt-msi to 0.2.0

### DIFF
--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -32,7 +32,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-msi==0.1.0',
+    'azure-mgmt-msi==0.2.0',
     'azure-mgmt-authorization==0.50.0',
     'azure-mgmt-compute==4.0.0',
     'azure-mgmt-keyvault==0.40.0',


### PR DESCRIPTION
@yugangw-msft This moves azure-mgmt-msi from 0.1.0 to 0.2.0. The only differences are:
- Autorest 3.0
- Fixing a bug in the setup.py that prevents me to release msrestazure ADAL

I wasn't able to do the full testing on my machine, by being that this package is super small and that this is the same Swagger, I don't expect troubles.