### PR TITLE
[Network] Fix public-ip create `--ip-tags`

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 2.2.8
 +++++
 * `express-route peering connection create`: Fix issue where `--peer-circuit` would not accept an ID.
+* `public-ip create`: Fix issue where `--ip-tags` did not work correctly.
 
 2.2.7
 +++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -713,6 +713,7 @@ def process_nic_create_namespace(cmd, namespace):
 def process_public_ip_create_namespace(cmd, namespace):
     get_default_location_from_resource_group(cmd, namespace)
     validate_public_ip_prefix(cmd, namespace)
+    validate_ip_tags(cmd, namespace)
     validate_tags(namespace)
 
 


### PR DESCRIPTION
Fixes issue where the public IP tag validator was not called due to the presence of a command validator.\
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
