### PR TITLE
Webapps backup - fix detection of unset schedule in upade_backup_schedule

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 0.2.6
 +++++
 * update ACR SDK
+* webapp: fix a bug in `az webapp config backup update` that prevents setting a backup schedule if one is not already set
 
 0.2.5
 +++++

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -31,7 +31,7 @@ from azure.mgmt.web.models import (Site, SiteConfig, User, AppServicePlan, SiteC
                                    BackupRequest, DatabaseBackupSetting, BackupSchedule,
                                    RestoreRequest, FrequencyUnit, Certificate, HostNameSslState,
                                    RampUpRule, UnauthenticatedClientAction, ManagedServiceIdentity,
-                                   DeletedAppRestoreRequest)
+                                   DeletedAppRestoreRequest, DefaultErrorResponseException)
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands import LongRunningOperation
@@ -1163,7 +1163,7 @@ def update_backup_schedule(cmd, resource_group_name, webapp_name, storage_accoun
     try:
         configuration = _generic_site_operation(cmd.cli_ctx, resource_group_name, webapp_name,
                                                 'get_backup_configuration', slot)
-    except Exception:
+    except DefaultErrorResponseException:
         # No configuration set yet
         if not all([storage_account_url, frequency, retention_period_in_days,
                     keep_at_least_one_backup]):

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1163,7 +1163,7 @@ def update_backup_schedule(cmd, resource_group_name, webapp_name, storage_accoun
     try:
         configuration = _generic_site_operation(cmd.cli_ctx, resource_group_name, webapp_name,
                                                 'get_backup_configuration', slot)
-    except CloudError:
+    except Exception:
         # No configuration set yet
         if not all([storage_account_url, frequency, retention_period_in_days,
                     keep_at_least_one_backup]):


### PR DESCRIPTION
This fixes a bug that is preventing users from setting a new backup schedule. Right now, when trying to update the backup schedule with 'az webapp config backup update', if the app does not have a backup schedule configured, then an error will be returned:
Backup configuration not found for site 'site' with slot 'Production'

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
