### PR TITLE
Minimize permissions given to install script

### DIFF
--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -28,6 +28,6 @@ then
   echo "If python is available on the system, add it to PATH. For example 'sudo ln -s /usr/bin/python3 /usr/bin/python'"
   exit 1
 fi
-chmod 775 $install_script
+chmod u+rx $install_script
 echo "Running install script."
 $install_script < $_TTY


### PR DESCRIPTION
Modify the chmod(1) call to grant only the minimum permissions necessary to execute the install script.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
