### PR TITLE
Updated help.py - generate-sas example

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -863,9 +863,13 @@ helps['storage account generate-sas'] = """
           short-summary: 'Storage account name. Must be used in conjunction with either storage account key or a SAS
                          token. Environment Variable: AZURE_STORAGE_ACCOUNT'
     examples:
-        - name: Generate a sas token for the account that is valid for queue and table services.
+        - name: Generate a sas token for the account that is valid for queue and table services on Linux.
           text: |
             end=`date -d "30 minutes" '+%Y-%m-%dT%H:%MZ'`
+            az storage account generate-sas --permissions cdlruwap --account-name MyStorageAccount --services qt --resource-types sco --expiry $end -otsv
+        - name: Generate a sas token for the account that is valid for queue and table services on MacOS.
+          text: |
+            end=`date -v+30M '+%Y-%m-%dT%H:%MZ'`
             az storage account generate-sas --permissions cdlruwap --account-name MyStorageAccount --services qt --resource-types sco --expiry $end -otsv
 """
 


### PR DESCRIPTION
Added MacOS example for generating SAS token with expiration time. The call to the date function `date -d` works on Linux, but not on MacOS. I provided MacOS sample.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
