### PR TITLE
Fix Issue 7409 (az storage cors list missing "Service" field)

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+2.2.3
++++++
+* Fix `az storage cors list` output formatting, all items show correct "Service" key
+
 2.2.2
 +++++
 * `--auth-mode login` parameter allows use of user's login credentials for blob and queue authorization.

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
@@ -31,11 +31,9 @@ def transform_cors_list_output(result):
     from collections import OrderedDict
     new_result = []
     for service in sorted(result.keys()):
-        service_name = service
         for i, rule in enumerate(result[service]):
             new_entry = OrderedDict()
-            new_entry['Service'] = service_name
-            service_name = ''
+            new_entry['Service'] = service
             new_entry['Rule'] = i + 1
 
             new_entry['AllowedMethods'] = ', '.join((x for x in rule.allowed_methods))

--- a/src/command_modules/azure-cli-storage/setup.py
+++ b/src/command_modules/azure-cli-storage/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.2.2"
+VERSION = "2.2.3"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
This PR fixes the issue #7409 https://github.com/Azure/azure-cli/issues/7409.

Steps to reproduce the issue:

1. Set AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY variables (refer to the documentation if necessary: https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-cli)

1. Add 2 or more CORS rules of same type (here are file rules from original issue).

```
#!/bin/bash

az storage cors clear --services f

az storage cors add \
	--allowed-headers "x-api-key" \
       	--methods GET \
       	--origins http://localhost:5000 \
       	--exposed-headers "x-ms-request-id, x-ms-lease-status" \
       	--max-age 10 \
       	--services f

az storage cors add \
	--allowed-headers "content-type" \
       	--methods GET \
       	--origins http://localhost:5001 \
       	--exposed-headers "x-*" \
       	--max-age 5 \
       	--services f

az storage cors add \
	--allowed-headers "x-api-key, x-app-*" \
       	--methods POST \
       	--origins http://localhost:5000 http://localhost:5001 \
       	--exposed-headers "*" \
       	--max-age 5 \
       	--services f

az storage cors add \
	--allowed-headers "*" \
       	--methods GET \
       	--origins "*" \
       	--exposed-headers "*" \
       	--max-age 30 \
       	--services f
```

1. Execute `az storage cors list`

# Example Output

```
[
  {
    "AllowedHeaders": "x-api-key",
    "AllowedMethods": "GET",
    "AllowedOrigins": "http://localhost:5000",
    "ExposedHeaders": "x-ms-request-id, x-ms-lease-status",
    "MaxAgeInSeconds": 10,
    "Rule": 1,
    "Service": "file"
  },
  {
    "AllowedHeaders": "content-type",
    "AllowedMethods": "GET",
    "AllowedOrigins": "http://localhost:5001",
    "ExposedHeaders": "x-*",
    "MaxAgeInSeconds": 5,
    "Rule": 2,
    "Service": ""
  },
  {
    "AllowedHeaders": "x-api-key, x-app-*",
    "AllowedMethods": "POST",
    "AllowedOrigins": "http://localhost:5000, http://localhost:5001",
    "ExposedHeaders": "*",
    "MaxAgeInSeconds": 5,
    "Rule": 3,
    "Service": ""
  },
  {
    "AllowedHeaders": "*",
    "AllowedMethods": "GET",
    "AllowedOrigins": "*",
    "ExposedHeaders": "*",
    "MaxAgeInSeconds": 30,
    "Rule": 4,
    "Service": ""
  }
]
```

# Expected Output

```
[
  {
    "AllowedHeaders": "x-api-key",
    "AllowedMethods": "GET",
    "AllowedOrigins": "http://localhost:5000",
    "ExposedHeaders": "x-ms-request-id, x-ms-lease-status",
    "MaxAgeInSeconds": 10,
    "Rule": 1,
    "Service": "file"
  },
  {
    "AllowedHeaders": "content-type",
    "AllowedMethods": "GET",
    "AllowedOrigins": "http://localhost:5001",
    "ExposedHeaders": "x-*",
    "MaxAgeInSeconds": 5,
    "Rule": 2,
    "Service": "file"
  },
  {
    "AllowedHeaders": "x-api-key, x-app-*",
    "AllowedMethods": "POST",
    "AllowedOrigins": "http://localhost:5000, http://localhost:5001",
    "ExposedHeaders": "*",
    "MaxAgeInSeconds": 5,
    "Rule": 3,
    "Service": "file"
  },
  {
    "AllowedHeaders": "*",
    "AllowedMethods": "GET",
    "AllowedOrigins": "*",
    "ExposedHeaders": "*",
    "MaxAgeInSeconds": 30,
    "Rule": 4,
    "Service": "file"
  }
]
```

# Comments

The problem was in the formatter function, which reset "Service" key output for each item except for the first one. I also removed unnecessary service_name variable

# Checklists

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

This PR does not change or add any functionality, bugfix only.

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

This PR does not change or add any functionality, bugfix only.