### PR TITLE
[VM] encryption changes

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -7,7 +7,7 @@ Release History
 ++++++
 * `image create`: expose storage-sku argument for setting the image's default storage account type
 * `vm resize`: fix bug where `--no-wait` option causes command to crash
-* `vm encryption show`: table output format shows status for encryption initiated using `--disk-encryption-keyvault`
+* `vm encryption show`: table output format shows status
 
 2.2.6
 ++++++

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -7,6 +7,7 @@ Release History
 ++++++
 * `image create`: expose storage-sku argument for setting the image's default storage account type
 * `vm resize`: fix bug where `--no-wait` option causes command to crash
+* `vm encryption show`: table output format shows status for encryption initiated using `--disk-encryption-keyvault`
 
 2.2.6
 ++++++
@@ -16,7 +17,7 @@ Release History
 
 2.2.5
 ++++++
-* Fix SDK issue that caused Homebrew instllation to fail.
+* Fix SDK issue that caused Homebrew installation to fail.
 
 2.2.4
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_format.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_format.py
@@ -118,7 +118,8 @@ def get_vmss_table_output_transformer(loader, for_list=True):
 
 def transform_vm_encryption_show_table_output(result):
     from collections import OrderedDict
-    if "status" in result and result["status"]:
+    if result.get("status", []):
         status_dict = result["status"][0]
-        return OrderedDict([("status", status_dict["displayStatus"]), ("message", status_dict["message"])])
+        return OrderedDict([("status", status_dict.get("displayStatus", "N/A")),
+                            ("message", status_dict.get("message", "N/A"))])
     return result

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_format.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_format.py
@@ -114,3 +114,12 @@ def get_vmss_table_output_transformer(loader, for_list=True):
     transform = transform.replace('$zone$', 'Zones: (!zones && \' \') || join(\' \', zones), '
                                   if loader.supported_api_version(min_api='2017-03-30') else ' ')
     return transform if not for_list else '[].' + transform
+
+
+def transform_vm_encryption_show_table_output(result):
+    from collections import OrderedDict
+    if "status" in result and len(result["status"]) > 0:
+        status_dict = result["status"][0]
+        return OrderedDict([("status", status_dict["displayStatus"]), ("message", status_dict["message"])])
+    else:
+        return result

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_format.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_format.py
@@ -118,8 +118,7 @@ def get_vmss_table_output_transformer(loader, for_list=True):
 
 def transform_vm_encryption_show_table_output(result):
     from collections import OrderedDict
-    if "status" in result and len(result["status"]) > 0:
+    if "status" in result and result["status"]:
         status_dict = result["status"][0]
         return OrderedDict([("status", status_dict["displayStatus"]), ("message", status_dict["message"])])
-    else:
-        return result
+    return result

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -16,7 +16,7 @@ from azure.cli.command_modules.vm._client_factory import (cf_vm, cf_avail_set, c
 from azure.cli.command_modules.vm._format import (
     transform_ip_addresses, transform_vm, transform_vm_create_output, transform_vm_usage_list, transform_vm_list,
     transform_sku_for_table_output, transform_disk_show_table_output, transform_extension_show_table_output,
-    get_vmss_table_output_transformer)
+    get_vmss_table_output_transformer, transform_vm_encryption_show_table_output)
 from azure.cli.command_modules.vm._validators import (
     process_vm_create_namespace, process_vmss_create_namespace, process_image_create_namespace,
     process_disk_or_snapshot_create_namespace, process_disk_encryption_namespace, process_assign_identity_namespace,
@@ -225,7 +225,7 @@ def load_command_table(self, _):
     with self.command_group('vm encryption', custom_command_type=compute_disk_encryption_custom) as g:
         g.custom_command('enable', 'encrypt_vm', validator=process_disk_encryption_namespace)
         g.custom_command('disable', 'decrypt_vm')
-        g.custom_show_command('show', 'show_vm_encryption_status')
+        g.custom_show_command('show', 'show_vm_encryption_status', table_transformer=transform_vm_encryption_show_table_output)
 
     with self.command_group('vm extension', compute_vm_extension_sdk) as g:
         g.command('delete', 'delete', supports_no_wait=True)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -161,6 +161,7 @@ def encrypt_vm(cmd, resource_group_name, vm_name,  # pylint: disable=too-many-lo
 
     poller = compute_client.virtual_machine_extensions.create_or_update(
         resource_group_name, vm_name, extension['name'], ext)
+    LongRunningOperation(cmd.cli_ctx)(poller)
     poller.result()
 
     # verify the extension was ok
@@ -258,6 +259,7 @@ def decrypt_vm(cmd, resource_group_name, vm_name, volume_type=None, force=False)
     poller = compute_client.virtual_machine_extensions.create_or_update(resource_group_name,
                                                                         vm_name,
                                                                         extension['name'], ext)
+    LongRunningOperation(cmd.cli_ctx)(poller)
     poller.result()
     extension_result = compute_client.virtual_machine_extensions.get(resource_group_name, vm_name,
                                                                      extension['name'],


### PR DESCRIPTION
Fixes #7410:

`vm encryption enable` shows "- Running .." during long running operations.
`vm encryption --disk-encryption-keyvault`  show outputs table data when `-o table` option is used.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
