### PR TITLE
Add table for exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,13 @@ jasonsha@MyVM:~$
 
 #### Exit Codes
 For scripting purposes, we output certain exit codes for differing scenarios.
-`0`: Command ran successfully.
-`1`: Generic error; server returned bad status code, CLI validation failed, etc.
-`2`: Parser error; check input to command line.
-`3`: Missing ARM resource; used for existence check from `show` commands.
+
+|Exit Code   |Scenario   |
+|---|---|
+|0  |Command ran successfully.   |
+|1   |Generic error; server returned bad status code, CLI validation failed, etc.   |
+|2   |Parser error; check input to command line.   |
+|3   |Missing ARM resource; used for existence check from `show` commands.   |
 
 #### More Samples and Snippets
 For more usage examples, take a look at our [GitHub samples repo](http://github.com/Azure/azure-cli-samples) or [https://docs.microsoft.com/en-us/cli/azure/overview](https://docs.microsoft.com/en-us/cli/azure/overview).


### PR DESCRIPTION
Moved exit code examples into a table to improve legibility.