### PR TITLE
[vm] Validate network params

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * `vm/vmss create --storage-sku`: can now specify the storage account sku for managed os and data disks separately.
 * `sig image-version`: Version names now consistently specified by  `--image-version -e`. `--image-version-name` deprecated.
 * `vm/vmss create --ephemeral-os-disk`: exposed parameter to create a vm/vmss with a local os disk.
+* `vm/vmss create --vnet-name`: validate that `--vnet-name` is a name and not an id.
 
 2.2.7
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -541,6 +541,9 @@ def _validate_vm_vmss_create_vnet(cmd, namespace, for_scale_set=False):
     location = namespace.location
     nics = getattr(namespace, 'nics', None)
 
+    if vnet and '/' in vnet:
+        raise CLIError("incorrect '--vnet-name' usage: '--vnet-name' must be a name, not an ID.")
+
     if not vnet and not subnet and not nics:
         logger.debug('no subnet specified. Attempting to find an existing Vnet and subnet...')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -542,7 +542,7 @@ def _validate_vm_vmss_create_vnet(cmd, namespace, for_scale_set=False):
     nics = getattr(namespace, 'nics', None)
 
     if vnet and '/' in vnet:
-        raise CLIError("incorrect '--vnet-name' usage: --subnet SUBNET_ID | --subnet SUBNET_NAME --vnet-name VNET_NAME")
+        raise CLIError("incorrect usage: --subnet SUBNET_ID | --subnet SUBNET_NAME --vnet-name VNET_NAME")
 
     if not vnet and not subnet and not nics:
         logger.debug('no subnet specified. Attempting to find an existing Vnet and subnet...')
@@ -577,7 +577,7 @@ def _validate_vm_vmss_create_vnet(cmd, namespace, for_scale_set=False):
     if subnet:
         subnet_is_id = is_valid_resource_id(subnet)
         if (subnet_is_id and vnet) or (not subnet_is_id and not vnet):
-            raise CLIError("incorrect '--subnet' usage: --subnet SUBNET_ID | "
+            raise CLIError("incorrect usage: --subnet SUBNET_ID | "
                            "--subnet SUBNET_NAME --vnet-name VNET_NAME")
 
         subnet_exists = \

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -542,7 +542,7 @@ def _validate_vm_vmss_create_vnet(cmd, namespace, for_scale_set=False):
     nics = getattr(namespace, 'nics', None)
 
     if vnet and '/' in vnet:
-        raise CLIError("incorrect usage: --subnet SUBNET_ID | --subnet SUBNET_NAME --vnet-name VNET_NAME")
+        raise CLIError("incorrect usage: --subnet ID | --subnet NAME --vnet-name NAME")
 
     if not vnet and not subnet and not nics:
         logger.debug('no subnet specified. Attempting to find an existing Vnet and subnet...')
@@ -577,8 +577,7 @@ def _validate_vm_vmss_create_vnet(cmd, namespace, for_scale_set=False):
     if subnet:
         subnet_is_id = is_valid_resource_id(subnet)
         if (subnet_is_id and vnet) or (not subnet_is_id and not vnet):
-            raise CLIError("incorrect usage: --subnet SUBNET_ID | "
-                           "--subnet SUBNET_NAME --vnet-name VNET_NAME")
+            raise CLIError("incorrect usage: --subnet ID | --subnet NAME --vnet-name NAME")
 
         subnet_exists = \
             check_existence(cmd.cli_ctx, subnet, rg, 'Microsoft.Network', 'subnets', vnet, 'virtualNetworks')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -542,7 +542,7 @@ def _validate_vm_vmss_create_vnet(cmd, namespace, for_scale_set=False):
     nics = getattr(namespace, 'nics', None)
 
     if vnet and '/' in vnet:
-        raise CLIError("incorrect '--vnet-name' usage: '--vnet-name' must be a name, not an ID.")
+        raise CLIError("incorrect '--vnet-name' usage: --subnet SUBNET_ID | --subnet SUBNET_NAME --vnet-name VNET_NAME")
 
     if not vnet and not subnet and not nics:
         logger.debug('no subnet specified. Attempting to find an existing Vnet and subnet...')


### PR DESCRIPTION
Validate that `--vnet-name` is not a resource id when creating a VM or VMSS

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
