### PR TITLE
[AKS] properly deprecate "az aks create --enable-rbac" argument

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -218,7 +218,7 @@ helps['aks create'] = """
           short-summary: Disable Kubernetes Role-Based Access Control.
         - name: --enable-rbac -r
           type: bool
-          short-summary: "[DEPRECATED: RBAC is on by default. Use --disable-rbac to disable it.] Enable Kubernetes Role-Based Access Control."
+          short-summary: "Enable Kubernetes Role-Based Access Control. Default: enabled."
         - name: --max-pods -m
           type: int
           short-summary: The maximum number of pods deployable to a node.

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -164,7 +164,8 @@ def load_arguments(self, _):
         c.argument('docker_bridge_address')
         c.argument('enable_addons', options_list=['--enable-addons', '-a'])
         c.argument('disable_rbac', action='store_true')
-        c.argument('enable_rbac', action='store_true', options_list=['--enable-rbac', '-r'])
+        c.argument('enable_rbac', action='store_true', options_list=['--enable-rbac', '-r'],
+                   deprecate_info=c.deprecate(redirect="--disable-rbac", hide="2.0.45"))
         c.argument('max_pods', type=int, options_list=['--max-pods', '-m'], validator=validate_max_pods)
         c.argument('network_plugin')
         c.argument('no_ssh_key', options_list=['--no-ssh-key', '-x'])


### PR DESCRIPTION
Improves on the hand-rolled deprecation notice in #6648 by using the framework added in #6472.

```console
$ az aks create -h

Command
    az aks create : Create a new managed Kubernetes cluster.

Arguments
...
    --enable-addons -a             : Enable the Kubernetes addons in a comma-separated list.
        These addons are available:
            http_application_routing - configure ingress with automatic public DNS name creation.
            monitoring - turn on Log Analytics monitoring. Uses the Log Analytics Default Workspace
        if it exists, else creates one. Specify "--workspace-resource-id" to use an existing
        workspace.
    --enable-rbac -r  [Deprecated] : Enable Kubernetes Role-Based Access Control. Default:
                                     enabled.
        Argument 'enable_rbac' has been deprecated and will be removed in a future release. Use
        '--disable-rbac' instead.
    --generate-ssh-keys            : Generate SSH public and private key files if missing.
...
```

---

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
