### PR TITLE
auth: support service principal sn+issuer auth

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,10 +2,9 @@
 
 Release History
 ===============
-
 2.0.50
 ++++++
-* Fix issue where update commands using `--remove` and `--ids` fail after first update is applied to first resource in ids list.
+* auth: support service principal sn+issuer auth
 
 2.0.49
 ++++++

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1165,7 +1165,34 @@ class TestProfile(unittest.TestCase):
         mock_arm_client.tenants.list.assert_not_called()
         mock_auth_context.acquire_token.assert_not_called()
         mock_auth_context.acquire_token_with_client_certificate.assert_called_once_with(
-            mgmt_resource, 'my app', mock.ANY, mock.ANY)
+            mgmt_resource, 'my app', mock.ANY, mock.ANY, None)
+
+    @mock.patch('adal.AuthenticationContext', autospec=True)
+    def test_find_subscriptions_from_service_principal_using_cert_sn_issuer(self, mock_auth_context):
+        cli = DummyCli()
+        mock_auth_context.acquire_token_with_client_certificate.return_value = self.token_entry1
+        mock_arm_client = mock.MagicMock()
+        mock_arm_client.subscriptions.list.return_value = [self.subscription1]
+        finder = SubscriptionFinder(cli, lambda _, _1, _2: mock_auth_context, None, lambda _: mock_arm_client)
+        mgmt_resource = 'https://management.core.windows.net/'
+
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        test_cert_file = os.path.join(curr_dir, 'sp_cert.pem')
+        with open(test_cert_file) as cert_file:
+            cert_file_string = cert_file.read()
+        match = re.search(r'\-+BEGIN CERTIFICATE.+\-+(?P<public>[^-]+)\-+END CERTIFICATE.+\-+',
+                          cert_file_string, re.I)
+        public_certificate = match.group('public').strip()
+        # action
+        subs = finder.find_from_service_principal_id('my app', ServicePrincipalAuth(test_cert_file, use_cert_sn_issuer=True),
+                                                     self.tenant_id, mgmt_resource)
+
+        # assert
+        self.assertEqual([self.subscription1], subs)
+        mock_arm_client.tenants.list.assert_not_called()
+        mock_auth_context.acquire_token.assert_not_called()
+        mock_auth_context.acquire_token_with_client_certificate.assert_called_once_with(
+            mgmt_resource, 'my app', mock.ANY, mock.ANY, public_certificate)
 
     @mock.patch('adal.AuthenticationContext', autospec=True)
     def test_refresh_accounts_one_user_account(self, mock_auth_context):

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,7 +53,7 @@ CLASSIFIERS = [
 
 # TODO These dependencies should be updated to reflect only what this package needs
 DEPENDENCIES = [
-    'adal>=1.0.2',
+    'adal>=1.2.0',
     'argcomplete>=1.8.0',
     'azure-cli-telemetry',
     'colorama>=0.3.9',

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.1.2
+++++++
+* az login: expose --use-cert-sn-issuer flag for service principal login with cert auto-rolls
 
 2.1.2
 ++++++

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -6,10 +6,6 @@ Release History
 ++++++
 * az login: expose --use-cert-sn-issuer flag for service principal login with cert auto-rolls
 
-2.1.2
-++++++
-* Minor fixes
-
 2.1.1
 ++++++
 * Moving _load_subscriptions into the core

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/__init__.py
@@ -51,6 +51,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('identity_port', type=int, help="the port to retrieve tokens for login. Default: 50342", arg_group='Managed Service Identity')
             c.argument('use_device_code', action='store_true',
                        help="Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell")
+            c.argument('use_cert_sn_issuer', action='store_true', help='used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls')
 
         with self.argument_context('logout') as c:
             c.argument('username', help='account user, if missing, logout the current active account')

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -86,7 +86,7 @@ def account_clear(cmd):
 
 # pylint: disable=inconsistent-return-statements
 def login(cmd, username=None, password=None, service_principal=None, tenant=None, allow_no_subscriptions=False,
-          identity=False, use_device_code=False):
+          identity=False, use_device_code=False, use_cert_sn_issuer=None):
     """Log in to access Azure subscriptions"""
     from adal.adal_error import AdalError
     import requests
@@ -96,6 +96,10 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
         raise CLIError("usage error: '--identity' is not applicable with other arguments")
     if any([password, service_principal, username, identity]) and use_device_code:
         raise CLIError("usage error: '--use-device-code' is not applicable with other arguments")
+    if use_cert_sn_issuer and not service_principal:
+        raise CLIError("usage error: '--use-sn-issuer' is only applicable with a service principal")
+    if service_principal and not username:
+        raise CLIError('usage error: --service-principal --username NAME --password SECRET -t TENANT')
 
     interactive = False
 
@@ -125,7 +129,8 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
             service_principal,
             tenant,
             use_device_code=use_device_code,
-            allow_no_subscriptions=allow_no_subscriptions)
+            allow_no_subscriptions=allow_no_subscriptions,
+            use_cert_sn_issuer=use_cert_sn_issuer)
     except AdalError as err:
         # try polish unfriendly server errors
         if username:

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -99,7 +99,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
     if use_cert_sn_issuer and not service_principal:
         raise CLIError("usage error: '--use-sn-issuer' is only applicable with a service principal")
     if service_principal and not username:
-        raise CLIError('usage error: --service-principal --username NAME --password SECRET -t TENANT')
+        raise CLIError('usage error: --service-principal --username NAME --password SECRET --tenant TENANT')
 
     interactive = False
 

--- a/src/command_modules/azure-cli-profile/setup.py
+++ b/src/command_modules/azure-cli-profile/setup.py
@@ -15,6 +15,7 @@ except ImportError:
     cmdclass = {}
 
 VERSION = "2.1.2"
+
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',

--- a/src/command_modules/azure-cli-profile/setup.py
+++ b/src/command_modules/azure-cli-profile/setup.py
@@ -15,7 +15,6 @@ except ImportError:
     cmdclass = {}
 
 VERSION = "2.1.2"
-
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
The goal is to support automatic certificate rolls. The tenant must be pre-configured with only accepting certain issuers  such as AME.

Mark it as `do not merge` as we are waiting for a new release of adal to have the capacity. Once it happens, i will update the PR with test coverage.


- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
