### PR TITLE
Modification to az aks install-connector command to handle RBAC

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.3.0
++++++
+* `az aks install-connector` will now detect if the cluster has RBAC and configure ACI Connector appropriately
+
 2.2.2
 +++++
 * Return 0 (success) when ending `az aks browse` by pressing [Ctrl+C]

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.2.2"
+VERSION = "2.3.0"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Modification to `az aks install-connector` command to handle RBAC correctly.  The virtual kubelet helm chart recently updated to enable RBAC by default. In an RBAC enabled cluster, this creates the needed clusterrolebinding and service account for virtual kubelet. On a non-RBAC cluster, these should not be created. The virtual-kubelet helm chart has a flag to drive this. This PR fetches the cluster info to determine if `enable-rbac` is true and drives the helm install or upgrade off of that. 

This PR fixes #6922. 



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
