### PR TITLE
On AKS create, load the tenant id from profile if it isn't specified.

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.3.5
++++++
+* `az aks create` no longer requires --aad-tenant-id
+
 2.3.4
 +++++
 * install-connector: Updates the install-connector command to set the AKS Master FQDN

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1359,6 +1359,16 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False, li
         return
 
 
+def _validate_ssh_key(no_ssh_key, ssh_key_value):
+    if not no_ssh_key:
+        try:
+            if not ssh_key_value or not is_valid_ssh_rsa_public_key(ssh_key_value):
+                raise ValueError()
+        except (TypeError, ValueError):
+            shortened_key = truncate_text(ssh_key_value)
+            raise CLIError('Provided ssh key ({}) is invalid or non-existent'.format(shortened_key))
+
+
 def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint: disable=too-many-locals
                dns_name_prefix=None,
                location=None,
@@ -1388,13 +1398,7 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
                tags=None,
                generate_ssh_keys=False,  # pylint: disable=unused-argument
                no_wait=False):
-    if not no_ssh_key:
-        try:
-            if not ssh_key_value or not is_valid_ssh_rsa_public_key(ssh_key_value):
-                raise ValueError()
-        except (TypeError, ValueError):
-            shortened_key = truncate_text(ssh_key_value)
-            raise CLIError('Provided ssh key ({}) is invalid or non-existent'.format(shortened_key))
+    _validate_ssh_key(no_ssh_key, ssh_key_value)
 
     subscription_id = _get_subscription_id(cmd.cli_ctx)
     if not dns_name_prefix:
@@ -1463,6 +1467,10 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
 
     aad_profile = None
     if any([aad_client_app_id, aad_server_app_id, aad_server_app_secret, aad_tenant_id]):
+        if aad_tenant_id is None:
+            profile = Profile(cli_ctx=cmd.cli_ctx)
+            _, _, aad_tenant_id = profile.get_login_credentials()
+
         aad_profile = ManagedClusterAADProfile(
             client_app_id=aad_client_app_id,
             server_app_id=aad_server_app_id,

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.3.4"
+VERSION = "2.3.5"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
@mboersma @yugangw-msft 

There's no reason to force the user to specify a tenant id when we have it in their subscription profile.