### PR TITLE
Fixes #7813 - fix keyerror

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 0.2.7
 +++++
 * remove client side sku check for linux app service plan create
+* minor fix to avoid key errors when trying to get zipdeploy status
 
 0.2.6
 +++++

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -1976,14 +1976,15 @@ def _check_zip_deployment_status(deployment_status_url, authorization):
         response = requests.get(deployment_status_url, headers=authorization)
         res_dict = response.json()
         num_trials = num_trials + 1
-        if res_dict['status'] == 5:
+        if res_dict.get('status', 0) == 5:
             logger.warning("Zip deployment failed status %s", res_dict['status_text'])
             break
-        elif res_dict['status'] == 4:
+        elif res_dict.get('status', 0) == 4:
             break
-        logger.info(res_dict['progress'])  # show only in debug mode, customers seem to find this confusing
+        if 'progress' in res_dict:
+            logger.info(res_dict['progress'])  # show only in debug mode, customers seem to find this confusing
     # if the deployment is taking longer than expected
-    if res_dict['status'] != 4:
+    if res_dict.get('status', 0) != 4:
         logger.warning("""Deployment is taking longer than expected. Please verify status at '%s'
             beforing launching the app""", deployment_status_url)
     return res_dict


### PR DESCRIPTION
Minor change to ensure that we do not exit with a key error if the zipdeploy returns a json without a status key. In that case, we want to continue with our retries.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).
