### PR TITLE
Fix key vault key import for RSA keys

### DIFF
--- a/src/command_modules/azure-cli-keyvault/HISTORY.rst
+++ b/src/command_modules/azure-cli-keyvault/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.2.3
++++++
+* Fixed Key Vault key import for RSA keys
+
 2.2.2
 +++++
 * adding commands for managing storage accounts and sas-definitions

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -621,14 +621,15 @@ def import_key(cmd, client, vault_base_url, key_name, protection=None, key_ops=N
         return codecs.decode(h, 'hex')
 
     def _private_rsa_key_to_jwk(rsa_key, jwk):
-        jwk.n = _int_to_bytes(rsa_key.private_numbers().public_numbers.n)
-        jwk.e = _int_to_bytes(rsa_key.private_numbers().public_numbers.e)
-        jwk.q = _int_to_bytes(rsa_key.private_numbers().q)
-        jwk.p = _int_to_bytes(rsa_key.private_numbers().p)
-        jwk.d = _int_to_bytes(rsa_key.private_numbers().d)
-        jwk.dq = _int_to_bytes(rsa_key.private_numbers().dmql)
-        jwk.dp = _int_to_bytes(rsa_key.private_numbers().dmpl)
-        jwk.qi = _int_to_bytes(rsa_key.private_numbers().iqmp)
+        priv = rsa_key.private_numbers()
+        jwk.n = _int_to_bytes(priv.public_numbers.n)
+        jwk.e = _int_to_bytes(priv.public_numbers.e)
+        jwk.q = _int_to_bytes(priv.q)
+        jwk.p = _int_to_bytes(priv.p)
+        jwk.d = _int_to_bytes(priv.d)
+        jwk.dq = _int_to_bytes(priv.dmq1)
+        jwk.dp = _int_to_bytes(priv.dmp1)
+        jwk.qi = _int_to_bytes(priv.iqmp)
 
     def _private_ec_key_to_jwk(ec_key, jwk):
         supported_curves = {

--- a/src/command_modules/azure-cli-keyvault/setup.py
+++ b/src/command_modules/azure-cli-keyvault/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.2.2"
+VERSION = "2.2.3"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
- Replace multiple calls to `rsa_key.private_numbers()` to avoid unnecessary
allocations
- Fix typo when accessing the DQ and DP values of the RSA private key (fixes #7151)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
