### PR TITLE
[ACS] Updates the install-connector command to use the master FQDN, undo deprecation

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.3.5
++++++
+* install-connector: Updates the install-connector command to set the AKS Master FQDN
+
 2.3.4
 +++++
 * install-connector: Beginning deprecation process for install-connector. This will be replaced with the enable-addons command

--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,14 +3,9 @@
 Release History
 ===============
 
-2.3.5
-+++++
-* install-connector: Updates the install-connector command to set the AKS Master FQDN
-
 2.3.4
 +++++
-* install-connector: Beginning deprecation process for install-connector. This will be replaced with the enable-addons command
-  with the new virtual-node add-on
+* install-connector: Updates the install-connector command to set the AKS Master FQDN
 
 2.3.3
 +++++

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -61,8 +61,7 @@ def load_command_table(self, _):
         g.custom_command('get-credentials', 'aks_get_credentials')
         g.command('get-upgrades', 'get_upgrade_profile', table_transformer=aks_upgrades_table_format)
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
-        g.custom_command('install-connector', 'k8s_install_connector',
-                         deprecate_info=g.deprecate(redirect="az aks enable-addons virtual-node", hide=True))
+        g.custom_command('install-connector', 'k8s_install_connector')
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
         g.custom_command('remove-connector', 'k8s_uninstall_connector')
         g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces')

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -418,7 +418,7 @@ def _helm_install_or_upgrade_aci_connector(helm_cmd, image_tag, url_chart, conne
             values += ",env.aciResourceGroup=" + aci_resource_group
         if norm_location:
             values += ",env.aciRegion=" + norm_location
-        # Currently, we need to set the master FQDN.   
+        # Currently, we need to set the master FQDN.
         # This is temporary and we should remove it when possible
         values += ",env.masterUri=" + k8s_master
         if helm_cmd == "install":

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -385,22 +385,23 @@ def _k8s_install_or_upgrade_connector(helm_cmd, cmd, client, name, resource_grou
     if os_type.lower() in ['linux', 'both']:
         _helm_install_or_upgrade_aci_connector(helm_cmd, image_tag, url_chart, connector_name, service_principal,
                                                client_secret, subscription_id, tenant_id, aci_resource_group,
-                                               norm_location, 'Linux', instance.enable_rbac)
+                                               norm_location, 'Linux', instance.enable_rbac, instance.fqdn)
 
     # Check if we want the windows connector
     if os_type.lower() in ['windows', 'both']:
         _helm_install_or_upgrade_aci_connector(helm_cmd, image_tag, url_chart, connector_name, service_principal,
                                                client_secret, subscription_id, tenant_id, aci_resource_group,
-                                               norm_location, 'Windows', instance.enable_rbac)
+                                               norm_location, 'Windows', instance.enable_rbac, instance.fqdn)
 
 
 def _helm_install_or_upgrade_aci_connector(helm_cmd, image_tag, url_chart, connector_name, service_principal,
                                            client_secret, subscription_id, tenant_id, aci_resource_group,
-                                           norm_location, os_type, use_rbac):
+                                           norm_location, os_type, use_rbac, masterFqdn):
     rbac_install = "true" if use_rbac else "false"
     node_taint = 'azure.com/aci'
     helm_release_name = connector_name.lower() + '-' + os_type.lower() + '-' + norm_location
     node_name = 'virtual-kubelet-' + helm_release_name
+    k8s_master = 'https://{}'.format(masterFqdn)
     logger.warning("Deploying the ACI connector for '%s' using Helm", os_type)
     try:
         values = 'env.nodeName={},env.nodeTaint={},env.nodeOsType={},image.tag={},rbac.install={}'.format(
@@ -417,7 +418,9 @@ def _helm_install_or_upgrade_aci_connector(helm_cmd, image_tag, url_chart, conne
             values += ",env.aciResourceGroup=" + aci_resource_group
         if norm_location:
             values += ",env.aciRegion=" + norm_location
-
+        # Currently, we need to set the master FQDN.   
+        # This is temporary and we should remove it when possible
+        values += ",env.masterUri=" + k8s_master
         if helm_cmd == "install":
             subprocess.call(["helm", "install", url_chart, "--name", helm_release_name, "--set", values])
         elif helm_cmd == "upgrade":

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.3.5"
+VERSION = "2.3.4"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.3.4"
+VERSION = "2.3.5"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Virtual Kubelet supports providing the MASTER_URI as a parameter to the helm chart. This PR grabs the masterfqdn from the instance and uses that when installing the chart.  

* NOTE: This also removed deprecation that was done in #7263. The replacement won't happen before Ignite. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ x ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
