### PR TITLE
vmss: avoid producing useless stroage accounts with unmanaged scaleset

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1960,7 +1960,7 @@ def create_vmss(cmd, vmss_name, resource_group_name, image,
         master_template.add_resource(ag_resource)
 
     # create storage accounts if needed for unmanaged disk storage
-    if storage_profile in [StorageProfile.SACustomImage, StorageProfile.SAPirImage]:
+    if storage_profile == StorageProfile.SAPirImage:
         master_template.add_resource(build_vmss_storage_account_pool_resource(
             cmd, 'storageLoop', location, tags, storage_sku))
         master_template.add_variable('storageAccountNames', [


### PR DESCRIPTION
It is just a bug in our code. Storage account pool won't work with unmanaged custom image. We already have code to [skip it](https://github.com/Azure/azure-cli/blob/dev/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py#L680), but there is one falling through the crack.

I have manually tested it. Because the code change is simple and it is pretty time consuming to test custom images with zero test dependency, I am asking to let this change in w/o automation coverage.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
