### PR TITLE
Added logic to handle_exception() to handle bad requests.

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.47
+++++++
+* Introduces generic behavior to handle "Bad Request" errors.
 
 2.0.47
 ++++++
@@ -11,7 +14,6 @@ Release History
 ++++++
 * Fixed issue where `az vm create --generate-ssh-keys` overwrites private key
   file if public key file is missing. (#4725, #6780)
-* CLI now has generic behavior to handle "Bad Request" errors.
 
 2.0.45
 ++++++

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -26,7 +26,7 @@ Release History
 
 2.0.43
 ++++++
-* Consuming mult api azure.mgmt.azutorization package for stack support
+* Consuming mult api azure.mgmt.authorization package for stack support
 * Minor fixes
 
 2.0.42

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -6,10 +6,6 @@ Release History
 ++++++
 * Introduces generic behavior to handle "Bad Request" errors.
 
-2.0.47
-++++++
-* Minor fixes
-
 2.0.46
 ++++++
 * Fixed issue where `az vm create --generate-ssh-keys` overwrites private key

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -11,6 +11,7 @@ Release History
 ++++++
 * Fixed issue where `az vm create --generate-ssh-keys` overwrites private key
   file if public key file is missing. (#4725, #6780)
+* CLI now has generic behavior to handle "Bad Request" errors.
 
 2.0.45
 ++++++
@@ -25,7 +26,7 @@ Release History
 
 2.0.43
 ++++++
-* Comnsuming mult api azure.mgmt.azutorization package for stack support
+* Consuming mult api azure.mgmt.azutorization package for stack support
 * Minor fixes
 
 2.0.42

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -9,11 +9,11 @@ import sys
 import unittest
 import mock
 import tempfile
-from datetime import date, time, datetime
+import json
 
 from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
-     open_page_in_browser, can_launch_browser)
+     open_page_in_browser, can_launch_browser, handle_exception)
 
 
 class TestUtils(unittest.TestCase):
@@ -182,6 +182,142 @@ class TestBase64ToHex(unittest.TestCase):
 
     def test_b64_to_hex_type(self):
         self.assertIsInstance(b64_to_hex(self.base64), str)
+
+
+class TestHandleException(unittest.TestCase):
+
+    @mock.patch('azure.cli.core.util.logger.error', autospec=True)
+    def test_handles_keyboardinterrupt(self, mock_logger_error):
+        from knack.util import CLIError
+
+        # create test KeyboardInterrupt Exception
+        keyboard_interrupt_ex = KeyboardInterrupt("KeyboardInterrupt")
+
+        # call handle_exception
+        ex_result = handle_exception(keyboard_interrupt_ex)
+
+        # test behavior
+        self.assertFalse(mock_logger_error.called)
+        self.assertEqual(ex_result, 1)
+
+    @mock.patch('azure.cli.core.util.logger.error', autospec=True)
+    def test_handles_clierror(self, mock_logger_error):
+        from knack.util import CLIError
+
+        # create test CLIError Exception
+        err_msg = "Error Message"
+        cli_error = CLIError(err_msg)
+
+        # call handle_exception
+        ex_result = handle_exception(cli_error)
+
+        # test behavior
+        self.assertTrue(mock_logger_error.called)
+        self.assertTrue(mock.call(err_msg) == mock_logger_error.call_args)
+        self.assertEqual(ex_result, 1)
+
+    @mock.patch('azure.cli.core.util.logger.error', autospec=True)
+    def test_handles_clouderror(self, mock_logger_error):
+        from msrestazure.azure_exceptions import CloudError
+
+        # create test CloudError Exception
+        err_detail = "There was a Cloud Error."
+        err_msg = "CloudError"
+        mock_cloud_error = mock.MagicMock(spec=CloudError)
+        mock_cloud_error.args = (err_detail, err_msg)
+
+        # call handle_exception
+        ex_result = handle_exception(mock_cloud_error)
+
+        # test behavior
+        self.assertTrue(mock_logger_error.called)
+        self.assertTrue(mock.call(mock_cloud_error.args[0]) == mock_logger_error.call_args)
+        self.assertEqual(ex_result, mock_cloud_error.args[1])
+
+    @mock.patch('azure.cli.core.util.logger.error', autospec=True)
+    def test_handles_httpoperationerror_typical_response_error(self, mock_logger_error):
+        # create test HttpOperationError Exception
+        err_msg = "Bad Request because of some incorrect param"
+        err_code = "BadRequest"
+        err = dict(error=dict(code=err_code, message=err_msg))
+        response_text = json.dumps(err)
+        mock_http_error = self._get_mock_HttpOperationError(response_text)
+
+        expected_message = "{} - {}".format(err_code, err_msg)
+
+        # call handle_exception
+        ex_result = handle_exception(mock_http_error)
+
+        # test behavior
+        self.assertTrue(mock_logger_error.called)
+        self.assertTrue(mock.call(expected_message) == mock_logger_error.call_args)
+        self.assertEqual(ex_result, 1)
+
+    @mock.patch('azure.cli.core.util.logger.error', autospec=True)
+    def test_handles_httpoperationerror_atypical_response_content(self, mock_logger_error):
+
+        # 1. test error in response, but has str value.
+
+        # create test HttpOperationError Exception
+        err_msg = "BadRequest"
+        err = dict(error=err_msg)
+        response_text = json.dumps(err)
+        mock_http_error = self._get_mock_HttpOperationError(response_text)
+
+        expected_message = "{}".format(err_msg)
+
+        # call handle_exception
+        ex_result = handle_exception(mock_http_error)
+
+        # test behavior
+        self.assertTrue(mock_logger_error.called)
+        self.assertTrue(mock.call(expected_message) == mock_logger_error.call_args)
+        self.assertEqual(ex_result, 1)
+
+        # 2. test error not in response
+
+        # create test HttpOperationError Exception
+        err_msg = "BadRequest"
+        err = dict(foo=err_msg)
+        response_text = json.dumps(err)
+        mock_http_error = self._get_mock_HttpOperationError(response_text)
+
+        expected_message = "{}".format(err_msg)
+
+        # call handle_exception
+        ex_result = handle_exception(mock_http_error)
+
+        # test behavior
+        self.assertTrue(mock_logger_error.called)
+        self.assertTrue(mock.call(mock_http_error) == mock_logger_error.call_args)
+        self.assertEqual(ex_result, 1)
+
+        # 3. test no response text
+
+        # create test HttpOperationError Exception
+        response_text = ""
+
+        mock_http_error = self._get_mock_HttpOperationError(response_text)
+
+        # call handle_exception
+        ex_result = handle_exception(mock_http_error)
+
+        # test behavior
+        self.assertTrue(mock_logger_error.called)
+        self.assertTrue(mock.call(mock_http_error) == mock_logger_error.call_args)
+        self.assertEqual(ex_result, 1)
+
+    @staticmethod
+    def _get_mock_HttpOperationError(response_text):
+        from msrest.exceptions import HttpOperationError
+        from requests import Response
+
+        mock_response = mock.MagicMock(spec=Response)
+        mock_response.text = response_text
+        mock_http_error = mock.MagicMock(spec=HttpOperationError)
+        mock_http_error.response = mock_response
+
+        return mock_http_error
 
 
 if __name__ == '__main__':

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -211,7 +211,7 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertTrue(mock.call(err_msg) == mock_logger_error.call_args)
+        self.assertEqual(mock.call(err_msg), mock_logger_error.call_args)
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.util.logger.error', autospec=True)
@@ -229,7 +229,7 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertTrue(mock.call(mock_cloud_error.args[0]) == mock_logger_error.call_args)
+        self.assertEqual(mock.call(mock_cloud_error.args[0]), mock_logger_error.call_args)
         self.assertEqual(ex_result, mock_cloud_error.args[1])
 
     @mock.patch('azure.cli.core.util.logger.error', autospec=True)
@@ -241,19 +241,19 @@ class TestHandleException(unittest.TestCase):
         response_text = json.dumps(err)
         mock_http_error = self._get_mock_HttpOperationError(response_text)
 
-        expected_message = "{} - {}".format(err_code, err_msg)
+        expected_call = mock.call("%s%s", "{} - ".format(err_code), err_msg)
 
         # call handle_exception
         ex_result = handle_exception(mock_http_error)
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertTrue(mock.call(expected_message) == mock_logger_error.call_args)
+        self.assertEqual(expected_call, mock_logger_error.call_args)
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.util.logger.error', autospec=True)
-    def test_handle_exception_httpoperationerror_atypical_response_content(self, mock_logger_error):
-        # 1. test error in response, but has str value.
+    def test_handle_exception_httpoperationerror_error_key_has_string_value(self, mock_logger_error):
+        # test error in response, but has str value.
 
         # create test HttpOperationError Exception
         err_msg = "BadRequest"
@@ -268,10 +268,12 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertTrue(mock.call(expected_message) == mock_logger_error.call_args)
+        self.assertEqual(mock.call(expected_message), mock_logger_error.call_args)
         self.assertEqual(ex_result, 1)
 
-        # 2. test error not in response
+    @mock.patch('azure.cli.core.util.logger.error', autospec=True)
+    def test_handle_exception_httpoperationerror_no_error_key(self, mock_logger_error):
+        # test error not in response
 
         # create test HttpOperationError Exception
         err_msg = "BadRequest"
@@ -279,17 +281,17 @@ class TestHandleException(unittest.TestCase):
         response_text = json.dumps(err)
         mock_http_error = self._get_mock_HttpOperationError(response_text)
 
-        expected_message = "{}".format(err_msg)
-
         # call handle_exception
         ex_result = handle_exception(mock_http_error)
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertTrue(mock.call(mock_http_error) == mock_logger_error.call_args)
+        self.assertEqual(mock.call(mock_http_error), mock_logger_error.call_args)
         self.assertEqual(ex_result, 1)
 
-        # 3. test no response text
+    @mock.patch('azure.cli.core.util.logger.error', autospec=True)
+    def test_handle_exception_httpoperationerror_no_response_text(self, mock_logger_error):
+        # test no response text
 
         # create test HttpOperationError Exception
         response_text = ""
@@ -301,7 +303,7 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertTrue(mock.call(mock_http_error) == mock_logger_error.call_args)
+        self.assertEqual(mock.call(mock_http_error), mock_logger_error.call_args)
         self.assertEqual(ex_result, 1)
 
     @staticmethod

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -187,9 +187,7 @@ class TestBase64ToHex(unittest.TestCase):
 class TestHandleException(unittest.TestCase):
 
     @mock.patch('azure.cli.core.util.logger.error', autospec=True)
-    def test_handles_keyboardinterrupt(self, mock_logger_error):
-        from knack.util import CLIError
-
+    def test_handle_exception_keyboardinterrupt(self, mock_logger_error):
         # create test KeyboardInterrupt Exception
         keyboard_interrupt_ex = KeyboardInterrupt("KeyboardInterrupt")
 
@@ -201,7 +199,7 @@ class TestHandleException(unittest.TestCase):
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.util.logger.error', autospec=True)
-    def test_handles_clierror(self, mock_logger_error):
+    def test_handle_exception_clierror(self, mock_logger_error):
         from knack.util import CLIError
 
         # create test CLIError Exception
@@ -217,7 +215,7 @@ class TestHandleException(unittest.TestCase):
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.util.logger.error', autospec=True)
-    def test_handles_clouderror(self, mock_logger_error):
+    def test_handle_exception_clouderror(self, mock_logger_error):
         from msrestazure.azure_exceptions import CloudError
 
         # create test CloudError Exception
@@ -235,7 +233,7 @@ class TestHandleException(unittest.TestCase):
         self.assertEqual(ex_result, mock_cloud_error.args[1])
 
     @mock.patch('azure.cli.core.util.logger.error', autospec=True)
-    def test_handles_httpoperationerror_typical_response_error(self, mock_logger_error):
+    def test_handle_exception_httpoperationerror_typical_response_error(self, mock_logger_error):
         # create test HttpOperationError Exception
         err_msg = "Bad Request because of some incorrect param"
         err_code = "BadRequest"
@@ -254,8 +252,7 @@ class TestHandleException(unittest.TestCase):
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.util.logger.error', autospec=True)
-    def test_handles_httpoperationerror_atypical_response_content(self, mock_logger_error):
-
+    def test_handle_exception_httpoperationerror_atypical_response_content(self, mock_logger_error):
         # 1. test error in response, but has str value.
 
         # create test HttpOperationError Exception

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -38,7 +38,7 @@ def handle_exception(ex):
             if isinstance(error, dict):
                 code = "{} - ".format(error.get('code', 'Unknown Code'))
                 message = error.get('message', ex)
-                logger.error("{}{}".format(code, message))
+                logger.error("%s%s", code, message)
             else:
                 logger.error(error)
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -42,7 +42,7 @@ def handle_exception(ex):
             else:
                 logger.error(error)
 
-        except (json.JSONDecodeError, KeyError):
+        except (ValueError, KeyError):
             logger.error(ex)
         return 1
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -2,7 +2,6 @@
 
 Release History
 ===============
-
 2.0.47
 ++++++
 * Minor fixes


### PR DESCRIPTION
Fixes issue #7202.

According to @lmazuel, the default behavior for the SDK when a request fails with an error is to throw a `CloudError`. However some teams modify this behavior through swagger by throwing a custom error response exception which inherits from `HttpOperationError`. So all autorest generated SDK's throw a CloudError or an instance of HttpOperationError. If an SDK is not autorest generated it might not throw either of these exceptions in the event of a bad request, so we might not catch it.

Moreover, ARM error responses are based on the [odata v4 error response](http://docs.oasis-open.org/odata/odata-json-format/v4.01/cs01/odata-json-format-v4.01-cs01.html#sec_ErrorResponse). This informs the logic in the if statement for handling `HttpOperationError` exceptions.

Please let me know your thoughts on the History.rst wording.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
