### PR TITLE
Add azure-cli-search to azure-cli dependencies

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -91,7 +91,8 @@ DEPENDENCIES = [
     'azure-cli-vm',
     'azure-cli-servicefabric',
     'azure-cli-servicebus',
-    'azure-cli-eventhubs'
+    'azure-cli-eventhubs',
+    'azure-cli-search'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
Add azure-cli-search to azure-cli dependencies.
So when user install azure-cli via "pip install azure-cli", search command will be supported.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
