### PR TITLE
Allow connection to storage services with SharedAccessSignature

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+2.2.4
++++++
+* Allow connection to storage services only with SAS and endpoints (without an account name or a key) as described in
+  `Configure Azure Storage connection strings <https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string>`_.
+
 2.2.3
 +++++
 * Fix `az storage cors list` output formatting, all items show correct "Service" key

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -119,7 +119,8 @@ def validate_client_parameters(cmd, namespace):
         conn_dict = validate_key_value_pairs(n.connection_string)
         n.account_name = conn_dict.get('AccountName')
         n.account_key = conn_dict.get('AccountKey')
-        if not n.account_name or not n.account_key:
+        n.sas_token = conn_dict.get('SharedAccessSignature')
+        if not n.sas_token and (not n.account_name or not n.account_key):
             from knack.util import CLIError
             raise CLIError('Connection-string: %s, is malformed. Some shell environments require the '
                            'connection string to be surrounded by quotes.' % n.connection_string)

--- a/src/command_modules/azure-cli-storage/setup.py
+++ b/src/command_modules/azure-cli-storage/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.2.3"
+VERSION = "2.2.4"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Storage services should be able to be accessed only with a SAS and relevant endpoint specifiers, as described in https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string , however cli ends up with the following error:

```
$  AZURE_STORAGE_CONNECTION_STRING='BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;SharedConnectionString=xxxx' az storage container list
Connection-string: BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;SharedConnectionString=xxxx, is malformed. Some shell environments require the connection string to be surrounded by quotes.
```

This patch addresses the problem.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
