### PR TITLE
[Storage] fixed incorrect help for list commands and warning for future break

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * Improve handling of corner cases for storage copy commands.
 * Fix issue with `storage blob copy start-batch` not using login credentials when the destination and source accounts are the same.
 * `storage blob/file url`- fix bug with sas_token not being incorporated into url.
+* Warn users about future breaking change: `blob/container list` will output first 5000 results by default.
 
 2.2.4
 +++++

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -12,7 +12,8 @@ from ._validators import (get_datetime_type, validate_metadata, get_permission_v
                           validate_included_datasets, validate_custom_domain, validate_container_public_access,
                           validate_table_payload_format, validate_key, add_progress_callback, process_resource_group,
                           storage_account_key_options, process_file_download_namespace, process_metric_update_namespace,
-                          get_char_options_validator, validate_bypass, validate_encryption_source, validate_marker)
+                          get_char_options_validator, validate_bypass, validate_encryption_source, validate_marker,
+                          validate_storage_data_plane_list)
 
 
 def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statements
@@ -204,8 +205,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
     with self.argument_context('storage blob list') as c:
         c.argument('include', validator=validate_included_datasets)
         c.argument('num_results', type=int,
-                   help='Specifies the maximum number of blobs to return. Must be in range [1,5000]. '
-                        'If this parameter is not provided, all blobs will be returned.')
+                   help='Specifies the maximum number of blobs to return. '
+                        'If this parameter is not provided, all blobs will be returned.',
+                   validator=validate_storage_data_plane_list)
         c.ignore('marker')  # https://github.com/Azure/azure-cli/issues/3745
 
     with self.argument_context('storage blob generate-sas') as c:
@@ -384,6 +386,10 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
 
     with self.argument_context('storage container exists') as c:
         c.ignore('blob_name', 'snapshot')
+
+    with self.argument_context('storage container list') as c:
+        c.argument('num_results', type=int, help='Specifies the maximum number of containers to return.',
+                   validator=validate_storage_data_plane_list)
 
     with self.argument_context('storage container set-permission') as c:
         c.ignore('signed_identifiers')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -106,9 +106,6 @@ def validate_client_parameters(cmd, namespace):
             account_key_args = [arg for arg in account_key_args if arg]
 
             if account_key_args:
-                from knack.log import get_logger
-
-                logger = get_logger(__name__)
                 logger.warning('In "login" auth mode, the following arguments are ignored: %s',
                                ' ,'.join(account_key_args))
             return

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -5,6 +5,7 @@
 
 # pylint: disable=protected-access
 
+from knack.log import get_logger
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.validators import validate_key_value_pairs
 from azure.cli.core.profiles import ResourceType, get_sdk
@@ -16,6 +17,7 @@ from azure.cli.command_modules.storage.url_quote_util import encode_for_url
 from azure.cli.command_modules.storage.oauth_token_util import TokenUpdater
 
 storage_account_key_options = {'primary': 'key1', 'secondary': 'key2'}
+logger = get_logger(__name__)
 
 
 # Utilities
@@ -322,6 +324,13 @@ def validate_source_uri(cmd, namespace):  # pylint: disable=too-many-statements
 def validate_blob_type(namespace):
     if not namespace.blob_type:
         namespace.blob_type = 'page' if namespace.file_path.endswith('.vhd') else 'block'
+
+
+def validate_storage_data_plane_list(namespace):
+    if namespace.num_results is None:
+        logger.warning('In a future release, if --num-results is not provided, the CLI will output only the first '
+                       '5000 results to minimize wait times. Users will be able to use a --all flag for the old '
+                       'behavior.')
 
 
 def get_content_setting_validator(settings_class, update, guess_from_file=None):


### PR DESCRIPTION
---
- blob/container list will current page by default for any specified number of `--num-results` through the sdk.
- warn users that list commands will output 5000 in a future release.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
