### PR TITLE
vm/vmss create: default on accelerated networking for all VM sizes

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.2.1
 ++++++
+* vm/vmss create: default on accelerated networking for all vm sizes
 * vm list-skus: add a few common filters to make the command easier to use 
 
 2.2.0

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -372,72 +372,19 @@ class TestActions(unittest.TestCase):
 
     @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
     def test_validate_vm_vmss_accelerated_networking(self, client_factory_mock):
-        client_mock, size_mock = mock.MagicMock(), mock.MagicMock()
-        client_mock.virtual_machine_sizes.list.return_value = [size_mock]
-        client_factory_mock.return_value = client_mock
-        # not a qualified size
+        
+        # recognized distro
         np = mock.MagicMock()
-        np.size = 'Standard_Ds1_v2'
-        np.accelerated_networking = None
-        _validate_vm_vmss_accelerated_networking(None, np)
-        self.assertIsNone(np.accelerated_networking)
-
-        # qualified size and recognized distro
-        np = mock.MagicMock()
-        np.size = 'Standard_f8'
-        size_mock.number_of_cores, size_mock.name = 8, 'Standard_f8'
         np.accelerated_networking = None
         np.os_publisher, np.os_offer, np.os_sku = 'Canonical', 'UbuntuServer', '16.04'
-        _validate_vm_vmss_accelerated_networking(mock.MagicMock(), np)
+        _validate_vm_vmss_accelerated_networking(np)
         self.assertTrue(np.accelerated_networking)
 
+        # not recognized distro
         np = mock.MagicMock()
-        np.size = 'Standard_DS4_v2'
         np.accelerated_networking = None
-        np.os_publisher, np.os_offer, np.os_sku = 'coreos', 'coreos', 'alpha'
-        size_mock.number_of_cores, size_mock.name = 8, 'Standard_DS4_v2'
-        _validate_vm_vmss_accelerated_networking(mock.MagicMock(), np)
-        self.assertTrue(np.accelerated_networking)
-
-        np = mock.MagicMock()
-        np.size = 'Standard_D3_v2'  # known supported 4 core size
-        np.accelerated_networking = None
-        np.os_publisher, np.os_offer, np.os_sku = 'coreos', 'coreos', 'alpha'
-        _validate_vm_vmss_accelerated_networking(None, np)
-        self.assertTrue(np.accelerated_networking)
-
-        # not a qualified size, but user want it
-        np = mock.MagicMock()
-        np.size = 'Standard_Ds1_v2'
-        np.accelerated_networking = True
-        _validate_vm_vmss_accelerated_networking(None, np)
-        self.assertTrue(np.accelerated_networking)
-
-        # qualified size, but distro version not good
-        np = mock.MagicMock()
-        np.size = 'Standard_f8'
-        size_mock.number_of_cores, size_mock.name = 8, 'Standard_f8'
-        np.accelerated_networking = None
-        np.os_publisher, np.os_offer, np.os_sku = 'canonical', 'UbuntuServer', '18.04'
-        _validate_vm_vmss_accelerated_networking(mock.MagicMock(), np)
-        self.assertIsNone(np.accelerated_networking)
-
-        # qualified size, but distro infor is not available (say, custom images)
-        np = mock.MagicMock()
-        np.size = 'Standard_f8'
-        size_mock.number_of_cores, size_mock.name = 8, 'Standard_f8'
-        np.accelerated_networking = None
-        np.os_publisher = None
-        _validate_vm_vmss_accelerated_networking(mock.MagicMock(), np)
-        self.assertIsNone(np.accelerated_networking)
-
-        # qualified size, but distro version is not right
-        np = mock.MagicMock()
-        np.size = 'Standard_f8'
-        size_mock.number_of_cores, size_mock.name = 8, 'Standard_f8'
-        np.accelerated_networking = None
-        np.os_publisher, np.os_offer, np.os_sku = 'oracle', 'oracle-linux', '7.3'
-        _validate_vm_vmss_accelerated_networking(mock.MagicMock(), np)
+        np.os_publisher, np.os_offer, np.os_sku = 'MyOwnBusiness', 'UbuntuServer', '16.04'
+        _validate_vm_vmss_accelerated_networking(np)
         self.assertIsNone(np.accelerated_networking)
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -372,7 +372,6 @@ class TestActions(unittest.TestCase):
 
     @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
     def test_validate_vm_vmss_accelerated_networking(self, client_factory_mock):
-        
         # recognized distro
         np = mock.MagicMock()
         np.accelerated_networking = None


### PR DESCRIPTION
Fix #6999 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
