### PR TITLE
[Network] Add support for multiple address prefixes on a subnet

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -352,6 +352,13 @@ class AzArgumentContext(ArgumentsContext):
         base = base_kwargs if base_kwargs is not None else getattr(self, 'group_kwargs')
         return merge_kwargs(kwargs, base, CLI_PARAM_KWARGS)
 
+    def _ignore_if_not_registered(self, dest):
+        scope = self.scope
+        arg_registry = self.command_loader.argument_registry
+        match = arg_registry.arguments[scope].get(dest, {})
+        if not match:
+            super(AzArgumentContext, self).argument(dest, arg_type=ignore_type)
+
     # pylint: disable=arguments-differ
     def argument(self, dest, arg_type=None, **kwargs):
         self._check_stale()
@@ -373,7 +380,7 @@ class AzArgumentContext(ArgumentsContext):
                                                      operation_group=operation_group):
             super(AzArgumentContext, self).argument(dest, **merged_kwargs)
         else:
-            super(AzArgumentContext, self).argument(dest, arg_type=ignore_type)
+            self._ignore_if_not_registered(dest)
 
     def positional(self, dest, arg_type=None, **kwargs):
         self._check_stale()
@@ -406,7 +413,7 @@ class AzArgumentContext(ArgumentsContext):
                                                      operation_group=operation_group):
             super(AzArgumentContext, self).argument(dest, **merged_kwargs)
         else:
-            super(AzArgumentContext, self).argument(dest, arg_type=ignore_type)
+            self._ignore_if_not_registered(dest)
 
     def expand(self, dest, model_type, group_name=None, patches=None):
         # TODO:

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -7,6 +7,8 @@ Release History
 +++++
 * Fix `network dns zone create`. Command succeeds even if the user has configured a default location. See #6052.
 * `network vnet peering create`: Deprecated `--remote-vnet-id`. Added --remote-vnet which accepts a name or ID.
+* `network vnet create`: Added support for multiple subnet prefixes with `--subnet-prefixes`.
+* `network vnet subnet create/update`: Added support for multiple subnet prefixes with `--address-prefixes`.
 
 2.2.5
 +++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -939,9 +939,12 @@ def load_arguments(self, _):
 
     with self.argument_context('network vnet create') as c:
         c.argument('location', get_location_type(self.cli_ctx))
-        c.argument('subnet_name', help='Name of a new subnet to create within the VNet.')
-        c.argument('subnet_prefix', help='IP address prefix for the new subnet. If omitted, automatically reserves a /24 (or as large as available) block within the VNet address space.', metavar='PREFIX')
         c.argument('vnet_name', virtual_network_name_type, options_list=('--name', '-n'), completer=None)
+
+    with self.argument_context('network vnet create', arg_group='Subnet') as c:
+        c.argument('subnet_name', help='Name of a new subnet to create within the VNet.')
+        c.argument('subnet_prefix', help='IP address prefix for the new subnet. If omitted, automatically reserves a /24 (or as large as available) block within the VNet address space.', metavar='PREFIX', max_api='2018-07-01')
+        c.argument('subnet_prefix', options_list='--subnet-prefixes', nargs='+', min_api='2018-08-01', help='Space-separated list of address prefixes in CIDR format for the new subnet. If omitted, automatically reserves a /24 (or as large as available) block within the VNet address space.', metavar='PREFIXES')
 
     with self.argument_context('network vnet update') as c:
         c.argument('address_prefixes', nargs='+')
@@ -959,7 +962,8 @@ def load_arguments(self, _):
 
     with self.argument_context('network vnet subnet') as c:
         c.argument('subnet_name', arg_type=subnet_name_type, options_list=('--name', '-n'), id_part='child_name_1')
-        c.argument('address_prefix', metavar='PREFIX', help='the address prefix in CIDR format.')
+        c.argument('address_prefix', metavar='PREFIX', help='Address prefix in CIDR format.', max_api='2018-07-01')
+        c.argument('address_prefix', metavar='PREFIXES', options_list='--address-prefixes', nargs='+', help='Space-separated list of address prefixes in CIDR format.', min_api='2018-08-01')
         c.argument('virtual_network_name', virtual_network_name_type)
         c.argument('network_security_group', validator=get_nsg_validator(), help='Name or ID of a network security group (NSG).')
         c.argument('route_table', help='Name or ID of a route table to associate with the subnet.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -781,7 +781,10 @@ def process_vnet_create_namespace(cmd, namespace):
     validate_tags(namespace)
 
     if namespace.subnet_prefix and not namespace.subnet_name:
-        raise ValueError('incorrect usage: --subnet-name NAME [--subnet-prefix PREFIX]')
+        if cmd.supported_api_version(min_api='2018-08-01'):
+            raise ValueError('incorrect usage: --subnet-name NAME [--subnet-prefixes PREFIXES]')
+        else:
+            raise ValueError('incorrect usage: --subnet-name NAME [--subnet-prefix PREFIX]')
 
     if namespace.subnet_name and not namespace.subnet_prefix:
         if isinstance(namespace.vnet_prefixes, str):
@@ -790,7 +793,8 @@ def process_vnet_create_namespace(cmd, namespace):
         address = prefix_components[0]
         bit_mask = int(prefix_components[1])
         subnet_mask = 24 if bit_mask < 24 else bit_mask
-        namespace.subnet_prefix = '{}/{}'.format(address, subnet_mask)
+        subnet_prefix = '{}/{}'.format(address, subnet_mask)
+        namespace.subnet_prefix = [subnet_prefix] if cmd.supported_api_version(min_api='2018-08-01') else subnet_prefix
 
 
 def process_vnet_gateway_create_namespace(cmd, namespace):


### PR DESCRIPTION
Closes #7318.

Updates the subnet create/update command and vnet create command to allow multiple subnet prefixes. This is currently blocked behind a feature flag, so some logic is required to populate *either* the `address_prefix` or `address_prefixes` property. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
