### PR TITLE
Fixed bug where --no-wait option causes vm resize to crash.

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -3,12 +3,15 @@
 Release History
 ===============
 
+2.2.7
+++++++
+* `vm resize`: fix bug where `--no-wait` option causes command to crash
+
 2.2.6
 ++++++
 * `vm/vmss create`: enforce disk caching mode be `None` for Lv/Lv2 series of machines
 * `vm create`: update supported size list supporting networking accelerator
 * `disk update`: expose strong typed arguments for ultrassd iops and mbps configs
-* `vm resize`: fix bug where `--no-wait` option causes command to crash
 
 2.2.5
 ++++++

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * `vm/vmss create`: enforce disk caching mode be `None` for Lv/Lv2 series of machines
 * `vm create`: update supported size list supporting networking accelerator
 * `disk update`: expose strong typed arguments for ultrassd iops and mbps configs
+* `vm resize`: fix bug where `--no-wait` option causes command to crash
 
 2.2.5
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -882,7 +882,7 @@ def resize_vm(cmd, resource_group_name, vm_name, size, no_wait=False):
         return None
 
     vm.hardware_profile.vm_size = size  # pylint: disable=no-member
-    return set_vm(cmd, vm, no_wait)
+    return set_vm(cmd, vm, no_wait=no_wait)
 
 
 def set_vm(cmd, instance, lro_operation=None, no_wait=False):

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.2.6"
+VERSION = "2.2.7"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fixes #6768 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
