### PR TITLE
Declare explicit dependency on azure-mgmt-resource in core and subsequently remove dependencies of it from command modules.

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -71,6 +71,7 @@ DEPENDENCIES = [
     'six',
     'tabulate>=0.7.7,<=0.8.2',
     'wheel==0.30.0',
+    'azure-mgmt-resource==2.0.0'
 ]
 
 if sys.version_info < (3, 4):

--- a/src/command_modules/azure-cli-acr/setup.py
+++ b/src/command_modules/azure-cli-acr/setup.py
@@ -31,7 +31,6 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-mgmt-resource==2.0.0',
     'azure-mgmt-storage==2.0.0rc4',
     'azure-storage-blob==1.1.0',
     'azure-mgmt-containerregistry==2.1.0',

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -33,7 +33,6 @@ DEPENDENCIES = [
     'azure-cli-core',
     'azure-mgmt-web==0.35.0',
     'azure-mgmt-containerregistry==2.1.0',
-    'azure-mgmt-resource==2.0.0',
     # v1.17 breaks on wildcard cert https://github.com/shazow/urllib3/issues/981
     'urllib3[secure]>=1.18',
     'xmltodict',

--- a/src/command_modules/azure-cli-dla/HISTORY.rst
+++ b/src/command_modules/azure-cli-dla/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.2.1
++++++
+* Minor fixes
+
 0.2.0
 +++++
 * BREAKING CHANGE: 'show' commands log error message and fail with exit code of 3 upon a missing resource.

--- a/src/command_modules/azure-cli-dla/HISTORY.rst
+++ b/src/command_modules/azure-cli-dla/HISTORY.rst
@@ -3,10 +3,6 @@
 Release History
 ===============
 
-0.2.1
-+++++
-* Minor fixes.
-
 0.2.0
 +++++
 * BREAKING CHANGE: 'show' commands log error message and fail with exit code of 3 upon a missing resource.

--- a/src/command_modules/azure-cli-dla/setup.py
+++ b/src/command_modules/azure-cli-dla/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-dla/setup.py
+++ b/src/command_modules/azure-cli-dla/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.2.1"
+VERSION = "0.2.0"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [
@@ -34,7 +34,6 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-resource==2.0.0',
     'azure-mgmt-datalake-store==0.2.0',
     'azure-mgmt-datalake-analytics==0.2.0',
     'azure-cli-core',

--- a/src/command_modules/azure-cli-iot/setup.py
+++ b/src/command_modules/azure-cli-iot/setup.py
@@ -32,7 +32,6 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-resource==2.0.0',
     'azure-mgmt-iothub==0.5.0',
     'azure-mgmt-iothubprovisioningservices==0.1.0',
     'pyOpenSSL',

--- a/src/command_modules/azure-cli-monitor/HISTORY.rst
+++ b/src/command_modules/azure-cli-monitor/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+0.2.2
++++++
+* Minor fixes
+
 0.2.1
 +++++
 * Minor fixes

--- a/src/command_modules/azure-cli-monitor/setup.py
+++ b/src/command_modules/azure-cli-monitor/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
@@ -29,8 +29,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-mgmt-monitor==0.5.0',
-    'azure-mgmt-resource==2.0.0'
+    'azure-mgmt-monitor==0.5.0'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.2.3
++++++
+* Minor fixes
+
 2.2.2
 +++++
 * `dns`: Added dns support to 2017-03-09-profile for Azure Stack 

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.2.2"
+VERSION = "2.2.3"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
@@ -33,7 +33,6 @@ DEPENDENCIES = [
     'azure-mgmt-network==2.0.0rc3',
     'azure-mgmt-trafficmanager==0.40.0',
     'azure-mgmt-dns==2.0.0rc2',
-    'azure-mgmt-resource==2.0.0',
     'azure-cli-core',
     'mock'
 ]

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.1.2
++++++
+* Minor changes
+
 2.1.1
 +++++
 * `group deployment create`: Add `--rollback-on-error` to execute a known-good deployment on error.

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.1.1"
+VERSION = "2.1.2"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
@@ -31,7 +31,6 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-resource==2.0.0',
     'azure-cli-core',
     'azure-mgmt-authorization==0.50.0',
     'azure-mgmt-managementgroups==0.1.0'

--- a/src/command_modules/azure-cli-search/HISTORY.rst
+++ b/src/command_modules/azure-cli-search/HISTORY.rst
@@ -3,7 +3,10 @@
 Release History
 ===============
 
+0.1.1
++++++
+* Minor fixes
+
 0.1.0
 +++++
-
 * Initial release of module.

--- a/src/command_modules/azure-cli-search/HISTORY.rst
+++ b/src/command_modules/azure-cli-search/HISTORY.rst
@@ -3,11 +3,7 @@
 Release History
 ===============
 
-0.1.1
-+++++
-* Minor fixes.
-
-
 0.1.0
 +++++
+
 * Initial release of module.

--- a/src/command_modules/azure-cli-search/setup.py
+++ b/src/command_modules/azure-cli-search/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/command_modules/azure-cli-search/setup.py
+++ b/src/command_modules/azure-cli-search/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.1"
+VERSION = "0.1.0"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -33,7 +33,6 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-mgmt-resource==2.0.0',
     'azure-mgmt-search==2.0.0',
 ]
 

--- a/src/command_modules/azure-cli-servicefabric/HISTORY.rst
+++ b/src/command_modules/azure-cli-servicefabric/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.1
++++++
+* Minor fixes
+
 0.1.0
 +++++
 * BREAKING CHANGE: 'show' commands log error message and fail with exit code of 3 upon a missing resource.

--- a/src/command_modules/azure-cli-servicefabric/HISTORY.rst
+++ b/src/command_modules/azure-cli-servicefabric/HISTORY.rst
@@ -3,10 +3,6 @@
 Release History
 ===============
 
-0.1.1
-+++++
-* Minor fixes.
-
 0.1.0
 +++++
 * BREAKING CHANGE: 'show' commands log error message and fail with exit code of 3 upon a missing resource.

--- a/src/command_modules/azure-cli-servicefabric/setup.py
+++ b/src/command_modules/azure-cli-servicefabric/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.1"
+VERSION = "0.1.0"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -37,7 +37,6 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-mgmt-servicefabric==0.1.0',
     'azure-mgmt-keyvault==0.40.0',
-    'azure-mgmt-resource==2.0.0',
     'azure-cli-core',
     'pyOpenSSL'
 ]

--- a/src/command_modules/azure-cli-servicefabric/setup.py
+++ b/src/command_modules/azure-cli-servicefabric/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -38,7 +38,6 @@ DEPENDENCIES = [
     'azure-mgmt-keyvault==0.40.0',
     'azure-keyvault==0.3.7',
     'azure-mgmt-network==2.0.0rc3',
-    'azure-mgmt-resource==2.0.0',
     'azure-multiapi-storage==0.2.2',
     'azure-mgmt-marketplaceordering==0.1.0',
     'azure-cli-core'


### PR DESCRIPTION
This change including a revert of previous commit (#6983). The original thought was to add the dependency to the individual command modules, therefore, avoid indirect dependency. However, the `azure-mgmt-resource` proves to be a crucial dependency. After the #6983 was made, newly added module `iotcentral` also takes a dependency on it while didn't declare it. Hence explicit declare at command module is not a sustainable approach.

In this change, the dependency will be declared in the core so that all the command module will indirectly share the dependency and the versioning of the dependency is centrally controlled.
