### PR TITLE
Addressing -ssh-key-gen bug.

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -6,6 +6,8 @@ Release History
 2.0.46
 ++++++
 * Minor fixes.
+* Fixed issue where `az vm create --generate-ssh-keys` overwrites private key
+  file if public key file is missing. (#4725, #6790)
 
 2.0.45
 ++++++

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -7,7 +7,7 @@ Release History
 ++++++
 * Minor fixes.
 * Fixed issue where `az vm create --generate-ssh-keys` overwrites private key
-  file if public key file is missing. (#4725, #6790)
+  file if public key file is missing. (#4725, #6780)
 
 2.0.45
 ++++++

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,6 @@ Release History
 
 2.0.46
 ++++++
-* Minor fixes.
 * Fixed issue where `az vm create --generate-ssh-keys` overwrites private key
   file if public key file is missing. (#4725, #6780)
 

--- a/src/azure-cli-core/azure/cli/core/keys.py
+++ b/src/azure-cli-core/azure/cli/core/keys.py
@@ -6,6 +6,7 @@
 import os
 import os.path
 
+from knack.util import CLIError
 from knack.log import get_logger
 logger = get_logger(__name__)
 
@@ -34,30 +35,38 @@ def is_valid_ssh_rsa_public_key(openssh_pubkey):
 
 def generate_ssh_keys(private_key_filepath, public_key_filepath):
     import paramiko
+    from paramiko.ssh_exception import PasswordRequiredException, SSHException
 
-    try:
-        with open(public_key_filepath, 'r') as public_key_file:
-            public_key = public_key_file.read()
-            pub_ssh_dir, _ = os.path.split(public_key_filepath)
-            logger.warning("Public SSH key file '%s' found in dir '%s'."
-                           "Use public key file. New RSA key pair will not be generated.",
-                           public_key_filepath, pub_ssh_dir)
+    if os.path.isfile(public_key_filepath):
+        try:
+            with open(public_key_filepath, 'r') as public_key_file:
+                public_key = public_key_file.read()
+                pub_ssh_dir = os.path.dirname(public_key_filepath)
+                logger.warning("Public SSH key file '%s' found in dir '%s'."
+                               "Use public key file. New RSA key pair will not be generated.",
+                               public_key_filepath, pub_ssh_dir)
 
-            return public_key
-    except IOError:
-        pass
+                return public_key
+        except IOError as e:
+            raise CLIError(e)
 
-    ssh_dir, _ = os.path.split(private_key_filepath)
+    ssh_dir = os.path.dirname(private_key_filepath)
     if not os.path.exists(ssh_dir):
         os.makedirs(ssh_dir)
         os.chmod(ssh_dir, 0o700)
 
     if os.path.isfile(private_key_filepath):
         # try to use existing private key if it exists.
-        key = paramiko.RSAKey(filename=private_key_filepath)
-        logger.warning("Private SSH key file '%s' found in dir '%s'."
-                       " Generating public key file '%s'",
-                       private_key_filepath, ssh_dir, public_key_filepath)
+
+        try:
+            key = paramiko.RSAKey(filename=private_key_filepath)
+            logger.warning("Private SSH key file '%s' found in dir '%s'. "
+                           "Generating new Public key file '%s'",
+                           private_key_filepath, ssh_dir, public_key_filepath)
+
+        except (PasswordRequiredException, SSHException, IOError) as e:
+            raise CLIError(e)
+
     else:
         # otherwise generate new private key.
         key = paramiko.RSAKey.generate(2048)
@@ -65,7 +74,7 @@ def generate_ssh_keys(private_key_filepath, public_key_filepath):
         os.chmod(private_key_filepath, 0o600)
 
     with open(public_key_filepath, 'w') as public_key_file:
-        public_key = '%s %s' % (key.get_name(), key.get_base64())
+        public_key = '{} {}'.format(key.get_name(), key.get_base64())
         public_key_file.write(public_key)
     os.chmod(public_key_filepath, 0o644)
 

--- a/src/azure-cli-core/azure/cli/core/keys.py
+++ b/src/azure-cli-core/azure/cli/core/keys.py
@@ -57,13 +57,11 @@ def generate_ssh_keys(private_key_filepath, public_key_filepath):
 
     if os.path.isfile(private_key_filepath):
         # try to use existing private key if it exists.
-
         try:
             key = paramiko.RSAKey(filename=private_key_filepath)
             logger.warning("Private SSH key file '%s' found in dir '%s'. "
                            "Generating new Public key file '%s'",
                            private_key_filepath, ssh_dir, public_key_filepath)
-
         except (PasswordRequiredException, SSHException, IOError) as e:
             raise CLIError(e)
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_keys.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_keys.py
@@ -108,7 +108,6 @@ class TestGenerateSSHKeys(unittest.TestCase):
             public_key = '{} {}'.format(key.get_name(), key.get_base64())
             self.assertEqual(public_key, new_public_key)
 
-
     def _create_new_temp_key_file(self, key_data, suffix=""):
         with tempfile.NamedTemporaryFile(mode='w', dir=self._tempdirName, delete=False, suffix=suffix) as f:
             f.write(key_data)

--- a/src/azure-cli-core/azure/cli/core/tests/test_keys.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_keys.py
@@ -1,0 +1,121 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+import unittest
+import tempfile
+import paramiko
+import io
+import os
+import shutil
+
+from azure.cli.core.keys import generate_ssh_keys
+
+
+class TestGenerateSSHKeys(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # set up temporary directory to be used for temp files.
+        cls._tempdirName = tempfile.mkdtemp(prefix="key_tmp_")
+
+        cls.key = paramiko.RSAKey.generate(2048)
+        keyOutput = io.StringIO()
+        cls.key.write_private_key(keyOutput)
+
+        cls.private_key = keyOutput.getvalue()
+        cls.public_key = '{} {}'.format(cls.key.get_name(), cls.key.get_base64())
+
+    @classmethod
+    def tearDownClass(cls):
+        # delete temporary directory to be used for temp files.
+        shutil.rmtree(cls._tempdirName)
+
+    def tearDown(self):
+
+        # remove all temporary files/directories created by previous test method.
+        dir = self._tempdirName
+        file_paths = [os.path.join(dir, name) for name in os.listdir(dir)]
+
+        for fp in file_paths:
+            if os.path.isfile(fp):
+                os.remove(fp)
+            else:
+                shutil.rmtree(fp)
+
+    def test_public_key_file_exists(self):
+
+        # Create public key file
+        public_key_path = self._create_new_temp_key_file(self.public_key, suffix=".pub")
+
+        # Create private key file
+        private_key_path = self._create_new_temp_key_file(self.private_key)
+
+        # Call generate_ssh_keys and assert that returned public key same as original
+        new_public_key = generate_ssh_keys("", public_key_path)
+        self.assertEqual(self.public_key, new_public_key)
+
+        # Check that private and public key file contents unchanged.
+        with open(public_key_path, 'r') as f:
+            new_public_key = f.read()
+            self.assertEqual(self.public_key, new_public_key)
+
+        with open(private_key_path, 'r') as f:
+            new_private_key = f.read()
+            self.assertEqual(self.private_key, new_private_key)
+
+    def test_private_key_file_exists(self):
+
+        # Create private key file
+        private_key_path = self._create_new_temp_key_file(self.private_key)
+
+        # Call generate_ssh_keys and assert that returned public key same as original
+        public_key_path = private_key_path + ".pub"
+        new_public_key = generate_ssh_keys(private_key_path, public_key_path)
+        self.assertEqual(self.public_key, new_public_key)
+
+        # Check that correct public key file has been created
+        with open(public_key_path, 'r') as f:
+            public_key = f.read()
+            self.assertEqual(self.public_key, public_key)
+
+        # Check that private key file contents unchanged
+        with open(private_key_path, 'r') as f:
+            private_key = f.read()
+            self.assertEqual(self.private_key, private_key)
+
+    def test_private_key_file_new(self):
+
+        # create random temp file name
+        f = tempfile.NamedTemporaryFile(mode='w', dir=self._tempdirName)
+        f.close()
+        private_key_path = f.name
+
+        # Call generate_ssh_keys and assert that returned public key same as original
+        public_key_path = private_key_path + ".pub"
+        new_public_key = generate_ssh_keys(private_key_path, public_key_path)
+
+        # Check that public key returned is same as public key in public key path
+        with open(public_key_path, 'r') as f:
+            public_key = f.read()
+            self.assertEqual(public_key, new_public_key)
+
+        # Check that public key corresponds to private key
+        with open(private_key_path, 'r') as f:
+            key = paramiko.RSAKey(filename=private_key_path)
+            public_key = '{} {}'.format(key.get_name(), key.get_base64())
+            self.assertEqual(public_key, new_public_key)
+
+
+    def _create_new_temp_key_file(self, key_data, suffix=""):
+        with tempfile.NamedTemporaryFile(mode='w', dir=self._tempdirName, delete=False, suffix=suffix) as f:
+            f.write(key_data)
+            file_path = f.name
+
+        return file_path
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_keys.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_keys.py
@@ -32,7 +32,7 @@ class TestGenerateSSHKeys(unittest.TestCase):
         # delete temporary directory to be used for temp files.
         shutil.rmtree(self._tempdirName)
 
-    def test_public_key_file_exists(self):
+    def test_when_public_key_file_exists(self):
         # Create public key file
         public_key_path = self._create_new_temp_key_file(self.public_key, suffix=".pub")
 
@@ -52,7 +52,7 @@ class TestGenerateSSHKeys(unittest.TestCase):
             new_private_key = f.read()
             self.assertEqual(self.private_key, new_private_key)
 
-    def test_public_key_file_exists_no_permissions(self):
+    def test_error_raised_when_public_key_file_exists_no_permissions(self):
         # Create public key file with no read or write access
         public_key_path = self._create_new_temp_key_file(self.public_key)
         os.chmod(public_key_path, 0o000)
@@ -61,7 +61,7 @@ class TestGenerateSSHKeys(unittest.TestCase):
         with self.assertRaises(CLIError):
             generate_ssh_keys("", public_key_path)
 
-    def test_private_key_file_exists_no_permissions(self):
+    def test_error_raised_when_private_key_file_exists_no_permissions(self):
         # Create private key file with no read or write access
         private_key_path = self._create_new_temp_key_file(self.private_key)
         os.chmod(private_key_path, 0o000)
@@ -71,7 +71,7 @@ class TestGenerateSSHKeys(unittest.TestCase):
             public_key_path = private_key_path + ".pub"
             generate_ssh_keys(private_key_path, public_key_path)
 
-    def test_private_key_file_exists_encrypted(self):
+    def test_error_raised_when_private_key_file_exists_encrypted(self):
         # Create empty private key file
         private_key_path = self._create_new_temp_key_file("")
 
@@ -83,7 +83,7 @@ class TestGenerateSSHKeys(unittest.TestCase):
             public_key_path = private_key_path + ".pub"
             generate_ssh_keys(private_key_path, public_key_path)
 
-    def test_private_key_file_exists(self):
+    def test_generate_public_key_file_from_existing_private_key_files(self):
         # Create private key file
         private_key_path = self._create_new_temp_key_file(self.private_key)
 
@@ -102,7 +102,7 @@ class TestGenerateSSHKeys(unittest.TestCase):
             private_key = f.read()
             self.assertEqual(self.private_key, private_key)
 
-    def test_private_key_file_new(self):
+    def test_generate_new_private_public_key_files(self):
         # create random temp file name
         f = tempfile.NamedTemporaryFile(mode='w', dir=self._tempdirName)
         f.close()
@@ -126,9 +126,7 @@ class TestGenerateSSHKeys(unittest.TestCase):
     def _create_new_temp_key_file(self, key_data, suffix=""):
         with tempfile.NamedTemporaryFile(mode='w', dir=self._tempdirName, delete=False, suffix=suffix) as f:
             f.write(key_data)
-            file_path = f.name
-
-        return file_path
+            return f.name
 
 
 if __name__ == '__main__':

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -864,28 +864,15 @@ def _validate_admin_password(password, os_type):
 
 
 def validate_ssh_key(namespace):
-
-    # check if id_rsa is present but id_rsa.pub is missing
-    def _public_key_is_missing():
-        private_key_path = os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa')
-        public_key_path = os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa.pub')
-        return (os.path.exists(private_key_path) and not os.path.exists(public_key_path))
-
-
-
     string_or_file = (namespace.ssh_key_value or
                       os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa.pub'))
     content = string_or_file
     if os.path.exists(string_or_file):
-        logger.info('Reusing existing SSH public key from %s', string_or_file)
+        logger.info('Use existing SSH public key file: %s', string_or_file)
         with open(string_or_file, 'r') as f:
             content = f.read()
     elif not keys.is_valid_ssh_rsa_public_key(content):
         if namespace.generate_ssh_keys:
-
-            if _public_key_is_missing():
-                raise CLIError('SSH private key id_rsa exists but public key is missing. Please export the public key.')
-
             # figure out appropriate file names:
             # 'base_name'(with private keys), and 'base_name.pub'(with public keys)
             public_key_filepath = string_or_file

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import os
+import shutil
 import tempfile
 import unittest
 import mock
@@ -27,8 +28,13 @@ from knack.util import CLIError
 
 class TestActions(unittest.TestCase):
     def test_generate_specfied_ssh_key_files(self):
-        _, private_key_file = tempfile.mkstemp()
+        temp_dir_name = tempfile.mkdtemp(prefix="ssh_dir_")
+
+        # first create file paths for the keys to be generated
+        _, private_key_file = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file = private_key_file + '.pub'
+        os.remove(private_key_file)
+
         args = mock.MagicMock()
         args.ssh_key_value = public_key_file
         args.generate_ssh_keys = True
@@ -51,7 +57,7 @@ class TestActions(unittest.TestCase):
         self.assertEqual(generated_public_key_string, args.ssh_key_value)
 
         # 3 verify we do not generate unless told so
-        _, private_key_file2 = tempfile.mkstemp()
+        _, private_key_file2 = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file2 = private_key_file2 + '.pub'
         args3 = mock.MagicMock()
         args3.ssh_key_value = public_key_file2
@@ -60,7 +66,7 @@ class TestActions(unittest.TestCase):
             validate_ssh_key(args3)
 
         # 4 verify file naming if the pub file doesn't end with .pub
-        _, public_key_file4 = tempfile.mkstemp()
+        _, public_key_file4 = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file4 += '1'  # make it nonexisting
         args4 = mock.MagicMock()
         args4.ssh_key_value = public_key_file4
@@ -68,6 +74,9 @@ class TestActions(unittest.TestCase):
         validate_ssh_key(args4)
         self.assertTrue(os.path.isfile(public_key_file4 + '.private'))
         self.assertTrue(os.path.isfile(public_key_file4))
+
+        # delete temporary directory and its files
+        shutil.rmtree(temp_dir_name)
 
     def test_figure_out_storage_source(self):
         test_data = 'https://av123images.blob.core.windows.net/images/TDAZBET.vhd'

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
@@ -30,6 +30,9 @@ class TestActions(unittest.TestCase):
     def test_generate_specfied_ssh_key_files(self):
         temp_dir_name = tempfile.mkdtemp(prefix="ssh_dir_")
 
+        # cleanup temporary directory and its contents
+        self.addCleanup(shutil.rmtree, path=temp_dir_name)
+
         # first create file paths for the keys to be generated
         _, private_key_file = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file = private_key_file + '.pub'
@@ -74,9 +77,6 @@ class TestActions(unittest.TestCase):
         validate_ssh_key(args4)
         self.assertTrue(os.path.isfile(public_key_file4 + '.private'))
         self.assertTrue(os.path.isfile(public_key_file4))
-
-        # delete temporary directory and its files
-        shutil.rmtree(temp_dir_name)
 
     def test_figure_out_storage_source(self):
         test_data = 'https://av123images.blob.core.windows.net/images/TDAZBET.vhd'

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import os
+import shutil
 import tempfile
 import unittest
 import mock
@@ -27,8 +28,13 @@ from knack.util import CLIError
 
 class TestActions(unittest.TestCase):
     def test_generate_specfied_ssh_key_files(self):
-        _, private_key_file = tempfile.mkstemp()
+        temp_dir_name = tempfile.mkdtemp(prefix="ssh_dir_")
+
+        # first create file paths for the keys to be generated
+        _, private_key_file = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file = private_key_file + '.pub'
+        os.remove(private_key_file)
+
         args = mock.MagicMock()
         args.ssh_key_value = public_key_file
         args.generate_ssh_keys = True
@@ -51,7 +57,7 @@ class TestActions(unittest.TestCase):
         self.assertEqual(generated_public_key_string, args.ssh_key_value)
 
         # 3 verify we do not generate unless told so
-        _, private_key_file2 = tempfile.mkstemp()
+        _, private_key_file2 = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file2 = private_key_file2 + '.pub'
         args3 = mock.MagicMock()
         args3.ssh_key_value = public_key_file2
@@ -60,7 +66,7 @@ class TestActions(unittest.TestCase):
             validate_ssh_key(args3)
 
         # 4 verify file naming if the pub file doesn't end with .pub
-        _, public_key_file4 = tempfile.mkstemp()
+        _, public_key_file4 = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file4 += '1'  # make it nonexisting
         args4 = mock.MagicMock()
         args4.ssh_key_value = public_key_file4
@@ -68,6 +74,9 @@ class TestActions(unittest.TestCase):
         validate_ssh_key(args4)
         self.assertTrue(os.path.isfile(public_key_file4 + '.private'))
         self.assertTrue(os.path.isfile(public_key_file4))
+
+        # delete temporary directory and its files
+        shutil.rmtree(temp_dir_name)
 
     def test_figure_out_storage_source(self):
         test_data = 'https://av123images.blob.core.windows.net/images/TDAZBET.vhd'

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -30,6 +30,9 @@ class TestActions(unittest.TestCase):
     def test_generate_specfied_ssh_key_files(self):
         temp_dir_name = tempfile.mkdtemp(prefix="ssh_dir_")
 
+        # cleanup temporary directory and its contents
+        self.addCleanup(shutil.rmtree, path=temp_dir_name)
+
         # first create file paths for the keys to be generated
         _, private_key_file = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file = private_key_file + '.pub'
@@ -74,9 +77,6 @@ class TestActions(unittest.TestCase):
         validate_ssh_key(args4)
         self.assertTrue(os.path.isfile(public_key_file4 + '.private'))
         self.assertTrue(os.path.isfile(public_key_file4))
-
-        # delete temporary directory and its files
-        shutil.rmtree(temp_dir_name)
 
     def test_figure_out_storage_source(self):
         test_data = 'https://av123images.blob.core.windows.net/images/TDAZBET.vhd'

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/profile_2017_03_09/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/profile_2017_03_09/test_vm_actions.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import os
+import shutil
 import tempfile
 import unittest
 import mock
@@ -26,8 +27,13 @@ from knack.util import CLIError
 
 class TestActions(unittest.TestCase):
     def test_generate_specfied_ssh_key_files(self):
-        _, private_key_file = tempfile.mkstemp()
+        temp_dir_name = tempfile.mkdtemp(prefix="ssh_dir_")
+
+        # first create file paths for the keys to be generated
+        _, private_key_file = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file = private_key_file + '.pub'
+        os.remove(private_key_file)
+
         args = mock.MagicMock()
         args.ssh_key_value = public_key_file
         args.generate_ssh_keys = True
@@ -50,7 +56,7 @@ class TestActions(unittest.TestCase):
         self.assertEqual(generated_public_key_string, args.ssh_key_value)
 
         # 3 verify we do not generate unless told so
-        _, private_key_file2 = tempfile.mkstemp()
+        _, private_key_file2 = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file2 = private_key_file2 + '.pub'
         args3 = mock.MagicMock()
         args3.ssh_key_value = public_key_file2
@@ -59,7 +65,7 @@ class TestActions(unittest.TestCase):
             validate_ssh_key(args3)
 
         # 4 verify file naming if the pub file doesn't end with .pub
-        _, public_key_file4 = tempfile.mkstemp()
+        _, public_key_file4 = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file4 += '1'  # make it nonexisting
         args4 = mock.MagicMock()
         args4.ssh_key_value = public_key_file4
@@ -67,6 +73,9 @@ class TestActions(unittest.TestCase):
         validate_ssh_key(args4)
         self.assertTrue(os.path.isfile(public_key_file4 + '.private'))
         self.assertTrue(os.path.isfile(public_key_file4))
+
+        # delete temporary directory and its files
+        shutil.rmtree(temp_dir_name)
 
     def test_figure_out_storage_source(self):
         test_data = 'https://av123images.blob.core.windows.net/images/TDAZBET.vhd'

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/profile_2017_03_09/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/profile_2017_03_09/test_vm_actions.py
@@ -29,6 +29,9 @@ class TestActions(unittest.TestCase):
     def test_generate_specfied_ssh_key_files(self):
         temp_dir_name = tempfile.mkdtemp(prefix="ssh_dir_")
 
+        # cleanup temporary directory and its contents
+        self.addCleanup(shutil.rmtree, path=temp_dir_name)
+
         # first create file paths for the keys to be generated
         _, private_key_file = tempfile.mkstemp(dir=temp_dir_name)
         public_key_file = private_key_file + '.pub'
@@ -73,9 +76,6 @@ class TestActions(unittest.TestCase):
         validate_ssh_key(args4)
         self.assertTrue(os.path.isfile(public_key_file4 + '.private'))
         self.assertTrue(os.path.isfile(public_key_file4))
-
-        # delete temporary directory and its files
-        shutil.rmtree(temp_dir_name)
 
     def test_figure_out_storage_source(self):
         test_data = 'https://av123images.blob.core.windows.net/images/TDAZBET.vhd'


### PR DESCRIPTION
Fixes #4725 and #6780 by using `id_rsa` as the private key file (if it exists) to generate a new public key instead of generating a new private-public key pair (which overwrites `id-rsa`).

I tested this fix by deleting my public key and running `az vm create ... --ssh-key-gen`.

A new public key was generated in `id_rsa.pub` and I was able to ssh into the newly created VM. I was able to create another vm using the existing keys pair and ssh into it.

Please let me know your thoughts on this PR.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
