### PR TITLE
[Storage] remove restrictive validation for connection string

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -120,10 +120,6 @@ def validate_client_parameters(cmd, namespace):
         n.account_name = conn_dict.get('AccountName')
         n.account_key = conn_dict.get('AccountKey')
         n.sas_token = conn_dict.get('SharedAccessSignature')
-        if not n.sas_token and (not n.account_name or not n.account_key):
-            from knack.util import CLIError
-            raise CLIError('Connection-string: %s, is malformed. Some shell environments require the '
-                           'connection string to be surrounded by quotes.' % n.connection_string)
 
     # otherwise, simply try to retrieve the remaining variables from environment variables
     if not n.account_name:


### PR DESCRIPTION
---
-Remove validation checking for presence of sas-token/or accountkey/name in the string.
-Connection strings come in various flavors, one of which can be: `UseDevelopmentStorage=true;` to enable storage emulator.
- Since the restriction is being imposed by our CLI, yet is supported by the sdk, removing it to unblock users from these niche scenarios.
