### PR TITLE
catch command exception to avoid CI failing

### DIFF
--- a/doc/sphinx/azhelpgen/azhelpgen.py
+++ b/doc/sphinx/azhelpgen/azhelpgen.py
@@ -27,7 +27,10 @@ def get_help_files(cli_ctx):
     cli_ctx.invocation.commands_loader.load_command_table([])
     cmd_table = cli_ctx.invocation.commands_loader.command_table
     for command in cmd_table:
-        cli_ctx.invocation.commands_loader.load_arguments(command)
+        try:
+            cli_ctx.invocation.commands_loader.load_arguments(command)        
+        except Exception as ex:
+            print("Skipped '{}' due to '{}'".format(command, ex))
     cli_ctx.invocation.parser.load_command_table(cli_ctx.invocation.commands_loader)
 
     parser_keys = []


### PR DESCRIPTION
Add try/catch for sphinx script to avoid CI failing on certain commands

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
