### PR TITLE
[IgniteNetwork] Add `--enable-tcp-reset` to existing commands

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -9,6 +9,7 @@ Release History
 * Add `network service-endpoint` commands to support service endpoint policy features.
 * Add `network lb outbound-rule` commands to support creation of Standard Load Balancer outbound rules.
 * Add `--public-ip-prefix` to `network lb frontend-ip create/update` to support frontend IP configurations using public IP prefixes.
+* Add `--enable-tcp-reset` to `network lb rule/inbound-nat-rule/inbound-nat-pool create/update`.
 
 2.2.4
 +++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -83,6 +83,7 @@ def load_arguments(self, _):
         c.argument('network_security_group_name', nsg_name_type, id_part='name')
         c.argument('private_ip_address', private_ip_address_type)
         c.argument('private_ip_address_version', arg_type=get_enum_type(IPVersion))
+        c.argument('enable_tcp_reset', arg_type=get_three_state_flag(), help='Receive bidirectional TCP reset on TCP flow idle timeout or unexpected connection termination. Only used when protocol is set to TCP.', min_api='2018-07-01')
     # endregion
 
     # region ApplicationGateways
@@ -528,7 +529,6 @@ def load_arguments(self, _):
     with self.argument_context('network lb outbound-rule') as c:
         c.argument('backend_address_pool', options_list='--address-pool', help='Name or ID of the backend address pool.')
         c.argument('frontend_ip_configurations', options_list='--frontend-ip-configs', help='Space-separated list of frontend IP configuration names or IDs.', nargs='+')
-        c.argument('enable_tcp_reset', arg_type=get_three_state_flag(), help='Receive bidirectional TCP reset on TCP flow idle timeout or unexpected connection termination. Only used when protocol is set to TCP.')
         c.argument('protocol', arg_type=get_enum_type(TransportProtocol), help='Network transport protocol.')
         c.argument('outbound_ports', type=int, help='The number of outbound ports to be used for NAT.')
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1681,7 +1681,7 @@ def create_load_balancer(cmd, load_balancer_name, resource_group_name, location=
 
 def create_lb_inbound_nat_rule(
         cmd, resource_group_name, load_balancer_name, item_name, protocol, frontend_port,
-        backend_port, frontend_ip_name=None, floating_ip="false", idle_timeout=None):
+        backend_port, frontend_ip_name=None, floating_ip="false", idle_timeout=None, enable_tcp_reset=None):
     InboundNatRule = cmd.get_models('InboundNatRule')
     ncf = network_client_factory(cmd.cli_ctx)
     lb = ncf.load_balancers.get(resource_group_name, load_balancer_name)
@@ -1693,7 +1693,8 @@ def create_lb_inbound_nat_rule(
         frontend_port=frontend_port, backend_port=backend_port,
         frontend_ip_configuration=frontend_ip,
         enable_floating_ip=floating_ip == 'true',
-        idle_timeout_in_minutes=idle_timeout)
+        idle_timeout_in_minutes=idle_timeout,
+        enable_tcp_reset=enable_tcp_reset)
     _upsert(lb, 'inbound_nat_rules', new_rule, 'name')
     poller = ncf.load_balancers.create_or_update(resource_group_name, load_balancer_name, lb)
     return _get_property(poller.result().inbound_nat_rules, item_name)
@@ -1701,13 +1702,16 @@ def create_lb_inbound_nat_rule(
 
 def set_lb_inbound_nat_rule(
         instance, parent, item_name, protocol=None, frontend_port=None,
-        frontend_ip_name=None, backend_port=None, floating_ip=None, idle_timeout=None):
+        frontend_ip_name=None, backend_port=None, floating_ip=None, idle_timeout=None, enable_tcp_reset=None):
     if frontend_ip_name:
         instance.frontend_ip_configuration = \
             _get_property(parent.frontend_ip_configurations, frontend_ip_name)
 
     if floating_ip is not None:
         instance.enable_floating_ip = floating_ip == 'true'
+
+    if enable_tcp_reset is not None:
+        instance.enable_tcp_reset = enable_tcp_reset
 
     _set_param(instance, 'protocol', protocol)
     _set_param(instance, 'frontend_port', frontend_port)
@@ -1719,7 +1723,7 @@ def set_lb_inbound_nat_rule(
 
 def create_lb_inbound_nat_pool(
         cmd, resource_group_name, load_balancer_name, item_name, protocol, frontend_port_range_start,
-        frontend_port_range_end, backend_port, frontend_ip_name=None):
+        frontend_port_range_end, backend_port, frontend_ip_name=None, enable_tcp_reset=None):
     InboundNatPool = cmd.get_models('InboundNatPool')
     ncf = network_client_factory(cmd.cli_ctx)
     lb = ncf.load_balancers.get(resource_group_name, load_balancer_name)
@@ -1733,7 +1737,8 @@ def create_lb_inbound_nat_pool(
         frontend_ip_configuration=frontend_ip,
         frontend_port_range_start=frontend_port_range_start,
         frontend_port_range_end=frontend_port_range_end,
-        backend_port=backend_port)
+        backend_port=backend_port,
+        enable_tcp_reset=enable_tcp_reset)
     _upsert(lb, 'inbound_nat_pools', new_pool, 'name')
     poller = ncf.load_balancers.create_or_update(resource_group_name, load_balancer_name, lb)
     return _get_property(poller.result().inbound_nat_pools, item_name)
@@ -1742,11 +1747,14 @@ def create_lb_inbound_nat_pool(
 def set_lb_inbound_nat_pool(
         instance, parent, item_name, protocol=None,
         frontend_port_range_start=None, frontend_port_range_end=None, backend_port=None,
-        frontend_ip_name=None):
+        frontend_ip_name=None, enable_tcp_reset=None):
     _set_param(instance, 'protocol', protocol)
     _set_param(instance, 'frontend_port_range_start', frontend_port_range_start)
     _set_param(instance, 'frontend_port_range_end', frontend_port_range_end)
     _set_param(instance, 'backend_port', backend_port)
+
+    if enable_tcp_reset is not None:
+        instance.enable_tcp_reset = enable_tcp_reset
 
     if frontend_ip_name == '':
         instance.frontend_ip_configuration = None
@@ -1877,7 +1885,7 @@ def create_lb_rule(
         cmd, resource_group_name, load_balancer_name, item_name,
         protocol, frontend_port, backend_port, frontend_ip_name=None,
         backend_address_pool_name=None, probe_name=None, load_distribution='default',
-        floating_ip='false', idle_timeout=None):
+        floating_ip='false', idle_timeout=None, enable_tcp_reset=None):
     LoadBalancingRule = cmd.get_models('LoadBalancingRule')
     ncf = network_client_factory(cmd.cli_ctx)
     lb = ncf.load_balancers.get(resource_group_name, load_balancer_name)
@@ -1897,7 +1905,8 @@ def create_lb_rule(
         probe=_get_property(lb.probes, probe_name) if probe_name else None,
         load_distribution=load_distribution,
         enable_floating_ip=floating_ip == 'true',
-        idle_timeout_in_minutes=idle_timeout)
+        idle_timeout_in_minutes=idle_timeout,
+        enable_tcp_reset=enable_tcp_reset)
     _upsert(lb, 'load_balancing_rules', new_rule, 'name')
     poller = ncf.load_balancers.create_or_update(resource_group_name, load_balancer_name, lb)
     return _get_property(poller.result().load_balancing_rules, item_name)
@@ -1906,7 +1915,7 @@ def create_lb_rule(
 def set_lb_rule(
         instance, parent, item_name, protocol=None, frontend_port=None,
         frontend_ip_name=None, backend_port=None, backend_address_pool_name=None, probe_name=None,
-        load_distribution='default', floating_ip=None, idle_timeout=None):
+        load_distribution='default', floating_ip=None, idle_timeout=None, enable_tcp_reset=None):
     _set_param(instance, 'protocol', protocol)
     _set_param(instance, 'frontend_port', frontend_port)
     _set_param(instance, 'backend_port', backend_port)
@@ -1923,6 +1932,9 @@ def set_lb_rule(
     if backend_address_pool_name is not None:
         instance.backend_address_pool = \
             _get_property(parent.backend_address_pools, backend_address_pool_name)
+
+    if enable_tcp_reset is not None:
+        instance.enable_tcp_reset = enable_tcp_reset
 
     if probe_name == '':
         instance.probe = None


### PR DESCRIPTION
cc/ @christiankuhtz 


**Note**: Merging to IgniteNetwork branch

Adds `--enable-tcp-reset` (added with outbound-rules) to the create/update commands for LB rule, inbound-nat-rule and inbound-nat-pool.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
