### PR TITLE
[IgniteNetwork] Fix issues with Network Watcher flog-log configure

### DIFF
--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -11,7 +11,7 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>MSBuild|{54f4b6dc-0859-46dc-99bb-b275c9d0aca3}|$(MSBuildProjectFullPath)</InterpreterId>
+    <InterpreterId>MSBuild|env|$(MSBuildProjectFullPath)</InterpreterId>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
     <CommandLineArguments>
     </CommandLineArguments>
@@ -1343,20 +1343,18 @@
     <Content Include="command_modules\azure-cli-vm\linter_exclusions.yml" />
   </ItemGroup>
   <ItemGroup>
-    <Interpreter Include="..\env\">
-      <Id>{54f4b6dc-0859-46dc-99bb-b275c9d0aca3}</Id>
-      <BaseInterpreter>Global|PythonCore|3.5-32</BaseInterpreter>
-      <Version>3.5</Version>
-      <Description>env (Python 3.5)</Description>
-      <InterpreterPath>Scripts\python.exe</InterpreterPath>
-      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
-      <LibraryPath>Lib\</LibraryPath>
-      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
-      <Architecture>X86</Architecture>
-    </Interpreter>
+    <InterpreterReference Include="Global|PythonCore|3.6" />
   </ItemGroup>
   <ItemGroup>
-    <InterpreterReference Include="Global|PythonCore|3.6" />
+    <Interpreter Include="..\env\">
+      <Id>env</Id>
+      <Version>3.6</Version>
+      <Description>env (Python 3.6 (64-bit))</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+      <Architecture>X64</Architecture>
+    </Interpreter>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
 </Project>

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.46
+++++++
+* Minor fixes
+
 2.0.45
 ++++++
 * Fix issue of loading empty configuration file.

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -10,6 +10,7 @@ Release History
 * Add `network lb outbound-rule` commands to support creation of Standard Load Balancer outbound rules.
 * Add `--public-ip-prefix` to `network lb frontend-ip create/update` to support frontend IP configurations using public IP prefixes.
 * Add `--enable-tcp-reset` to `network lb rule/inbound-nat-rule/inbound-nat-pool create/update`.
+* Allow `network watcher flow-log show/configure` to be used with classic NSGs.
 
 2.2.4
 +++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -951,6 +951,7 @@ def process_nw_flow_log_set_namespace(cmd, namespace):
 
 def process_nw_flow_log_show_namespace(cmd, namespace):
     from msrestazure.tools import is_valid_resource_id, resource_id, parse_resource_id
+    from azure.cli.core.commands.arm import get_arm_resource_by_id
 
     if not is_valid_resource_id(namespace.nsg):
         namespace.nsg = resource_id(
@@ -960,11 +961,7 @@ def process_nw_flow_log_show_namespace(cmd, namespace):
             type='networkSecurityGroups',
             name=namespace.nsg)
 
-    network_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_NETWORK).network_security_groups
-    id_parts = parse_resource_id(namespace.nsg)
-    nsg_name = id_parts['name']
-    rg = id_parts['resource_group']
-    nsg = network_client.get(rg, nsg_name)
+    nsg = get_arm_resource_by_id(cmd.cli_ctx, namespace.nsg)
     namespace.location = nsg.location  # pylint: disable=no-member
     get_network_watcher_from_location(remove=True)(cmd, namespace)
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -2580,6 +2580,7 @@ def set_nsg_flow_logging(cmd, client, watcher_rg, watcher_name, nsg, storage_acc
     if retention is not None:
         RetentionPolicyParameters = cmd.get_models('RetentionPolicyParameters')
         config.retention_policy = RetentionPolicyParameters(days=retention, enabled=int(retention) > 0)
+    setattr(config, 'flow_analytics_configuration', None)
     return client.set_flow_log_configuration(watcher_rg, watcher_name, config)
 
 

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -6,7 +6,6 @@ Release History
 ++++++
 * Minor fixes.
 
-
 2.1.3
 ++++++
 * role assignment: fix a recent regression that principalName is missing


### PR DESCRIPTION
**Merge to IgniteNetwork branch**

Fixes #7065. Fixes #7066.

Adds a "get_arm_resource_by_id" method to core that allows us to get basic info on any resource (including classic resources) with an ARM ID. This unblocks the scenario to allow flow-log configuration on a classic NSG. 

cc/ @zwswim

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
