### PR TITLE
[Monitor] Improve EventHub validation for `diagnostic-settings create`.

### DIFF
--- a/src/command_modules/azure-cli-monitor/HISTORY.rst
+++ b/src/command_modules/azure-cli-monitor/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.2.5
++++++
+* `monitor diagnostic-settings create`: Improve validation for arguments `--event-hub` and `--event-hub-rule`.
+
 0.2.4
 +++++
 * Minor fixes

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
@@ -227,11 +227,12 @@ helps['monitor metrics alert create'] = """
         - name: Create a high CPU usage alert on a VM with no actions.
           text: >
             az monitor metrics alert create -n alert1 -g {ResourceGroup} --scopes {VirtualMachineID} --condition "avg Percentage CPU > 90"
+            --description "High CPU"
         - name: Create a high CPU usage alert on a VM with email and webhook actions.
           text: |
             az monitor metrics alert create -n alert1 -g {ResourceGroup} --scopes {VirtualMachineID} \\
                 --condition "avg Percentage CPU > 90" --window-size 5m --evaluation-frequency 1m \\
-                --action {actionGroupId} apiKey={APIKey} type=HighCPU
+                --action {actionGroupId} apiKey={APIKey} type=HighCPU --description "High CPU"
         - name: Create an alert when a storage account shows a high number of slow transactions, using multi-dimensional filters.
           text: |
             az monitor metrics alert create -g {ResourceGroup} -n alert1 --scopes {StorageAccountId} \\
@@ -349,10 +350,10 @@ helps['monitor diagnostic-settings create'] = """
                   short-summary: Name or ID of the Log Analytics workspace to send diagnostic logs to.
                 - name: --event-hub
                   type: string
-                  short-summary: The name of the event hub. If none is specified, the default event hub will be
-                                 selected.
+                  short-summary: >
+                    Name or ID an event hub. If none is specified, the default event hub will be selected.
                 - name: --event-hub-rule
-                  short-summary: The resource Id for the event hub authorization rule
+                  short-summary: Name or ID of the event hub authorization rule.
             """
 helps['monitor diagnostic-settings update'] = """
             type: command
@@ -817,6 +818,41 @@ helps['monitor activity-log alert scope remove'] = """
           short-summary: Name of the activity log alerts
         - name: --scope -s
           short-summary: The scopes to remove
+"""
+
+helps['monitor activity-log list'] = """
+    type: command
+    short-summary: List events from the activity log.
+    parameters:
+        - name: --filters
+          short-summary: >
+            The OData filter for the list activity logs. If this argument is provided OData Filter
+            Arguments will be ignored.
+        - name: --correlation-id
+          short-summary: Correlation ID of the query.
+        - name: --resource-group
+          short-summary: Resource group to query.
+        - name: --resource-id
+          short-summary: Identifier of the resource.
+        - name: --resource-provider
+          short-summary: Resource provider
+        - name: --start-time
+          short-summary: >
+            Start time of the query. ISO format with explicit indication of timezone: 1970-01-01T00:00:00Z,
+            1970-01-01T00:00:00-0500. Defaults to 1 Hour prior to the current time.
+        - name: --end-time
+          short-summary: >
+            End time of the query. ISO format with explicit indication of timezone: 1970-01-01T00:00:00Z,
+            1970-01-01T00:00:00-0500. Defaults to current time.
+        - name: --caller
+          short-summary: Caller to look for when querying.
+        - name: --status
+          short-summary: >
+            Status value to query (ex: Failed)
+        - name: --max-events
+          short-summary: Maximum number of records to be returned by the command.
+        - name: --select
+          short-summary: Space-separated list of event names to select.
 """
 
 helps['monitor activity-log list-categories'] = """

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
@@ -253,13 +253,13 @@ def load_arguments(self, _):
 
     with self.argument_context('monitor activity-log list', arg_group='OData Filter') as c:
         c.argument('correlation_id')
+        c.argument('caller')
         c.argument('resource_group')
         c.argument('resource_id')
         c.argument('resource_provider')
+        c.argument('status')
         c.argument('start_time')
         c.argument('end_time')
-        c.argument('caller')
-        c.argument('status')
     # endregion
 
     # region ActionGroup

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/activity_log.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/activity_log.py
@@ -9,24 +9,6 @@ from azure.cli.command_modules.monitor.util import validate_time_range_and_add_d
 def list_activity_log(client, filters=None, correlation_id=None, resource_group=None, resource_id=None,
                       resource_provider=None, start_time=None, end_time=None, caller=None, status=None, max_events=50,
                       select=None):
-    """Provides the list of activity log.
-    :param str filters: The OData filter for the list activity logs. If this argument is provided
-                        OData Filter Arguments will be ignored
-    :param str correlation_id: The correlation id of the query
-    :param str resource_group: The resource group
-    :param str resource_id: The identifier of the resource
-    :param str resource_provider: The resource provider
-    :param str start_time: The start time of the query. In ISO format with explicit indication of
-                           timezone: 1970-01-01T00:00:00Z, 1970-01-01T00:00:00-0500. Defaults to
-                           1 Hour prior to the current time.
-    :param str end_time: The end time of the query. In ISO format with explicit indication of
-                         timezone: 1970-01-01T00:00:00Z, 1970-01-01T00:00:00-0500. Defaults to
-                         current time.
-    :param str caller: The caller to look for when querying
-    :param str status: The status value to query (ex: Failed)
-    :param str max_events: The maximum number of records to be returned by the command
-    :param str select: The list of event names
-    """
     if filters:
         odata_filters = filters
     else:

--- a/src/command_modules/azure-cli-monitor/setup.py
+++ b/src/command_modules/azure-cli-monitor/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.2.4"
+VERSION = "0.2.5"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fix #5274. Fix #5698. Fix #7418.

Allow user to specify name or ID for `--event-hub` and `--event-hub-rule`. For `--event-hub`, if ID is provided, only the name is extracted. For `--event-hub-rule`, if only name is supplied, then ID is built using `--event-hub NAME`.  If ID is provided and `--event-hub` is NOT provided, then `--event-hub` is extracted from the `--event-hub-rule ID`. 

This allows you to use different hubs for `--event-hub` and `--event-hub-rule` but allows the smart extract of data when the hubs are the same without a lot of redundancy.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
