### PR TITLE
[Core] Add bot service to azure-cli setup

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -58,6 +58,7 @@ DEPENDENCIES = [
     'azure-cli-batchai',
     'azure-cli-backup',
     'azure-cli-billing',
+    'azure-cli-botservice',
     'azure-cli-cdn',
     'azure-cli-cloud',
     'azure-cli-cognitiveservices',


### PR DESCRIPTION
Closes https://github.com/Azure/azure-cli/issues/7448.

The homebrew formula generating process fails to bring in `azure-mgmt-botservice` dependency because of this missing reference.