### PR TITLE
[WIP] Add support for virtual-node AKS addon

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.47
+++++++
+* Add support `virtual-node` addon in aks subcommands
+
 2.0.46
 ++++++
 * Minor fixes

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -174,6 +174,7 @@ def load_arguments(self, _):
         c.argument('vnet_subnet_id')
         c.argument('workspace_resource_id')
         c.argument('skip_subnet_role_assignment', action='store_true')
+        c.argument('virtual_node_subnet_name')
 
     with self.argument_context('aks disable-addons') as c:
         c.argument('addons', options_list=['--addons', '-a'])


### PR DESCRIPTION
- Adds `--subnet-name` to `az aks enable-addons`
- Adds `--virtual-node-subnet-name` to `az aks create`

I've marked this as WIP because disabling this add-on doesn't currently work (seemingly due to issues in the Azure resource provider, this is being worked on).

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).