### PR TITLE
Added additional regions for Azure Container Instances as per https:/…

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -2113,13 +2113,17 @@ def _validate_aci_location(norm_location):
     Validate the Azure Container Instance location
     """
     aci_locations = [
-        "westus",
+        "centralus",
         "eastus",
+        "eastus2",
+        "westus",
+        "westus2",
+        "northeurope",
         "westeurope",
         "southeastasia",
-        "westus2",
-        "northeurope"
+        "australiaeast"
     ]
+    
     if norm_location not in aci_locations:
         raise CLIError('Azure Container Instance is not available at location "{}".'.format(norm_location) +
                        ' The available locations are "{}"'.format(','.join(aci_locations)))

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -2123,7 +2123,7 @@ def _validate_aci_location(norm_location):
         "southeastasia",
         "australiaeast"
     ]
-    
+
     if norm_location not in aci_locations:
         raise CLIError('Azure Container Instance is not available at location "{}".'.format(norm_location) +
                        ' The available locations are "{}"'.format(','.join(aci_locations)))


### PR DESCRIPTION
Hello Everyone,

The `az aks install-connector` command doesn't allow installation in AustraliaEast. I've added to the aci_locations as [documented](https://azure.microsoft.com/en-gb/global-infrastructure/services/) which includes Sydney.

I wasn't sure if or how to reflect this in HISTORY.rst. Appreciate any help here. Thanks.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
