### PR TITLE
[Role] Adds support for listing app and service principal owners

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,6 +2,12 @@
 
 Release History
 ===============
+
+2.1.7
+++++++
+* ad app owner: Adds support for listing Azure AD app owners.
+* ad sp owner: Adds support for listing Azure AD service principal owners.
+
 2.1.6
 ++++++
 * role: ensure role definition create & update commands accept multiple permission configurations

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -109,6 +109,14 @@ helps['ad sp list'] = """
     type: command
     short-summary: List service principals.
 """
+helps['ad sp owner'] = """
+    type: group
+    short-summary: Manage service principal owners.
+"""
+helps['ad sp owner list'] = """
+    type: command
+    short-summary: List service principal owners.
+"""
 helps['ad sp show'] = """
     type: command
     short-summary: Get the details of a service principal.
@@ -150,6 +158,14 @@ helps['ad app update'] = """
           text: >
                 az ad app update --id e042ec79-34cd-498f-9d9f-123456781234 --set groupMembershipClaims=All
 
+"""
+helps['ad app owner'] = """
+    type: group
+    short-summary: Manage application owners.
+"""
+helps['ad app owner list'] = """
+    type: command
+    short-summary: List application owners.
 """
 helps['ad user list'] = """
     type: command

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -42,6 +42,9 @@ def load_arguments(self, _):
                    help="resource scopes and roles the application requires access to. Should be in manifest json format. See examples below for details")
         c.argument('native_app', arg_type=get_three_state_flag(), help="an application which can be installed on a user's device or computer")
 
+    with self.argument_context('ad app owner list') as c:
+        c.argument('identifier', options_list=['--id'], help='identifier uri, application id, or object id of the application')
+
     with self.argument_context('ad sp') as c:
         c.argument('identifier', options_list=['--id'], help='service principal name, or object id')
 
@@ -53,6 +56,9 @@ def load_arguments(self, _):
         c.argument('role', completer=get_role_definition_name_completion_list)
         c.argument('skip_assignment', arg_type=get_three_state_flag(), help='do not create default assignment')
         c.argument('show_auth_for_sdk', options_list='--sdk-auth', help='output result in compatible with Azure SDK auth file', arg_type=get_three_state_flag())
+
+    with self.argument_context('ad sp owner list') as c:
+        c.argument('identifier', options_list=['--id'], help='service principal name, or object id or the service principal')
 
     for item in ['create-for-rbac', 'credential reset']:
         with self.argument_context('ad sp {}'.format(item)) as c:

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
@@ -51,7 +51,7 @@ def get_graph_client_groups(cli_ctx, _):
     return _graph_client_factory(cli_ctx).groups
 
 
-# pylint: disable=line-too-long
+# pylint: disable=line-too-long, too-many-statements
 def load_command_table(self, _):
 
     role_users_sdk = CliCommandType(
@@ -88,11 +88,19 @@ def load_command_table(self, _):
                                  getter_name='show_application', getter_type=role_custom,
                                  custom_func_name='update_application', custom_func_type=role_custom)
 
+    with self.command_group('ad app owner', exception_handler=graph_err_handler) as g:
+        g.custom_command('list', 'list_application_owners', client_factory=get_graph_client_applications)
+        # TODO: Add support for 'add' and 'remove'
+
     with self.command_group('ad sp', resource_type=PROFILE_TYPE, exception_handler=graph_err_handler) as g:
         g.custom_command('create', 'create_service_principal')
         g.custom_command('delete', 'delete_service_principal')
         g.custom_command('list', 'list_sps', client_factory=get_graph_client_service_principals)
         g.custom_show_command('show', 'show_service_principal', client_factory=get_graph_client_service_principals)
+
+    with self.command_group('ad sp owner', exception_handler=graph_err_handler) as g:
+        g.custom_command('list', 'list_service_principal_owners')
+        # TODO: Add support for 'add' and 'remove'
 
     # RBAC related
     with self.command_group('ad sp', exception_handler=graph_err_handler) as g:

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -500,6 +500,12 @@ def list_apps(client, app_id=None, display_name=None, identifier_uri=None, query
     return client.list(filter=(' and '.join(sub_filters)))
 
 
+def list_application_owners(cmd, identifier):
+    client = _graph_client_factory(cmd.cli_ctx)
+    object_id = _resolve_application(client.applications, identifier)
+    return client.applications.list_owners(object_id)
+
+
 def list_sps(client, spn=None, display_name=None, query_filter=None):
     sub_filters = []
     if query_filter:
@@ -785,6 +791,12 @@ def _get_app_object_id_from_sp_object_id(client, sp_object_id):
         if result:
             app_object_id = result[0].object_id
     return app_object_id
+
+
+def list_service_principal_owners(cmd, identifier):
+    client = _graph_client_factory(cmd.cli_ctx)
+    sp_object_id = _resolve_service_principal(client.service_principals, identifier)
+    return client.service_principals.list_owners(sp_object_id)
 
 
 def list_service_principal_credentials(cmd, identifier, cert=False):

--- a/src/command_modules/azure-cli-role/setup.py
+++ b/src/command_modules/azure-cli-role/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.1.6"
+VERSION = "2.1.7"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Adds support for `az ad app owner list` and `az ad sp owner list`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
