### PR TITLE
[CDN]  Added help text for profile_name.

### DIFF
--- a/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_params.py
+++ b/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_params.py
@@ -79,6 +79,8 @@ def load_arguments(self, _):
         c.argument('query_string_caching_behavior', options_list='--query-string-caching',
                    arg_type=get_enum_type(caching_behavior))
         c.argument('content_types_to_compress', nargs='+')
+        c.argument('profile_name', help=profile_name_help)
+
 
     with self.argument_context('cdn endpoint create') as c:
         c.argument('name', name_arg_type, id_part='name', help='Name of the CDN endpoint.')


### PR DESCRIPTION
`az cdn endpoint create`'s `--profile-name` parameter has no help text.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
