### PR TITLE
Handle .dockerignore file properly in acr build comand

### DIFF
--- a/src/command_modules/azure-cli-acr/HISTORY.rst
+++ b/src/command_modules/azure-cli-acr/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 2.1.3
 +++++
 * Add content-trust policy commands.
+* Fix a few issues to handle .dockerignore file properly in build command.
 * Minor fixes
 
 2.1.2

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -31,6 +31,7 @@ from azure.mgmt.containerregistry.v2018_02_01_preview.models import (
 from ._utils import validate_managed_registry
 from ._client_factory import cf_acr_registries
 from ._build_polling import get_build_with_polling
+from builtins import open as bltn_open
 
 
 logger = get_logger(__name__)
@@ -353,38 +354,7 @@ def _check_remote_source_code(source_location):
 
 
 def _upload_source_code(client, registry_name, resource_group_name, source_location, tar_file_path, docker_file_path):
-    ignore_list = _load_dockerignore_file(source_location)
-    common_vcs_ignore_list = {'.git', '.gitignore', '.bzr', 'bzrignore', '.hg', '.hgignore', '.svn'}
-
-    logger.warning("Packing source code into tar file to upload...")
-
-    def _filter_file(tarinfo):
-        # ignore common vcs dir or file
-        if tarinfo.name in common_vcs_ignore_list:
-            logger.debug(".dockerignore: ignore vcs file '%s'", tarinfo.name)
-            return None
-
-        if ignore_list is None:
-            return tarinfo
-
-        # always include docker file
-        # file path comparision is case-sensitive
-        if tarinfo.name == docker_file_path:
-            logger.debug(".dockerignore: skip checking '%s'", docker_file_path)
-            return tarinfo
-
-        for item in ignore_list:
-            if re.match(item.pattern, tarinfo.name):
-                logger.debug(".dockerignore: rule '%s' matches '%s'.", item.rule, tarinfo.name)
-                return None if item.ignore else tarinfo
-
-        logger.debug(".dockerignore: no rule for '%s'.", tarinfo.name)
-        return tarinfo
-
-    with tarfile.open(tar_file_path, "w:gz") as tar:
-        # NOTE: Need to set arcname to empty string;
-        # otherwise the child item name will have a prefix (eg, ../) which can block unpacking.
-        tar.add(source_location, arcname="", filter=_filter_file)
+    _pack_source_code(source_location, tar_file_path, docker_file_path)
 
     size = os.path.getsize(tar_file_path)
     unit = 'GiB'
@@ -422,6 +392,73 @@ def _upload_source_code(client, registry_name, resource_group_name, source_locat
     return relative_path
 
 
+def _pack_source_code(source_location, tar_file_path, docker_file_path):
+    logger.warning("Packing source code into tar file to upload...")
+
+    ignore_list, ignore_list_size = _load_dockerignore_file(source_location)
+    common_vcs_ignore_list = {'.git', '.gitignore', '.bzr', 'bzrignore', '.hg', '.hgignore', '.svn'}
+
+    def _ignore_check(tarinfo, parent_ignored, parent_matching_rule_index):
+        # ignore common vcs dir or file
+        if tarinfo.name in common_vcs_ignore_list:
+            logger.debug(".dockerignore: ignore vcs file '%s'", tarinfo.name)
+            return True, parent_matching_rule_index
+
+        if ignore_list is None:
+            return False, parent_matching_rule_index
+
+        # always include docker file
+        # file path comparision is case-sensitive
+        if tarinfo.name == docker_file_path:
+            logger.debug(".dockerignore: skip checking '%s'", docker_file_path)
+            return False, parent_matching_rule_index
+
+        for index, item in enumerate(ignore_list):
+            # stop checking the remaining rules whose priorities are lower than the parent matching rule
+            # at this point, current item should just inherit from parent
+            if index >= parent_matching_rule_index:
+                break
+            if re.match(item.pattern, tarinfo.name):
+                logger.debug(".dockerignore: rule '%s' matches '%s'.", item.rule, tarinfo.name)
+                return item.ignore, index
+
+        logger.debug(".dockerignore: no rule for '%s'. parent ignore '%s'", tarinfo.name, parent_ignored)
+        # inherit from parent
+        return parent_ignored, parent_matching_rule_index
+
+    with tarfile.open(tar_file_path, "w:gz") as tar:
+        # need to set arcname to empty string as the archive root path
+        _archive_file_recursively(tar, source_location, arcname="",
+                                  parent_ignored=False, parent_matching_rule_index=ignore_list_size,
+                                  ignore_check=_ignore_check)
+
+
+def _archive_file_recursively(tar, name, arcname, parent_ignored, parent_matching_rule_index, ignore_check):
+    # create a TarInfo object from the file
+    tarinfo = tar.gettarinfo(name, arcname)
+
+    if tarinfo is None:
+        raise CLIError("tarfile: unsupported type {}".format(name))
+
+    # check if the file/dir is ignored
+    ignored, matching_rule_index = ignore_check(tarinfo, parent_ignored, parent_matching_rule_index)
+
+    if not ignored:
+        # append the tar header and data to the archive
+        if tarinfo.isreg():
+            with bltn_open(name, "rb") as f:
+                tar.addfile(tarinfo, f)
+        else:
+            tar.addfile(tarinfo)
+
+    # even the dir is ignored, its child items can still be included, so continue to scan
+    if tarinfo.isdir():
+        for f in os.listdir(name):
+            _archive_file_recursively(tar, os.path.join(name, f), os.path.join(arcname, f),
+                                      parent_ignored=ignored, parent_matching_rule_index=matching_rule_index,
+                                      ignore_check=ignore_check)
+
+
 class IgnoreRule(object):  # pylint: disable=too-few-public-methods
     def __init__(self, rule):
 
@@ -451,7 +488,7 @@ def _load_dockerignore_file(source_location):
     # reference: https://docs.docker.com/engine/reference/builder/#dockerignore-file
     docker_ignore_file = os.path.join(source_location, ".dockerignore")
     if not os.path.exists(docker_ignore_file):
-        return None
+        return None, 0
 
     ignore_list = []
 
@@ -466,4 +503,4 @@ def _load_dockerignore_file(source_location):
         # add ignore rule
         ignore_list.append(IgnoreRule(rule))
 
-    return ignore_list
+    return ignore_list, len(ignore_list)

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -438,8 +438,11 @@ class IgnoreRule(object):  # pylint: disable=too-few-public-methods
             if token == "**":
                 tokens[index] = ".*"
             else:
+                # * matches any sequence of non-seperator characters
+                # ? matches any single non-seperator character
+                # . matches dot character
                 tokens[index] = token.replace(
-                    "*", "[^/]*").replace("?", "[^/]")
+                    "*", "[^/]*").replace("?", "[^/]").replace(".", "\\.")
 
         self.pattern = "^{}$".format("/".join(tokens))
 

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/build.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from io import BytesIO
 import tempfile
 import tarfile
+from builtins import open as bltn_open
 import requests
 import colorama
 from knack.log import get_logger
@@ -31,7 +32,6 @@ from azure.mgmt.containerregistry.v2018_02_01_preview.models import (
 from ._utils import validate_managed_registry
 from ._client_factory import cf_acr_registries
 from ._build_polling import get_build_with_polling
-from builtins import open as bltn_open
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
Fix #6798 - follow unix glob pattern to match dot character. NB: Unable to use python fnmatch module as it handles * different from docker.
Fix #6896 - handle the ignore case in which the parent folder is excluded but its child items are included.

@djyou @ehotinger 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
