### PR TITLE
CLI now prints extension warnings upon '-h'

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -80,9 +80,9 @@ class AzCliHelp(CLIHelp):
             if help_file.command_source.preview:
                 logger.warning(help_file.command_source.get_preview_warn_msg())
 
-    def print_detailed_help(self, cli_name, help_file):
+    def _print_detailed_help(self, cli_name, help_file):
         AzCliHelp._print_extensions_msg(help_file)
-        self._print_detailed_help(cli_name, help_file)
+        super(AzCliHelp, self)._print_detailed_help(cli_name, help_file)
 
 
 class CliHelpFile(KnackHelpFile):


### PR DESCRIPTION
CLI now prints extension messages. E.g. "This extension is in preview" or "The behavior of this command has been altered by the following extension: storage-preview".

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
