### PR TITLE
Variable log level when session files are invalid

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -54,7 +54,7 @@ class Session(collections.MutableMapping):
             log_level = logger.INFO
             if isinstance(load_exception, t_JSONDecodeError):
                 log_level = logger.WARNING
-            
+
             get_logger(__name__).log(log_level, "Failed to load or parse file %s. It will be overridden by default settings.",
                                      self.filename)
             self.save()

--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -48,14 +48,15 @@ class Session(collections.MutableMapping):
             with codecs_open(self.filename, 'r', encoding=self._encoding) as f:
                 self.data = json.load(f)
         except (OSError, IOError, t_JSONDecodeError) as load_exception:
-            # OSError / IOError should imply file not found issues which are expected on fresh runs (e.g. on build agents
-            # or new systems). A parse error indicates invalid/bad data in the file. We do not wish to warn on missing
-            # files since we expect that, but do if the data isn't as expected.
+            # OSError / IOError should imply file not found issues which are expected on fresh runs (e.g. on build
+            # agents or new systems). A parse error indicates invalid/bad data in the file. We do not wish to warn
+            # on missing files since we expect that, but do if the data isn't parsing as expected.
             log_level = logging.INFO
             if isinstance(load_exception, t_JSONDecodeError):
                 log_level = logging.WARNING
 
-            get_logger(__name__).log(log_level, "Failed to load or parse file %s. It will be overridden by default settings.",
+            get_logger(__name__).log(log_level,
+                                     "Failed to load or parse file %s. It will be overridden by default settings.",
                                      self.filename)
             self.save()
 

--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import json
-import logger
+import logging
 import os
 import time
 
@@ -51,9 +51,9 @@ class Session(collections.MutableMapping):
             # OSError / IOError should imply file not found issues which are expected on fresh runs (e.g. on build agents
             # or new systems). A parse error indicates invalid/bad data in the file. We do not wish to warn on missing
             # files since we expect that, but do if the data isn't as expected.
-            log_level = logger.INFO
+            log_level = logging.INFO
             if isinstance(load_exception, t_JSONDecodeError):
-                log_level = logger.WARNING
+                log_level = logging.WARNING
 
             get_logger(__name__).log(log_level, "Failed to load or parse file %s. It will be overridden by default settings.",
                                      self.filename)

--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -58,7 +58,7 @@ class Session(collections.MutableMapping):
             get_logger(__name__).log(log_level, "Failed to load or parse file %s. It will be overridden by default settings.",
                                      self.filename)
             self.save()
-        
+
     def save(self):
         if self.filename:
             with codecs_open(self.filename, 'w', encoding=self._encoding) as f:

--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import json
+import logger
 import os
 import time
 
@@ -46,11 +47,18 @@ class Session(collections.MutableMapping):
                     self.save()
             with codecs_open(self.filename, 'r', encoding=self._encoding) as f:
                 self.data = json.load(f)
-        except (OSError, IOError, t_JSONDecodeError):
-            get_logger(__name__).warning("Fail to load or parse file %s. It is overridden by default settings.",
-                                         self.filename)
+        except (OSError, IOError, t_JSONDecodeError) as load_exception:
+            # OSError / IOError should imply file not found issues which are expected on fresh runs (e.g. on build agents
+            # or new systems). A parse error indicates invalid/bad data in the file. We do not wish to warn on missing
+            # files since we expect that, but do if the data isn't as expected.
+            log_level = logger.INFO
+            if isinstance(load_exception, t_JSONDecodeError):
+                log_level = logger.WARNING
+            
+            get_logger(__name__).log(log_level, "Failed to load or parse file %s. It will be overridden by default settings.",
+                                     self.filename)
             self.save()
-
+        
     def save(self):
         if self.filename:
             with codecs_open(self.filename, 'w', encoding=self._encoding) as f:


### PR DESCRIPTION
When session files are missing (e.g. in a new instance of a build agent) we do not wish to log at warning level as this breaks existing CI/CD systems not expecting this output.

Do log warnings for invalid JSON data (corrupted / malformed files) however.

Inspired by VSTS agents broken by using az cli 2.0.45 and failing during az login. :)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
