### PR TITLE
[AKS] Take into account listen_port while doing aks_browse from within the Azure Cloud Shell

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1353,7 +1353,7 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False, li
     # launch kubectl port-forward locally to access the remote dashboard
     if in_cloud_console():
         # TODO: better error handling here.
-        response = requests.post('http://localhost:8888/openport/8001')
+        response = requests.post('http://localhost:8888/openport/{0}'.format(listen_port))
         result = json.loads(response.text)
         term_id = os.environ.get('ACC_TERM_ID')
         if term_id:


### PR DESCRIPTION
Take into account listen_port while doing aks_browse from within the Azure Cloud Shell.

Fix #7724 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
