### PR TITLE
vm/vmss create: ensure caching mode is None for Lv/Lv2 machines

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.2.5
 ++++++
+* `vm/vmss create`: enforce disk caching mode be `None` for Lv/Lv2 series of machines
 * `vm create`: update supported size list supporting networking accelerator
 * `disk update`: expose strong typed arguments for ultrassd iops and mbps configs
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -458,7 +458,8 @@ def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):
 
     from ._vm_utils import normalize_disk_info
     # attach_data_disks are not exposed yet for VMSS, so use 'getattr' to avoid crash
-    namespace.disk_info = normalize_disk_info(size=(getattr(namespace, 'size', None) or getattr(namespace, 'vm_sku', None)),
+    vm_size = (getattr(namespace, 'size', None) or getattr(namespace, 'vm_sku', None))
+    namespace.disk_info = normalize_disk_info(size=vm_size,
                                               image_data_disks_num=image_data_disks_num,
                                               data_disk_sizes_gb=namespace.data_disk_sizes_gb,
                                               attach_data_disks=getattr(namespace, 'attach_data_disks', []),

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -458,7 +458,8 @@ def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):
 
     from ._vm_utils import normalize_disk_info
     # attach_data_disks are not exposed yet for VMSS, so use 'getattr' to avoid crash
-    namespace.disk_info = normalize_disk_info(image_data_disks_num=image_data_disks_num,
+    namespace.disk_info = normalize_disk_info(size=(getattr(namespace, 'size', None) or getattr(namespace, 'vm_sku', None)),
+                                              image_data_disks_num=image_data_disks_num,
                                               data_disk_sizes_gb=namespace.data_disk_sizes_gb,
                                               attach_data_disks=getattr(namespace, 'attach_data_disks', []),
                                               storage_sku=namespace.storage_sku,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import re
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -129,7 +130,8 @@ def list_sku_info(cli_ctx, location=None):
 
 
 def normalize_disk_info(image_data_disks_num=0, data_disk_sizes_gb=None, attach_data_disks=None, storage_sku=None,
-                        os_disk_caching=None, data_disk_cachings=None):
+                        os_disk_caching=None, data_disk_cachings=None, size=''):
+    is_lv_size = re.search('_L[0-9]+s', size, re.I)
     # we should return a dictionary with info like below and will emoit when see conflictions
     # {
     #   'os': { caching: 'Read', write_accelerator: None},
@@ -179,7 +181,13 @@ def normalize_disk_info(image_data_disks_num=0, data_disk_sizes_gb=None, attach_
     if os_disk_caching:
         info['os']['caching'] = os_disk_caching
     else:
-        info['os']['caching'] = 'ReadWrite'
+        info['os']['caching'] = 'None' if is_lv_size else 'ReadWrite'
+
+    # error out on invalid vm sizes
+    if is_lv_size:
+        for v in info.values():
+            if v.get('caching', 'None').lower() != 'none':
+                raise CLIError('usage error: for Lv/Lv2 series machines, disk caching mode must be set to "None"')
     return info
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -187,7 +187,7 @@ def normalize_disk_info(image_data_disks_num=0, data_disk_sizes_gb=None, attach_
     if is_lv_size:
         for v in info.values():
             if v.get('caching', 'None').lower() != 'none':
-                raise CLIError('usage error: for Lv/Lv2 series machines, disk caching mode must be set to "None"')
+                raise CLIError('usage error: for Lv series of machines, "None" is the only supported caching mode')
     return info
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_defaults.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_defaults.py
@@ -323,6 +323,7 @@ class TestVMImageDefaults(unittest.TestCase):
         ns.storage_sku = 'Premium_LRS'
         ns.os_caching, ns.data_caching = None, None
         ns.os_type, ns.attach_os_disk, ns.storage_account, ns.storage_container_name, ns.use_unmanaged_disk, ns.data_disk_sizes_gb = None, None, None, None, False, None
+        ns.size = 'Standard_DS1_v2'
         _validate_vm_create_storage_profile(cmd, ns, False)
 
         self.assertEqual(ns.os_type, 'someOS')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -382,6 +382,16 @@ class TestActions(unittest.TestCase):
             normalize_disk_info(data_disk_cachings=['0=None', '1=foo'])
         self.assertTrue("data disk with lun of '0' doesn't exist" in str(err.exception))
 
+        # default to "None" across for Lv/Lv2 machines
+        r = normalize_disk_info(data_disk_sizes_gb=[1], size='standard_L8s')
+        self.assertEqual(r['os']['caching'], CachingTypes.none.value)
+        self.assertEqual(r[0].get('caching'), None)
+
+        # error on lv/lv2 machines with caching mode other than "None"
+        with self.assertRaises(CLIError) as err:
+            normalize_disk_info(data_disk_cachings=['ReadWrite'], data_disk_sizes_gb=[1, 2], size='standard_L16s_v2')
+        self.assertTrue('for Lv/Lv2 series machines, disk caching mode must be set to "None"' in str(err.exception))
+
     @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
     def test_validate_vm_vmss_accelerated_networking(self, client_factory_mock):
         client_mock, size_mock = mock.MagicMock(), mock.MagicMock()

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -390,7 +390,7 @@ class TestActions(unittest.TestCase):
         # error on lv/lv2 machines with caching mode other than "None"
         with self.assertRaises(CLIError) as err:
             normalize_disk_info(data_disk_cachings=['ReadWrite'], data_disk_sizes_gb=[1, 2], size='standard_L16s_v2')
-        self.assertTrue('for Lv/Lv2 series machines, disk caching mode must be set to "None"' in str(err.exception))
+        self.assertTrue('for Lv series of machines, "None" is the only supported caching mode' in str(err.exception))
 
     @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
     def test_validate_vm_vmss_accelerated_networking(self, client_factory_mock):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_defaults.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_defaults.py
@@ -323,6 +323,7 @@ class TestVMImageDefaults(unittest.TestCase):
         ns.storage_sku = 'Premium_LRS'
         ns.os_caching, ns.data_caching = None, None
         ns.os_type, ns.attach_os_disk, ns.storage_account, ns.storage_container_name, ns.use_unmanaged_disk, ns.data_disk_sizes_gb = None, None, None, None, False, None
+        ns.size = 'Standard_DS1_v2'
         _validate_vm_create_storage_profile(cmd, ns, False)
 
         self.assertEqual(ns.os_type, 'someOS')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/profile_2017_03_09/test_vm_defaults.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/profile_2017_03_09/test_vm_defaults.py
@@ -323,6 +323,7 @@ class TestVMImageDefaults(unittest.TestCase):
         ns.storage_sku = 'Premium_LRS'
         ns.os_caching, ns.data_caching = None, None
         ns.os_type, ns.attach_os_disk, ns.storage_account, ns.storage_container_name, ns.use_unmanaged_disk, ns.data_disk_sizes_gb = None, None, None, None, False, None
+        ns.size = 'Standard_DS1_v2'
         _validate_vm_create_storage_profile(cmd, ns, False)
 
         self.assertEqual(ns.os_type, 'someOS')


### PR DESCRIPTION
Compute service has no capacity to cross check the cache mode, hence they are asking CLI to do it

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
