### PR TITLE
[ACS] Starting the install-connector deprecation process

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+2.3.4
++++++
+* install-connector: Beginning deprecation process for install-connector. This will be replaced with the enable-addons command
+  with the new virtual-node add-on
+
 2.3.3
 +++++
 * bugfix: creating role assignment for vnet-subnet-id when not specifying service principal and skip-role-assignemnt

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -61,7 +61,8 @@ def load_command_table(self, _):
         g.custom_command('get-credentials', 'aks_get_credentials')
         g.command('get-upgrades', 'get_upgrade_profile', table_transformer=aks_upgrades_table_format)
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
-        g.custom_command('install-connector', 'k8s_install_connector', deprecate_info=g.deprecate(redirect="az aks enable-addons virtual-node", hide=True))
+        g.custom_command('install-connector', 'k8s_install_connector',
+                         deprecate_info=g.deprecate(redirect="az aks enable-addons virtual-node", hide=True))
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
         g.custom_command('remove-connector', 'k8s_uninstall_connector')
         g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces')

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -61,7 +61,7 @@ def load_command_table(self, _):
         g.custom_command('get-credentials', 'aks_get_credentials')
         g.command('get-upgrades', 'get_upgrade_profile', table_transformer=aks_upgrades_table_format)
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
-        g.custom_command('install-connector', 'k8s_install_connector')
+        g.custom_command('install-connector', 'k8s_install_connector', deprecate_info=g.deprecate(redirect="az aks enable-addons virtual-node", hide=True))
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
         g.custom_command('remove-connector', 'k8s_uninstall_connector')
         g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces')

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.3.3"
+VERSION = "2.3.4"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
We will be replacing the `install-connector` command with a new add-on in AKS. This PR begins the process of deprecating the `install-connector` command. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ x ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
