### PR TITLE
[batchai] logger: specify 'group' resource type

### DIFF
--- a/src/command_modules/azure-cli-batchai/HISTORY.rst
+++ b/src/command_modules/azure-cli-batchai/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.4.1
++++++
+* Logger output for auto-storage account creation now specifies "resource *group*".
+
 0.4.0
 +++++
 * BREAKING CHANGE: 'show' commands log error message and fail with exit code of 3 upon a missing resource.

--- a/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/custom.py
+++ b/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/custom.py
@@ -532,7 +532,7 @@ def _configure_auto_storage(cli_ctx, location):
         logger.warning('BatchAI will use existing %s resource group for auto-storage account',
                        resource_group)
     else:
-        logger.warning('Creating %s resource for auto-storage account', resource_group)
+        logger.warning('Creating %s resource group for auto-storage account', resource_group)
         resource_client.resource_groups.create_or_update(
             resource_group, ResourceGroup(location=location))
     storage_client = _get_storage_management_client(cli_ctx)

--- a/src/command_modules/azure-cli-batchai/setup.py
+++ b/src/command_modules/azure-cli-batchai/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.4.0"
+VERSION = "0.4.1"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
Changes logger output on `az batchai cluster create` to specify that the resource type it's creating is a resource **group**.

* was: Creating %s resource for auto-storage account
* now: Creating %s resource group for auto-storage account

Unsure if this counts as **docs only**. If it doesn't, let me know and I'll update HISTORY.rst. Thanks!

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
