### PR TITLE
ad: clarify the confusion between displayName and service principal name

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.1.9
 ++++++
+* `ad sp create-for-rbac`: clarify the confusion between displayName and service principal name
 * support grant permissions to AAD apps
 
 2.1.8

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -12,7 +12,7 @@ helps['ad sp create-for-rbac'] = """
     short-summary: Create a service principal and configure its access to Azure resources.
     parameters:
         - name: --name -n
-          short-summary: Name or app URI to associate the RBAC with. If not present, a name will be generated.
+          short-summary: a URI to use as the logic name. It doesn't need to exist. If not present, CLI will generate one.
         - name: --password -p
           short-summary: The password used to log in.
           long-summary: If not present and `--cert` is not specified, a random password will be generated.

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -1028,14 +1028,18 @@ def create_service_principal_for_rbac(
 
     app_display_name = None
     if name and '://' not in name:
+        prefix = "http://"
         app_display_name = name
-        name = "http://" + name  # normalize be a valid graph service principal name
+        logger.warning('Changing "%s" to a valid URI of "%s%s", which is the required format'
+                       ' used for service principal names', name, prefix, name)
+        name = prefix + name  # normalize be a valid graph service principal name
 
     if name:
         query_exp = 'servicePrincipalNames/any(x:x eq \'{}\')'.format(name)
         aad_sps = list(graph_client.service_principals.list(filter=query_exp))
         if aad_sps:
             raise CLIError("'{}' already exists.".format(name))
+        app_display_name = name.split('://')[-1]
 
     app_start_date = datetime.datetime.now(TZ_UTC)
     app_end_date = app_start_date + relativedelta(years=years or 1)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role_commands_thru_mock.py
@@ -136,6 +136,7 @@ class TestRoleMocked(unittest.TestCase):
         # assert
         self.assertEqual(result['password'], test_pwd)
         self.assertEqual(result['name'], 'http://' + name)
+        self.assertEqual(result['displayName'], name)
         self.assertEqual(result['appId'], test_app_id)
 
     @mock.patch('azure.cli.command_modules.role.custom._auth_client_factory', autospec=True)


### PR DESCRIPTION
Fix #6594
Fix #2042


- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
