### PR TITLE
 graph: output warnings to communicate breaking changes in the near future

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+2.1.10
+++++++
+* graph: output warnings to communicate breaking changes in the near future for "ad app/sp list"
+
 2.1.9
 ++++++
 * support API permission management, signed-in-user, and application password & certificate credential management

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -497,6 +497,11 @@ def list_apps(client, app_id=None, display_name=None, identifier_uri=None, query
     if identifier_uri:
         sub_filters.append("identifierUris/any(s:s eq '{}')".format(identifier_uri))
 
+    if not sub_filters:
+        logger.warning('In a future relase, if no filter arguments are provided, CLI will only output the first'
+        ' 100 objects to avoid long waiting. You can still use "--all" for old behavior, though it is much'
+        ' recommended to avoid it')
+
     return client.list(filter=(' and '.join(sub_filters)))
 
 
@@ -525,6 +530,10 @@ def list_sps(client, spn=None, display_name=None, query_filter=None):
     if display_name:
         sub_filters.append("startswith(displayName,'{}')".format(display_name))
 
+    if not sub_filters:
+        logger.warning('In a future relase, if no filter arguments are provided, CLI will only output the first'
+        ' 100 objects to avoid long waiting. You can still use "--all" for old behavior, though it is much'
+        ' recommended to avoid it')
     return client.list(filter=(' and '.join(sub_filters)))
 
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -498,9 +498,9 @@ def list_apps(client, app_id=None, display_name=None, identifier_uri=None, query
         sub_filters.append("identifierUris/any(s:s eq '{}')".format(identifier_uri))
 
     if not sub_filters:
-        logger.warning('In a future relase, if no filter arguments are provided, CLI will only output the first'
-                       ' 100 objects to avoid long waiting. You can still use "--all" for old behavior, though'
-                       ' it is much recommended to avoid it')
+        logger.warning('In a future release, if no filter arguments are provided, CLI will output only the first'
+                       ' 100 objects to minimize wait times. You can still use --all for the old behavior,'
+                       ' though it is not recommended')
 
     return client.list(filter=(' and '.join(sub_filters)))
 
@@ -531,9 +531,9 @@ def list_sps(client, spn=None, display_name=None, query_filter=None):
         sub_filters.append("startswith(displayName,'{}')".format(display_name))
 
     if not sub_filters:
-        logger.warning('In a future relase, if no filter arguments are provided, CLI will only output the first'
-                       ' 100 objects to avoid long waiting. You can still use "--all" for old behavior,'
-                       ' though it is much recommended to avoid it')
+        logger.warning('In a future release, if no filter arguments are provided, CLI will output only the first'
+                       ' 100 objects to to minimize wait times. You can still use --all for the old behavior,'
+                       ' though it is not recommended')
     return client.list(filter=(' and '.join(sub_filters)))
 
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -532,8 +532,8 @@ def list_sps(client, spn=None, display_name=None, query_filter=None):
 
     if not sub_filters:
         logger.warning('In a future relase, if no filter arguments are provided, CLI will only output the first'
-        ' 100 objects to avoid long waiting. You can still use "--all" for old behavior, though it is much'
-        ' recommended to avoid it')
+                       ' 100 objects to avoid long waiting. You can still use "--all" for old behavior,'
+                       ' though it is much recommended to avoid it')
     return client.list(filter=(' and '.join(sub_filters)))
 
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -499,8 +499,8 @@ def list_apps(client, app_id=None, display_name=None, identifier_uri=None, query
 
     if not sub_filters:
         logger.warning('In a future relase, if no filter arguments are provided, CLI will only output the first'
-        ' 100 objects to avoid long waiting. You can still use "--all" for old behavior, though it is much'
-        ' recommended to avoid it')
+                       ' 100 objects to avoid long waiting. You can still use "--all" for old behavior, though'
+                       ' it is much recommended to avoid it')
 
     return client.list(filter=(' and '.join(sub_filters)))
 

--- a/src/command_modules/azure-cli-role/setup.py
+++ b/src/command_modules/azure-cli-role/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.1.9"
+VERSION = "2.1.10"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
For #1150 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
