### PR TITLE
[rbac] fix a service breaking change that homepage must be https

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -1016,7 +1016,7 @@ def create_service_principal_for_rbac(
 
     aad_application = create_application(graph_client.applications,
                                          display_name=app_display_name,
-                                         homepage='http://' + app_display_name,
+                                         homepage='https://' + app_display_name,
                                          identifier_uris=[name],
                                          available_to_other_tenants=False,
                                          password=password,


### PR DESCRIPTION
Only MS tenant enforces this
Fix #7375 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
