### PR TITLE
[Storage] show-usage command allows for different api-versions

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -47,7 +47,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.command('delete', 'delete', confirmation=True)
         g.show_command('show', 'get_properties')
         g.custom_command('list', 'list_storage_accounts')
-        g.custom_command('show-usage', 'show_storage_account_usage', min_api='2018-03-01-preview')
+        g.custom_command('show-usage', 'show_storage_account_usage', min_api='2018-02-01')
         g.custom_command('show-usage', 'show_storage_account_usage_no_location', max_api='2016-01-01')
         g.custom_command('show-connection-string', 'show_storage_account_connection_string')
         g.generic_update_command('update', getter_name='get_properties', setter_name='update',

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/account.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/account.py
@@ -76,7 +76,11 @@ def show_storage_account_connection_string(cmd, resource_group_name, account_nam
 
 def show_storage_account_usage(cmd, location):
     scf = storage_client_factory(cmd.cli_ctx)
-    return next((x for x in scf.usages.list_by_location(location) if x.name.value == 'StorageAccounts'), None)  # pylint: disable=no-member
+    try:
+        client = scf.usages
+    except NotImplementedError:
+        client = scf.usage
+    return next((x for x in client.list_by_location(location) if x.name.value == 'StorageAccounts'), None)  # pylint: disable=no-member
 
 
 def show_storage_account_usage_no_location(cmd):


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
