### PR TITLE
use io.open that supports encoding option in python2

### DIFF
--- a/src/command_modules/azure-cli-acr/HISTORY.rst
+++ b/src/command_modules/azure-cli-acr/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.1.7
++++++
+* Fix an ACR Build encoding issue in Python2.
+
 2.1.6
 +++++
 * Support similar table format as helm client.

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_archive_utils.py
@@ -7,6 +7,7 @@ import tarfile
 import os
 import re
 import codecs
+from io import open
 import requests
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/command_modules/azure-cli-acr/setup.py
+++ b/src/command_modules/azure-cli-acr/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.1.6"
+VERSION = "2.1.7"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes #7546 

io.open is the default interface in python3

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
