### PR TITLE
[Network] vnet peering: deprecated --remote-vnet-id in favor of --remote-vnet

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -6,6 +6,8 @@ Release History
 2.2.6
 +++++
 * Fix `network dns zone create`. Command succeeds even if the user has configured a default location. See #6052.
+* `network vnet peering create`: depecrated `--remote-vnet-id` for `--remote-vnet`. Passing a name instead of resource ID to either parameter does not crash the CLI.
+* `network vnet peering create`: users can specify remote vnet's resource group through `--remote-vnet-rg` when using `--remote-vnet` to specify the name of the vnet.
 
 2.2.5
 +++++

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -6,8 +6,7 @@ Release History
 2.2.6
 +++++
 * Fix `network dns zone create`. Command succeeds even if the user has configured a default location. See #6052.
-* `network vnet peering create`: depecrated `--remote-vnet-id` for `--remote-vnet`. Passing a name instead of resource ID to either parameter does not crash the CLI.
-* `network vnet peering create`: users can specify remote vnet's resource group through `--remote-vnet-rg` when using `--remote-vnet` to specify the name of the vnet.
+* `network vnet peering create`: Deprecated `--remote-vnet-id`. Added --remote-vnet which accepts a name or ID.
 
 2.2.5
 +++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -3493,7 +3493,7 @@ helps['network vnet peering create'] = """
     short-summary: Create a virtual network peering connection.
     long-summary: >
         To successfully peer two virtual networks this command must be called twice with
-        the values for --vnet-name and --remote-vnet-id reversed.
+        the values for --vnet-name and --remote-vnet reversed.
     examples:
         - name: Create a peering connection between two virtual networks.
           text: |

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -949,8 +949,7 @@ def load_arguments(self, _):
     with self.argument_context('network vnet peering') as c:
         c.argument('virtual_network_name', virtual_network_name_type)
         c.argument('virtual_network_peering_name', options_list=('--name', '-n'), help='The name of the VNet peering.', id_part='child_name_1')
-        c.argument('remote_virtual_network', options_list=['--remote-vnet', c.deprecate(target='--remote-vnet-id', redirect='--remote-vnet', expiration='2.0.52')], help='Resource ID or name of the remote VNet.')
-        c.argument('remote_virtual_network_rg_name', options_list=('--remote-vnet-rg',), help='Resource group name of the remote VNet. Use if remote VNet name specified and remote VNet is in another resource group.')
+        c.argument('remote_virtual_network', options_list=['--remote-vnet', c.deprecate(target='--remote-vnet-id', hide=True, expiration='2.1.0')], help='Resource ID or name of the remote VNet.')
 
     with self.argument_context('network vnet peering create') as c:
         c.argument('allow_virtual_network_access', options_list=('--allow-vnet-access',), action='store_true', help='Allows VMs in the remote VNet to access all VMs in the local VNet.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -949,7 +949,8 @@ def load_arguments(self, _):
     with self.argument_context('network vnet peering') as c:
         c.argument('virtual_network_name', virtual_network_name_type)
         c.argument('virtual_network_peering_name', options_list=('--name', '-n'), help='The name of the VNet peering.', id_part='child_name_1')
-        c.argument('remote_virtual_network', options_list=('--remote-vnet-id',), help='ID of the remote VNet.')
+        c.argument('remote_virtual_network', options_list=['--remote-vnet', c.deprecate(target='--remote-vnet-id', redirect='--remote-vnet', expiration='2.0.52')], help='Resource ID or name of the remote VNet.')
+        c.argument('remote_virtual_network_rg_name', options_list=('--remote-vnet-rg',), help='Resource group name of the remote VNet. Use if remote VNet name specified and remote VNet is in another resource group.')
 
     with self.argument_context('network vnet peering create') as c:
         c.argument('allow_virtual_network_access', options_list=('--allow-vnet-access',), action='store_true', help='Allows VMs in the remote VNet to access all VMs in the local VNet.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -3190,13 +3190,13 @@ def list_avail_subnet_delegations(cmd, resource_group_name=None, location=None):
 
 
 def create_vnet_peering(cmd, resource_group_name, virtual_network_name, virtual_network_peering_name,
-                        remote_virtual_network, remote_virtual_network_rg_name=None, allow_virtual_network_access=False,
+                        remote_virtual_network, allow_virtual_network_access=False,
                         allow_forwarded_traffic=False, allow_gateway_transit=False,
                         use_remote_gateways=False):
     if not is_valid_resource_id(remote_virtual_network):
         remote_virtual_network = resource_id(
             subscription=get_subscription_id(cmd.cli_ctx),
-            resource_group=remote_virtual_network_rg_name if remote_virtual_network_rg_name else resource_group_name,
+            resource_group=resource_group_name,
             namespace='Microsoft.Network',
             type='virtualNetworks',
             name=remote_virtual_network

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -3190,9 +3190,17 @@ def list_avail_subnet_delegations(cmd, resource_group_name=None, location=None):
 
 
 def create_vnet_peering(cmd, resource_group_name, virtual_network_name, virtual_network_peering_name,
-                        remote_virtual_network, allow_virtual_network_access=False,
+                        remote_virtual_network, remote_virtual_network_rg_name=None, allow_virtual_network_access=False,
                         allow_forwarded_traffic=False, allow_gateway_transit=False,
                         use_remote_gateways=False):
+    if not is_valid_resource_id(remote_virtual_network):
+        remote_virtual_network = resource_id(
+            subscription=get_subscription_id(cmd.cli_ctx),
+            resource_group=remote_virtual_network_rg_name if remote_virtual_network_rg_name else resource_group_name,
+            namespace='Microsoft.Network',
+            type='virtualNetworks',
+            name=remote_virtual_network
+        )
     SubResource, VirtualNetworkPeering = cmd.get_models('SubResource', 'VirtualNetworkPeering')
     peering = VirtualNetworkPeering(
         id=resource_id(

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: !!python/unicode '{"location": "westus", "tags": {"date": "2018-09-10T15:33:52Z",
-      "product": "azurecli", "cause": "automation"}}'
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2018-09-21T21:08:41Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -9,19 +9,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnet_peering000001?api-version=2018-05-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"date":"2018-09-10T15:33:52Z","product":"azurecli","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:08:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:33:53 GMT']
+      date: ['Fri, 21 Sep 2018 21:08:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -36,19 +36,19 @@ interactions:
       CommandName: [network vnet create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnet_peering000001?api-version=2018-05-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"date":"2018-09-10T15:33:52Z","product":"azurecli","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:08:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:33:54 GMT']
+      date: ['Fri, 21 Sep 2018 21:08:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -56,8 +56,8 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"location": "westus", "properties": {"dhcpOptions": {},
-      "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}, "tags": {}}'
+    body: '{"location": "westus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "dhcpOptions": {}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -65,35 +65,35 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"6d3c65a9-bda5-4546-9e60-80bbfbdf3339\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        ,\r\n  \"etag\": \"W/\\\"33aeca82-40bb-4dfe-9259-b8ddd03fc3f9\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"ab557d04-f180-49ee-938b-c8e1f1dc5b85\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"ffb04011-01fe-40dc-aef2-cfa30722428a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
         \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
         : false\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/921ed5c9-265e-495a-b6f4-e90f69b4fd0a?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/fdead9bf-7bf8-4d22-9305-ca338276571c?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['766']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:33:54 GMT']
+      date: ['Fri, 21 Sep 2018 21:08:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -102,18 +102,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/921ed5c9-265e-495a-b6f4-e90f69b4fd0a?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/fdead9bf-7bf8-4d22-9305-ca338276571c?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:33:58 GMT']
+      date: ['Fri, 21 Sep 2018 21:08:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -129,18 +129,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/921ed5c9-265e-495a-b6f4-e90f69b4fd0a?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/fdead9bf-7bf8-4d22-9305-ca338276571c?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:08 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -156,17 +156,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"6eb13fba-5f90-4b00-b39d-43eeb37c5742\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        ,\r\n  \"etag\": \"W/\\\"ff4eaf5e-c955-4324-a7dd-41683831babc\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ab557d04-f180-49ee-938b-c8e1f1dc5b85\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ffb04011-01fe-40dc-aef2-cfa30722428a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -176,8 +176,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['767']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:09 GMT']
-      etag: [W/"6eb13fba-5f90-4b00-b39d-43eeb37c5742"]
+      date: ['Fri, 21 Sep 2018 21:09:03 GMT']
+      etag: [W/"ff4eaf5e-c955-4324-a7dd-41683831babc"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -194,19 +194,19 @@ interactions:
       CommandName: [network vnet create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnet_peering000001?api-version=2018-05-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"date":"2018-09-10T15:33:52Z","product":"azurecli","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:08:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:09 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -214,9 +214,9 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"location": "westus", "properties": {"subnets": [{"properties":
-      {"addressPrefix": "11.0.0.0/24"}, "name": "GatewaySubnet"}], "dhcpOptions":
-      {}, "addressSpace": {"addressPrefixes": ["11.0.0.0/16"]}}, "tags": {}}'
+    body: '{"location": "westus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["11.0.0.0/16"]}, "dhcpOptions": {}, "subnets": [{"properties": {"addressPrefix":
+      "11.0.0.0/24"}, "name": "GatewaySubnet"}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -224,40 +224,40 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['211']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
-        ,\r\n  \"etag\": \"W/\\\"16f2bec1-526e-490b-a066-72be3a2f5922\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        ,\r\n  \"etag\": \"W/\\\"a37d8014-3c2f-41e0-a7e3-f6bd49a65454\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"117a1eaf-8459-4761-a095-8a9750bfbbb7\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"55e97904-319f-4e40-bcb0-99f1c1729e6d\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"GatewaySubnet\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/GatewaySubnet\"\
-        ,\r\n        \"etag\": \"W/\\\"16f2bec1-526e-490b-a066-72be3a2f5922\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"a37d8014-3c2f-41e0-a7e3-f6bd49a65454\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"addressPrefix\": \"11.0.0.0/24\",\r\n          \"delegations\"\
         : []\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
         \r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\"\
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/84465a6e-9c42-45e0-aa34-2c0752545b87?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2876bbbc-aeed-412f-b3ef-2bb4b2bf9d03?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['1334']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:11 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -266,18 +266,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/84465a6e-9c42-45e0-aa34-2c0752545b87?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2876bbbc-aeed-412f-b3ef-2bb4b2bf9d03?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:13 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -293,18 +293,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/84465a6e-9c42-45e0-aa34-2c0752545b87?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2876bbbc-aeed-412f-b3ef-2bb4b2bf9d03?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:23 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -320,22 +320,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
-        ,\r\n  \"etag\": \"W/\\\"dc7cf6bf-7ff8-492c-8091-f60c5b8ce392\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        ,\r\n  \"etag\": \"W/\\\"78855557-6d4d-4124-9093-419612161347\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"117a1eaf-8459-4761-a095-8a9750bfbbb7\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"55e97904-319f-4e40-bcb0-99f1c1729e6d\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"GatewaySubnet\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/GatewaySubnet\"\
-        ,\r\n        \"etag\": \"W/\\\"dc7cf6bf-7ff8-492c-8091-f60c5b8ce392\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"78855557-6d4d-4124-9093-419612161347\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"11.0.0.0/24\",\r\n          \"delegations\"\
         : []\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
@@ -345,8 +345,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1336']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:24 GMT']
-      etag: [W/"dc7cf6bf-7ff8-492c-8091-f60c5b8ce392"]
+      date: ['Fri, 21 Sep 2018 21:09:19 GMT']
+      etag: [W/"78855557-6d4d-4124-9093-419612161347"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -363,19 +363,19 @@ interactions:
       CommandName: [network public-ip create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnet_peering000001?api-version=2018-05-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"date":"2018-09-10T15:33:52Z","product":"azurecli","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:08:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:24 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -383,9 +383,8 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"sku": {"name": "Basic"}, "properties": {"publicIPAllocationMethod":
-      "Dynamic", "publicIPAddressVersion": "IPv4", "idleTimeoutInMinutes": 4}, "location":
-      "westus"}'
+    body: '{"location": "westus", "sku": {"name": "Basic"}, "properties": {"publicIPAllocationMethod":
+      "Dynamic", "publicIPAddressVersion": "IPv4", "idleTimeoutInMinutes": 4}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -393,33 +392,33 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['164']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
-        ,\r\n  \"etag\": \"W/\\\"f056a001-309c-446d-9db5-3ab11be2ba8d\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
+        ,\r\n  \"etag\": \"W/\\\"545b122f-1af0-4e72-abfa-8efb5ce5e7de\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"c7574ca9-e3c0-44e9-ad54-6c07e33335b4\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"a49217f8-487f-42e6-82bb-f6c95267fa69\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\
         \n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
         : {\r\n    \"name\": \"Basic\",\r\n    \"tier\": \"Regional\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/efbb2af4-c1ea-4548-8546-0848d83301da?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/62cc3139-865d-49cc-916e-2c6d755ddbfb?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['679']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:24 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -428,18 +427,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network public-ip create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/efbb2af4-c1ea-4548-8546-0848d83301da?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/62cc3139-865d-49cc-916e-2c6d755ddbfb?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:27 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -455,16 +454,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network public-ip create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
-        ,\r\n  \"etag\": \"W/\\\"67c719c4-f749-43af-816f-96e6c626db2b\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
+        ,\r\n  \"etag\": \"W/\\\"fdd3276f-0389-4e7d-9975-46918a1b846a\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"c7574ca9-e3c0-44e9-ad54-6c07e33335b4\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"a49217f8-487f-42e6-82bb-f6c95267fa69\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\
         \n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
@@ -473,8 +472,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['680']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:28 GMT']
-      etag: [W/"67c719c4-f749-43af-816f-96e6c626db2b"]
+      date: ['Fri, 21 Sep 2018 21:09:27 GMT']
+      etag: [W/"fdd3276f-0389-4e7d-9975-46918a1b846a"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -490,17 +489,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network public-ip show]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
-        ,\r\n  \"etag\": \"W/\\\"67c719c4-f749-43af-816f-96e6c626db2b\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
+        ,\r\n  \"etag\": \"W/\\\"fdd3276f-0389-4e7d-9975-46918a1b846a\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"c7574ca9-e3c0-44e9-ad54-6c07e33335b4\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"a49217f8-487f-42e6-82bb-f6c95267fa69\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\
         \n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
@@ -509,8 +508,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['680']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:28 GMT']
-      etag: [W/"67c719c4-f749-43af-816f-96e6c626db2b"]
+      date: ['Fri, 21 Sep 2018 21:09:28 GMT']
+      etag: [W/"fdd3276f-0389-4e7d-9975-46918a1b846a"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -526,23 +525,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet show]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
-        ,\r\n  \"etag\": \"W/\\\"dc7cf6bf-7ff8-492c-8091-f60c5b8ce392\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        ,\r\n  \"etag\": \"W/\\\"78855557-6d4d-4124-9093-419612161347\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"117a1eaf-8459-4761-a095-8a9750bfbbb7\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"55e97904-319f-4e40-bcb0-99f1c1729e6d\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"GatewaySubnet\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/GatewaySubnet\"\
-        ,\r\n        \"etag\": \"W/\\\"dc7cf6bf-7ff8-492c-8091-f60c5b8ce392\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"78855557-6d4d-4124-9093-419612161347\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"11.0.0.0/24\",\r\n          \"delegations\"\
         : []\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
@@ -552,8 +551,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1336']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:29 GMT']
-      etag: [W/"dc7cf6bf-7ff8-492c-8091-f60c5b8ce392"]
+      date: ['Fri, 21 Sep 2018 21:09:29 GMT']
+      etag: [W/"78855557-6d4d-4124-9093-419612161347"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -570,19 +569,19 @@ interactions:
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnet_peering000001?api-version=2018-05-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"date":"2018-09-10T15:33:52Z","product":"azurecli","cause":"automation"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001","name":"cli_test_vnet_peering000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:08:41Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:29 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -590,11 +589,11 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"location": "westus", "properties": {"sku": {"tier":
-      "Basic", "name": "Basic"}, "activeActive": false, "gatewayType": "Vpn", "ipConfigurations":
-      [{"properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/GatewaySubnet"},
-      "privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1"}},
-      "name": "vnetGatewayConfig0"}], "vpnType": "RouteBased"}, "tags": {"foo": "doo"}}'
+    body: 'b''{"location": "westus", "tags": {"foo": "doo"}, "properties": {"ipConfigurations":
+      [{"properties": {"privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/GatewaySubnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/publicIPAddresses/ip1"}},
+      "name": "vnetGatewayConfig0"}], "gatewayType": "Vpn", "vpnType": "RouteBased",
+      "activeActive": false, "sku": {"name": "Basic", "tier": "Basic"}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -602,23 +601,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['744']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"gateway1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1\"\
-        ,\r\n  \"etag\": \"W/\\\"3579b481-d174-4a5f-b767-80ba137c08b3\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"gateway1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1\"\
+        ,\r\n  \"etag\": \"W/\\\"5bc3bc14-be9e-4349-9307-0bb046a28c41\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworkGateways\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"foo\": \"doo\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"\
-        11e3fc62-e66d-4efc-81e4-4dfbde631dca\",\r\n    \"ipConfigurations\": [\r\n\
+        95759609-51f9-4a81-aedb-280ad7f5ecec\",\r\n    \"ipConfigurations\": [\r\n\
         \      {\r\n        \"name\": \"vnetGatewayConfig0\",\r\n        \"id\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1/ipConfigurations/vnetGatewayConfig0\"\
-        ,\r\n        \"etag\": \"W/\\\"3579b481-d174-4a5f-b767-80ba137c08b3\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"5bc3bc14-be9e-4349-9307-0bb046a28c41\\\"\"\
         ,\r\n        \"type\": \"Microsoft.Network/virtualNetworkGateways/ipConfigurations\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
@@ -632,17 +630,17 @@ interactions:
         \      \"vpnClientRootCertificates\": [],\r\n      \"vpnClientRevokedCertificates\"\
         : [],\r\n      \"vpnClientIpsecPolicies\": []\r\n    }\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['2109']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:30 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -651,18 +649,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:41 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -678,18 +676,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:34:51 GMT']
+      date: ['Fri, 21 Sep 2018 21:09:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -705,18 +703,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:35:01 GMT']
+      date: ['Fri, 21 Sep 2018 21:10:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -732,18 +730,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:35:11 GMT']
+      date: ['Fri, 21 Sep 2018 21:10:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -759,18 +757,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:35:21 GMT']
+      date: ['Fri, 21 Sep 2018 21:10:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -786,18 +784,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:35:31 GMT']
+      date: ['Fri, 21 Sep 2018 21:10:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -813,18 +811,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:35:41 GMT']
+      date: ['Fri, 21 Sep 2018 21:10:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -840,18 +838,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:35:52 GMT']
+      date: ['Fri, 21 Sep 2018 21:11:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -867,18 +865,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:36:02 GMT']
+      date: ['Fri, 21 Sep 2018 21:11:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -894,18 +892,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:36:13 GMT']
+      date: ['Fri, 21 Sep 2018 21:11:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -921,18 +919,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:36:22 GMT']
+      date: ['Fri, 21 Sep 2018 21:11:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -948,18 +946,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:36:33 GMT']
+      date: ['Fri, 21 Sep 2018 21:11:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -975,18 +973,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:36:43 GMT']
+      date: ['Fri, 21 Sep 2018 21:12:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1002,18 +1000,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:36:54 GMT']
+      date: ['Fri, 21 Sep 2018 21:12:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1029,18 +1027,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:37:03 GMT']
+      date: ['Fri, 21 Sep 2018 21:12:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1056,18 +1054,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:37:16 GMT']
+      date: ['Fri, 21 Sep 2018 21:12:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1083,18 +1081,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:37:25 GMT']
+      date: ['Fri, 21 Sep 2018 21:12:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1110,18 +1108,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:37:37 GMT']
+      date: ['Fri, 21 Sep 2018 21:12:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1137,18 +1135,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:37:47 GMT']
+      date: ['Fri, 21 Sep 2018 21:13:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1164,18 +1162,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:37:57 GMT']
+      date: ['Fri, 21 Sep 2018 21:13:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1191,18 +1189,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:38:07 GMT']
+      date: ['Fri, 21 Sep 2018 21:13:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1218,18 +1216,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:38:17 GMT']
+      date: ['Fri, 21 Sep 2018 21:13:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1245,18 +1243,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:38:27 GMT']
+      date: ['Fri, 21 Sep 2018 21:13:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1272,18 +1270,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:38:38 GMT']
+      date: ['Fri, 21 Sep 2018 21:13:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1299,18 +1297,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:38:48 GMT']
+      date: ['Fri, 21 Sep 2018 21:14:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1326,18 +1324,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:38:58 GMT']
+      date: ['Fri, 21 Sep 2018 21:14:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1353,18 +1351,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:39:08 GMT']
+      date: ['Fri, 21 Sep 2018 21:14:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1380,18 +1378,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:39:18 GMT']
+      date: ['Fri, 21 Sep 2018 21:14:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1407,18 +1405,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:39:29 GMT']
+      date: ['Fri, 21 Sep 2018 21:14:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1434,18 +1432,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:39:39 GMT']
+      date: ['Fri, 21 Sep 2018 21:15:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1461,18 +1459,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:39:49 GMT']
+      date: ['Fri, 21 Sep 2018 21:15:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1488,18 +1486,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:39:59 GMT']
+      date: ['Fri, 21 Sep 2018 21:15:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1515,18 +1513,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:40:09 GMT']
+      date: ['Fri, 21 Sep 2018 21:15:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1542,18 +1540,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:40:20 GMT']
+      date: ['Fri, 21 Sep 2018 21:15:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1569,18 +1567,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:40:30 GMT']
+      date: ['Fri, 21 Sep 2018 21:15:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1596,18 +1594,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:40:40 GMT']
+      date: ['Fri, 21 Sep 2018 21:16:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1623,18 +1621,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:40:50 GMT']
+      date: ['Fri, 21 Sep 2018 21:16:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1650,18 +1648,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:41:00 GMT']
+      date: ['Fri, 21 Sep 2018 21:16:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1677,18 +1675,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:41:11 GMT']
+      date: ['Fri, 21 Sep 2018 21:16:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1704,18 +1702,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:41:21 GMT']
+      date: ['Fri, 21 Sep 2018 21:16:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1731,18 +1729,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:41:31 GMT']
+      date: ['Fri, 21 Sep 2018 21:16:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1758,18 +1756,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:41:41 GMT']
+      date: ['Fri, 21 Sep 2018 21:17:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1785,18 +1783,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:41:51 GMT']
+      date: ['Fri, 21 Sep 2018 21:17:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1812,18 +1810,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:42:02 GMT']
+      date: ['Fri, 21 Sep 2018 21:17:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1839,18 +1837,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:42:13 GMT']
+      date: ['Fri, 21 Sep 2018 21:17:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1866,18 +1864,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:42:22 GMT']
+      date: ['Fri, 21 Sep 2018 21:17:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1893,18 +1891,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:42:33 GMT']
+      date: ['Fri, 21 Sep 2018 21:18:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1920,18 +1918,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:42:43 GMT']
+      date: ['Fri, 21 Sep 2018 21:18:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1947,18 +1945,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:42:53 GMT']
+      date: ['Fri, 21 Sep 2018 21:18:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1974,18 +1972,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:43:04 GMT']
+      date: ['Fri, 21 Sep 2018 21:18:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2001,18 +1999,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:43:14 GMT']
+      date: ['Fri, 21 Sep 2018 21:18:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2028,18 +2026,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:43:24 GMT']
+      date: ['Fri, 21 Sep 2018 21:18:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2055,18 +2053,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:43:35 GMT']
+      date: ['Fri, 21 Sep 2018 21:19:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2082,18 +2080,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:43:45 GMT']
+      date: ['Fri, 21 Sep 2018 21:19:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2109,18 +2107,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:43:55 GMT']
+      date: ['Fri, 21 Sep 2018 21:19:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2136,18 +2134,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:44:06 GMT']
+      date: ['Fri, 21 Sep 2018 21:19:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2163,18 +2161,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:44:15 GMT']
+      date: ['Fri, 21 Sep 2018 21:19:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2190,18 +2188,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:44:27 GMT']
+      date: ['Fri, 21 Sep 2018 21:20:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2217,18 +2215,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:44:36 GMT']
+      date: ['Fri, 21 Sep 2018 21:20:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2244,18 +2242,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:44:47 GMT']
+      date: ['Fri, 21 Sep 2018 21:20:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2271,18 +2269,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:44:57 GMT']
+      date: ['Fri, 21 Sep 2018 21:20:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2298,18 +2296,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:45:08 GMT']
+      date: ['Fri, 21 Sep 2018 21:20:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2325,18 +2323,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:45:18 GMT']
+      date: ['Fri, 21 Sep 2018 21:20:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2352,18 +2350,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:45:28 GMT']
+      date: ['Fri, 21 Sep 2018 21:21:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2379,18 +2377,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:45:38 GMT']
+      date: ['Fri, 21 Sep 2018 21:21:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2406,18 +2404,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:45:48 GMT']
+      date: ['Fri, 21 Sep 2018 21:21:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2433,18 +2431,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:45:59 GMT']
+      date: ['Fri, 21 Sep 2018 21:21:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2460,18 +2458,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:46:09 GMT']
+      date: ['Fri, 21 Sep 2018 21:21:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2487,18 +2485,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:46:19 GMT']
+      date: ['Fri, 21 Sep 2018 21:21:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2514,18 +2512,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:46:29 GMT']
+      date: ['Fri, 21 Sep 2018 21:22:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2541,18 +2539,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:46:40 GMT']
+      date: ['Fri, 21 Sep 2018 21:22:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2568,18 +2566,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:46:50 GMT']
+      date: ['Fri, 21 Sep 2018 21:22:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2595,18 +2593,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:47:00 GMT']
+      date: ['Fri, 21 Sep 2018 21:22:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2622,18 +2620,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:47:10 GMT']
+      date: ['Fri, 21 Sep 2018 21:22:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2649,18 +2647,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:47:20 GMT']
+      date: ['Fri, 21 Sep 2018 21:23:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2676,18 +2674,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:47:31 GMT']
+      date: ['Fri, 21 Sep 2018 21:23:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2703,18 +2701,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:47:41 GMT']
+      date: ['Fri, 21 Sep 2018 21:23:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2730,18 +2728,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:47:52 GMT']
+      date: ['Fri, 21 Sep 2018 21:23:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2757,18 +2755,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:48:01 GMT']
+      date: ['Fri, 21 Sep 2018 21:23:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2784,18 +2782,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:48:12 GMT']
+      date: ['Fri, 21 Sep 2018 21:23:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2811,18 +2809,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:48:22 GMT']
+      date: ['Fri, 21 Sep 2018 21:24:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2838,18 +2836,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:48:32 GMT']
+      date: ['Fri, 21 Sep 2018 21:24:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2865,18 +2863,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:48:43 GMT']
+      date: ['Fri, 21 Sep 2018 21:24:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2892,18 +2890,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:48:53 GMT']
+      date: ['Fri, 21 Sep 2018 21:24:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2919,18 +2917,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:49:03 GMT']
+      date: ['Fri, 21 Sep 2018 21:24:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2946,18 +2944,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:49:13 GMT']
+      date: ['Fri, 21 Sep 2018 21:24:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2973,18 +2971,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:49:24 GMT']
+      date: ['Fri, 21 Sep 2018 21:25:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3000,18 +2998,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:49:34 GMT']
+      date: ['Fri, 21 Sep 2018 21:25:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3027,18 +3025,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:49:45 GMT']
+      date: ['Fri, 21 Sep 2018 21:25:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3054,18 +3052,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:49:55 GMT']
+      date: ['Fri, 21 Sep 2018 21:25:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3081,18 +3079,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:50:05 GMT']
+      date: ['Fri, 21 Sep 2018 21:25:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3108,18 +3106,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:50:16 GMT']
+      date: ['Fri, 21 Sep 2018 21:26:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3135,18 +3133,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:50:26 GMT']
+      date: ['Fri, 21 Sep 2018 21:26:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3162,18 +3160,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:50:36 GMT']
+      date: ['Fri, 21 Sep 2018 21:26:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3189,18 +3187,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:50:47 GMT']
+      date: ['Fri, 21 Sep 2018 21:26:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3216,18 +3214,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:50:56 GMT']
+      date: ['Fri, 21 Sep 2018 21:26:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3243,18 +3241,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:51:06 GMT']
+      date: ['Fri, 21 Sep 2018 21:26:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3270,18 +3268,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:51:17 GMT']
+      date: ['Fri, 21 Sep 2018 21:27:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3297,18 +3295,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:51:27 GMT']
+      date: ['Fri, 21 Sep 2018 21:27:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3324,18 +3322,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:51:38 GMT']
+      date: ['Fri, 21 Sep 2018 21:27:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3351,18 +3349,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:51:48 GMT']
+      date: ['Fri, 21 Sep 2018 21:27:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3378,18 +3376,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:51:58 GMT']
+      date: ['Fri, 21 Sep 2018 21:27:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3405,18 +3403,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:52:08 GMT']
+      date: ['Fri, 21 Sep 2018 21:27:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3432,18 +3430,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:52:19 GMT']
+      date: ['Fri, 21 Sep 2018 21:28:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3459,18 +3457,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:52:29 GMT']
+      date: ['Fri, 21 Sep 2018 21:28:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3486,18 +3484,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:52:39 GMT']
+      date: ['Fri, 21 Sep 2018 21:28:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3513,18 +3511,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:52:50 GMT']
+      date: ['Fri, 21 Sep 2018 21:28:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3540,18 +3538,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:52:59 GMT']
+      date: ['Fri, 21 Sep 2018 21:28:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3567,18 +3565,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:53:11 GMT']
+      date: ['Fri, 21 Sep 2018 21:29:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3594,18 +3592,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:53:20 GMT']
+      date: ['Fri, 21 Sep 2018 21:29:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3621,18 +3619,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:53:30 GMT']
+      date: ['Fri, 21 Sep 2018 21:29:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3648,18 +3646,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:53:41 GMT']
+      date: ['Fri, 21 Sep 2018 21:29:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3675,18 +3673,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:53:51 GMT']
+      date: ['Fri, 21 Sep 2018 21:29:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3702,18 +3700,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:54:01 GMT']
+      date: ['Fri, 21 Sep 2018 21:29:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3729,18 +3727,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:54:12 GMT']
+      date: ['Fri, 21 Sep 2018 21:30:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3756,18 +3754,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:54:22 GMT']
+      date: ['Fri, 21 Sep 2018 21:30:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3783,18 +3781,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:54:32 GMT']
+      date: ['Fri, 21 Sep 2018 21:30:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3810,18 +3808,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:54:43 GMT']
+      date: ['Fri, 21 Sep 2018 21:30:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3837,18 +3835,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:54:53 GMT']
+      date: ['Fri, 21 Sep 2018 21:30:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3864,18 +3862,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:55:02 GMT']
+      date: ['Fri, 21 Sep 2018 21:31:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3891,18 +3889,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:55:13 GMT']
+      date: ['Fri, 21 Sep 2018 21:31:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3918,18 +3916,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:55:23 GMT']
+      date: ['Fri, 21 Sep 2018 21:31:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3945,18 +3943,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:55:33 GMT']
+      date: ['Fri, 21 Sep 2018 21:31:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3972,18 +3970,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:55:43 GMT']
+      date: ['Fri, 21 Sep 2018 21:31:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3999,18 +3997,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:55:54 GMT']
+      date: ['Fri, 21 Sep 2018 21:31:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4026,18 +4024,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:56:04 GMT']
+      date: ['Fri, 21 Sep 2018 21:32:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4053,18 +4051,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:56:15 GMT']
+      date: ['Fri, 21 Sep 2018 21:32:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4080,18 +4078,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:56:25 GMT']
+      date: ['Fri, 21 Sep 2018 21:32:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4107,18 +4105,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:56:35 GMT']
+      date: ['Fri, 21 Sep 2018 21:32:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4134,18 +4132,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:56:45 GMT']
+      date: ['Fri, 21 Sep 2018 21:32:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4161,18 +4159,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:56:55 GMT']
+      date: ['Fri, 21 Sep 2018 21:33:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4188,18 +4186,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:57:05 GMT']
+      date: ['Fri, 21 Sep 2018 21:33:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4215,18 +4213,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:57:16 GMT']
+      date: ['Fri, 21 Sep 2018 21:33:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4242,18 +4240,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:57:26 GMT']
+      date: ['Fri, 21 Sep 2018 21:33:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4269,18 +4267,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:57:36 GMT']
+      date: ['Fri, 21 Sep 2018 21:33:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4296,18 +4294,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:57:47 GMT']
+      date: ['Fri, 21 Sep 2018 21:33:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4323,18 +4321,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:57:57 GMT']
+      date: ['Fri, 21 Sep 2018 21:34:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4350,18 +4348,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:58:07 GMT']
+      date: ['Fri, 21 Sep 2018 21:34:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4377,18 +4375,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:58:17 GMT']
+      date: ['Fri, 21 Sep 2018 21:34:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4404,18 +4402,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:58:27 GMT']
+      date: ['Fri, 21 Sep 2018 21:34:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4431,18 +4429,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:58:37 GMT']
+      date: ['Fri, 21 Sep 2018 21:34:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4458,18 +4456,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:58:48 GMT']
+      date: ['Fri, 21 Sep 2018 21:34:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4485,18 +4483,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:58:58 GMT']
+      date: ['Fri, 21 Sep 2018 21:35:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4512,18 +4510,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:59:09 GMT']
+      date: ['Fri, 21 Sep 2018 21:35:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4539,18 +4537,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:59:18 GMT']
+      date: ['Fri, 21 Sep 2018 21:35:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4566,18 +4564,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:59:29 GMT']
+      date: ['Fri, 21 Sep 2018 21:35:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4593,18 +4591,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:59:39 GMT']
+      date: ['Fri, 21 Sep 2018 21:35:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4620,18 +4618,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 15:59:50 GMT']
+      date: ['Fri, 21 Sep 2018 21:36:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4647,18 +4645,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:00:00 GMT']
+      date: ['Fri, 21 Sep 2018 21:36:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4674,18 +4672,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:00:09 GMT']
+      date: ['Fri, 21 Sep 2018 21:36:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4701,18 +4699,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:00:20 GMT']
+      date: ['Fri, 21 Sep 2018 21:36:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4728,18 +4726,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:00:30 GMT']
+      date: ['Fri, 21 Sep 2018 21:36:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4755,18 +4753,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:00:40 GMT']
+      date: ['Fri, 21 Sep 2018 21:36:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4782,18 +4780,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:00:51 GMT']
+      date: ['Fri, 21 Sep 2018 21:37:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4809,18 +4807,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:01 GMT']
+      date: ['Fri, 21 Sep 2018 21:37:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4836,18 +4834,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:12 GMT']
+      date: ['Fri, 21 Sep 2018 21:37:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4863,18 +4861,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:22 GMT']
+      date: ['Fri, 21 Sep 2018 21:37:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4890,18 +4888,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:32 GMT']
+      date: ['Fri, 21 Sep 2018 21:37:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4917,18 +4915,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:42 GMT']
+      date: ['Fri, 21 Sep 2018 21:37:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4944,18 +4942,1746 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce5c46db-0a32-46e0-9591-3493d3e8f1e8?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:38:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:38:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:38:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:38:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:38:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:39:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:39:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:39:24 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:39:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:39:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:39:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:40:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:40:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:40:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:40:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:40:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:41:01 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:41:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:41:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:41:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:41:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:41:54 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:42:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:42:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:42:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:42:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:42:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:42:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:43:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:43:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:43:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:43:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:43:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:44:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:44:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:44:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:44:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:44:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:44:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:45:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:45:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:45:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:45:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:45:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:46:01 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:46:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:46:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:46:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:46:45 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:46:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:47:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:47:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:47:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:47:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:47:49 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:48:00 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:48:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:48:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:48:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:48:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:48:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:49:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:49:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 21:49:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet-gateway create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/082fc91b-3ad7-4e64-a430-0f61e5f70499?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:53 GMT']
+      date: ['Fri, 21 Sep 2018 21:49:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4971,22 +6697,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"gateway1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1\"\
-        ,\r\n  \"etag\": \"W/\\\"0bbad73c-c655-4268-a457-f657c3e53e57\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"gateway1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1\"\
+        ,\r\n  \"etag\": \"W/\\\"01a0805d-b010-4549-a9e1-bb7c15f69ae8\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworkGateways\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"foo\": \"doo\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"11e3fc62-e66d-4efc-81e4-4dfbde631dca\",\r\n    \"ipConfigurations\": [\r\
+        \ \"95759609-51f9-4a81-aedb-280ad7f5ecec\",\r\n    \"ipConfigurations\": [\r\
         \n      {\r\n        \"name\": \"vnetGatewayConfig0\",\r\n        \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1/ipConfigurations/vnetGatewayConfig0\"\
-        ,\r\n        \"etag\": \"W/\\\"0bbad73c-c655-4268-a457-f657c3e53e57\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"01a0805d-b010-4549-a9e1-bb7c15f69ae8\\\"\"\
         ,\r\n        \"type\": \"Microsoft.Network/virtualNetworkGateways/ipConfigurations\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
@@ -5002,7 +6727,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2010']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:53 GMT']
+      date: ['Fri, 21 Sep 2018 21:49:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5018,18 +6743,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet show]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"6eb13fba-5f90-4b00-b39d-43eeb37c5742\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        ,\r\n  \"etag\": \"W/\\\"ff4eaf5e-c955-4324-a7dd-41683831babc\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ab557d04-f180-49ee-938b-c8e1f1dc5b85\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ffb04011-01fe-40dc-aef2-cfa30722428a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -5039,8 +6764,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['767']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:54 GMT']
-      etag: [W/"6eb13fba-5f90-4b00-b39d-43eeb37c5742"]
+      date: ['Fri, 21 Sep 2018 21:49:40 GMT']
+      etag: [W/"ff4eaf5e-c955-4324-a7dd-41683831babc"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5056,23 +6781,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet show]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
-        ,\r\n  \"etag\": \"W/\\\"12d71a6a-52fd-42ce-b813-72e2e0a97513\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        ,\r\n  \"etag\": \"W/\\\"70030d3e-9236-4620-83e4-f654180836a9\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"117a1eaf-8459-4761-a095-8a9750bfbbb7\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"55e97904-319f-4e40-bcb0-99f1c1729e6d\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"GatewaySubnet\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/GatewaySubnet\"\
-        ,\r\n        \"etag\": \"W/\\\"12d71a6a-52fd-42ce-b813-72e2e0a97513\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"70030d3e-9236-4620-83e4-f654180836a9\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"11.0.0.0/24\",\r\n          \"ipConfigurations\"\
         : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1/ipConfigurations/vnetGatewayConfig0\"\
@@ -5084,8 +6809,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1675']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:55 GMT']
-      etag: [W/"12d71a6a-52fd-42ce-b813-72e2e0a97513"]
+      date: ['Fri, 21 Sep 2018 21:49:41 GMT']
+      etag: [W/"70030d3e-9236-4620-83e4-f654180836a9"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5095,10 +6820,11 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"allowVirtualNetworkAccess": false, "allowForwardedTraffic":
-      false, "remoteVirtualNetwork": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1"},
-      "allowGatewayTransit": true, "useRemoteGateways": false}, "name": "peering2",
-      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2"}'
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2",
+      "properties": {"allowVirtualNetworkAccess": false, "allowForwardedTraffic":
+      false, "allowGatewayTransit": true, "useRemoteGateways": false, "remoteVirtualNetwork":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1"}},
+      "name": "peering2"}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -5106,16 +6832,15 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['591']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"peering2\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
-        ,\r\n  \"etag\": \"W/\\\"8d005540-207c-40bc-8926-237ed9dbf6ce\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"peering2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
+        ,\r\n  \"etag\": \"W/\\\"2d3c311f-6308-4570-8ded-82b2ce3f2501\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringState\": \"Initiated\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
@@ -5126,17 +6851,17 @@ interactions:
         : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
         \r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/24e732d5-2464-4e9b-8467-5fb4afbc0244?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ab4656bd-67d8-49bf-a1c8-6ca3c09a8c73?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['1005']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:01:56 GMT']
+      date: ['Fri, 21 Sep 2018 21:49:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -5145,18 +6870,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/24e732d5-2464-4e9b-8467-5fb4afbc0244?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ab4656bd-67d8-49bf-a1c8-6ca3c09a8c73?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:07 GMT']
+      date: ['Fri, 21 Sep 2018 21:49:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5172,15 +6897,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"peering2\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
-        ,\r\n  \"etag\": \"W/\\\"731dcf7e-0caa-4fe1-a0ed-06ba3338e819\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"peering2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
+        ,\r\n  \"etag\": \"W/\\\"15fc7d0a-c053-44d0-8abb-bd24f9dceeb3\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringState\": \"Initiated\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
@@ -5194,8 +6918,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1006']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:07 GMT']
-      etag: [W/"731dcf7e-0caa-4fe1-a0ed-06ba3338e819"]
+      date: ['Fri, 21 Sep 2018 21:49:58 GMT']
+      etag: [W/"15fc7d0a-c053-44d0-8abb-bd24f9dceeb3"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5205,10 +6929,11 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"allowVirtualNetworkAccess": false, "allowForwardedTraffic":
-      true, "remoteVirtualNetwork": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2"},
-      "allowGatewayTransit": false, "useRemoteGateways": true}, "name": "peering1",
-      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1"}'
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1",
+      "properties": {"allowVirtualNetworkAccess": false, "allowForwardedTraffic":
+      true, "allowGatewayTransit": false, "useRemoteGateways": true, "remoteVirtualNetwork":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2"}},
+      "name": "peering1"}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -5216,16 +6941,15 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['590']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
-        ,\r\n  \"etag\": \"W/\\\"5b0f0811-84fa-4450-a782-795f6e9004c9\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
+        ,\r\n  \"etag\": \"W/\\\"ba71ba8b-2225-4602-aa18-1db8ebf1c586\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
@@ -5237,17 +6961,17 @@ interactions:
         : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
         \r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c32dd3b6-f95d-49e3-8d49-608ea8804e64?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eaa37ac0-0c8d-4d33-93fe-406e7479cfda?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['1275']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:09 GMT']
+      date: ['Fri, 21 Sep 2018 21:50:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -5256,18 +6980,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c32dd3b6-f95d-49e3-8d49-608ea8804e64?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eaa37ac0-0c8d-4d33-93fe-406e7479cfda?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:18 GMT']
+      date: ['Fri, 21 Sep 2018 21:50:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5283,15 +7007,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering create]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
-        ,\r\n  \"etag\": \"W/\\\"5b35e739-1819-4caa-b709-f20c3a067bdf\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
+        ,\r\n  \"etag\": \"W/\\\"db5454db-4914-4b28-aa55-c0e5e6c78120\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
@@ -5306,8 +7029,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1276']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:19 GMT']
-      etag: [W/"5b35e739-1819-4caa-b709-f20c3a067bdf"]
+      date: ['Fri, 21 Sep 2018 21:50:15 GMT']
+      etag: [W/"db5454db-4914-4b28-aa55-c0e5e6c78120"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5323,16 +7046,15 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering show]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
-        ,\r\n  \"etag\": \"W/\\\"5b35e739-1819-4caa-b709-f20c3a067bdf\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
+        ,\r\n  \"etag\": \"W/\\\"db5454db-4914-4b28-aa55-c0e5e6c78120\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
@@ -5347,8 +7069,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1276']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:20 GMT']
-      etag: [W/"5b35e739-1819-4caa-b709-f20c3a067bdf"]
+      date: ['Fri, 21 Sep 2018 21:50:18 GMT']
+      etag: [W/"db5454db-4914-4b28-aa55-c0e5e6c78120"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5364,16 +7086,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering list]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"peering2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
-        ,\r\n      \"etag\": \"W/\\\"acf64a51-0b25-4c8f-974e-8e82db702b8b\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"peering2\",\r\
+        \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
+        ,\r\n      \"etag\": \"W/\\\"c6af5c9f-6513-4120-b3b2-35dc89d74822\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"peeringState\": \"Connected\",\r\n        \"remoteVirtualNetwork\"\
         : {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
@@ -5388,7 +7110,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1123']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:20 GMT']
+      date: ['Fri, 21 Sep 2018 21:50:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5404,16 +7126,15 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering update]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
-        ,\r\n  \"etag\": \"W/\\\"5b35e739-1819-4caa-b709-f20c3a067bdf\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
+        ,\r\n  \"etag\": \"W/\\\"db5454db-4914-4b28-aa55-c0e5e6c78120\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
@@ -5428,8 +7149,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1276']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:21 GMT']
-      etag: [W/"5b35e739-1819-4caa-b709-f20c3a067bdf"]
+      date: ['Fri, 21 Sep 2018 21:50:22 GMT']
+      etag: [W/"db5454db-4914-4b28-aa55-c0e5e6c78120"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5439,12 +7160,13 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "W/\"5b35e739-1819-4caa-b709-f20c3a067bdf\"",
-      "properties": {"allowVirtualNetworkAccess": false, "remoteVirtualNetwork": {"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2"},
-      "useRemoteGateways": false, "allowGatewayTransit": false, "allowForwardedTraffic":
-      true, "remoteAddressSpace": {"addressPrefixes": ["11.0.0.0/16"]}, "peeringState":
-      "Connected", "provisioningState": "Succeeded"}, "name": "peering1", "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1"}'
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1",
+      "properties": {"allowVirtualNetworkAccess": false, "allowForwardedTraffic":
+      true, "allowGatewayTransit": false, "useRemoteGateways": false, "remoteVirtualNetwork":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2"},
+      "remoteAddressSpace": {"addressPrefixes": ["11.0.0.0/16"]}, "peeringState":
+      "Connected", "provisioningState": "Succeeded"}, "name": "peering1", "etag":
+      "W/\\"db5454db-4914-4b28-aa55-c0e5e6c78120\\""}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -5452,16 +7174,15 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['800']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
-        ,\r\n  \"etag\": \"W/\\\"67e57184-488a-4cef-92e2-264d368ca88b\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
+        ,\r\n  \"etag\": \"W/\\\"d8cb4943-7dc0-4676-8099-7c5d7f9597df\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
@@ -5472,11 +7193,11 @@ interactions:
         : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
         \r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6f914fb9-dcb9-4d06-9a8a-32d384dbc546?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/fb4783d1-82b5-4ed8-871c-000cba36d80c?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['1005']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:22 GMT']
+      date: ['Fri, 21 Sep 2018 21:50:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5484,7 +7205,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -5493,18 +7214,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering update]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6f914fb9-dcb9-4d06-9a8a-32d384dbc546?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/fb4783d1-82b5-4ed8-871c-000cba36d80c?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:31 GMT']
+      date: ['Fri, 21 Sep 2018 21:50:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5520,15 +7241,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering update]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
-        ,\r\n  \"etag\": \"W/\\\"2e2f2beb-7d24-4eec-bee2-5dc1d2a1b41a\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
+        ,\r\n  \"etag\": \"W/\\\"77e58ee9-73b3-4e32-a3d8-a072a22ebc76\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
@@ -5542,8 +7262,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1006']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:32 GMT']
-      etag: [W/"2e2f2beb-7d24-4eec-bee2-5dc1d2a1b41a"]
+      date: ['Fri, 21 Sep 2018 21:50:38 GMT']
+      etag: [W/"77e58ee9-73b3-4e32-a3d8-a072a22ebc76"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5560,26 +7280,26 @@ interactions:
       CommandName: [network vnet peering delete]
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/0f214541-7844-4733-a52d-7552df364be6?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/3c3ead2f-f00d-4bee-9fa1-a1a17a597f7a?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 10 Sep 2018 16:02:33 GMT']
+      date: ['Fri, 21 Sep 2018 21:50:43 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/0f214541-7844-4733-a52d-7552df364be6?api-version=2018-08-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/3c3ead2f-f00d-4bee-9fa1-a1a17a597f7a?api-version=2018-08-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-deletes: ['14997']
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -5588,18 +7308,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/0f214541-7844-4733-a52d-7552df364be6?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/3c3ead2f-f00d-4bee-9fa1-a1a17a597f7a?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:43 GMT']
+      date: ['Fri, 21 Sep 2018 21:50:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5615,19 +7335,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering list]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": []\r\n}"}
+    body: {string: "{\r\n  \"value\": []\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['19']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:45 GMT']
+      date: ['Fri, 21 Sep 2018 21:50:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5644,26 +7364,26 @@ interactions:
       CommandName: [network vnet peering delete]
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/0f70d17f-3e59-4d91-8e26-1d948ebf5d01?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5317c6d1-9ad7-44b2-85e7-59b726b6d015?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 10 Sep 2018 16:02:45 GMT']
+      date: ['Fri, 21 Sep 2018 21:50:59 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/0f70d17f-3e59-4d91-8e26-1d948ebf5d01?api-version=2018-08-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/5317c6d1-9ad7-44b2-85e7-59b726b6d015?api-version=2018-08-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-deletes: ['14997']
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -5672,18 +7392,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet peering delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/0f70d17f-3e59-4d91-8e26-1d948ebf5d01?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5317c6d1-9ad7-44b2-85e7-59b726b6d015?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:02:56 GMT']
+      date: ['Fri, 21 Sep 2018 21:51:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5700,26 +7420,26 @@ interactions:
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnet_peering000001/providers/Microsoft.Network/virtualNetworkGateways/gateway1?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 10 Sep 2018 16:02:57 GMT']
+      date: ['Fri, 21 Sep 2018 21:51:15 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-deletes: ['14998']
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -5728,18 +7448,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:03:07 GMT']
+      date: ['Fri, 21 Sep 2018 21:51:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5755,18 +7475,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:03:18 GMT']
+      date: ['Fri, 21 Sep 2018 21:51:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5782,18 +7502,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:03:28 GMT']
+      date: ['Fri, 21 Sep 2018 21:51:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5809,18 +7529,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:03:38 GMT']
+      date: ['Fri, 21 Sep 2018 21:52:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5836,18 +7556,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:03:48 GMT']
+      date: ['Fri, 21 Sep 2018 21:52:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5863,18 +7583,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:03:59 GMT']
+      date: ['Fri, 21 Sep 2018 21:52:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5890,18 +7610,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:04:09 GMT']
+      date: ['Fri, 21 Sep 2018 21:52:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5917,18 +7637,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:04:20 GMT']
+      date: ['Fri, 21 Sep 2018 21:52:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5944,18 +7664,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:04:29 GMT']
+      date: ['Fri, 21 Sep 2018 21:53:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5971,18 +7691,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:04:40 GMT']
+      date: ['Fri, 21 Sep 2018 21:53:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5998,18 +7718,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:04:50 GMT']
+      date: ['Fri, 21 Sep 2018 21:53:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6025,18 +7745,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:05:01 GMT']
+      date: ['Fri, 21 Sep 2018 21:53:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6052,18 +7772,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:05:10 GMT']
+      date: ['Fri, 21 Sep 2018 21:53:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6079,18 +7799,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:05:22 GMT']
+      date: ['Fri, 21 Sep 2018 21:53:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6106,18 +7826,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:05:31 GMT']
+      date: ['Fri, 21 Sep 2018 21:54:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6133,18 +7853,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:05:43 GMT']
+      date: ['Fri, 21 Sep 2018 21:54:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6160,18 +7880,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:05:53 GMT']
+      date: ['Fri, 21 Sep 2018 21:54:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6187,18 +7907,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:06:04 GMT']
+      date: ['Fri, 21 Sep 2018 21:54:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6214,18 +7934,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:06:14 GMT']
+      date: ['Fri, 21 Sep 2018 21:54:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6241,18 +7961,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:06:24 GMT']
+      date: ['Fri, 21 Sep 2018 21:55:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6268,18 +7988,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:06:34 GMT']
+      date: ['Fri, 21 Sep 2018 21:55:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6295,18 +8015,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:06:45 GMT']
+      date: ['Fri, 21 Sep 2018 21:55:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6322,18 +8042,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:06:55 GMT']
+      date: ['Fri, 21 Sep 2018 21:55:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6349,18 +8069,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:07:06 GMT']
+      date: ['Fri, 21 Sep 2018 21:55:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6376,18 +8096,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:07:15 GMT']
+      date: ['Fri, 21 Sep 2018 21:56:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6403,18 +8123,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:07:26 GMT']
+      date: ['Fri, 21 Sep 2018 21:56:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6430,18 +8150,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:07:36 GMT']
+      date: ['Fri, 21 Sep 2018 21:56:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6457,18 +8177,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:07:46 GMT']
+      date: ['Fri, 21 Sep 2018 21:56:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6484,18 +8204,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:07:58 GMT']
+      date: ['Fri, 21 Sep 2018 21:56:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6511,18 +8231,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:08:08 GMT']
+      date: ['Fri, 21 Sep 2018 21:57:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6538,18 +8258,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:08:18 GMT']
+      date: ['Fri, 21 Sep 2018 21:57:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6565,18 +8285,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:08:28 GMT']
+      date: ['Fri, 21 Sep 2018 21:57:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6592,18 +8312,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:08:39 GMT']
+      date: ['Fri, 21 Sep 2018 21:57:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6619,18 +8339,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:08:49 GMT']
+      date: ['Fri, 21 Sep 2018 21:57:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6646,18 +8366,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:08:58 GMT']
+      date: ['Fri, 21 Sep 2018 21:58:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6673,18 +8393,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:09:09 GMT']
+      date: ['Fri, 21 Sep 2018 21:58:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6700,18 +8420,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:09:20 GMT']
+      date: ['Fri, 21 Sep 2018 21:58:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6727,18 +8447,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:09:30 GMT']
+      date: ['Fri, 21 Sep 2018 21:58:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -6754,261 +8474,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network vnet-gateway delete]
       Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1574daa7-3473-4c9f-9290-969ef25c97d4?api-version=2018-08-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:09:40 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [network vnet-gateway delete]
-      Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:09:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [network vnet-gateway delete]
-      Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:10:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [network vnet-gateway delete]
-      Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:10:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [network vnet-gateway delete]
-      Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:10:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [network vnet-gateway delete]
-      Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:10:32 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [network vnet-gateway delete]
-      Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:10:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [network vnet-gateway delete]
-      Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:10:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [network vnet-gateway delete]
-      Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:11:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [network vnet-gateway delete]
-      Connection: [keep-alive]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 networkmanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4b0433a1-f007-4590-8791-3a7331dabf5f?api-version=2018-08-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 10 Sep 2018 16:11:14 GMT']
+      date: ['Fri, 21 Sep 2018 21:58:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -7026,20 +8503,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.7.0-x86_64-i386-64bit) requests/2.19.1
-          msrest/0.5.5 msrest_azure/0.5.0 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.46]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnet_peering000001?api-version=2018-05-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 10 Sep 2018 16:11:14 GMT']
+      date: ['Fri, 21 Sep 2018 21:58:54 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGVk5FVDo1RlBFRVJJTkdOSkZORkg2RkxEQlBQTldVN1NGR3w2NUE4RTA1OEI3NTMzMEY4LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGVk5FVDo1RlBFRVJJTkdOQU1aTDRRWFhTQ0QzNFdZR0NWQ3w3NDNCRDFEQzU4MzlERUQzLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering_different_resource_groups.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering_different_resource_groups.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-09-21T00:38:39Z"}}'
+      "date": "2018-09-21T21:58:56Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -16,12 +16,12 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_2000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001","name":"cli-test_vnet_peering_group_2000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:39Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001","name":"cli-test_vnet_peering_group_2000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:58:56Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:38:42 GMT']
+      date: ['Fri, 21 Sep 2018 21:58:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -30,7 +30,7 @@ interactions:
     status: {code: 201, message: Created}
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-09-21T00:38:43Z"}}'
+      "date": "2018-09-21T21:58:58Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -45,12 +45,12 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_1000002?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002","name":"cli-test_vnet_peering_group_1000002","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:43Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002","name":"cli-test_vnet_peering_group_1000002","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:58:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:38:44 GMT']
+      date: ['Fri, 21 Sep 2018 21:58:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -72,12 +72,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_1000002?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002","name":"cli-test_vnet_peering_group_1000002","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:43Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002","name":"cli-test_vnet_peering_group_1000002","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:58:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:38:44 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -102,21 +102,21 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"c902517b-52b0-4d05-9dc9-bf05c9aca500\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"db820f30-9bc8-4b1c-aefd-f8555df42af7\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"335d5289-247f-4b05-90cf-fab9684ae197\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"e6b3e8a8-3dd9-4d5b-a645-19bea1c626dc\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
         \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
         : false\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/15c4a92a-c883-42bd-a7b4-caa2cdb79744?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1b0e9de8-66a7-4c57-8282-fef2ca95472a?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['766']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:38:46 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -135,14 +135,14 @@ interactions:
           msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/15c4a92a-c883-42bd-a7b4-caa2cdb79744?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1b0e9de8-66a7-4c57-8282-fef2ca95472a?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:38:50 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -162,14 +162,14 @@ interactions:
           msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/15c4a92a-c883-42bd-a7b4-caa2cdb79744?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1b0e9de8-66a7-4c57-8282-fef2ca95472a?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:00 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -192,10 +192,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"f6c7e503-8e91-4195-adaf-5382ba3d57f8\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"67b67d8a-8301-43bf-a2bb-3193017d99c5\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"335d5289-247f-4b05-90cf-fab9684ae197\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"e6b3e8a8-3dd9-4d5b-a645-19bea1c626dc\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -205,8 +205,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['767']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:01 GMT']
-      etag: [W/"f6c7e503-8e91-4195-adaf-5382ba3d57f8"]
+      date: ['Fri, 21 Sep 2018 21:59:16 GMT']
+      etag: [W/"67b67d8a-8301-43bf-a2bb-3193017d99c5"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -230,12 +230,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_2000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001","name":"cli-test_vnet_peering_group_2000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:39Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001","name":"cli-test_vnet_peering_group_2000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:58:56Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:02 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -260,27 +260,27 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
-        ,\r\n  \"etag\": \"W/\\\"96ecc711-7d93-477f-a362-c7e1949d3915\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"8399fc08-9c84-451b-ac97-0d1f123560d3\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"111e800e-15af-4d48-8a65-f73860889e64\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"3f9da9be-7864-4d5b-bd05-011c1e244e33\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
         \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
         : false\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f1a09156-c009-4aa7-b369-ed4d64bfa125?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/64dd0144-c63f-41d6-a595-48ea25273bbb?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['766']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:03 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -293,14 +293,14 @@ interactions:
           msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f1a09156-c009-4aa7-b369-ed4d64bfa125?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/64dd0144-c63f-41d6-a595-48ea25273bbb?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:06 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -320,14 +320,14 @@ interactions:
           msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f1a09156-c009-4aa7-b369-ed4d64bfa125?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/64dd0144-c63f-41d6-a595-48ea25273bbb?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:39 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -350,10 +350,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
-        ,\r\n  \"etag\": \"W/\\\"9903ccd6-10b5-4fb2-8925-15befa167a7c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"32106eb7-866f-4bf6-b9ff-38b31821a1ca\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"111e800e-15af-4d48-8a65-f73860889e64\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"3f9da9be-7864-4d5b-bd05-011c1e244e33\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -363,8 +363,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['767']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:40 GMT']
-      etag: [W/"9903ccd6-10b5-4fb2-8925-15befa167a7c"]
+      date: ['Fri, 21 Sep 2018 21:59:32 GMT']
+      etag: [W/"32106eb7-866f-4bf6-b9ff-38b31821a1ca"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -388,12 +388,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_2000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001","name":"cli-test_vnet_peering_group_2000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:39Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001","name":"cli-test_vnet_peering_group_2000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T21:58:56Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:42 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -418,25 +418,25 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
-        ,\r\n  \"etag\": \"W/\\\"7a6e7c6d-eff5-4f81-9ba9-978e023a07fe\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"329123c1-e83c-4eff-b9d5-d368909c8f40\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"1583e8ce-9c9c-475c-86fa-37bdfce33e57\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"2324ab70-b6cf-4740-bf73-5baabfc9aa6e\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\
         \n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
         : {\r\n    \"name\": \"Basic\",\r\n    \"tier\": \"Regional\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b7f5de4f-5cf0-4d28-89ec-ca631a63950c?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5019967c-ce03-49c2-a87f-a53947e99cd3?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['679']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:44 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -449,14 +449,14 @@ interactions:
           msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b7f5de4f-5cf0-4d28-89ec-ca631a63950c?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5019967c-ce03-49c2-a87f-a53947e99cd3?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:47 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -479,9 +479,9 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
-        ,\r\n  \"etag\": \"W/\\\"3541d6d5-6360-4fff-889e-37e2b43081a2\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"3b407fed-249a-4d42-9405-54dd9be7612e\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"1583e8ce-9c9c-475c-86fa-37bdfce33e57\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"2324ab70-b6cf-4740-bf73-5baabfc9aa6e\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\
         \n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
@@ -490,8 +490,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['680']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:48 GMT']
-      etag: [W/"3541d6d5-6360-4fff-889e-37e2b43081a2"]
+      date: ['Fri, 21 Sep 2018 21:59:38 GMT']
+      etag: [W/"3b407fed-249a-4d42-9405-54dd9be7612e"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -515,9 +515,9 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
-        ,\r\n  \"etag\": \"W/\\\"3541d6d5-6360-4fff-889e-37e2b43081a2\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"3b407fed-249a-4d42-9405-54dd9be7612e\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"1583e8ce-9c9c-475c-86fa-37bdfce33e57\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"2324ab70-b6cf-4740-bf73-5baabfc9aa6e\"\
         ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
         : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\
         \n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
@@ -526,8 +526,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['680']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:49 GMT']
-      etag: [W/"3541d6d5-6360-4fff-889e-37e2b43081a2"]
+      date: ['Fri, 21 Sep 2018 21:59:39 GMT']
+      etag: [W/"3b407fed-249a-4d42-9405-54dd9be7612e"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -551,10 +551,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
-        ,\r\n  \"etag\": \"W/\\\"9903ccd6-10b5-4fb2-8925-15befa167a7c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"32106eb7-866f-4bf6-b9ff-38b31821a1ca\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"111e800e-15af-4d48-8a65-f73860889e64\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"3f9da9be-7864-4d5b-bd05-011c1e244e33\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -564,8 +564,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['767']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:50 GMT']
-      etag: [W/"9903ccd6-10b5-4fb2-8925-15befa167a7c"]
+      date: ['Fri, 21 Sep 2018 21:59:40 GMT']
+      etag: [W/"32106eb7-866f-4bf6-b9ff-38b31821a1ca"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -589,10 +589,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"f6c7e503-8e91-4195-adaf-5382ba3d57f8\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"67b67d8a-8301-43bf-a2bb-3193017d99c5\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"335d5289-247f-4b05-90cf-fab9684ae197\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"e6b3e8a8-3dd9-4d5b-a645-19bea1c626dc\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -602,8 +602,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['767']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:53 GMT']
-      etag: [W/"f6c7e503-8e91-4195-adaf-5382ba3d57f8"]
+      date: ['Fri, 21 Sep 2018 21:59:41 GMT']
+      etag: [W/"67b67d8a-8301-43bf-a2bb-3193017d99c5"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -627,10 +627,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
-        ,\r\n  \"etag\": \"W/\\\"9903ccd6-10b5-4fb2-8925-15befa167a7c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"32106eb7-866f-4bf6-b9ff-38b31821a1ca\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"111e800e-15af-4d48-8a65-f73860889e64\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"3f9da9be-7864-4d5b-bd05-011c1e244e33\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -640,8 +640,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['767']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:54 GMT']
-      etag: [W/"9903ccd6-10b5-4fb2-8925-15befa167a7c"]
+      date: ['Fri, 21 Sep 2018 21:59:43 GMT']
+      etag: [W/"32106eb7-866f-4bf6-b9ff-38b31821a1ca"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -671,7 +671,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"peering2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
-        ,\r\n  \"etag\": \"W/\\\"ae90fba5-59e1-47f7-8a8c-0220286845b1\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"142d3481-1ad7-4a35-ab09-1f848b8d0c8f\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringState\": \"Initiated\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
@@ -682,17 +682,17 @@ interactions:
         : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
         \r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2b5f3d02-fbf7-4514-8889-bafb5492ca2f?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c1199ff3-ced2-4e25-abea-c31b91f92bc8?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['1005']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:39:56 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -705,14 +705,14 @@ interactions:
           msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2b5f3d02-fbf7-4514-8889-bafb5492ca2f?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c1199ff3-ced2-4e25-abea-c31b91f92bc8?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:08 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -735,7 +735,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"peering2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
-        ,\r\n  \"etag\": \"W/\\\"25cf4bbf-b1f8-4b19-91d7-3559d7b28e55\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"b546d811-2576-49f9-8580-025e1164ad95\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringState\": \"Initiated\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
@@ -749,8 +749,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1006']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:09 GMT']
-      etag: [W/"25cf4bbf-b1f8-4b19-91d7-3559d7b28e55"]
+      date: ['Fri, 21 Sep 2018 21:59:56 GMT']
+      etag: [W/"b546d811-2576-49f9-8580-025e1164ad95"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -780,7 +780,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
-        ,\r\n  \"etag\": \"W/\\\"1b7e597a-2429-4cd8-88e9-c0dc2b9cedec\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"cfe34148-3486-4954-a3d0-364b29231832\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
@@ -791,17 +791,17 @@ interactions:
         : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
         \r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9b819033-72d0-497d-9193-01a4ca24d3dc?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c49f978a-63f2-4c66-ab87-81be467380eb?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['1005']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:12 GMT']
+      date: ['Fri, 21 Sep 2018 21:59:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -814,14 +814,14 @@ interactions:
           msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9b819033-72d0-497d-9193-01a4ca24d3dc?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c49f978a-63f2-4c66-ab87-81be467380eb?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:22 GMT']
+      date: ['Fri, 21 Sep 2018 22:00:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -844,7 +844,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
-        ,\r\n  \"etag\": \"W/\\\"bfa590ed-a888-4703-be12-03c0b13543b6\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"3ddcf4e3-56ca-4d36-9768-37eaf1396e9a\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
@@ -858,8 +858,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1006']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:23 GMT']
-      etag: [W/"bfa590ed-a888-4703-be12-03c0b13543b6"]
+      date: ['Fri, 21 Sep 2018 22:00:10 GMT']
+      etag: [W/"3ddcf4e3-56ca-4d36-9768-37eaf1396e9a"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -883,7 +883,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
-        ,\r\n  \"etag\": \"W/\\\"bfa590ed-a888-4703-be12-03c0b13543b6\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"3ddcf4e3-56ca-4d36-9768-37eaf1396e9a\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
@@ -897,8 +897,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1006']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:24 GMT']
-      etag: [W/"bfa590ed-a888-4703-be12-03c0b13543b6"]
+      date: ['Fri, 21 Sep 2018 22:00:12 GMT']
+      etag: [W/"3ddcf4e3-56ca-4d36-9768-37eaf1396e9a"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -923,7 +923,7 @@ interactions:
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"peering2\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
-        ,\r\n      \"etag\": \"W/\\\"4887efba-ccd1-440e-b2af-784d9ae5de39\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"0bfc093c-f9c3-47bf-b34d-b42dbb7a51e5\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"peeringState\": \"Connected\",\r\n        \"remoteVirtualNetwork\"\
         : {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
@@ -938,7 +938,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1123']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:26 GMT']
+      date: ['Fri, 21 Sep 2018 22:00:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -964,12 +964,12 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/af829f11-68a9-419b-831d-cd10c5aa3d50?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5a02ae2b-63b6-4392-91d6-d9f9b0228f1a?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 21 Sep 2018 00:40:28 GMT']
+      date: ['Fri, 21 Sep 2018 22:00:14 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/af829f11-68a9-419b-831d-cd10c5aa3d50?api-version=2018-08-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/5a02ae2b-63b6-4392-91d6-d9f9b0228f1a?api-version=2018-08-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -987,14 +987,14 @@ interactions:
           msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/af829f11-68a9-419b-831d-cd10c5aa3d50?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5a02ae2b-63b6-4392-91d6-d9f9b0228f1a?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:38 GMT']
+      date: ['Fri, 21 Sep 2018 22:00:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1022,7 +1022,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['19']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:40 GMT']
+      date: ['Fri, 21 Sep 2018 22:00:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1048,12 +1048,12 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2b668e12-1538-4c58-93c0-7fbc004a85a2?api-version=2018-08-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce82408c-b2ce-42c3-9efb-7883fa1501c3?api-version=2018-08-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 21 Sep 2018 00:40:40 GMT']
+      date: ['Fri, 21 Sep 2018 22:00:28 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/2b668e12-1538-4c58-93c0-7fbc004a85a2?api-version=2018-08-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/ce82408c-b2ce-42c3-9efb-7883fa1501c3?api-version=2018-08-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1071,14 +1071,14 @@ interactions:
           msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
           AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2b668e12-1538-4c58-93c0-7fbc004a85a2?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce82408c-b2ce-42c3-9efb-7883fa1501c3?api-version=2018-08-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 21 Sep 2018 00:40:52 GMT']
+      date: ['Fri, 21 Sep 2018 22:00:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1107,9 +1107,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 21 Sep 2018 00:40:53 GMT']
+      date: ['Fri, 21 Sep 2018 22:00:41 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6MkRURVNUOjVGVk5FVDo1RlBFRVJJTkc6NUZHUk9VUDo1RjFCWk00N0dYSXxBN0RBM0JDMUUxNzNBQzZFLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6MkRURVNUOjVGVk5FVDo1RlBFRVJJTkc6NUZHUk9VUDo1RjFLRFJCS1ZLM3w3MjYzQUYxMUM1MzhCRDA3LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
@@ -1135,12 +1135,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 21 Sep 2018 00:40:54 GMT']
+      date: ['Fri, 21 Sep 2018 22:00:43 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6MkRURVNUOjVGVk5FVDo1RlBFRVJJTkc6NUZHUk9VUDo1RjJLN0RMU0oyQnxBOTVGQTQ5NzBGMzE2Nzg1LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6MkRURVNUOjVGVk5FVDo1RlBFRVJJTkc6NUZHUk9VUDo1RjJGVTZNNElNNHwzNkEzMzJBNkRBRjVDRUE5LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-deletes: ['14998']
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering_different_resource_groups.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_vnet_peering_different_resource_groups.yaml
@@ -1,0 +1,1146 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2018-09-21T00:38:39Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_2000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001","name":"cli-test_vnet_peering_group_2000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:39Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:38:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2018-09-21T00:38:43Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_1000002?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002","name":"cli-test_vnet_peering_group_1000002","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:43Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:38:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_1000002?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002","name":"cli-test_vnet_peering_group_1000002","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:43Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:38:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "dhcpOptions": {}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Length: ['123']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        ,\r\n  \"etag\": \"W/\\\"c902517b-52b0-4d05-9dc9-bf05c9aca500\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"335d5289-247f-4b05-90cf-fab9684ae197\"\
+        ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
+        10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
+        : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
+        \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
+        : false\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/15c4a92a-c883-42bd-a7b4-caa2cdb79744?api-version=2018-08-01']
+      cache-control: [no-cache]
+      content-length: ['766']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:38:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/15c4a92a-c883-42bd-a7b4-caa2cdb79744?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:38:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/15c4a92a-c883-42bd-a7b4-caa2cdb79744?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:00 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        ,\r\n  \"etag\": \"W/\\\"f6c7e503-8e91-4195-adaf-5382ba3d57f8\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"335d5289-247f-4b05-90cf-fab9684ae197\"\
+        ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
+        10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
+        : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
+        \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
+        : false\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:01 GMT']
+      etag: [W/"f6c7e503-8e91-4195-adaf-5382ba3d57f8"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_2000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001","name":"cli-test_vnet_peering_group_2000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:39Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:02 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["11.0.0.0/16"]}, "dhcpOptions": {}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Length: ['123']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        ,\r\n  \"etag\": \"W/\\\"96ecc711-7d93-477f-a362-c7e1949d3915\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"111e800e-15af-4d48-8a65-f73860889e64\"\
+        ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
+        11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
+        : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
+        \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
+        : false\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f1a09156-c009-4aa7-b369-ed4d64bfa125?api-version=2018-08-01']
+      cache-control: [no-cache]
+      content-length: ['766']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f1a09156-c009-4aa7-b369-ed4d64bfa125?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f1a09156-c009-4aa7-b369-ed4d64bfa125?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        ,\r\n  \"etag\": \"W/\\\"9903ccd6-10b5-4fb2-8925-15befa167a7c\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"111e800e-15af-4d48-8a65-f73860889e64\"\
+        ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
+        11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
+        : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
+        \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
+        : false\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:40 GMT']
+      etag: [W/"9903ccd6-10b5-4fb2-8925-15befa167a7c"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_2000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001","name":"cli-test_vnet_peering_group_2000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-09-21T00:38:39Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "sku": {"name": "Basic"}, "properties": {"publicIPAllocationMethod":
+      "Dynamic", "publicIPAddressVersion": "IPv4", "idleTimeoutInMinutes": 4}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip create]
+      Connection: [keep-alive]
+      Content-Length: ['164']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
+        ,\r\n  \"etag\": \"W/\\\"7a6e7c6d-eff5-4f81-9ba9-978e023a07fe\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"1583e8ce-9c9c-475c-86fa-37bdfce33e57\"\
+        ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
+        : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\
+        \n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
+        : {\r\n    \"name\": \"Basic\",\r\n    \"tier\": \"Regional\"\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b7f5de4f-5cf0-4d28-89ec-ca631a63950c?api-version=2018-08-01']
+      cache-control: [no-cache]
+      content-length: ['679']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b7f5de4f-5cf0-4d28-89ec-ca631a63950c?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
+        ,\r\n  \"etag\": \"W/\\\"3541d6d5-6360-4fff-889e-37e2b43081a2\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"1583e8ce-9c9c-475c-86fa-37bdfce33e57\"\
+        ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
+        : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\
+        \n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
+        : {\r\n    \"name\": \"Basic\",\r\n    \"tier\": \"Regional\"\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['680']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:48 GMT']
+      etag: [W/"3541d6d5-6360-4fff-889e-37e2b43081a2"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip show]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\
+        ,\r\n  \"etag\": \"W/\\\"3541d6d5-6360-4fff-889e-37e2b43081a2\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"1583e8ce-9c9c-475c-86fa-37bdfce33e57\"\
+        ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
+        : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\
+        \n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
+        : {\r\n    \"name\": \"Basic\",\r\n    \"tier\": \"Regional\"\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['680']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:49 GMT']
+      etag: [W/"3541d6d5-6360-4fff-889e-37e2b43081a2"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet show]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        ,\r\n  \"etag\": \"W/\\\"9903ccd6-10b5-4fb2-8925-15befa167a7c\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"111e800e-15af-4d48-8a65-f73860889e64\"\
+        ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
+        11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
+        : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
+        \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
+        : false\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:50 GMT']
+      etag: [W/"9903ccd6-10b5-4fb2-8925-15befa167a7c"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet show]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        ,\r\n  \"etag\": \"W/\\\"f6c7e503-8e91-4195-adaf-5382ba3d57f8\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"335d5289-247f-4b05-90cf-fab9684ae197\"\
+        ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
+        10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
+        : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
+        \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
+        : false\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:53 GMT']
+      etag: [W/"f6c7e503-8e91-4195-adaf-5382ba3d57f8"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet show]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        ,\r\n  \"etag\": \"W/\\\"9903ccd6-10b5-4fb2-8925-15befa167a7c\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"111e800e-15af-4d48-8a65-f73860889e64\"\
+        ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
+        11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
+        : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
+        \ [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\"\
+        : false\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:54 GMT']
+      etag: [W/"9903ccd6-10b5-4fb2-8925-15befa167a7c"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''b\''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2",
+      "properties": {"allowVirtualNetworkAccess": false, "allowForwardedTraffic":
+      false, "allowGatewayTransit": true, "useRemoteGateways": false, "remoteVirtualNetwork":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1"}},
+      "name": "peering2"}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering create]
+      Connection: [keep-alive]
+      Content-Length: ['591']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"peering2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
+        ,\r\n  \"etag\": \"W/\\\"ae90fba5-59e1-47f7-8a8c-0220286845b1\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
+        peeringState\": \"Initiated\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        \r\n    },\r\n    \"allowVirtualNetworkAccess\": false,\r\n    \"allowForwardedTraffic\"\
+        : false,\r\n    \"allowGatewayTransit\": true,\r\n    \"useRemoteGateways\"\
+        : false,\r\n    \"remoteAddressSpace\": {\r\n      \"addressPrefixes\": [\r\
+        \n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"routeServiceVips\"\
+        : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
+        \r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2b5f3d02-fbf7-4514-8889-bafb5492ca2f?api-version=2018-08-01']
+      cache-control: [no-cache]
+      content-length: ['1005']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:39:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2b5f3d02-fbf7-4514-8889-bafb5492ca2f?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"peering2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
+        ,\r\n  \"etag\": \"W/\\\"25cf4bbf-b1f8-4b19-91d7-3559d7b28e55\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        peeringState\": \"Initiated\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        \r\n    },\r\n    \"allowVirtualNetworkAccess\": false,\r\n    \"allowForwardedTraffic\"\
+        : false,\r\n    \"allowGatewayTransit\": true,\r\n    \"useRemoteGateways\"\
+        : false,\r\n    \"remoteAddressSpace\": {\r\n      \"addressPrefixes\": [\r\
+        \n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"routeServiceVips\"\
+        : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1006']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:09 GMT']
+      etag: [W/"25cf4bbf-b1f8-4b19-91d7-3559d7b28e55"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''b\''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1",
+      "properties": {"allowVirtualNetworkAccess": false, "allowForwardedTraffic":
+      true, "allowGatewayTransit": false, "useRemoteGateways": false, "remoteVirtualNetwork":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2"}},
+      "name": "peering1"}\'''''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering create]
+      Connection: [keep-alive]
+      Content-Length: ['591']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
+        ,\r\n  \"etag\": \"W/\\\"1b7e597a-2429-4cd8-88e9-c0dc2b9cedec\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
+        peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        \r\n    },\r\n    \"allowVirtualNetworkAccess\": false,\r\n    \"allowForwardedTraffic\"\
+        : true,\r\n    \"allowGatewayTransit\": false,\r\n    \"useRemoteGateways\"\
+        : false,\r\n    \"remoteAddressSpace\": {\r\n      \"addressPrefixes\": [\r\
+        \n        \"11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"routeServiceVips\"\
+        : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
+        \r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9b819033-72d0-497d-9193-01a4ca24d3dc?api-version=2018-08-01']
+      cache-control: [no-cache]
+      content-length: ['1005']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9b819033-72d0-497d-9193-01a4ca24d3dc?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
+        ,\r\n  \"etag\": \"W/\\\"bfa590ed-a888-4703-be12-03c0b13543b6\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        \r\n    },\r\n    \"allowVirtualNetworkAccess\": false,\r\n    \"allowForwardedTraffic\"\
+        : true,\r\n    \"allowGatewayTransit\": false,\r\n    \"useRemoteGateways\"\
+        : false,\r\n    \"remoteAddressSpace\": {\r\n      \"addressPrefixes\": [\r\
+        \n        \"11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"routeServiceVips\"\
+        : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1006']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:23 GMT']
+      etag: [W/"bfa590ed-a888-4703-be12-03c0b13543b6"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering show]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"peering1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1\"\
+        ,\r\n  \"etag\": \"W/\\\"bfa590ed-a888-4703-be12-03c0b13543b6\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        peeringState\": \"Connected\",\r\n    \"remoteVirtualNetwork\": {\r\n    \
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2\"\
+        \r\n    },\r\n    \"allowVirtualNetworkAccess\": false,\r\n    \"allowForwardedTraffic\"\
+        : true,\r\n    \"allowGatewayTransit\": false,\r\n    \"useRemoteGateways\"\
+        : false,\r\n    \"remoteAddressSpace\": {\r\n      \"addressPrefixes\": [\r\
+        \n        \"11.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"routeServiceVips\"\
+        : {}\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
+        \r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1006']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:24 GMT']
+      etag: [W/"bfa590ed-a888-4703-be12-03c0b13543b6"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering list]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"peering2\",\r\
+        \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2\"\
+        ,\r\n      \"etag\": \"W/\\\"4887efba-ccd1-440e-b2af-784d9ae5de39\\\"\",\r\
+        \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
+        ,\r\n        \"peeringState\": \"Connected\",\r\n        \"remoteVirtualNetwork\"\
+        : {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        \r\n        },\r\n        \"allowVirtualNetworkAccess\": false,\r\n      \
+        \  \"allowForwardedTraffic\": false,\r\n        \"allowGatewayTransit\": true,\r\
+        \n        \"useRemoteGateways\": false,\r\n        \"remoteAddressSpace\"\
+        : {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n\
+        \          ]\r\n        },\r\n        \"routeServiceVips\": {}\r\n      },\r\
+        \n      \"type\": \"Microsoft.Network/virtualNetworks/virtualNetworkPeerings\"\
+        \r\n    }\r\n  ]\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1123']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peering1?api-version=2018-08-01
+  response:
+    body: {string: ''}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/af829f11-68a9-419b-831d-cd10c5aa3d50?api-version=2018-08-01']
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 21 Sep 2018 00:40:28 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/af829f11-68a9-419b-831d-cd10c5aa3d50?api-version=2018-08-01']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering delete]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/af829f11-68a9-419b-831d-cd10c5aa3d50?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering list]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_1000002/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"value\": []\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['19']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test_vnet_peering_group_2000001/providers/Microsoft.Network/virtualNetworks/vnet2/virtualNetworkPeerings/peering2?api-version=2018-08-01
+  response:
+    body: {string: ''}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2b668e12-1538-4c58-93c0-7fbc004a85a2?api-version=2018-08-01']
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 21 Sep 2018 00:40:40 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/2b668e12-1538-4c58-93c0-7fbc004a85a2?api-version=2018-08-01']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet peering delete]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2b668e12-1538-4c58-93c0-7fbc004a85a2?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 21 Sep 2018 00:40:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_1000002?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 21 Sep 2018 00:40:53 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6MkRURVNUOjVGVk5FVDo1RlBFRVJJTkc6NUZHUk9VUDo1RjFCWk00N0dYSXxBN0RBM0JDMUUxNzNBQzZFLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-test_vnet_peering_group_2000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 21 Sep 2018 00:40:54 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6MkRURVNUOjVGVk5FVDo1RlBFRVJJTkc6NUZHUk9VUDo1RjJLN0RMU0oyQnxBOTVGQTQ5NzBGMzE2Nzg1LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14998']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -1649,12 +1649,12 @@ class NetworkVNetPeeringScenarioTest(ScenarioTest):
             'vnet2_id': vnet2_id
         })
         # set up gateway sharing from vnet1 to vnet2
-        self.cmd('network vnet peering create -g {rg} -n peering2 --vnet-name vnet2 --remote-vnet-id {vnet1_id} --allow-gateway-transit', checks=[
+        self.cmd('network vnet peering create -g {rg} -n peering2 --vnet-name vnet2 --remote-vnet {vnet1_id} --allow-gateway-transit', checks=[
             self.check('allowGatewayTransit', True),
             self.check('remoteVirtualNetwork.id', '{vnet1_id}'),
             self.check('peeringState', 'Initiated')
         ])
-        self.cmd('network vnet peering create -g {rg} -n peering1 --vnet-name vnet1 --remote-vnet-id {vnet2_id} --use-remote-gateways --allow-forwarded-traffic', checks=[
+        self.cmd('network vnet peering create -g {rg} -n peering1 --vnet-name vnet1 --remote-vnet {vnet2_id} --use-remote-gateways --allow-forwarded-traffic', checks=[
             self.check('useRemoteGateways', True),
             self.check('remoteVirtualNetwork.id', '{vnet2_id}'),
             self.check('peeringState', 'Connected'),
@@ -1677,6 +1677,63 @@ class NetworkVNetPeeringScenarioTest(ScenarioTest):
         self.cmd('network vnet peering delete -g {rg} -n peering2 --vnet-name vnet2')
         self.cmd('network vnet-gateway delete -g {rg} -n gateway1')
 
+    @ResourceGroupPreparer(name_prefix='cli-test_vnet_peering_group_2', parameter_name='resource_group_2')
+    @ResourceGroupPreparer(name_prefix='cli-test_vnet_peering_group_1', parameter_name='resource_group_1')
+    def test_network_vnet_peering_different_resource_groups(self, resource_group_1, resource_group_2):
+
+        self.kwargs.update({
+            'rg_1': resource_group_1,
+            'rg_2': resource_group_2
+        })
+
+        # create two vnets with non-overlapping prefixes
+        self.cmd('network vnet create -g {rg_1} -n vnet1')
+        self.cmd('network vnet create -g {rg_2} -n vnet2 --address-prefix 11.0.0.0/16 ')
+
+        # create supporting resources for gateway
+        self.cmd('network public-ip create -g {rg_2} -n ip1')
+        ip_id = self.cmd('network public-ip show -g {rg_2} -n ip1 --query id').get_output_in_json()
+        vnet_id = self.cmd('network vnet show -g {rg_2} -n vnet2 --query id').get_output_in_json()
+
+        self.kwargs.update({
+            'ip_id': ip_id,
+            'vnet_id': vnet_id
+        })
+
+        vnet1_id = self.cmd('network vnet show -g {rg_1} -n vnet1 --query id').get_output_in_json()
+        vnet2_id = self.cmd('network vnet show -g {rg_2} -n vnet2 --query id').get_output_in_json()
+
+        self.kwargs.update({
+            'vnet1_id': vnet1_id,
+            'vnet2_id': vnet2_id
+        })
+        # set up gateway sharing from vnet1 to vnet2
+        self.cmd('network vnet peering create -g {rg_2} -n peering2 --vnet-name vnet2 --remote-vnet vnet1 --remote-vnet-rg {rg_1} --allow-gateway-transit', checks=[
+            self.check('allowGatewayTransit', True),
+            self.check('remoteVirtualNetwork.id', '{vnet1_id}'),
+            self.check('remoteVirtualNetwork.resourceGroup', '{rg_1}'),
+            self.check('name','peering2'),
+            self.check('peeringState', 'Initiated')
+        ])
+        self.cmd('network vnet peering create -g {rg_1} -n peering1 --vnet-name vnet1 --remote-vnet {vnet2_id} --allow-forwarded-traffic', checks=[
+            self.check('remoteVirtualNetwork.id', '{vnet2_id}'),
+            self.check('remoteVirtualNetwork.resourceGroup', '{rg_2}'),
+            self.check('name', 'peering1'),
+            self.check('peeringState', 'Connected'),
+            self.check('allowVirtualNetworkAccess', False),
+            self.check('allowForwardedTraffic', True)
+        ])
+        self.cmd('network vnet peering show -g {rg_1} -n peering1 --vnet-name vnet1',
+                 checks=self.check('name', 'peering1'))
+        self.cmd('network vnet peering list -g {rg_2} --vnet-name vnet2', checks=[
+            self.check('[0].name', 'peering2'),
+            self.check('length(@)', 1)
+        ])
+        self.cmd('network vnet peering delete -g {rg_1} -n peering1 --vnet-name vnet1')
+        self.cmd('network vnet peering list -g {rg_1} --vnet-name vnet1',
+                 checks=self.is_empty())
+        # must delete the second peering and the gateway or the resource group delete will fail
+        self.cmd('network vnet peering delete -g {rg_2} -n peering2 --vnet-name vnet2')
 
 class NetworkVpnConnectionIpSecPolicy(ScenarioTest):
 


### PR DESCRIPTION
Addressed #7016:
- Deprecated `--remote-vnet-id` in favor of `--remote-vnet`. 
- Passing remote vnet's name instead of resource ID through `--remote-vnet` / ` --remote-vnet-id` does not crash CLI.
- Can also specify resource group of remote vnet if only name is provided through --remote-vnet-rg. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
