### PR TITLE
EventHub create: fix extra dash

### DIFF
--- a/src/command_modules/azure-cli-eventhubs/azure/cli/command_modules/eventhubs/_help.py
+++ b/src/command_modules/azure-cli-eventhubs/azure/cli/command_modules/eventhubs/_help.py
@@ -174,7 +174,7 @@ helps['eventhubs eventhub create'] = """
     short-summary: Creates the Event Hubs Eventhub
     examples:
         - name: Create a new Eventhub.
-          text: az eventhubs eventhub create --resource-group myresourcegroup --namespace-name mynamespace --name myeventhub --message-retention 4 ---partition-count 15
+          text: az eventhubs eventhub create --resource-group myresourcegroup --namespace-name mynamespace --name myeventhub --message-retention 4 --partition-count 15
 """
 
 helps['eventhubs eventhub update'] = """
@@ -182,7 +182,7 @@ helps['eventhubs eventhub update'] = """
     short-summary: Updates the Event Hubs Eventhub
     examples:
         - name: Updates a new Eventhub.
-          text: az eventhubs eventhub update --resource-group myresourcegroup --namespace-name mynamespace --name myeventhub --message-retention 3 ---partition-count 12
+          text: az eventhubs eventhub update --resource-group myresourcegroup --namespace-name mynamespace --name myeventhub --message-retention 3 --partition-count 12
 """
 
 helps['eventhubs eventhub show'] = """


### PR DESCRIPTION
Extra dash in the create eventhub example

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
