### PR TITLE
[test]: remove the skip on blob live tests

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_blob_live_scenarios.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_blob_live_scenarios.py
@@ -4,13 +4,11 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-import unittest
 from azure.cli.testsdk import (LiveScenarioTest, ResourceGroupPreparer, StorageAccountPreparer,
                                JMESPathCheck, JMESPathCheckExists, NoneCheck, api_version_constraint)
 from azure.cli.core.profiles import ResourceType
 
 
-@unittest.skip("will reenable back once the test server gets fixed to recycle disk spaces")
 @api_version_constraint(ResourceType.MGMT_STORAGE, min_api='2016-12-01')
 class StorageBlobUploadLiveTests(LiveScenarioTest):
     @ResourceGroupPreparer()


### PR DESCRIPTION
I chose to skip it on a01 test launcher which is a more correct place

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
