### PR TITLE
Add validation to generic update

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -330,14 +330,13 @@ remove_usage = '--remove property.list <indexToRemove> OR --remove propertyToRem
 
 
 def _get_child(parent, collection_name, item_name, collection_key):
+    if not item_name:
+        raise CLIError("Name property for collection '{}' not provided. Check your input.".format(collection_name))
     items = getattr(parent, collection_name)
-    result = next((x for x in items if getattr(x, collection_key, '').lower() ==
-                   item_name.lower()), None)
+    result = next((x for x in items if getattr(x, collection_key, '').lower() == item_name.lower()), None)
     if not result:
-        raise CLIError("Property '{}' does not exist for key '{}'.".format(
-            item_name, collection_key))
-    else:
-        return result
+        raise CLIError("Property '{}' does not exist for key '{}'.".format(item_name, collection_key))
+    return result
 
 
 def _get_operations_tmpl(cmd, custom_command=False):


### PR DESCRIPTION
Closes #7552.

Adds validation for generic update so that if the user provides an insufficient --ids string they will get a better error and not a stack trace.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
