### PR TITLE
[vmss create] reserve large enough frontend port range for overprovision

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 2.2.4
 ++++++
-* `vmss create`: reserve large enough frontend port range for overprovision
+* `vmss create`: reserve large enough frontend port range to handle overprovisioning
 * `az sig`: fix update commands, support --no-wait on managing image versions
 * `vm list-ip-addresses`: now shows availability zone of public IP addresses.
 

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.2.4
 ++++++
+* `vmss create`: reserve large enough frontend port range for overprovision
 * `az sig`: fix update commands, support --no-wait on managing image versions
 * `vm list-ip-addresses`: now shows availability zone of public IP addresses.
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -525,8 +525,8 @@ def build_application_gateway_resource(_, name, location, tags, backend_pool_nam
 
 
 def build_load_balancer_resource(cmd, name, location, tags, backend_pool_name, nat_pool_name,
-                                 backend_port, frontend_ip_name, public_ip_id, subnet_id,
-                                 private_ip_address, private_ip_allocation, sku):
+                                 backend_port, frontend_ip_name, public_ip_id, subnet_id, private_ip_address,
+                                 private_ip_allocation, sku, instance_count, disable_overprovision):
     lb_id = "resourceId('Microsoft.Network/loadBalancers', '{}')".format(name)
 
     frontend_ip_config = _build_frontend_ip_config(frontend_ip_name, public_ip_id,
@@ -549,7 +549,9 @@ def build_load_balancer_resource(cmd, name, location, tags, backend_pool_name, n
                     },
                     'protocol': 'tcp',
                     'frontendPortRangeStart': '50000',
-                    'frontendPortRangeEnd': '50119',
+                    # keep 50119 as minimum for backward compat, and ensure over-provision is taken care of
+                    'frontendPortRangeEnd': str(max(50119,
+                                                    49999 + instance_count * (1 if disable_overprovision else 2))),
                     'backendPort': backend_port
                 }
             }

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1912,8 +1912,9 @@ def create_vmss(cmd, vmss_name, resource_group_name, image,
 
         lb_resource = build_load_balancer_resource(
             cmd, load_balancer, location, tags, backend_pool_name, nat_pool_name, backend_port,
-            'loadBalancerFrontEnd', public_ip_address_id, subnet_id,
-            private_ip_address='', private_ip_allocation='Dynamic', sku=load_balancer_sku)
+            'loadBalancerFrontEnd', public_ip_address_id, subnet_id, private_ip_address='',
+            private_ip_allocation='Dynamic', sku=load_balancer_sku, instance_count=instance_count,
+            disable_overprovision=disable_overprovision)
         lb_resource['dependsOn'] = lb_dependencies
         master_template.add_resource(lb_resource)
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_template_builder.py
@@ -1,0 +1,38 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+import mock
+
+from azure.cli.command_modules.vm._template_builder import build_load_balancer_resource
+
+
+class TestTemplateBuilder(unittest.TestCase):
+
+    @mock.patch('azure.cli.command_modules.vm._template_builder.get_target_network_api', autospec=True)
+    def test_build_load_balancer_resource(self, mock_get_api):
+        mock_get_api.returtn_value = '1970-01-01'
+        cmd_mock = mock.MagicMock()
+        cmd_mock.supported_api_version.return_value = False
+
+        result = build_load_balancer_resource(cmd_mock, 'lb1', 'westus', None, 'bepool1', 'natpool1', 'be_port',
+                                              'frontip', 'pip_id1', 'subnet_id1', 'private_ip_address', 'dynamic',
+                                              'basic', instance_count=1, disable_overprovision=False)
+        self.assertEqual(result['properties']['inboundNatPools'][0]['properties']['frontendPortRangeEnd'], '50119')
+
+        result = build_load_balancer_resource(cmd_mock, 'lb1', 'westus', None, 'bepool1', 'natpool1', 'be_port',
+                                              'frontip', 'pip_id1', 'subnet_id1', 'private_ip_address', 'dynamic',
+                                              'basic', instance_count=80, disable_overprovision=False)
+        self.assertEqual(result['properties']['inboundNatPools'][0]['properties']['frontendPortRangeEnd'], '50159')
+
+        result = build_load_balancer_resource(cmd_mock, 'lb1', 'westus', None, 'bepool1', 'natpool1', 'be_port',
+                                              'frontip', 'pip_id1', 'subnet_id1', 'private_ip_address', 'dynamic',
+                                              'basic', instance_count=80, disable_overprovision=True)
+        self.assertEqual(result['properties']['inboundNatPools'][0]['properties']['frontendPortRangeEnd'], '50119')
+
+        result = build_load_balancer_resource(cmd_mock, 'lb1', 'westus', None, 'bepool1', 'natpool1', 'be_port',
+                                              'frontip', 'pip_id1', 'subnet_id1', 'private_ip_address', 'dynamic',
+                                              'basic', instance_count=140, disable_overprovision=True)
+        self.assertEqual(result['properties']['inboundNatPools'][0]['properties']['frontendPortRangeEnd'], '50139')


### PR DESCRIPTION

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
