### PR TITLE
Deal with deprecation objects within the command table by ignoring them

### DIFF
--- a/src/command_modules/azure-cli-interactive/HISTORY.rst
+++ b/src/command_modules/azure-cli-interactive/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.3.29
+++++++
+* Fix command loading problem in interactive that was caused by deprecated objects.
+
 0.3.28
 ++++++
 * Minor fixes

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/_dump_commands.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/_dump_commands.py
@@ -123,7 +123,7 @@ class FreshTable(object):
         # dump into the cache file
         command_file = shell_ctx.config.get_help_files()
         with open(os.path.join(get_cache_dir(shell_ctx), command_file), 'w') as help_file:
-            json.dump(cmd_table_data, help_file)
+            json.dump(cmd_table_data, help_file, default=lambda x: x.target or '', skipkeys=True)
 
 
 def load_help_files(data):

--- a/src/command_modules/azure-cli-interactive/setup.py
+++ b/src/command_modules/azure-cli-interactive/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     cmdclass = {}
 
 # Version is also defined in azclishell.__init__.py.
-VERSION = "0.3.28"
+VERSION = "0.3.29"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
---
-keys in dictionaries are ignored
- values are converted to their deprecated target.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
