### PR TITLE
Attempting to add an extension that is already installed will not raise an exception

### DIFF
--- a/src/command_modules/azure-cli-extension/HISTORY.rst
+++ b/src/command_modules/azure-cli-extension/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.2.2
++++++
+* Attempting to add an extension that is already installed will not raise an exception.
+
 0.2.1
 +++++
 * Fix index url failing requests.

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/custom.py
@@ -195,7 +195,8 @@ def add_extension(source=None, extension_name=None, index_url=None, yes=None,  #
     ext_sha256 = None
     if extension_name:
         if extension_exists(extension_name):
-            raise CLIError('The extension {} already exists.'.format(extension_name))
+            logger.warning("The extension '%s' already exists.", extension_name)
+            return
         try:
             source, ext_sha256 = resolve_from_index(extension_name, index_url=index_url)
         except NoExtensionCandidatesError as err:

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
@@ -161,8 +161,9 @@ class TestExtensionCommands(unittest.TestCase):
             with mock.patch('azure.cli.command_modules.extension.custom.logger') as mock_logger:
                 add_extension(extension_name=MY_EXT_NAME)
                 call_args = mock_logger.warning.call_args
-                self.assertTrue("The extension '%s' already exists." == call_args[0][0])
-                self.assertTrue(MY_EXT_NAME == call_args[0][1])
+                self.assertEqual("The extension '%s' already exists.", call_args[0][0])
+                self.assertEqual(MY_EXT_NAME, call_args[0][1])
+                self.assertEqual(mock_logger.warning.call_count, 1)
 
     def test_update_extension(self):
         add_extension(source=MY_EXT_SOURCE)

--- a/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
+++ b/src/command_modules/azure-cli-extension/azure/cli/command_modules/extension/tests/latest/test_extension_commands.py
@@ -158,9 +158,11 @@ class TestExtensionCommands(unittest.TestCase):
         # Now add using name
         computed_extension_sha256 = _compute_file_hash(MY_EXT_SOURCE)
         with mock.patch('azure.cli.command_modules.extension.custom.resolve_from_index', return_value=(MY_EXT_SOURCE, computed_extension_sha256)):
-            with self.assertRaises(CLIError) as err:
+            with mock.patch('azure.cli.command_modules.extension.custom.logger') as mock_logger:
                 add_extension(extension_name=MY_EXT_NAME)
-            self.assertTrue('The extension {} already exists.'.format(MY_EXT_NAME) in str(err.exception))
+                call_args = mock_logger.warning.call_args
+                self.assertTrue("The extension '%s' already exists." == call_args[0][0])
+                self.assertTrue(MY_EXT_NAME == call_args[0][1])
 
     def test_update_extension(self):
         add_extension(source=MY_EXT_SOURCE)

--- a/src/command_modules/azure-cli-extension/setup.py
+++ b/src/command_modules/azure-cli-extension/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This is a philosophical change in the extension command module for the add extension functionality. Thought behind this is, 'if a resource I need is already installed, why would that cause an error?'.

At a basic level, this simplifies Azure CLI's extension CI/CD experience particularly when reusing an environment. Without this change a user has to explicitly handle the above stated scenario as its common for CI workflows to fail when an executed element returns a none zero exit code.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
