### PR TITLE
[Network] dns zone create works even if default location is configured.

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.2.6
++++++
+* Fix `network dns zone create`. Command succeeds even if the user has configured a default location. See #6052.
+
 2.2.5
 +++++
 * Add `network public-ip prefix` commands to support public IP prefixes features.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -904,10 +904,10 @@ def list_ddos_plans(cmd, resource_group_name=None):
 
 
 # region DNS Commands
-def create_dns_zone(cmd, client, resource_group_name, zone_name, location='global', tags=None,
+def create_dns_zone(cmd, client, resource_group_name, zone_name, tags=None,
                     if_none_match=False, zone_type='Public', resolution_vnets=None, registration_vnets=None):
     Zone = cmd.get_models('Zone', resource_type=ResourceType.MGMT_NETWORK_DNS)
-    zone = Zone(location=location, tags=tags)
+    zone = Zone(location='global', tags=tags)
 
     if hasattr(zone, 'zone_type'):
         zone.zone_type = zone_type

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.2.5"
+VERSION = "2.2.6"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes #6052. 

Removed location parameter in create_dns_zone and made it a local variable. This prevents the configured default location being passed in as the location. DNS Zone's are global.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
