### PR TITLE
[Storage] Get sas-token from container url and cleanup code

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -9,6 +9,7 @@ Release History
 * Make '--resource-group' parameter optional for 'storage account' commands.
 * Remove 'Failed precondition' warnings for individual failures in batch commands for single aggregated message.
 * blob/file delete-batch commands no longer output array of nulls.
+* blob download/upload/delete-batch commands will read sas-token from container url
 
 2.1.1
 +++++

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -330,8 +330,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.register_source_uri_arguments(validator=validate_source_uri)
 
     with self.argument_context('storage blob copy start-batch', arg_group='Copy Source') as c:
-        from azure.cli.command_modules.storage._validators import (get_source_file_or_blob_service_client,
-                                                                   process_blob_copy_batch_namespace)
+        from azure.cli.command_modules.storage._validators import get_source_file_or_blob_service_client
 
         c.argument('source_client', ignore_type, validator=get_source_file_or_blob_service_client)
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -305,10 +305,10 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('delete_snapshots', arg_type=get_enum_type(get_delete_blob_snapshot_type_names()))
 
     with self.argument_context('storage blob delete-batch') as c:
-        from azure.cli.command_modules.storage._validators import process_blob_batch_source_parameters
+        from azure.cli.command_modules.storage._validators import process_blob_delete_batch_parameters
 
         c.ignore('source_container_name')
-        c.argument('source', options_list=('--source', '-s'), validator=process_blob_batch_source_parameters)
+        c.argument('source', options_list=('--source', '-s'), validator=process_blob_delete_batch_parameters)
         c.argument('delete_snapshots', arg_type=get_enum_type(get_delete_blob_snapshot_type_names()),
                    help='Required if the blob has associated snapshots.')
         c.argument('lease_id', help='Required if the blob has an active lease.')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -264,13 +264,12 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
 
     with self.argument_context('storage blob upload-batch') as c:
         from .sdkutil import get_blob_types
-        from ._validators import process_blob_upload_batch_parameters
 
         t_blob_content_settings = self.get_sdk('blob.models#ContentSettings')
         c.register_content_settings_argument(t_blob_content_settings, update=False, arg_group='Content Control')
         c.ignore('source_files', 'destination_container_name')
 
-        c.argument('source', options_list=('--source', '-s'), validator=process_blob_upload_batch_parameters)
+        c.argument('source', options_list=('--source', '-s'))
         c.argument('destination', options_list=('--destination', '-d'))
         c.argument('max_connections', type=int,
                    help='Maximum number of parallel connections to use when the blob size exceeds 64MB.')
@@ -290,11 +289,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.extra('socket_timeout', socket_timeout_type)
 
     with self.argument_context('storage blob download-batch') as c:
-        from azure.cli.command_modules.storage._validators import process_blob_download_batch_parameters
-
         c.ignore('source_container_name')
         c.argument('destination', options_list=('--destination', '-d'))
-        c.argument('source', options_list=('--source', '-s'), validator=process_blob_download_batch_parameters)
+        c.argument('source', options_list=('--source', '-s'))
         c.extra('no_progress', progress_type)
         c.extra('socket_timeout', socket_timeout_type)
         c.argument('max_connections', type=int,
@@ -305,10 +302,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('delete_snapshots', arg_type=get_enum_type(get_delete_blob_snapshot_type_names()))
 
     with self.argument_context('storage blob delete-batch') as c:
-        from azure.cli.command_modules.storage._validators import process_blob_delete_batch_parameters
-
         c.ignore('source_container_name')
-        c.argument('source', options_list=('--source', '-s'), validator=process_blob_delete_batch_parameters)
+        c.argument('source', options_list=('--source', '-s'))
         c.argument('delete_snapshots', arg_type=get_enum_type(get_delete_blob_snapshot_type_names()),
                    help='Required if the blob has associated snapshots.')
         c.argument('lease_id', help='Required if the blob has an active lease.')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -341,7 +341,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('source_sas')
         c.argument('source_container')
         c.argument('source_share')
-        c.argument('prefix', validator=process_blob_copy_batch_namespace)
 
     with self.argument_context('storage blob incremental-copy start') as c:
         from azure.cli.command_modules.storage._validators import process_blob_source_uri

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -704,6 +704,10 @@ def process_blob_batch_source_parameters(cmd, namespace):
         if namespace.account_name is None:
             namespace.account_name = identifier.account_name
 
+    # if no sas-token is given and the container url contains one, use it
+    if not namespace.sas_token and identifier.sas_token:
+        namespace.sas_token = identifier.sas_token
+
 
 def process_blob_upload_batch_parameters(cmd, namespace):
     """Process the source and destination of storage blob upload command"""
@@ -734,16 +738,14 @@ def process_blob_upload_batch_parameters(cmd, namespace):
         else:
             namespace.account_name = identifier.account_name
 
-        if not (namespace.account_key or namespace.sas_token or namespace.connection_string):
-            validate_client_parameters(cmd, namespace)
+        # if no sas-token is given and the container url contains one, use it
+        if not namespace.sas_token and identifier.sas_token:
+            namespace.sas_token = identifier.sas_token
 
         # it is possible the account name be overwritten by the connection string
         if namespace.account_name != identifier.account_name:
             raise ValueError(
                 'The given storage account name is not consistent with the account name in the destination URI')
-
-        if not (namespace.account_key or namespace.sas_token or namespace.connection_string):
-            raise ValueError('Missing storage account credential information.')
 
     # 3. collect the files to be uploaded
     namespace.source = os.path.realpath(namespace.source)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -766,11 +766,6 @@ def _process_blob_batch_container_parameters(cmd, namespace, source=True):
     validate_client_parameters(cmd, namespace)
 
 
-def process_blob_copy_batch_namespace(namespace):
-    if namespace.prefix is None and not namespace.recursive:
-        raise ValueError('incorrect usage: --recursive | --pattern PATTERN')
-
-
 def process_file_upload_batch_parameters(cmd, namespace):
     """Process the parameters of storage file batch upload command"""
     import os

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -93,6 +93,8 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         from ._format import transform_boolean_for_table, transform_blob_output
         from ._transformers import (transform_storage_list_output, transform_url,
                                     create_boolean_result_output_transformer)
+        from ._validators import (process_blob_download_batch_parameters, process_blob_delete_batch_parameters,
+                                  process_blob_upload_batch_parameters)
 
         g.storage_command('list', 'list_blobs', transform=transform_storage_list_output,
                           table_transformer=transform_blob_output)
@@ -110,9 +112,9 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.storage_custom_command('set-tier', 'set_blob_tier')
         g.storage_custom_command('upload', 'upload_blob',
                                  doc_string_source='blob#BlockBlobService.create_blob_from_path')
-        g.storage_custom_command('upload-batch', 'storage_blob_upload_batch')
-        g.storage_custom_command('download-batch', 'storage_blob_download_batch')
-        g.storage_custom_command('delete-batch', 'storage_blob_delete_batch')
+        g.storage_custom_command('upload-batch', 'storage_blob_upload_batch', validator=process_blob_upload_batch_parameters)
+        g.storage_custom_command('download-batch', 'storage_blob_download_batch', validator=process_blob_download_batch_parameters)
+        g.storage_custom_command('delete-batch', 'storage_blob_delete_batch', validator=process_blob_delete_batch_parameters)
         g.storage_custom_command('show', 'show_blob', table_transformer=transform_blob_output,
                                  client_factory=page_blob_service_factory,
                                  doc_string_source='blob#PageBlobService.get_blob_properties',

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -112,9 +112,12 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.storage_custom_command('set-tier', 'set_blob_tier')
         g.storage_custom_command('upload', 'upload_blob',
                                  doc_string_source='blob#BlockBlobService.create_blob_from_path')
-        g.storage_custom_command('upload-batch', 'storage_blob_upload_batch', validator=process_blob_upload_batch_parameters)
-        g.storage_custom_command('download-batch', 'storage_blob_download_batch', validator=process_blob_download_batch_parameters)
-        g.storage_custom_command('delete-batch', 'storage_blob_delete_batch', validator=process_blob_delete_batch_parameters)
+        g.storage_custom_command('upload-batch', 'storage_blob_upload_batch',
+                                 validator=process_blob_upload_batch_parameters)
+        g.storage_custom_command('download-batch', 'storage_blob_download_batch',
+                                 validator=process_blob_download_batch_parameters)
+        g.storage_custom_command('delete-batch', 'storage_blob_delete_batch',
+                                 validator=process_blob_delete_batch_parameters)
         g.storage_custom_command('show', 'show_blob', table_transformer=transform_blob_output,
                                  client_factory=page_blob_service_factory,
                                  doc_string_source='blob#PageBlobService.get_blob_properties',

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
@@ -201,7 +201,8 @@ def storage_blob_upload_batch(cmd, client, source, destination, pattern=None,  #
                 results.append(_create_return_result(dst, guessed_content_settings, result))
 
         num_failures = len(source_files) - len(results)
-        logger.warning('%s of %s files not uploaded due to "Failed Precondition"', num_failures, len(source_files))
+        if num_failures:
+            logger.warning('%s of %s files not uploaded due to "Failed Precondition"', num_failures, len(source_files))
     return results
 
 
@@ -322,10 +323,10 @@ def storage_blob_delete_batch(client, source, source_container_name, pattern=Non
         }
         return client.delete_blob(**delete_blob_args)
 
+    logger = get_logger(__name__)
     source_blobs = list(collect_blobs(client, source_container_name, pattern))
 
     if dryrun:
-        logger = get_logger(__name__)
         logger.warning('delete action: from %s', source)
         logger.warning('    pattern %s', pattern)
         logger.warning('  container %s', source_container_name)
@@ -337,7 +338,8 @@ def storage_blob_delete_batch(client, source, source_container_name, pattern=Non
 
     results = [result for include, result in (_delete_blob(blob) for blob in source_blobs) if include]
     num_failures = len(source_blobs) - len(results)
-    logger.warning('%s of %s blobs not deleted due to "Failed Precondition"', num_failures, len(source_blobs))
+    if num_failures:
+        logger.warning('%s of %s blobs not deleted due to "Failed Precondition"', num_failures, len(source_blobs))
 
 
 def _copy_blob_to_blob_container(blob_service, source_blob_service, destination_container, destination_path,


### PR DESCRIPTION
---
- Closes: https://github.com/Azure/azure-cli/issues/1434
- Use command validators to specify order. Previously, if container url/ENV variable were both present, the account-name would be set depending on which validator was called first.
- Consolidated batch validator code for parsing container url

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
