### PR TITLE
Update doc for SP role assignment include_groups

### DIFF
--- a/src/command_modules/azure-cli-ams/azure/cli/command_modules/ams/operations/sp.py
+++ b/src/command_modules/azure-cli-ams/azure/cli/command_modules/ams/operations/sp.py
@@ -108,7 +108,7 @@ def _get_displayable_name(graph_object):
 def list_role_assignments(cmd, assignee_object_id):
     '''
     :param include_groups: include extra assignments to the groups of which the user is a
-    member(transitively). Supported only for a user principal.
+    member(transitively).
     '''
     graph_client = _graph_client_factory(cmd.cli_ctx)
     factory = _auth_client_factory(cmd.cli_ctx)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -211,7 +211,7 @@ def list_role_assignments(cmd, assignee=None, role=None, resource_group_name=Non
                           show_all=False, include_groups=False, include_classic_administrators=False):
     '''
     :param include_groups: include extra assignments to the groups of which the user is a
-    member(transitively). Supported only for a user principal.
+    member(transitively).
     '''
     graph_client = _graph_client_factory(cmd.cli_ctx)
     factory = _auth_client_factory(cmd.cli_ctx, scope)


### PR DESCRIPTION
Role assignment transitivity for service principals is now supported, so
update the documentation on the --include-groups flag to indicate this.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
