### PR TITLE
max_api fix

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -283,7 +283,7 @@ class ModExtensionSuppress(object):  # pylint: disable=too-few-public-methods
 
 class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, cli_ctx=None, min_profile=None, max_profile='latest',
+    def __init__(self, cli_ctx=None, min_profile=None, max_profile=None,
                  command_group_cls=None, argument_context_cls=None, suppress_extension=None,
                  **kwargs):
         from azure.cli.core.commands import AzCliCommand, AzCommandGroup, AzArgumentContext

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -283,7 +283,7 @@ class ModExtensionSuppress(object):  # pylint: disable=too-few-public-methods
 
 class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, cli_ctx=None, min_profile=None, max_profile=None,
+    def __init__(self, cli_ctx=None, min_profile=None, max_profile='latest',
                  command_group_cls=None, argument_context_cls=None, suppress_extension=None,
                  **kwargs):
         from azure.cli.core.commands import AzCliCommand, AzCommandGroup, AzArgumentContext
@@ -370,8 +370,8 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         api_support = supported_api_version(
             cli_ctx=self.cli_ctx,
             resource_type=resource_type or self._get_resource_type(),
-            min_api=min_api or self.min_profile,
-            max_api=max_api or self.max_profile,
+            min_api=min_api,
+            max_api=max_api,
             operation_group=operation_group)
         if isinstance(api_support, bool):
             return api_support

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -595,8 +595,7 @@ def _load_command_loader(loader, args, name, prefix):
     if loader_cls:
         command_loader = loader_cls(cli_ctx=loader.cli_ctx)
         loader.loaders.append(command_loader)  # This will be used by interactive
-        if command_loader.supported_api_version(min_api=command_loader.min_profile, max_api=command_loader.max_profile,
-                                                resource_type=PROFILE_TYPE):
+        if command_loader.supported_api_version(resource_type=PROFILE_TYPE):
             command_table = command_loader.load_command_table(args)
             if command_table:
                 for cmd in list(command_table.keys()):

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -310,8 +310,7 @@ def supported_api_version(api_profile, resource_type, min_api=None, max_api=None
         raise ValueError("'resource_type' is required.")
     if min_api is None and max_api is None:
         raise ValueError('At least a min or max version must be specified')
-    api_version_obj = get_api_version(api_profile, resource_type, as_sdk_profile=True) \
-        if isinstance(resource_type, (ResourceType, CustomResourceType)) else api_profile
+    api_version_obj = get_api_version(api_profile, resource_type, as_sdk_profile=True)
     if isinstance(api_version_obj, SDKProfile):
         api_version_obj = api_version_obj.profile.get(operation_group or '', api_version_obj.default_api_version)
     return _validate_api_version(api_version_obj, min_api, max_api)

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -228,37 +228,28 @@ class _SemVerAPIFormat(object):
 class _DateAPIFormat(object):
     """ Class to support comparisons for API versions in
         YYYY-MM-DD, YYYY-MM-DD-preview, YYYY-MM-DD-profile, YYYY-MM-DD-profile-preview
-        or any string that starts with YYYY-MM-DD format. A special case is made for 'latest'.
+        or any string that starts with YYYY-MM-DD format.
     """
 
     def __init__(self, api_version_str):
         try:
-            self.latest = self.preview = False
+            self.preview = False
             self.yyyy = self.mm = self.dd = None
-            if api_version_str == 'latest':
-                self.latest = True
-            else:
-                if 'preview' in api_version_str:
-                    self.preview = True
-                parts = api_version_str.split('-')
-                self.yyyy = int(parts[0])
-                self.mm = int(parts[1])
-                self.dd = int(parts[2])
+            if 'preview' in api_version_str:
+                self.preview = True
+            parts = api_version_str.split('-')
+            self.yyyy = int(parts[0])
+            self.mm = int(parts[1])
+            self.dd = int(parts[2])
         except (ValueError, TypeError):
             raise ValueError('The API version {} is not in a '
                              'supported format'.format(api_version_str))
 
     def __eq__(self, other):
-        return self.latest == other.latest and self.yyyy == other.yyyy and self.mm == other.mm and \
+        return self.yyyy == other.yyyy and self.mm == other.mm and \
             self.dd == other.dd and self.preview == other.preview
 
     def __lt__(self, other):  # pylint: disable=too-many-return-statements
-        if self.latest or other.latest:
-            if not self.latest and other.latest:
-                return True
-            if self.latest and not other.latest:
-                return False
-            return False
         if self.yyyy < other.yyyy:
             return True
         if self.yyyy == other.yyyy:

--- a/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
@@ -128,6 +128,14 @@ class TestAPIProfiles(unittest.TestCase):
             self.assertTrue(
                 supported_api_version(cli, ResourceType.MGMT_KEYVAULT, min_api='6.0', max_api='8.0'))
 
+    def test_supported_api_version_min_max_constraint_semver_boundaries(self):
+        cli = DummyCli()
+        cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_KEYVAULT: '7.0'}}
+        with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
+            self.assertTrue(
+                supported_api_version(cli, ResourceType.MGMT_KEYVAULT, min_api='7.0', max_api='7.0'))
+
     def test_supported_api_version_max_constraint_not_supported(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')

--- a/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
@@ -49,13 +49,6 @@ class TestAPIProfiles(unittest.TestCase):
             with self.assertRaises(APIVersionException):
                 get_api_version(cli, ResourceType.MGMT_STORAGE)
 
-    def test_supported_api_version_invalid_profile_name(self):
-        # Invalid name for the profile name
-        cli = DummyCli()
-        cli.cloud = Cloud('TestCloud', profile='not-a-real-profile')
-        with self.assertRaises(ValueError):
-            supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01')
-
     def test_get_api_version_invalid_rt_2(self):
         # None is not a valid resource type
         cli = DummyCli()
@@ -70,41 +63,6 @@ class TestAPIProfiles(unittest.TestCase):
         cli = DummyCli()
         with self.assertRaises(ValueError):
             supported_api_version(cli, PROFILE_TYPE)
-
-    def test_supported_api_profile_min_constraint(self):
-        cli = DummyCli()
-        cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile')
-        self.assertTrue(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01'))
-
-    def test_supported_api_profile_min_constraint_not_supported(self):
-        cli = DummyCli()
-        cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile-preview')
-        self.assertFalse(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-02'))
-
-    def test_supported_api_profile_min_max_constraint(self):
-        cli = DummyCli()
-        cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile')
-        self.assertTrue(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01', max_api='2000-01-01'))
-
-    def test_supported_api_profile_max_constraint_not_supported(self):
-        cli = DummyCli()
-        cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile')
-        self.assertFalse(supported_api_version(cli, PROFILE_TYPE, max_api='1999-12-30'))
-
-    def test_supported_api_profile_preview_constraint(self):
-        cli = DummyCli()
-        cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile')
-        self.assertTrue(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01-preview'))
-
-    def test_supported_api_profile_preview_constraint_in_profile(self):
-        cli = DummyCli()
-        cli.cloud = Cloud('TestCloud', profile='2000-01-01-profile-preview')
-        self.assertFalse(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01'))
-
-    def test_supported_api_profile_latest(self):
-        cli = DummyCli()
-        cli.cloud = Cloud('TestCloud', profile='latest')
-        self.assertTrue(supported_api_version(cli, PROFILE_TYPE, min_api='2000-01-01'))
 
     def test_supported_api_version_no_constraints(self):
         # At least a min or max version must be specified


### PR DESCRIPTION
Remove the special value "latest" from max_api. If no max_api is needed, just let None be the value.

This will fix https://github.com/Azure/azure-cli/pull/7140, since this "latest" special string was not backported to SemVer API versionning.

FYI @schaabs 