### PR TITLE
add linux only help for webapp config storage-account

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -121,17 +121,17 @@ examples:
 
 helps['webapp config storage-account'] = """
 type: group
-short-summary: Manage a web app's Azure storage account configurations.
+short-summary: Manage a web app's Azure storage account configurations. (Linux Web Apps and Windows Containers Web Apps Only)
 """
 
 helps['webapp config storage-account list'] = """
 type: command
-short-summary: Get a web app's Azure storage account configurations.
+short-summary: Get a web app's Azure storage account configurations. (Linux Web Apps and Windows Containers Web Apps Only)
 """
 
 helps['webapp config storage-account add'] = """
 type: command
-short-summary: Add an Azure storage account configuration to a web app.
+short-summary: Add an Azure storage account configuration to a web app. (Linux Web Apps and Windows Containers Web Apps Only)
 examples:
     - name: Add a connection to the Azure Files file share called MyShare in the storage account named MyStorageAccount.
       text: >
@@ -146,7 +146,7 @@ examples:
 
 helps['webapp config storage-account update'] = """
 type: command
-short-summary: Update an existing Azure storage account configuration on a web app.
+short-summary: Update an existing Azure storage account configuration on a web app. (Linux Web Apps and Windows Containers Web Apps Only)
 examples:
     - name: Update the mount path for a connection to the Azure Files file share with the ID MyId.
       text: >
@@ -157,7 +157,7 @@ examples:
 
 helps['webapp config storage-account delete'] = """
 type: command
-short-summary: Delete a web app's Azure storage account configuration.
+short-summary: Delete a web app's Azure storage account configuration. (Linux Web Apps and Windows Containers Web Apps Only)
 """
 
 helps['webapp config connection-string'] = """


### PR DESCRIPTION
clarify help to Mounting Azure Storage is only supported on Linux Web Apps and in Windows Containers Web Apps 

```
C:\Users\patle>az webapp config storage-account -h

Group
    az webapp config storage-account : Manage a web app's Azure storage account configurations.
    (Linux Web Apps and Windows Containers Web Apps Only).

Commands:
    add    : Add an Azure storage account configuration to a web app. (Linux Web Apps and Windows
             Containers Web Apps Only).
    delete : Delete a web app's Azure storage account configuration. (Linux Web Apps and Windows
             Containers Web Apps Only).
    list   : Get a web app's Azure storage account configurations. (Linux Web Apps and Windows
             Containers Web Apps Only).
    update : Update an existing Azure storage account configuration on a web app. (Linux Web Apps
             and Windows Containers Web Apps Only).
```


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
