### PR TITLE
Fixed bug with update --remove --ids

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.0.50
 ++++++
-* Minor fixes.
+* Fix issue where update commands using `--remove` and `--ids` fail after first update is applied to first resource in ids list.
 
 2.0.49
 ++++++

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -416,7 +416,6 @@ class AzCliCommandInvoker(CommandInvoker):
                 new_params[key] = copy.deepcopy(value)
         return new_params
 
-
     def _rudimentary_get_command(self, args):  # pylint: disable=no-self-use
         """ Rudimentary parsing to get the command """
         nouns = []

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -343,7 +343,7 @@ class AzCliCommandInvoker(CommandInvoker):
                 logger.warning(d.message)
 
             try:
-                result = cmd(self._copy_params(params))
+                result = cmd(params)
                 if cmd.supports_no_wait and getattr(expanded_arg, 'no_wait', False):
                     result = None
                 elif cmd.no_wait_param and getattr(expanded_arg, cmd.no_wait_param, False):
@@ -401,20 +401,6 @@ class AzCliCommandInvoker(CommandInvoker):
             if ('additionalProperties' in converted_dic and isinstance(obj.additional_properties, dict)):
                 converted_dic.update(converted_dic.pop('additionalProperties'))
         return converted_dic
-
-    @staticmethod
-    # copy params so that original params remain unmodified when.
-    # params need to be unmodified in the event that a command is executed multiple times against different --ids
-    def _copy_params(params):
-        import copy
-        new_params = {}
-        for key, value in params.items():
-            # TODO: is try except more robust here???
-            if isinstance(value, AzCliCommand):
-                new_params[key] = value
-            else:
-                new_params[key] = copy.deepcopy(value)
-        return new_params
 
     def _rudimentary_get_command(self, args):  # pylint: disable=no-self-use
         """ Rudimentary parsing to get the command """

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -343,7 +343,7 @@ class AzCliCommandInvoker(CommandInvoker):
                 logger.warning(d.message)
 
             try:
-                result = cmd(params)
+                result = cmd(self._copy_params(params))
                 if cmd.supports_no_wait and getattr(expanded_arg, 'no_wait', False):
                     result = None
                 elif cmd.no_wait_param and getattr(expanded_arg, cmd.no_wait_param, False):
@@ -401,6 +401,21 @@ class AzCliCommandInvoker(CommandInvoker):
             if ('additionalProperties' in converted_dic and isinstance(obj.additional_properties, dict)):
                 converted_dic.update(converted_dic.pop('additionalProperties'))
         return converted_dic
+
+    @staticmethod
+    # copy params so that original params remain unmodified when.
+    # params need to be unmodified in the event that a command is executed multiple times against different --ids
+    def _copy_params(params):
+        import copy
+        new_params = {}
+        for key, value in params.items():
+            # TODO: is try except more robust here???
+            if isinstance(value, AzCliCommand):
+                new_params[key] = value
+            else:
+                new_params[key] = copy.deepcopy(value)
+        return new_params
+
 
     def _rudimentary_get_command(self, args):  # pylint: disable=no-self-use
         """ Rudimentary parsing to get the command """

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -794,6 +794,7 @@ def set_properties(instance, expression, force_string):
 
 def add_properties(instance, argument_values, force_string):
     # The first argument indicates the path to the collection to add to.
+    argument_values = list(argument_values)
     list_attribute_path = _get_internal_path(argument_values.pop(0))
     list_to_add_to = _find_property(instance, list_attribute_path)
 
@@ -833,8 +834,8 @@ def add_properties(instance, argument_values, force_string):
 
 
 def remove_properties(instance, argument_values):
-    # The first argument indicates the path to the collection to add to.
-    argument_values = argument_values if isinstance(argument_values, list) else [argument_values]
+    # The first argument indicates the path to the collection to remove from.
+    argument_values = list(argument_values) if isinstance(argument_values, list) else [argument_values]
 
     list_attribute_path = _get_internal_path(argument_values.pop(0))
     list_index = None

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -154,6 +154,7 @@ class ResourceIDScenarioTest(ScenarioTest):
         self.cmd('resource delete --id {subnet_id}', checks=self.is_empty())
         self.cmd('resource delete --id {vnet_id}', checks=self.is_empty())
 
+
 class ResourceGenericUpdate(LiveScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_test_resource_id')
     def test_resource_id_scenario(self, resource_group):

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -154,6 +154,52 @@ class ResourceIDScenarioTest(ScenarioTest):
         self.cmd('resource delete --id {subnet_id}', checks=self.is_empty())
         self.cmd('resource delete --id {vnet_id}', checks=self.is_empty())
 
+class ResourceGenericUpdate(LiveScenarioTest):
+    @ResourceGroupPreparer(name_prefix='cli_test_resource_id')
+    def test_resource_id_scenario(self, resource_group):
+        self.kwargs.update({
+            'stor_1': self.create_random_name(prefix='stor1', length=10),
+            'stor_2': self.create_random_name(prefix='stor2', length=10)
+        })
+
+        # create storage accounts
+        self.cmd('az storage account create -g {rg} -n {stor_1}')
+        self.cmd('az storage account create -g {rg} -n {stor_2}')
+
+        # get ids
+        self.kwargs['stor_ids'] = " ".join(self.cmd('az storage account list -g {rg} --query "[].id"').get_output_in_json())
+
+        # update tags
+        self.cmd('az storage account update --ids {stor_ids} --set tags.isTag=True tags.isNotTag=False')
+
+        self.cmd('az storage account show --name {stor_1} -g {rg}', checks=[
+            self.check('tags.isTag', 'True'),
+            self.check('tags.isNotTag', 'False')
+        ])
+        self.cmd('az storage account show --name {stor_2} -g {rg}', checks=[
+            self.check('tags.isTag', 'True'),
+            self.check('tags.isNotTag', 'False')
+        ])
+
+        # delete tags.isTag
+        self.cmd('az storage account update --ids {stor_ids} --remove tags.isTag')
+
+        self.cmd('az storage account show --name {stor_1} -g {rg} --query "tags"', checks=[
+            self.check('isNotTag', 'False'),
+            self.check('isTag', None)
+        ])
+        self.cmd('az storage account show --name {stor_2} -g {rg} --query "tags"', checks=[
+            self.check('isNotTag', 'False'),
+            self.check('isTag', None)
+        ])
+
+        # delete tags.isNotTag
+        self.cmd('az storage account update --ids {stor_ids} --remove tags.isNotTag')
+
+        # check tags is empty.
+        self.cmd('az storage account show --name {stor_1} -g {rg} --query "tags"', checks=self.is_empty())
+        self.cmd('az storage account show --name {stor_2} -g {rg} --query "tags"', checks=self.is_empty())
+
 
 class ResourceCreateAndShowScenarioTest(ScenarioTest):
 


### PR DESCRIPTION
Fixed bug where if update --remove is called with --ids, the correct params aren't passed in subsequent iterations of the update command.

This applies to all generic update commands that use the --ids and --remove (and possibly those that use the--add) parameters.

Fix #6767 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
