### PR TITLE
Created new rule for linter to check for mismatched syntax in help files

### DIFF
--- a/tools/automation/cli_linter/linter.py
+++ b/tools/automation/cli_linter/linter.py
@@ -63,6 +63,14 @@ class Linter(object):
     def is_valid_parameter_help_name(self, entry_name, param_name):
         return param_name in [param.name for param in getattr(self._loaded_help.get(entry_name), 'parameters', [])]
 
+    def get_help_entry_example_names(self, entry_name):
+        return [param_help.get('name', None) for param_help in \
+            self._all_yaml_help.get(entry_name).get('examples', [])]
+
+    def get_help_entry_example_text(self, entry_name):
+        return [param_help.get('text', None) for param_help in \
+            self._all_yaml_help.get(entry_name).get('examples', [])]
+
     def get_command_help(self, command_name):
         return self._get_loaded_help_description(command_name)
 

--- a/tools/automation/cli_linter/rules/help_rules.py
+++ b/tools/automation/cli_linter/rules/help_rules.py
@@ -33,3 +33,17 @@ def unrecognized_help_parameter_rule(linter, help_entry):
             violations.append(param_help_name)
     if violations:
         raise RuleError('The following parameter help names are invalid: {}'.format(' | '.join(violations)))
+
+@help_file_entry_rule
+def mismatched_help_parameter_rule(linter, help_entry):
+    if help_entry not in linter.commands:
+        return
+
+    help_names = linter.get_help_entry_example_names(help_entry)
+    help_texts = linter.get_help_entry_example_text(help_entry)
+    violations = []
+    for help_name, help_text in zip(help_names, help_texts):
+        if help_name not in help_text:
+            violations.append(help_name)
+    if violations:
+        raise RuleError('The following commands have mismatched names and text: {}'.format(' | '.join(violations)))


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
