### PR TITLE
Fixed bug in create_application() for marketplace managedapps.

### DIFF
--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 2.1.3
 +++++
 * `provider operation show`: exception handling to exit with code 3 upon a missing resource for consistency.
+* `managedapp create --kind MarketPlace`: fixed bug in create_application where positional arguments were used instead of key-word arguments when instantiating a Plan Model.
 
 2.1.2
 +++++

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -2,10 +2,13 @@
 
 Release History
 ===============
+2.1.4
++++++
+* `managedapp create --kind MarketPlace`: fixed bug causing instance creation of a Marketplace managed app to crash.
+
 2.1.3
 +++++
 * `provider operation show`: exception handling to exit with code 3 upon a missing resource for consistency.
-* `managedapp create --kind MarketPlace`: fixed bug in create_application where positional arguments were used instead of key-word arguments when instantiating a Plan Model.
 
 2.1.2
 +++++

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -579,7 +579,7 @@ def create_application(cmd, resource_group_name,
             raise CLIError('--plan-name, --plan-product, --plan-publisher and \
             --plan-version are all required if kind is MarketPlace')
         else:
-            application.plan = Plan(plan_name, plan_publisher, plan_product, plan_version)
+            application.plan = Plan(name=plan_name, publisher=plan_publisher, product=plan_product, version=plan_version)
 
     applicationParameters = None
 

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.1.3"
+VERSION = "2.1.4"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fixes issue #7238.

Fixed bug in create_application() for marketplace managedapps where positional arguments were being passed into Plan object's __init__ instead of key-word arguments.

This bug was introduced through a change to the `Plan` model signature in this [commit](https://github.com/Azure/azure-sdk-for-python/commit/0ff3ea47c5c622c17e7e9d63d6e93ec6aac1dc86#diff-aa15f09e1f1ef7d92f246bd786dc244c) to the azure SDK. According to the release history file for `azure-mgmt-resource` from this commit onwards all model signatures use only keyword-argument syntax.

![plan model signature change](https://user-images.githubusercontent.com/15149427/45317704-9ed8ec80-b4ef-11e8-89a3-0970abd84f2d.png)



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
