### PR TITLE
[Network] Rename `interface-endpoint` command group to `private-endpoint`

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 2.2.8
 +++++
+* Deprecated `network interface-endpoint` command names in favor of `network private-endpoint`.
 * `express-route peering connection create`: Fix issue where `--peer-circuit` would not accept an ID.
 
 2.2.7

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1977,16 +1977,6 @@ helps['network interface-endpoint'] = """
     short-summary: Manage interface endpoints.
 """
 
-# helps['network interface-endpoint create'] = """
-#    type: command
-#    short-summary: Create an interface endpoint.
-# """
-
-# helps['network interface-endpoint delete'] = """
-#    type: command
-#    short-summary: Delete an interface endpoint.
-# """
-
 helps['network interface-endpoint list'] = """
     type: command
     short-summary: List interface endpoints.
@@ -1996,12 +1986,26 @@ helps['network interface-endpoint show'] = """
     type: command
     short-summary: Get the details of an interface endpoint.
 """
-
-# helps['network interface-endpoint update'] = """
-#    type: command
-#    short-summary: Update an interface endpoint.
-# """
 # endregion
+
+# region Private Endpoint
+helps['network private-endpoint'] = """
+    type: group
+    short-summary: Manage private endpoints.
+"""
+
+
+helps['network private-endpoint list'] = """
+    type: command
+    short-summary: List private endpoints.
+"""
+
+helps['network private-endpoint show'] = """
+    type: command
+    short-summary: Get the details of an private endpoint.
+"""
+# endregion
+
 
 # region Load Balancer
 helps['network lb'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -469,11 +469,12 @@ def load_arguments(self, _):
     # endregion
 
     # region InterfaceEndpoint
-    interface_endpoint_name = CLIArgumentType(options_list='--endpoint-name', id_part='name', help='Name of the interface endpoint.', completer=get_resource_name_completion_list('Microsoft.Network/interfaceEndpoints'))
+    private_endpoint_name = CLIArgumentType(options_list='--endpoint-name', id_part='name', help='Name of the private endpoint.', completer=get_resource_name_completion_list('Microsoft.Network/interfaceEndpoints'))
 
-    with self.argument_context('network interface-endpoint') as c:
-        c.argument('interface_endpoint_name', interface_endpoint_name, options_list=['--name', '-n'])
-        c.argument('location', get_location_type(self.cli_ctx), validator=get_default_location_from_resource_group)
+    for scope in ['interface-endpoint', 'private-endpoint']:
+        with self.argument_context('network {}'.format(scope)) as c:
+            c.argument('interface_endpoint_name', private_endpoint_name, options_list=['--name', '-n'])
+            c.argument('location', get_location_type(self.cli_ctx), validator=get_default_location_from_resource_group)
     # endregion
 
     # region LoadBalancers

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -129,7 +129,7 @@ def load_command_table(self, _):
         client_factory=cf_express_route_circuit_peerings
     )
 
-    network_interface_endpoint_sdk = CliCommandType(
+    network_private_endpoint_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.network.operations.interface_endpoints_operations#InterfaceEndpointsOperations.{}',
         client_factory=cf_interface_endpoints,
         min_api='2018-08-01'
@@ -446,14 +446,15 @@ def load_command_table(self, _):
         g.show_command('show')
     # endregion
 
-    # region InterfaceEndpoint
-    with self.command_group('network interface-endpoint', network_interface_endpoint_sdk) as g:
-        # TODO: Re-enable when service team asks. See issue #7271
-        # g.custom_command('create', 'create_interface_endpoint')
-        # g.command('delete', 'delete')
-        g.custom_command('list', 'list_interface_endpoints')
+    # region PrivateEndpoint
+    with self.command_group('network interface-endpoint', network_private_endpoint_sdk, deprecate_info=self.deprecate(redirect='network private-endpoint', hide=True)) as g:
+        g.custom_command('list', 'list_private_endpoints')
         g.show_command('show')
-        # g.generic_update_command('update', custom_func_name='update_interface_endpoint')
+
+    with self.command_group('network private-endpoint', network_private_endpoint_sdk) as g:
+        # TODO: Re-enable when service team asks. See issue #7271
+        g.custom_command('list', 'list_private_endpoints')
+        g.show_command('show')
     # endregion
 
     # region LoadBalancers

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1662,9 +1662,9 @@ def update_express_route_peering(cmd, instance, peer_asn=None, primary_peer_addr
 # endregion
 
 
-# region InterfaceEndpoints
-def create_interface_endpoint(cmd, resource_group_name, interface_endpoint_name, subnet, location=None, tags=None,
-                              fqdn=None, endpoint_service=None, nics=None):
+# region PrivateEndpoints
+def create_private_endpoint(cmd, resource_group_name, interface_endpoint_name, subnet, location=None, tags=None,
+                            fqdn=None, endpoint_service=None, nics=None):
     client = network_client_factory(cmd.cli_ctx).interface_endpoints
     InterfaceEndpoint, SubResource = cmd.get_models(
         'InterfaceEndpoint', 'SubResource')
@@ -1679,7 +1679,7 @@ def create_interface_endpoint(cmd, resource_group_name, interface_endpoint_name,
     return client.create_or_update(resource_group_name, interface_endpoint_name, endpoint)
 
 
-def list_interface_endpoints(cmd, resource_group_name=None):
+def list_private_endpoints(cmd, resource_group_name=None):
     client = network_client_factory(cmd.cli_ctx).interface_endpoints
     if resource_group_name:
         return client.list(resource_group_name)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_private_endpoints.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_private_endpoints.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2018-10-19T22:46:51Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) msrest/0.6.1 msrest_azure/0.4.34
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_network_private_endpoints000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_private_endpoints000001","name":"cli_test_network_private_endpoints000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-19T22:46:51Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 19 Oct 2018 22:46:54 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network private-endpoint list]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) msrest/0.6.1 msrest_azure/0.4.34
+          networkmanagementclient/2.2.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/interfaceEndpoints?api-version=2018-08-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 19 Oct 2018 22:46:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network private-endpoint list]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) msrest/0.6.1 msrest_azure/0.4.34
+          networkmanagementclient/2.2.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_private_endpoints000001/providers/Microsoft.Network/interfaceEndpoints?api-version=2018-08-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 19 Oct 2018 22:46:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network private-endpoint show]
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) msrest/0.6.1 msrest_azure/0.4.34
+          networkmanagementclient/2.2.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_network_private_endpoints000001/providers/Microsoft.Network/interfaceEndpoints/dummy?api-version=2018-08-01
+  response:
+    body: {string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/interfaceEndpoints/dummy''
+        under resource group ''cli_test_network_private_endpoints000001'' was not
+        found."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['221']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 19 Oct 2018 22:46:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-failure-cause: [gateway]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.17763-SP0) msrest/0.6.1 msrest_azure/0.4.34
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_network_private_endpoints000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 19 Oct 2018 22:46:58 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGTkVUV09SSzo1RlBSSVZBVEU6NUZFTkRQT0lOVFNVRlZSWXw0MTc1NzExNkI5QUNBMEE4LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -70,18 +70,18 @@ class NetworkLoadBalancerWithSku(ScenarioTest):
         ])
 
 
-class NetworkInterfaceEndpoints(ScenarioTest):
+class NetworkPrivateEndpoints(ScenarioTest):
 
-    @ResourceGroupPreparer(name_prefix='cli_test_network_interface_endpoints')
-    def test_network_interface_endpoints(self, resource_group):
+    @ResourceGroupPreparer(name_prefix='cli_test_network_private_endpoints')
+    def test_network_private_endpoints(self, resource_group):
 
         # unable to create resource so we can only verify the commands don't fail (or fail expectedly)
-        self.cmd('network interface-endpoint list')
-        self.cmd('network interface-endpoint list -g {rg}')
+        self.cmd('network private-endpoint list')
+        self.cmd('network private-endpoint list -g {rg}')
 
         # system code 3 for 'not found'
         with self.assertRaisesRegexp(SystemExit, '3'):
-            self.cmd('network interface-endpoint show -g {rg} -n dummy')
+            self.cmd('network private-endpoint show -g {rg} -n dummy')
 
 
 class NetworkLoadBalancerWithZone(ScenarioTest):


### PR DESCRIPTION
Closes #7536. Deprecates `interface-endpoint` so that the commands continue to appear for now.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
