### PR TITLE
convert long 'or not' chains to use any()

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -155,7 +155,7 @@ class CliCommandHelpFile(KnackCommandHelpFile, CliHelpFile):
     def _load_from_data(self, data):
         super(CliCommandHelpFile, self)._load_from_data(data)
 
-        if isinstance(data, str) or not self.parameters or not data.get('parameters'):
+        if isinstance(data, str) or not any([self.parameters, data.get('parameters')]):
             return
 
         loaded_params = []

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_azure_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_azure_utils.py
@@ -16,7 +16,7 @@ def get_blob_info(blob_sas_url):
     blob_name = match.group('blob_name')
     sas_token = match.group('sas_token')
 
-    if not account_name or not container_name or not blob_name or not sas_token:
+    if not any([account_name, container_name, blob_name, sas_token]):
         raise CLIError("Failed to parse the SAS URL: '{!s}'.".format(blob_sas_url))
 
     return account_name, endpoint_suffix, container_name, blob_name, sas_token

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/custom.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/custom.py
@@ -60,7 +60,7 @@ def create_adls_account(cmd, client, resource_group_name, account_name, location
         identity = EncryptionIdentity()
         config = EncryptionConfig(type=encryption_type)
         if encryption_type == EncryptionConfigType.user_managed:
-            if not key_name or not key_vault_id or not key_version:
+            if not any([key_name, key_vault_id, key_version]):
                 # pylint: disable=line-too-long
                 raise CLIError('For user managed encryption, --key_vault_id, --key_name and --key_version are required parameters and must be supplied.')
             config.key_vault_meta_info = KeyVaultMetaInfo(key_vault_id, key_name, key_version)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1329,7 +1329,7 @@ def show_vm_image(cmd, urn=None, publisher=None, offer=None, sku=None, version=N
         publisher, offer, sku, version = urn.split(":")
         if version.lower() == 'latest':
             version = _get_latest_image_version(cmd.cli_ctx, location, publisher, offer, sku)
-    elif not publisher or not offer or not sku or not version:
+    elif not any([publisher, offer, sku, version]):
         raise CLIError(usage_err)
     client = _compute_client_factory(cmd.cli_ctx)
     return client.virtual_machine_images.get(location, publisher, offer, sku, version)
@@ -1349,7 +1349,7 @@ def accept_market_ordering_terms(cmd, urn=None, publisher=None, offer=None, plan
             return
         plan = image.plan.name
     else:
-        if not publisher or not offer or not plan:
+        if not any([publisher, offer, plan]):
             raise CLIError(usage_err)
 
     market_place_client = get_mgmt_service_client(cmd.cli_ctx, MarketplaceOrderingAgreements)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -376,7 +376,7 @@ def _check_encrypt_is_supported(image_reference, volume_type):
     sku = getattr(image_reference, 'sku', None)
 
     # custom image?
-    if not offer or not publisher or not sku:
+    if not any([offer, publisher, sku]):
         return (True, None)
     publisher, sku, offer = publisher.lower(), sku.lower(), offer.lower()
     supported = [


### PR DESCRIPTION
There were a few spots throughout the codebase I noticed a list of multiple `or not` clauses. To shorten these conditionals and clean up a few lines, I've converted to these clauses to use the `any()` built-in.
---
