### PR TITLE
[Storage] fixed bugs and improvements for copy commands

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -5,7 +5,8 @@ Release History
 
 2.2.5
 +++++
-* Improvements and fixes for storage copy commands.
+* Improve handling of corner cases for storage copy commands.
+* Fix issue with `storage blob copy start-batch` not using login credentials when the destination and source accounts are the same.
 
 2.2.4
 +++++

--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.2.5
 +++++
-* Minor fixes.
+* Improvements and fixes for storage copy commands.
 
 2.2.4
 +++++

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -377,7 +377,7 @@ helps['storage blob copy start-batch'] = """
     type: command
     short-summary: Copy multiple blobs or files to a blob container.
     parameters:
-        - name: --destination-container
+        - name: --destination-container -c
           type: string
           short-summary: The blob container where the selected source files or blobs will be copied to.
         - name: --pattern

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -627,13 +627,13 @@ def get_source_file_or_blob_service_client(cmd, namespace):
 
     if source_uri and source_account:
         raise ValueError(usage_string)
-    if not source_uri and not bool(source_container) ^ bool(source_share):
+    if not source_uri and bool(source_container) == bool(source_share):  # must be container or share
         raise ValueError(usage_string)
 
     if (not source_account) and (not source_uri):
         # Set the source_client to None if neither source_account or source_uri is given. This
         # indicates the command that the source files share or blob container is in the same storage
-        # account as the destination file share.
+        # account as the destination file share or blob container.
         #
         # The command itself should create the source service client since the validator can't
         # access the destination client through the namespace.

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -599,6 +599,7 @@ def validate_select(namespace):
         namespace.select = ','.join(namespace.select)
 
 
+# pylint: disable=too-many-statements
 def get_source_file_or_blob_service_client(cmd, namespace):
     """
     Create the second file service or blob service client for batch copy command, which is used to
@@ -625,7 +626,7 @@ def get_source_file_or_blob_service_client(cmd, namespace):
 
     if source_uri and source_account:
         raise ValueError(usage_string)
-    if not source_uri and not (bool(source_container) ^ bool(source_share)):
+    if not source_uri and not bool(source_container) ^ bool(source_share):
         raise ValueError(usage_string)
 
     if (not source_account) and (not source_uri):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -258,6 +258,7 @@ def validate_source_uri(cmd, namespace):  # pylint: disable=too-many-statements
         if source_sas:
             source_sas = source_sas.lstrip('?')
             uri = '{}{}{}'.format(uri, '?', source_sas)
+            namespace.copy_source = uri
         return
 
     # ensure either a file or blob source is specified

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/blob.py
@@ -56,7 +56,7 @@ def set_delete_policy(client, enable=None, days_retained=None):
     return client.get_blob_service_properties().delete_retention_policy
 
 
-def storage_blob_copy_batch(cmd, client, source_client, destination_container=None,
+def storage_blob_copy_batch(cmd, client, source_client, container_name=None,
                             destination_path=None, source_container=None, source_share=None,
                             source_sas=None, pattern=None, dryrun=False):
     """Copy a group of blob or files to a blob container."""
@@ -65,7 +65,7 @@ def storage_blob_copy_batch(cmd, client, source_client, destination_container=No
         logger = get_logger(__name__)
         logger.warning('copy files or blobs to blob container')
         logger.warning('    account %s', client.account_name)
-        logger.warning('  container %s', destination_container)
+        logger.warning('  container %s', container_name)
         logger.warning('     source %s', source_container or source_share)
         logger.warning('source type %s', 'blob' if source_container else 'file')
         logger.warning('    pattern %s', pattern)
@@ -76,7 +76,6 @@ def storage_blob_copy_batch(cmd, client, source_client, destination_container=No
 
         # if the source client is None, recreate one from the destination client.
         source_client = source_client or create_blob_service_from_storage_client(cmd, client)
-
         if not source_sas:
             source_sas = create_short_lived_container_sas(cmd, source_client.account_name, source_client.account_key,
                                                           source_container)
@@ -86,7 +85,7 @@ def storage_blob_copy_batch(cmd, client, source_client, destination_container=No
             if dryrun:
                 logger.warning('  - copy blob %s', blob_name)
             else:
-                return _copy_blob_to_blob_container(client, source_client, destination_container, destination_path,
+                return _copy_blob_to_blob_container(client, source_client, container_name, destination_path,
                                                     source_container, source_sas, blob_name)
 
         return list(filter_none(action_blob_copy(blob) for blob in collect_blobs(source_client,
@@ -109,7 +108,7 @@ def storage_blob_copy_batch(cmd, client, source_client, destination_container=No
             if dryrun:
                 logger.warning('  - copy file %s', os.path.join(dir_name, file_name))
             else:
-                return _copy_file_to_blob_container(client, source_client, destination_container, destination_path,
+                return _copy_file_to_blob_container(client, source_client, container_name, destination_path,
                                                     source_share, source_sas, dir_name, file_name)
 
         return list(filter_none(action_file_copy(file) for file in collect_files(cmd,

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/hybrid_2018_03_01/test_storage_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/hybrid_2018_03_01/test_storage_validators.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
+import mock
 from argparse import Namespace
 from six import StringIO
 
@@ -168,7 +169,8 @@ class TestGetSourceClientValidator(unittest.TestCase):
         # source given in form of uri, source_container parsed from uri, source and dest account are the same
         ns = self._create_namespace(source_uri='https://storage_name.blob.core.windows.net/container2',
                                     destination_container='container1')
-        get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
+        with mock.patch('azure.cli.command_modules.storage._validators._query_account_key', return_value="fake_key"):
+            get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
         self.assertEqual(ns.source_container, 'container2')
         self.assertIsNone(ns.source_client)
 
@@ -191,7 +193,8 @@ class TestGetSourceClientValidator(unittest.TestCase):
         # source given in form of uri, source_share parsed from uri, source and dest account are the same
         ns = self._create_namespace(source_uri='https://storage_name.file.core.windows.net/share2',
                                     destination_share='share1')
-        get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
+        with mock.patch('azure.cli.command_modules.storage._validators._query_account_key', return_value="fake_key"):
+            get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
         self.assertEqual(ns.source_share, 'share2')
         self.assertIsNone(ns.source_client)
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
@@ -18,7 +18,7 @@ from azure.cli.command_modules.storage._validators import (get_permission_valida
                                                            ipv4_range_type, resource_type_type, services_type,
                                                            process_blob_source_uri, get_char_options_validator,
                                                            get_source_file_or_blob_service_client,
-                                                           validate_encryption_source,
+                                                           validate_encryption_source, validate_source_uri,
                                                            validate_encryption_services)
 from azure.cli.testsdk import api_version_constraint
 
@@ -155,6 +155,12 @@ class TestStorageValidators(unittest.TestCase):
         result = getattr(ns, 'services')
         self.assertIs(type(result), set)
         self.assertEqual(result, set('ab'))
+
+    def test_validate_source_uri(self):
+        ns = Namespace(copy_source='https://other_name.file.core.windows.net/share2',
+                       source_sas='some_sas_token')
+        validate_source_uri(MockCmd(self.cli), ns)
+        self.assertEqual(ns.copy_source, 'https://other_name.file.core.windows.net/share2?some_sas_token')
 
 
 @api_version_constraint(resource_type=ResourceType.MGMT_STORAGE, min_api='2016-12-01')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
+import mock
 from argparse import Namespace
 from six import StringIO
 
@@ -219,7 +220,8 @@ class TestGetSourceClientValidator(unittest.TestCase):
         # source given in form of uri, source_container parsed from uri, source and dest account are the same
         ns = self._create_namespace(source_uri='https://storage_name.blob.core.windows.net/container2',
                                     destination_container='container1')
-        get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
+        with mock.patch('azure.cli.command_modules.storage._validators._query_account_key', return_value="fake_key"):
+            get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
         self.assertEqual(ns.source_container, 'container2')
         self.assertIsNone(ns.source_client)
 
@@ -242,7 +244,8 @@ class TestGetSourceClientValidator(unittest.TestCase):
         # source given in form of uri, source_share parsed from uri, source and dest account are the same
         ns = self._create_namespace(source_uri='https://storage_name.file.core.windows.net/share2',
                                     destination_share='share1')
-        get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
+        with mock.patch('azure.cli.command_modules.storage._validators._query_account_key', return_value="fake_key"):
+            get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
         self.assertEqual(ns.source_share, 'share2')
         self.assertIsNone(ns.source_client)
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/profile_2017_03_09/test_storage_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/profile_2017_03_09/test_storage_validators.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
+import mock
 from argparse import Namespace
 from six import StringIO
 
@@ -224,7 +225,8 @@ class TestGetSourceClientValidator(unittest.TestCase):
         # source given in form of uri, source_container parsed from uri, source and dest account are the same
         ns = self._create_namespace(source_uri='https://storage_name.blob.core.windows.net/container2',
                                     destination_container='container1')
-        get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
+        with mock.patch('azure.cli.command_modules.storage._validators._query_account_key', return_value="fake_key"):
+            get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
         self.assertEqual(ns.source_container, 'container2')
         self.assertIsNone(ns.source_client)
 
@@ -247,7 +249,8 @@ class TestGetSourceClientValidator(unittest.TestCase):
         # source given in form of uri, source_share parsed from uri, source and dest account are the same
         ns = self._create_namespace(source_uri='https://storage_name.file.core.windows.net/share2',
                                     destination_share='share1')
-        get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
+        with mock.patch('azure.cli.command_modules.storage._validators._query_account_key', return_value="fake_key"):
+            get_source_file_or_blob_service_client(MockCmd(self.cli), ns)
         self.assertEqual(ns.source_share, 'share2')
         self.assertIsNone(ns.source_client)
 


### PR DESCRIPTION
---
- specifying uri and sas-token form a new uri with the sas-token.
- validate that both source sas and key are not specified when the source-account is not specified
- deal with oauth incapability to use the token credentials for both source and destination when both the source and destination are the same account.
- query for account key if sas-token not given for source and not in source uri

Closes: https://github.com/Azure/azure-cli/issues/1479
Closes: https://github.com/Azure/azure-cli/issues/7652

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

