### PR TITLE
fix get curren user id azure-graphrbac Breaking change fixes #7839

### DIFF
--- a/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
@@ -1692,7 +1692,7 @@ def _create_keyvault(cmd,
 # pylint: disable=inconsistent-return-statements
 def _get_current_user_object_id(graph_client):
     try:
-        current_user = graph_client.objects.get_current_user()
+        current_user = graph_client.signed_in_user.get()
         if current_user and current_user.object_id:  # pylint:disable=no-member
             return current_user.object_id  # pylint:disable=no-member
     except CloudError:


### PR DESCRIPTION
change method objects.get_current_user that has been removed from azure.graphrbac now we should use signed_in_user.get
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
