### PR TITLE
test: fix vm live test errors

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -796,7 +796,6 @@ class VMAvailSetLiveScenarioTest(ScenarioTest):
 
 class ComputeListSkusScenarioTest(LiveScenarioTest):
 
-    @AllowLargeResponse(size_kb=3072)
     def test_list_compute_skus_table_output(self):
         result = self.cmd('vm list-skus -l eastus2 -otable')
         lines = result.output.split('\n')
@@ -820,7 +819,6 @@ class ComputeListSkusScenarioTest(LiveScenarioTest):
         self.assertTrue(size_found)
         self.assertTrue(zone_found)
 
-    @AllowLargeResponse(size_kb=3072)
     def test_list_compute_skus_fiter(self):
         result = self.cmd('vm list-skus -l eastus2 --size Standard_DS1_V2 --zone').get_output_in_json()
         self.assertTrue(result and len(result) == len([x for x in result if x['name'] == 'Standard_DS1_v2' and x['locationInfo'][0]['zones']]))


### PR DESCRIPTION
Test runner failed because of the recording only decorators

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
