### PR TITLE
Revise Azure CLI Core version to 2.0.43.

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,12 +3,9 @@
 Release History
 ===============
 
-2.0.44
-++++++
-* Comnsuming mult api azure.mgmt.azutorization package for stack support
-
 2.0.43
 ++++++
+* Comnsuming mult api azure.mgmt.azutorization package for stack support
 * Minor fixes
 
 2.0.42

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 from __future__ import print_function
 
-__version__ = "2.0.44"
+__version__ = "2.0.43"
 
 import os
 import sys

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.0.44"
+VERSION = "2.0.43"
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:


### PR DESCRIPTION
The version of the Core was bumped prematurely. The version `2.0.43` hasn't been used yet.