### PR TITLE
Retry webbrowser.open() after a TypeError

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -288,7 +288,10 @@ def open_page_in_browser(url):
         #    understand the "open location" message"
         # b. Python 2.x can't sniff out the default browser
         return subprocess.Popen(['open', url])
-    return webbrowser.open(url, new=2)  # 2 means: open in a new tab, if possible
+    try:
+        return webbrowser.open(url, new=2)  # 2 means: open in a new tab, if possible
+    except TypeError as err:  # See https://bugs.python.org/msg322439
+        return webbrowser.open(url, new=2)
 
 
 def _get_platform_info():

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -290,7 +290,7 @@ def open_page_in_browser(url):
         return subprocess.Popen(['open', url])
     try:
         return webbrowser.open(url, new=2)  # 2 means: open in a new tab, if possible
-    except TypeError as err:  # See https://bugs.python.org/msg322439
+    except TypeError:  # See https://bugs.python.org/msg322439
         return webbrowser.open(url, new=2)
 
 


### PR DESCRIPTION
This is a workaround for [This bug](https://bugs.python.org/msg322439) in Python 3.7

Fixes #7033

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
