### PR TITLE
Allow config to set extension dir

### DIFF
--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -13,8 +13,7 @@
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <InterpreterId>MSBuild|env|$(MSBuildProjectFullPath)</InterpreterId>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <CommandLineArguments>
-    </CommandLineArguments>
+    <CommandLineArguments>--version</CommandLineArguments>
     <IsWindowsApplication>False</IsWindowsApplication>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
@@ -38,12 +37,19 @@
     <Compile Include="azure-cli-core\azure\cli\core\commands\parameters.py" />
     <Compile Include="azure-cli-core\azure\cli\core\commands\progress.py" />
     <Compile Include="azure-cli-core\azure\cli\core\commands\template_create.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\commands\transform.py" />
     <Compile Include="azure-cli-core\azure\cli\core\commands\validators.py" />
     <Compile Include="azure-cli-core\azure\cli\core\commands\__init__.py" />
     <Compile Include="azure-cli-core\azure\cli\core\decorators.py" />
-    <Compile Include="azure-cli-core\azure\cli\core\extensions\experimental.py" />
-    <Compile Include="azure-cli-core\azure\cli\core\extensions\transform.py" />
-    <Compile Include="azure-cli-core\azure\cli\core\extensions\__init__.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\extension\operations.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\extension\tests\latest\test_extension_commands.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\extension\tests\latest\test_index_get.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\extension\tests\latest\test_resolve.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\extension\tests\latest\__init__.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\extension\_homebrew_patch.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\extension\_index.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\extension\_resolve.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\extension\__init__.py" />
     <Compile Include="azure-cli-core\azure\cli\core\file_util.py" />
     <Compile Include="azure-cli-core\azure\cli\core\keys.py" />
     <Compile Include="azure-cli-core\azure\cli\core\mock.py" />
@@ -60,6 +66,7 @@
     <Compile Include="azure-cli-core\azure\cli\core\tests\test_extension.py" />
     <Compile Include="azure-cli-core\azure\cli\core\tests\test_generic_update.py" />
     <Compile Include="azure-cli-core\azure\cli\core\tests\test_help.py" />
+    <Compile Include="azure-cli-core\azure\cli\core\tests\test_keys.py" />
     <Compile Include="azure-cli-core\azure\cli\core\tests\test_output.py" />
     <Compile Include="azure-cli-core\azure\cli\core\tests\test_parser.py" />
     <Compile Include="azure-cli-core\azure\cli\core\tests\test_profile.py" />
@@ -852,8 +859,11 @@
     <Folder Include="azure-cli-core\azure\" />
     <Folder Include="azure-cli-core\azure\cli\" />
     <Folder Include="azure-cli-core\azure\cli\core\" />
+    <Folder Include="azure-cli-core\azure\cli\core\auth_landing_pages\" />
     <Folder Include="azure-cli-core\azure\cli\core\commands\" />
-    <Folder Include="azure-cli-core\azure\cli\core\extensions\" />
+    <Folder Include="azure-cli-core\azure\cli\core\extension\" />
+    <Folder Include="azure-cli-core\azure\cli\core\extension\tests\" />
+    <Folder Include="azure-cli-core\azure\cli\core\extension\tests\latest\" />
     <Folder Include="azure-cli-core\azure\cli\core\profiles\" />
     <Folder Include="azure-cli-core\azure\cli\core\tests\" />
     <Folder Include="azure-cli-nspkg\" />
@@ -1258,6 +1268,10 @@
   <ItemGroup>
     <Content Include="azure-cli-command_modules-nspkg\HISTORY.rst" />
     <Content Include="azure-cli-command_modules-nspkg\setup.cfg" />
+    <Content Include="azure-cli-core\azure\cli\core\auth_landing_pages\fail.html" />
+    <Content Include="azure-cli-core\azure\cli\core\auth_landing_pages\fail.html" />
+    <Content Include="azure-cli-core\azure\cli\core\auth_landing_pages\ok.html" />
+    <Content Include="azure-cli-core\azure\cli\core\auth_landing_pages\ok.html" />
     <Content Include="azure-cli-core\HISTORY.rst" />
     <Content Include="azure-cli-core\setup.cfg" />
     <Content Include="azure-cli-nspkg\HISTORY.rst" />

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -55,11 +55,21 @@ class AzCli(CLI):
         self.cloud = get_active_cloud(self)
         logger.debug('Current cloud config:\n%s', str(self.cloud.name))
 
+        self._patch_extensions_dir()
+
         register_global_transforms(self)
         register_global_subscription_argument(self)
         register_ids_argument(self)  # global subscription must be registered first!
 
         self.progress_controller = None
+
+    def _patch_extensions_dir(self):
+        from importlib import import_module
+        from azure.cli.core._config import GLOBAL_CONFIG_DIR
+        ext_module = import_module('azure.cli.core.extension')
+        custom_ext_dir = self.config.get('extension', 'dir', None)
+        setattr(ext_module, 'EXTENSIONS_DIR', os.path.expanduser(custom_ext_dir)
+                if custom_ext_dir else os.path.join(GLOBAL_CONFIG_DIR, 'cliextensions'))
 
     def refresh_request_id(self):
         """Assign a new random GUID as x-ms-client-request-id

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -15,6 +15,7 @@ from azure.cli.core._config import GLOBAL_CONFIG_DIR
 _CUSTOM_EXT_DIR = os.environ.get('AZURE_EXTENSION_DIR')
 EXTENSIONS_DIR = os.path.expanduser(_CUSTOM_EXT_DIR) if _CUSTOM_EXT_DIR else os.path.join(GLOBAL_CONFIG_DIR,
                                                                                           'cliextensions')
+
 EXTENSIONS_MOD_PREFIX = 'azext_'
 
 WHL_METADATA_FILENAME = 'metadata.json'


### PR DESCRIPTION
Allows the user to configure their extension directory using a config file rather than solely via environment variable.

Will be used in the standalone version of `azdev`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
