### PR TITLE
[IgniteNetwork] Read-only support for InterfaceEndpoints

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -22,6 +22,7 @@ Release History
 * `network lb frontend-ip create/update`: Fixed the logic for setting private IP allocation method. If a private IP address is provided, the
   allocation will be static. If no private IP address is provided, or empty string is provided for private IP address, allocation is dynamic.
 * `dns record-set * create/update`: Add support for `--target-resource`.
+* Add `network interface-endpoint` commands to query interface endpoint objects.
 
 2.2.4
 +++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_client_factory.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_client_factory.py
@@ -53,6 +53,10 @@ def cf_express_route_service_providers(cli_ctx, _):
     return network_client_factory(cli_ctx).express_route_service_providers
 
 
+def cf_interface_endpoints(cli_ctx, _):
+    return network_client_factory(cli_ctx).interface_endpoints
+
+
 def cf_load_balancers(cli_ctx, _):
     return network_client_factory(cli_ctx).load_balancers
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1945,6 +1945,38 @@ helps['network express-route peering update'] = """
 """
 # endregion
 
+# region Interface Endpoint
+helps['network interface-endpoint'] = """
+    type: group
+    short-summary: Manage interface endpoints.
+"""
+
+helps['network interface-endpoint create'] = """
+    type: command
+    short-summary: Create an interface endpoint.
+"""
+
+helps['network interface-endpoint delete'] = """
+    type: command
+    short-summary: Delete an interface endpoint.
+"""
+
+helps['network interface-endpoint list'] = """
+    type: command
+    short-summary: List interface endpoints.
+"""
+
+helps['network interface-endpoint show'] = """
+    type: command
+    short-summary: Get the details of an interface endpoint.
+"""
+
+helps['network interface-endpoint update'] = """
+    type: command
+    short-summary: Update an interface endpoint.
+"""
+# endregion
+
 # region Load Balancer
 helps['network lb'] = """
     type: group

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1951,15 +1951,15 @@ helps['network interface-endpoint'] = """
     short-summary: Manage interface endpoints.
 """
 
-helps['network interface-endpoint create'] = """
-    type: command
-    short-summary: Create an interface endpoint.
-"""
+# helps['network interface-endpoint create'] = """
+#    type: command
+#    short-summary: Create an interface endpoint.
+# """
 
-helps['network interface-endpoint delete'] = """
-    type: command
-    short-summary: Delete an interface endpoint.
-"""
+# helps['network interface-endpoint delete'] = """
+#    type: command
+#    short-summary: Delete an interface endpoint.
+# """
 
 helps['network interface-endpoint list'] = """
     type: command
@@ -1971,10 +1971,10 @@ helps['network interface-endpoint show'] = """
     short-summary: Get the details of an interface endpoint.
 """
 
-helps['network interface-endpoint update'] = """
-    type: command
-    short-summary: Update an interface endpoint.
-"""
+# helps['network interface-endpoint update'] = """
+#    type: command
+#    short-summary: Update an interface endpoint.
+# """
 # endregion
 
 # region Load Balancer

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -463,6 +463,14 @@ def load_arguments(self, _):
 
     # endregion
 
+    # region InterfaceEndpoint
+    interface_endpoint_name = CLIArgumentType(options_list='--endpoint-name', id_part='name', help='Name of the interface endpoint.', completer=get_resource_name_completion_list('Microsoft.Network/interfaceEndpoints'))
+
+    with self.argument_context('network interface-endpoint') as c:
+        c.argument('interface_endpoint_name', interface_endpoint_name, options_list=['--name', '-n'])
+        c.argument('location', get_location_type(self.cli_ctx), validator=get_default_location_from_resource_group)
+    # endregion
+
     # region LoadBalancers
     lb_subresources = [
         {'name': 'address-pool', 'display': 'backend address pool', 'ref': 'backend_address_pools'},

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -22,7 +22,7 @@ from azure.cli.command_modules.network._client_factory import (
     cf_tm_geographic, cf_security_rules, cf_subnets, cf_usages, cf_service_community,
     cf_public_ip_addresses, cf_endpoint_services, cf_application_security_groups, cf_connection_monitor,
     cf_ddos_protection_plans, cf_public_ip_prefixes, cf_service_endpoint_policies,
-    cf_service_endpoint_policy_definitions, cf_dns_references)
+    cf_service_endpoint_policy_definitions, cf_dns_references, cf_interface_endpoints)
 from azure.cli.command_modules.network._util import (
     list_network_resource_property, get_network_resource_property_entry, delete_network_resource_property_entry)
 from azure.cli.command_modules.network._format import (
@@ -120,6 +120,12 @@ def load_command_table(self, _):
     network_er_peering_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.network.operations.express_route_circuit_peerings_operations#ExpressRouteCircuitPeeringsOperations.{}',
         client_factory=cf_express_route_circuit_peerings
+    )
+
+    network_interface_endpoint_sdk = CliCommandType(
+        operations_tmpl='azure.mgmt.network.operations.interface_endpoints_operations#InterfaceEndpointsOperations.{}',
+        client_factory=cf_interface_endpoints,
+        min_api='2018-08-01'
     )
 
     network_lb_sdk = CliCommandType(
@@ -420,7 +426,15 @@ def load_command_table(self, _):
         g.show_command('show', 'get')
         g.command('list', 'list')
         g.generic_update_command('update', setter_arg_name='peering_parameters', custom_func_name='update_express_route_peering')
+    # endregion
 
+    # region InterfaceEndpoint
+    with self.command_group('network interface-endpoint', network_interface_endpoint_sdk) as g:
+        g.custom_command('create', 'create_interface_endpoint')
+        g.command('delete', 'delete')
+        g.custom_command('list', 'list_interface_endpoints')
+        g.show_command('show')
+        g.generic_update_command('update', custom_func_name='update_interface_endpoint')
     # endregion
 
     # region LoadBalancers
@@ -493,11 +507,9 @@ def load_command_table(self, _):
         g.custom_command('create', 'create_local_gateway', supports_no_wait=True, validator=process_local_gateway_create_namespace)
         g.generic_update_command('update', custom_func_name='update_local_gateway', supports_no_wait=True)
         g.wait_command('wait')
-
     # endregion
 
     # region NetworkInterfaces: (NIC)
-
     with self.command_group('network nic', network_nic_sdk) as g:
         g.custom_command('create', 'create_nic', transform=transform_nic_create_output, validator=process_nic_create_namespace, supports_no_wait=True)
         g.command('delete', 'delete', supports_no_wait=True)
@@ -664,7 +676,6 @@ def load_command_table(self, _):
         g.show_command('show')
         g.generic_update_command('update', custom_func_name='update_service_endpoint_policy_definition',
                                  setter_arg_name='service_endpoint_policy_definitions')
-
     # endregion
 
     # region TrafficManagers

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -430,11 +430,12 @@ def load_command_table(self, _):
 
     # region InterfaceEndpoint
     with self.command_group('network interface-endpoint', network_interface_endpoint_sdk) as g:
-        g.custom_command('create', 'create_interface_endpoint')
-        g.command('delete', 'delete')
+        # TODO: Re-enable when service team asks. See issue #7271
+        # g.custom_command('create', 'create_interface_endpoint')
+        # g.command('delete', 'delete')
         g.custom_command('list', 'list_interface_endpoints')
         g.show_command('show')
-        g.generic_update_command('update', custom_func_name='update_interface_endpoint')
+        # g.generic_update_command('update', custom_func_name='update_interface_endpoint')
     # endregion
 
     # region LoadBalancers

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1638,6 +1638,38 @@ def update_express_route_peering(cmd, instance, peer_asn=None, primary_peer_addr
 # endregion
 
 
+# region InterfaceEndpoints
+def create_interface_endpoint(cmd, resource_group_name, interface_endpoint_name, subnet, location=None, tags=None,
+                              fqdn=None, endpoint_service=None, nics=None):
+    client = network_client_factory(cmd.cli_ctx).interface_endpoints
+    InterfaceEndpoint, SubResource = cmd.get_models(
+        'InterfaceEndpoint', 'SubResource')
+    endpoint = InterfaceEndpoint(
+        tags=tags,
+        location=location,
+        fqdn=fqdn,
+        endpoint_service=SubResource(id=endpoint_service) if endpoint_service else None,
+        subnet=SubResource(id=subnet) if subnet else None,
+        network_interfaces=[SubResource(id=nics)] if nics else None
+    )
+    return client.create_or_update(resource_group_name, interface_endpoint_name, endpoint)
+
+
+def list_interface_endpoints(cmd, resource_group_name=None):
+    client = network_client_factory(cmd.cli_ctx).interface_endpoints
+    if resource_group_name:
+        return client.list(resource_group_name)
+    return client.list_by_subscription()
+
+
+def update_interface_endpoint(instance, tags=None):
+    if tags is not None:
+        instance.tags = tags
+
+    return instance
+# endregion
+
+
 # region LoadBalancers
 def create_load_balancer(cmd, load_balancer_name, resource_group_name, location=None, tags=None,
                          backend_pool_name=None, frontend_ip_name='LoadBalancerFrontEnd',
@@ -1986,8 +2018,6 @@ def set_lb_rule(
         instance.probe = _get_property(parent.probes, probe_name)
 
     return parent
-
-
 # endregion
 
 
@@ -2037,8 +2067,6 @@ def update_local_gateway(cmd, instance, gateway_ip_address=None, local_address_p
     if tags is not None:
         instance.tags = tags
     return instance
-
-
 # endregion
 
 
@@ -2275,8 +2303,6 @@ def remove_nic_ip_config_inbound_nat_rule(
     ip_config.load_balancer_inbound_nat_rules = keep_items
     poller = client.create_or_update(resource_group_name, network_interface_name, nic)
     return _get_property(poller.result().ip_configurations, ip_config_name)
-
-
 # endregion
 
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_interface_endpoints.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_interface_endpoints.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2018-09-11T17:08:31Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_network_interface_endpoints000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_interface_endpoints000001","name":"cli_test_network_interface_endpoints000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-11T17:08:31Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 11 Sep 2018 17:08:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network interface-endpoint list]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/interfaceEndpoints?api-version=2018-08-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 11 Sep 2018 17:08:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network interface-endpoint list]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_interface_endpoints000001/providers/Microsoft.Network/interfaceEndpoints?api-version=2018-08-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 11 Sep 2018 17:08:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network interface-endpoint show]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_interface_endpoints000001/providers/Microsoft.Network/interfaceEndpoints/dummy?api-version=2018-08-01
+  response:
+    body: {string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/interfaceEndpoints/dummy''
+        under resource group ''cli_test_network_interface_endpoints000001'' was not
+        found."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['221']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 11 Sep 2018 17:08:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-failure-cause: [gateway]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_network_interface_endpoints000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Tue, 11 Sep 2018 17:08:36 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGTkVUV09SSzo1RklOVEVSRkFDRTo1RkVORFBPSU5UUzRHUnxENkEwOTQ2OTg5OTlBRDcwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_subnet_delegation.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_subnet_delegation.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-09-10T22:26:08Z"}}'
+      "date": "2018-09-10T22:45:47Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -15,12 +15,12 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_subnet_delegation000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001","name":"cli_subnet_delegation000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-10T22:26:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001","name":"cli_subnet_delegation000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-10T22:45:47Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 22:26:11 GMT']
+      date: ['Mon, 10 Sep 2018 22:45:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -72,7 +72,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2596']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 22:26:11 GMT']
+      date: ['Mon, 10 Sep 2018 22:45:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -95,12 +95,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_subnet_delegation000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001","name":"cli_subnet_delegation000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-10T22:26:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001","name":"cli_subnet_delegation000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-10T22:45:47Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 22:26:12 GMT']
+      date: ['Mon, 10 Sep 2018 22:45:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -152,7 +152,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3136']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 22:26:12 GMT']
+      date: ['Mon, 10 Sep 2018 22:45:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -178,20 +178,20 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1\",\r\n
-        \ \"etag\": \"W/\\\"cbea7c34-27e6-45d2-bf02-f58c7e7e00ac\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"7e64bced-5dc3-48c2-96ad-009a46df4e8f\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"7f2d0df1-9b8e-4f00-a554-db93208e6258\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"068f6abb-2eac-4c82-89e0-b1a1bbae5c92\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
         false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/2a0cec58-892d-4410-8b89-17f6fa13b7a0?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/a18ad875-4682-46f5-bd68-04cd945b7d85?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['773']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 22:26:14 GMT']
+      date: ['Mon, 10 Sep 2018 22:45:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -209,14 +209,14 @@ interactions:
       User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
           msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/2a0cec58-892d-4410-8b89-17f6fa13b7a0?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/a18ad875-4682-46f5-bd68-04cd945b7d85?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 22:26:17 GMT']
+      date: ['Mon, 10 Sep 2018 22:45:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -235,14 +235,14 @@ interactions:
       User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
           msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/2a0cec58-892d-4410-8b89-17f6fa13b7a0?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/a18ad875-4682-46f5-bd68-04cd945b7d85?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 22:26:27 GMT']
+      date: ['Mon, 10 Sep 2018 22:46:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -264,10 +264,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1\",\r\n
-        \ \"etag\": \"W/\\\"79f7b254-519f-4f3b-884a-ad7f17183437\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"06180aeb-ab29-4ac5-8ff6-939bfba38f68\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"7f2d0df1-9b8e-4f00-a554-db93208e6258\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"068f6abb-2eac-4c82-89e0-b1a1bbae5c92\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -276,8 +276,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['774']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 22:26:28 GMT']
-      etag: [W/"79f7b254-519f-4f3b-884a-ad7f17183437"]
+      date: ['Mon, 10 Sep 2018 22:46:07 GMT']
+      etag: [W/"06180aeb-ab29-4ac5-8ff6-939bfba38f68"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -302,22 +302,238 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1?api-version=2018-08-01
   response:
-    body: {string: "{\r\n  \"error\": {\r\n    \"code\": \"SubscriptionNotRegisteredForFeature\",\r\n
-        \   \"message\": \"Subscription /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/subscriptions/
-        is not registered for feature Microsoft.Network/AllowInterfaceEndpoints required
-        to carry out the requested operation.\",\r\n    \"details\": []\r\n  }\r\n}"}
+    body: {string: "{\r\n  \"name\": \"subnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\",\r\n
+        \ \"etag\": \"W/\\\"8ea5874e-61ac-4665-b74c-ff65ab655960\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [\r\n      {\r\n        \"name\": \"0\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1/delegations/0\",\r\n
+        \       \"etag\": \"W/\\\"8ea5874e-61ac-4665-b74c-ff65ab655960\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"serviceName\": \"Microsoft.Sql/servers\",\r\n          \"actions\":
+        []\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets/delegations\"\r\n
+        \     }\r\n    ],\r\n    \"purpose\": \"InterfaceEndpoints\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"}
     headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/e8707c2f-38cb-456f-92db-138ac8563c6f?api-version=2018-08-01']
       cache-control: [no-cache]
-      content-length: ['356']
+      content-length: ['1101']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 22:26:28 GMT']
+      date: ['Mon, 10 Sep 2018 22:46:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 400, message: Bad Request}
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet subnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/e8707c2f-38cb-456f-92db-138ac8563c6f?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 10 Sep 2018 22:46:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet subnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"subnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\",\r\n
+        \ \"etag\": \"W/\\\"f6544a29-1dc7-4da9-870b-5f31f191dd49\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [\r\n      {\r\n        \"name\": \"0\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1/delegations/0\",\r\n
+        \       \"etag\": \"W/\\\"f6544a29-1dc7-4da9-870b-5f31f191dd49\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"serviceName\": \"Microsoft.Sql/servers\",\r\n          \"actions\":
+        []\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets/delegations\"\r\n
+        \     }\r\n    ],\r\n    \"purpose\": \"InterfaceEndpoints\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1102']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 10 Sep 2018 22:46:13 GMT']
+      etag: [W/"f6544a29-1dc7-4da9-870b-5f31f191dd49"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet subnet update]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"subnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\",\r\n
+        \ \"etag\": \"W/\\\"f6544a29-1dc7-4da9-870b-5f31f191dd49\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [\r\n      {\r\n        \"name\": \"0\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1/delegations/0\",\r\n
+        \       \"etag\": \"W/\\\"f6544a29-1dc7-4da9-870b-5f31f191dd49\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"serviceName\": \"Microsoft.Sql/servers\",\r\n          \"actions\":
+        []\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets/delegations\"\r\n
+        \     }\r\n    ],\r\n    \"purpose\": \"InterfaceEndpoints\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1102']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 10 Sep 2018 22:46:14 GMT']
+      etag: [W/"f6544a29-1dc7-4da9-870b-5f31f191dd49"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1",
+      "properties": {"addressPrefix": "10.0.0.0/24", "delegations": [{"properties":
+      {"serviceName": "Microsoft.Sql/Servers"}, "name": "0"}], "provisioningState":
+      "Succeeded"}, "name": "subnet1", "etag": "W/\\"f6544a29-1dc7-4da9-870b-5f31f191dd49\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet subnet update]
+      Connection: [keep-alive]
+      Content-Length: ['461']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"subnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\",\r\n
+        \ \"etag\": \"W/\\\"60e531b1-87ae-4441-8e36-bf51404e14dc\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [\r\n      {\r\n        \"name\": \"0\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1/delegations/0\",\r\n
+        \       \"etag\": \"W/\\\"60e531b1-87ae-4441-8e36-bf51404e14dc\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"serviceName\": \"Microsoft.Sql/Servers\",\r\n          \"actions\":
+        []\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets/delegations\"\r\n
+        \     }\r\n    ],\r\n    \"purpose\": \"InterfaceEndpoints\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/146554c2-5343-4080-bf50-25f3eaeab1ae?api-version=2018-08-01']
+      cache-control: [no-cache]
+      content-length: ['1101']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 10 Sep 2018 22:46:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet subnet update]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/146554c2-5343-4080-bf50-25f3eaeab1ae?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 10 Sep 2018 22:46:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet subnet update]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Windows-10-10.0.17134-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.46]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"subnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\",\r\n
+        \ \"etag\": \"W/\\\"51858271-95e2-4288-be74-2a6984f7112f\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [\r\n      {\r\n        \"name\": \"0\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_delegation000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1/delegations/0\",\r\n
+        \       \"etag\": \"W/\\\"51858271-95e2-4288-be74-2a6984f7112f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"serviceName\": \"Microsoft.Sql/Servers\",\r\n          \"actions\":
+        []\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets/delegations\"\r\n
+        \     }\r\n    ],\r\n    \"purpose\": \"InterfaceEndpoints\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1102']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 10 Sep 2018 22:46:19 GMT']
+      etag: [W/"51858271-95e2-4288-be74-2a6984f7112f"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
@@ -337,9 +553,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 10 Sep 2018 22:26:29 GMT']
+      date: ['Mon, 10 Sep 2018 22:46:21 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZTVUJORVQ6NUZERUxFR0FUSU9OMkFFQlNNTjNBVVFOQUNPNFRLUUtJRHxDRUJFNjQ0RUY4MTdENkUzLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZTVUJORVQ6NUZERUxFR0FUSU9OUEFUVkgyWkhIV1JJM0hIVkQ2SUxXN3xFNDA2RDlBMkQyMUE0RTY3LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -1741,12 +1741,14 @@ class NetworkSubnetScenarioTests(ScenarioTest):
         result = self.cmd('network vnet subnet list-available-delegations -g {rg}').get_output_in_json()
         self.assertTrue(len(result) > 1, True)
 
-        # self.cmd('network vnet create -g {rg} -n {vnet} -l westcentralus')
-        # self.cmd('network vnet subnet create -g {rg} --vnet-name {vnet} -n {subnet} --address-prefix 10.0.0.0/24 --delegations Microsoft.Sql/servers',
-        #         checks=self.check('delegations[0].serviceName', 'Microsoft.Sql/servers'))
-        # # verify the update command, and that CLI validation will accept either serviceName or Name
-        # self.cmd('network vnet subnet update -g {rg} --vnet-name {vnet} -n {subnet} --delegations Microsoft.Sql.Servers',
-        #         checks=self.check('delegations[0].serviceName', 'Microsoft.Sql/Servers'))
+        self.cmd('network vnet create -g {rg} -n {vnet} -l westcentralus')
+        self.cmd('network vnet subnet create -g {rg} --vnet-name {vnet} -n {subnet} --address-prefix 10.0.0.0/24 --delegations Microsoft.Sql/servers', checks=[
+            self.check('delegations[0].serviceName', 'Microsoft.Sql/servers'),
+            self.check('purpose', 'InterfaceEndpoints')
+        ])
+        # verify the update command, and that CLI validation will accept either serviceName or Name
+        self.cmd('network vnet subnet update -g {rg} --vnet-name {vnet} -n {subnet} --delegations Microsoft.Sql.Servers',
+                 checks=self.check('delegations[0].serviceName', 'Microsoft.Sql/Servers'))
 
 
 class NetworkActiveActiveCrossPremiseScenarioTest(ScenarioTest):  # pylint: disable=too-many-instance-attributes

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -70,6 +70,20 @@ class NetworkLoadBalancerWithSku(ScenarioTest):
         ])
 
 
+class NetworkInterfaceEndpoints(ScenarioTest):
+
+    @ResourceGroupPreparer(name_prefix='cli_test_network_interface_endpoints')
+    def test_network_interface_endpoints(self, resource_group):
+
+        # unable to create resource so we can only verify the commands don't fail (or fail expectedly)
+        self.cmd('network interface-endpoint list')
+        self.cmd('network interface-endpoint list -g {rg}')
+
+        # system code 3 for 'not found'
+        with self.assertRaisesRegexp(SystemExit, '3'):
+            self.cmd('network interface-endpoint show -g {rg} -n dummy')
+
+
 class NetworkLoadBalancerWithZone(ScenarioTest):
 
     @ResourceGroupPreparer(name_prefix='cli_test_network_lb_zone')


### PR DESCRIPTION
**NOTE**: Merge to IgniteNetwork branch.

cc/ @rupalivohra 

Adds support for `network interface-endpoint show/list`.  `create`, `update`, `delete` code is included but blocked since the service does not fully support those operations. These will be enabled at the service team's request, tracked via issue #7271.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
