### PR TITLE
Cleared up inconsistent language.

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -207,7 +207,7 @@ helps['aks create'] = """
                         For example, 10.0.0.10.
         - name: --docker-bridge-address
           type: string
-          short-summary: A CIDR notation IP range assigned to the Docker bridge.
+          short-summary: A specific IP address and netmask for the Docker bridge, using standard CIDR notation.
           long-summary: This address must not be in any Subnet IP ranges, or the Kubernetes service address range.
                         For example, 172.17.0.1/16.
         - name: --enable-addons -a

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -207,7 +207,7 @@ helps['aks create'] = """
                         For example, 10.0.0.10.
         - name: --docker-bridge-address
           type: string
-          short-summary: An IP address and netmask assigned to the Docker bridge.
+          short-summary: A CIDR notation IP range assigned to the Docker bridge.
           long-summary: This address must not be in any Subnet IP ranges, or the Kubernetes service address range.
                         For example, 172.17.0.1/16.
         - name: --enable-addons -a


### PR DESCRIPTION
The short descriptions for ```--service-cidr``` and ```--docker-bridge-address``` are inconsistent. Both require a CIDR notation IP range. However, while the description of ```--service-cidr``` call it a CIDR notation IP range in the ```--docker-bridge-address``` description it is mentioned as an IP address and netmask. I've noticed this creates confusion among less experienced users.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
