### PR TITLE
`--ids` parameter fixes

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -4,7 +4,8 @@ Release History
 ===============
 2.0.48
 ++++++
-* Minor fixes
+* Fix issue with `--ids` where `--subscription` would take precedence over the subscription in `--ids`.
+  Adding explicit warnings when name parameters would be ignored by use of `--ids`.
 
 2.0.47
 ++++++

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -33,12 +33,12 @@ class AzCli(CLI):
     def __init__(self, **kwargs):
         super(AzCli, self).__init__(**kwargs)
 
-        from azure.cli.core.commands.arm import add_id_parameters, register_global_subscription_parameter
+        from azure.cli.core.commands.arm import (
+            register_ids_argument, register_global_subscription_argument)
         from azure.cli.core.cloud import get_active_cloud
         from azure.cli.core.extensions import register_extensions
         from azure.cli.core._session import ACCOUNT, CONFIG, SESSION
 
-        import knack.events as events
         from knack.util import ensure_dir
 
         self.data['headers'] = {}
@@ -56,8 +56,8 @@ class AzCli(CLI):
         logger.debug('Current cloud config:\n%s', str(self.cloud.name))
 
         register_extensions(self)
-        self.register_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, add_id_parameters)
-        register_global_subscription_parameter(self)
+        register_global_subscription_argument(self)
+        register_ids_argument(self)  # global subscription must be registered first!
 
         self.progress_controller = None
 

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -172,128 +172,128 @@ def resource_exists(cli_ctx, resource_group, name, namespace, type, **_):  # pyl
     return existing
 
 
-def add_id_parameters(_, **kwargs):  # pylint: disable=unused-argument
+def register_ids_argument(cli_ctx):
 
-    command_table = kwargs.get('commands_loader').command_table
+    from knack import events
+    from msrestazure.tools import parse_resource_id, is_valid_resource_id
+    import os
 
-    if not command_table:
-        return
+    ids_metadata = {}
 
-    def split_action(arguments, deprecate_info):
-        class SplitAction(argparse.Action):  # pylint: disable=too-few-public-methods
-            def __call__(self, parser, namespace, values, option_string=None):
-                ''' The SplitAction will take the given ID parameter and spread the parsed
-                parts of the id into the individual backing fields.
+    def add_ids_arguments(_, **kwargs):  # pylint: disable=unused-argument
 
-                Since the id value is expected to be of type `IterateValue`, all the backing
-                (dest) fields will also be of type `IterateValue`
-                '''
-                from msrestazure.tools import parse_resource_id
-                import os
+        command_table = kwargs.get('commands_loader').command_table
 
-                if isinstance(values, str):
-                    values = [values]
-                expanded_values = []
-                for val in values:
-                    try:
-                        # support piping values from JSON. Does not require use of --query
-                        json_vals = json.loads(val)
-                        if not isinstance(json_vals, list):
-                            json_vals = [json_vals]
-                        for json_val in json_vals:
-                            if 'id' in json_val:
-                                expanded_values += [json_val['id']]
-                    except ValueError:
-                        # supports piping of --ids to the command when using TSV. Requires use of --query
-                        expanded_values = expanded_values + val.split(os.linesep)
-                try:
-                    for value in expanded_values:
-                        parts = parse_resource_id(value)
-                        for arg in [arg for arg in arguments.values() if arg.type.settings.get('id_part')]:
-                            self.set_argument_value(namespace, arg, parts)
-                except Exception as ex:
-                    raise ValueError(ex)
+        if not command_table:
+            return
 
-                if deprecate_info:
-                    if not hasattr(namespace, '_argument_deprecations'):
-                        setattr(namespace, '_argument_deprecations', [deprecate_info])
-                    else:
-                        namespace._argument_deprecations.append(deprecate_info)  # pylint: disable=protected-access
+        for command in command_table.values():
 
-            @staticmethod
-            def set_argument_value(namespace, arg, parts):
+            # Somewhat blunt hammer, but any create commands will not have an automatic id parameter
+            if command.name.split()[-1] == 'create':
+                continue
 
-                existing_values = getattr(namespace, arg.name, None)
-                if existing_values is None:
-                    existing_values = IterateValue()
-                    existing_values.append(parts.get(arg.type.settings['id_part'], None))
-                else:
-                    if isinstance(existing_values, str):
-                        if not getattr(arg.type, 'configured_default_applied', None):
-                            logger.warning(
-                                "Property '%s=%s' being overriden by value '%s' from IDs parameter.",
-                                arg.name, existing_values, parts[arg.type.settings['id_part']]
-                            )
-                        existing_values = IterateValue()
-                    existing_values.append(parts.get(arg.type.settings['id_part']))
-                setattr(namespace, arg.name, existing_values)
-
-        return SplitAction
-
-    def command_loaded_handler(command):
-        id_parts = [arg.type.settings['id_part'] for arg in command.arguments.values()
-                    if arg.type.settings.get('id_part')]
-        if 'name' not in id_parts and 'resource_name' not in id_parts:
             # Only commands with a resource name are candidates for an id parameter
+            id_parts = [a.type.settings.get('id_part') for a in command.arguments.values()]
+            if 'name' not in id_parts and 'resource_name' not in id_parts:
+                continue
+
+            group_name = 'Resource Id'
+
+            # determine which arguments are required and optional and store in ids_metadata
+            ids_metadata[command.name] = {'required': [], 'optional': []}
+            for arg in [a for a in command.arguments.values() if a.type.settings.get('id_part')]:
+                if arg.options.get('required', False):
+                    ids_metadata[command.name]['required'].append(arg.name)
+                else:
+                    ids_metadata[command.name]['optional'].append(arg.name)
+                arg.required = False
+                arg.arg_group = group_name
+
+            # retrieve existing `ids` arg if it exists
+            id_arg = command.loader.argument_registry.arguments[command.name].get('ids', None)
+            deprecate_info = id_arg.settings.get('deprecate_info', None) if id_arg else None
+            id_kwargs = {
+                'metavar': 'ID',
+                'help': "One or more resource IDs (space-delimited). If provided, "
+                        "no other 'Resource Id' arguments should be specified.",
+                'dest': 'ids' if id_arg else '_ids',
+                'deprecate_info': deprecate_info,
+                'nargs': '+',
+                'arg_group': group_name
+            }
+            command.add_argument('ids', '--ids', **id_kwargs)
+
+    def parse_ids_arguments(_, command, args):
+
+        namespace = args
+        cmd = namespace._cmd  # pylint: disable=protected-access
+
+        # some commands have custom IDs and parsing. This will not work for that.
+        if not ids_metadata.get(command, None):
             return
-        if command.name.split()[-1] == 'create':
-            # Somewhat blunt hammer, but any create commands will not have an automatic id
-            # parameter
-            return
 
-        required_arguments = []
-        optional_arguments = []
-        for arg in [argument for argument in command.arguments.values() if argument.type.settings.get('id_part')]:
-            if arg.options.get('required', False):
-                required_arguments.append(arg)
-            else:
-                optional_arguments.append(arg)
-            arg.required = False
+        ids = getattr(namespace, 'ids', getattr(namespace, '_ids', None))
+        required_args = [cmd.arguments[x] for x in ids_metadata[command]['required']]
+        optional_args = [cmd.arguments[x] for x in ids_metadata[command]['optional']]
+        combined_args = required_args + optional_args
 
-        def required_values_validator(namespace):
-
-            errors = [arg for arg in required_arguments
-                      if getattr(namespace, arg.name, None) is None]
-
+        if not ids:
+            # ensure the required parameters are provided if --ids is not
+            errors = [arg for arg in required_args if getattr(namespace, arg.name, None) is None]
             if errors:
                 missing_required = ' '.join((arg.options_list[0] for arg in errors))
                 raise ValueError('({} | {}) are required'.format(missing_required, '--ids'))
+            return
 
-        group_name = 'Resource Id'
-        for key, arg in command.arguments.items():
-            if command.arguments[key].type.settings.get('id_part'):
-                command.arguments[key].arg_group = group_name
+        # show warning if names are used in conjunction with --ids
+        other_values = {arg.name: {'arg': arg, 'value': getattr(namespace, arg.name, None)}
+                        for arg in combined_args}
+        for _, data in other_values.items():
+            if data['value'] and not getattr(data['value'], 'is_default', None):
+                logger.warning("option '%s' will be ignored due to use of '--ids'.",
+                               data['arg'].type.settings['options_list'][0])
 
-        id_arg = command.loader.argument_registry.arguments[command.name].get('ids', None)
-        deprecate_info = id_arg.settings.get('deprecate_info', None) if id_arg else None
-        id_kwargs = {
-            'metavar': 'RESOURCE_ID',
-            'help': "One or more resource IDs (space-delimited). If provided, "
-                    "no other 'Resource Id' arguments should be specified.",
-            'dest': argparse.SUPPRESS,
-            'action': split_action(command.arguments, deprecate_info),
-            'deprecate_info': deprecate_info,
-            'nargs': '+',
-            'validator': required_values_validator,
-            'arg_group': group_name
-        }
-        command.add_argument('ids', '--ids', **id_kwargs)
+        # create the empty lists, overwriting any values that may already be there
+        for arg in combined_args:
+            setattr(namespace, arg.name, IterateValue())
 
-    for command in command_table.values():
-        command_loaded_handler(command)
+        # expand the IDs into the relevant fields
+        full_id_list = []
+        for val in ids:
+            try:
+                # support piping values from JSON. Does not require use of --query
+                json_vals = json.loads(val)
+                if not isinstance(json_vals, list):
+                    json_vals = [json_vals]
+                for json_val in json_vals:
+                    if 'id' in json_val:
+                        full_id_list += [json_val['id']]
+            except ValueError:
+                # supports piping of --ids to the command when using TSV. Requires use of --query
+                full_id_list = full_id_list + val.split(os.linesep)
+
+        for val in full_id_list:
+            if not is_valid_resource_id(val):
+                raise CLIError('invalid resource ID: {}'.format(val))
+            # place the ID parts into the correct property lists
+            parts = parse_resource_id(val)
+            for arg in combined_args:
+                getattr(namespace, arg.name).append(parts[arg.type.settings['id_part']])
+
+        # support deprecating --ids
+        deprecate_info = cmd.arguments['ids'].type.settings.get('deprecate_info')
+        if deprecate_info:
+            if not hasattr(namespace, '_argument_deprecations'):
+                setattr(namespace, '_argument_deprecations', [deprecate_info])
+            else:
+                namespace._argument_deprecations.append(deprecate_info)  # pylint: disable=protected-access
+
+    cli_ctx.register_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, add_ids_arguments)
+    cli_ctx.register_event(events.EVENT_INVOKER_POST_PARSE_ARGS, parse_ids_arguments)
 
 
-def register_global_subscription_parameter(cli_ctx):
+def register_global_subscription_argument(cli_ctx):
 
     import knack.events as events
 
@@ -307,21 +307,14 @@ def register_global_subscription_parameter(cli_ctx):
                     'using `az account set -s NAME_OR_ID`',
             'completer': get_subscription_id_list,
             'arg_group': 'Global',
-            'configured_default': 'subscription'
+            'configured_default': 'subscription',
+            'id_part': 'subscription'
         }
         for _, cmd in cmd_tbl.items():
             if 'subscription' not in cmd.arguments:
                 cmd.add_argument('_subscription', '--subscription', **subscription_kwargs)
 
-    def parse_subscription_parameter(cli_ctx, args, **kwargs):  # pylint: disable=unused-argument
-        subscription = getattr(args, '_subscription', None)
-        if subscription:
-            from azure.cli.core._profile import Profile
-            subscription_id = Profile(cli_ctx=cli_ctx).get_subscription_id(subscription)
-            cli_ctx.data['subscription_id'] = subscription_id
-
     cli_ctx.register_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, add_subscription_parameter)
-    cli_ctx.register_event(events.EVENT_INVOKER_POST_PARSE_ARGS, parse_subscription_parameter)
 
 
 add_usage = '--add property.listProperty <key=value, string or JSON string>'

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -171,11 +171,9 @@ def get_data_service_client(cli_ctx, service_type, account_name, account_key, co
 
 def get_subscription_id(cli_ctx):
     from azure.cli.core._profile import Profile
-    if 'subscription_id' in cli_ctx.data:
-        subscription_id = cli_ctx.data['subscription_id']
-    else:
-        subscription_id = Profile(cli_ctx=cli_ctx).get_subscription_id()
-    return subscription_id
+    if not cli_ctx.data.get('subscription_id'):
+        cli_ctx.data['subscription_id'] = Profile(cli_ctx=cli_ctx).get_subscription_id()
+    return cli_ctx.data['subscription_id']
 
 
 def _get_add_headers_callback(cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -25,7 +25,7 @@ class HelpTest(unittest.TestCase):
         logging.shutdown()
 
     def test_help_loads(self):
-        from azure.cli.core.commands.arm import add_id_parameters
+        from azure.cli.core.commands.arm import register_global_subscription_argument, register_ids_argument
         import knack.events as events
 
         cli = DummyCli()
@@ -44,7 +44,8 @@ class HelpTest(unittest.TestCase):
                 cmd_tbl[cmd].loader.load_arguments(cmd)
             except KeyError:
                 pass
-        cli.register_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, add_id_parameters)
+        cli.register_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, register_global_subscription_argument)
+        cli.register_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, register_ids_argument)
         cli.raise_event(events.EVENT_INVOKER_CMD_TBL_LOADED, command_table=cmd_tbl)
         cli.invocation.parser.load_command_table(cli.invocation.commands_loader)
         _store_parsers(cli.invocation.parser, parser_dict)

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -59,7 +59,7 @@ DEPENDENCIES = [
     'colorama>=0.3.9',
     'humanfriendly>=4.7',
     'jmespath',
-    'knack==0.4.3',
+    'knack==0.4.4',
     'msrest>=0.4.4',
     'msrestazure>=0.4.25',
     'paramiko>=2.0.8',

--- a/src/command_modules/azure-cli-interactive/HISTORY.rst
+++ b/src/command_modules/azure-cli-interactive/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.3.31
+++++++
+* Ensure global subscription parameter appears in parameters.
+
 0.3.30
 ++++++
 * Fix error found on windows where commands fail to run properly.

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/_dump_commands.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/azclishell/_dump_commands.py
@@ -11,7 +11,6 @@ from knack.help import REQUIRED_TAG
 from knack.help_files import helps
 from knack.log import get_logger
 from azure.cli.core import MainCommandsLoader
-from azure.cli.core.commands.arm import add_id_parameters
 
 
 logger = get_logger(__name__)
@@ -76,6 +75,8 @@ class FreshTable(object):
 
     def dump_command_table(self, shell_ctx=None):
         """ dumps the command table """
+        from azure.cli.core.commands.arm import register_global_subscription_argument, register_ids_argument
+        from knack import events
         import timeit
 
         start_time = timeit.default_timer()
@@ -84,7 +85,9 @@ class FreshTable(object):
 
         main_loader.load_command_table(None)
         main_loader.load_arguments(None)
-        add_id_parameters(None, commands_loader=main_loader)
+        register_global_subscription_argument(shell_ctx.cli_ctx)
+        register_ids_argument(shell_ctx.cli_ctx)
+        shell_ctx.cli_ctx.raise_event(events.EVENT_INVOKER_POST_CMD_TBL_CREATE, commands_loader=main_loader)
         cmd_table = main_loader.command_table
 
         cmd_table_data = {}

--- a/src/command_modules/azure-cli-interactive/setup.py
+++ b/src/command_modules/azure-cli-interactive/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     cmdclass = {}
 
 # Version is also defined in azclishell.__init__.py.
-VERSION = "0.3.30"
+VERSION = "0.3.31"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/recordings/test_global_ids.yaml
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/recordings/test_global_ids.yaml
@@ -1,0 +1,247 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2018-10-12T22:04:59Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.48]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_global_ids000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_global_ids000001","name":"cli_test_global_ids000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-12T22:04:59Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Oct 2018 22:05:02 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.48]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_global_ids000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_global_ids000001","name":"cli_test_global_ids000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-12T22:04:59Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Oct 2018 22:05:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "dhcpOptions": {}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      Content-Length: ['123']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python AZURECLI/2.0.48]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_global_ids000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_global_ids000001/providers/Microsoft.Network/virtualNetworks/vnet1\",\r\n
+        \ \"etag\": \"W/\\\"8f2d7d44-d8fa-45be-a8ae-adc2f50b2641\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"7475371c-ea65-4fcb-9a95-2b5377272e70\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/64236506-f28e-449f-b78c-9e51a4c0a1ac?api-version=2018-08-01']
+      cache-control: [no-cache]
+      content-length: ['766']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Oct 2018 22:05:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python AZURECLI/2.0.48]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/64236506-f28e-449f-b78c-9e51a4c0a1ac?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Oct 2018 22:05:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python AZURECLI/2.0.48]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/64236506-f28e-449f-b78c-9e51a4c0a1ac?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Oct 2018 22:05:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python AZURECLI/2.0.48]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_global_ids000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_global_ids000001/providers/Microsoft.Network/virtualNetworks/vnet1\",\r\n
+        \ \"etag\": \"W/\\\"ca644146-350f-40b2-938d-bedad52fb013\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"7475371c-ea65-4fcb-9a95-2b5377272e70\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Oct 2018 22:05:19 GMT']
+      etag: [W/"ca644146-350f-40b2-938d-bedad52fb013"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet show]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 networkmanagementclient/2.2.1 Azure-SDK-For-Python AZURECLI/2.0.48]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_global_ids000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2018-08-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_global_ids000001/providers/Microsoft.Network/virtualNetworks/vnet1\",\r\n
+        \ \"etag\": \"W/\\\"ca644146-350f-40b2-938d-bedad52fb013\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"7475371c-ea65-4fcb-9a95-2b5377272e70\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['767']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 12 Oct 2018 22:05:20 GMT']
+      etag: [W/"ca644146-350f-40b2-938d-bedad52fb013"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.48]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_global_ids000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 12 Oct 2018 22:05:21 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGR0xPQkFMOjVGSURTRDNMQTZIQ1hBV0dWU1NBTFZTVVpOUnwyMzNEMTRBQzExOUUwRDAxLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -881,5 +881,17 @@ class InvokeActionTest(ScenarioTest):
         self.cmd('resource invoke-action --action capture --ids {vm_id} --request-body {request_body}')
 
 
+class GlobalIdsScenarioTest(ScenarioTest):
+    @ResourceGroupPreparer(name_prefix='cli_test_global_ids')
+    def test_global_ids(self, resource_group):
+
+        self.kwargs.update({
+            'vnet': 'vnet1'
+        })
+        self.kwargs['vnet_id'] = self.cmd('network vnet create -g {rg} -n {vnet}').get_output_in_json()['newVNet']['id']
+        # command will fail if the other parameters were actually used
+        self.cmd('network vnet show --subscription fakesub --resource-group fakerg -n fakevnet --ids {vnet_id}')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Fixes the behavior when `--ids` and `--subscription` are used together. Previously, the subscription from `--subscription` would override the value in `--ids`.  Now the values in the IDs take precedence.
- Issues an explicit warning when name parameters (`--subscription`, `--resource-group`, `--name`, etc) are used in conjunction with `--ids` to inform the user that the named parameters will be ignored. This used to happen for resource-group and name, but ONLY if they preceded `--ids` on the command line. Now the warning will also show for subscription and will show regardless of where the named arguments appear relative to `--ids`.
- bumps knack version to 0.4.4 to fix issue with argument deprecations.
- ensures `--subscription` parameter appears in `az interactive`. 🥂 

Items remaining
- [x] write tests for these scenarios
- [x] test interactive

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
