### PR TITLE
[image] create. Add --os-disk-caching parameter.

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * `vm extension show / wait`: deprecated --expand parameter.
 * `vm restart`: Added `--force` which redeploys unresponsive VMs.
 * `vm/vmss create`: `--authentication-type` now accepts/infers "all" to create a VM with both password and ssh authentication.
+* `image create`: Added `--os-disk-caching` parameter to set os disk caching for an image.
 
 2.2.8
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -114,6 +114,7 @@ def load_arguments(self, _):
         c.argument('zone_resilient', min_api='2017-12-01', arg_type=get_three_state_flag(), help='Specifies whether an image is zone resilient or not. '
                    'Default is false. Zone resilient images can be created only in regions that provide Zone Redundant Storage')
         c.argument('storage_sku', arg_type=disk_sku, help='The SKU of the storage account with which to create the VM image. Unused if source VM is specified.')
+        c.argument('os_disk_caching', arg_type=get_enum_type(CachingTypes), help="Storage caching type for the image's OS disk. Default: None")
         c.ignore('source_virtual_machine', 'os_blob_uri', 'os_disk', 'os_snapshot', 'data_blob_uris', 'data_disks', 'data_snapshots')
     # endregion
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -114,7 +114,7 @@ def load_arguments(self, _):
         c.argument('zone_resilient', min_api='2017-12-01', arg_type=get_three_state_flag(), help='Specifies whether an image is zone resilient or not. '
                    'Default is false. Zone resilient images can be created only in regions that provide Zone Redundant Storage')
         c.argument('storage_sku', arg_type=disk_sku, help='The SKU of the storage account with which to create the VM image. Unused if source VM is specified.')
-        c.argument('os_disk_caching', arg_type=get_enum_type(CachingTypes), help="Storage caching type for the image's OS disk. Default: None")
+        c.argument('os_disk_caching', arg_type=get_enum_type(CachingTypes), help="Storage caching type for the image's OS disk.")
         c.ignore('source_virtual_machine', 'os_blob_uri', 'os_disk', 'os_snapshot', 'data_blob_uris', 'data_disks', 'data_snapshots')
     # endregion
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -328,7 +328,7 @@ def create_image(cmd, resource_group_name, name, source, os_type=None, data_disk
     else:
         os_disk = ImageOSDisk(os_type=os_type,
                               os_state=OperatingSystemStateTypes.generalized,
-                              caching=os_disk_caching if os_disk_caching else 'None',
+                              caching=os_disk_caching,
                               snapshot=SubResource(id=os_snapshot) if os_snapshot else None,
                               managed_disk=SubResource(id=os_disk) if os_disk else None,
                               blob_uri=os_blob_uri,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -316,7 +316,7 @@ def create_image(cmd, resource_group_name, name, source, os_type=None, data_disk
                  source_virtual_machine=None, storage_sku=None,
                  os_blob_uri=None, data_blob_uris=None,
                  os_snapshot=None, data_snapshots=None,
-                 os_disk=None, data_disks=None, tags=None, zone_resilient=None):
+                 os_disk=None, os_disk_caching=None, data_disks=None, tags=None, zone_resilient=None):
     ImageOSDisk, ImageDataDisk, ImageStorageProfile, Image, SubResource, OperatingSystemStateTypes = cmd.get_models(
         'ImageOSDisk', 'ImageDataDisk', 'ImageStorageProfile', 'Image', 'SubResource', 'OperatingSystemStateTypes')
 
@@ -328,6 +328,7 @@ def create_image(cmd, resource_group_name, name, source, os_type=None, data_disk
     else:
         os_disk = ImageOSDisk(os_type=os_type,
                               os_state=OperatingSystemStateTypes.generalized,
+                              caching=os_disk_caching,
                               snapshot=SubResource(id=os_snapshot) if os_snapshot else None,
                               managed_disk=SubResource(id=os_disk) if os_disk else None,
                               blob_uri=os_blob_uri,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -328,7 +328,7 @@ def create_image(cmd, resource_group_name, name, source, os_type=None, data_disk
     else:
         os_disk = ImageOSDisk(os_type=os_type,
                               os_state=OperatingSystemStateTypes.generalized,
-                              caching=os_disk_caching,
+                              caching=os_disk_caching if os_disk_caching else 'None',
                               snapshot=SubResource(id=os_snapshot) if os_snapshot else None,
                               managed_disk=SubResource(id=os_disk) if os_disk else None,
                               blob_uri=os_blob_uri,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_managed_disk.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_managed_disk.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-10-23T19:19:08Z"}}'
+      "date": "2018-11-26T23:15:58Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -9,23 +9,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-23T19:19:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:19:12 GMT']
+      date: ['Mon, 26 Nov 2018 23:15:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -35,18 +36,19 @@ interactions:
       CommandName: [disk create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --size-gb --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-23T19:19:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:19:14 GMT']
+      date: ['Mon, 26 Nov 2018 23:16:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -63,8 +65,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['154']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --size-gb --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1?api-version=2018-06-01
@@ -76,18 +79,18 @@ interactions:
         \ \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"name\"\
         : \"d1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/fd023cf2-63e4-457a-ad4f-66ea2436c4d0?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a6712d9f-1a2b-4f7d-996a-26f9a29e7a0c?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['301']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:19:15 GMT']
+      date: ['Mon, 26 Nov 2018 23:16:02 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/fd023cf2-63e4-457a-ad4f-66ea2436c4d0?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a6712d9f-1a2b-4f7d-996a-26f9a29e7a0c?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateUpdateDisks3Min;999,Microsoft.Compute/CreateUpdateDisks30Min;3996']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateUpdateDisks3Min;999,Microsoft.Compute/CreateUpdateDisks30Min;3999']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -97,26 +100,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [disk create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --size-gb --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/fd023cf2-63e4-457a-ad4f-66ea2436c4d0?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a6712d9f-1a2b-4f7d-996a-26f9a29e7a0c?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:19:15.4795231+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:19:15.620145+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:16:02.2662458+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:16:02.3912777+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Premium_LRS\",\"tier\":\"Premium\"},\"properties\":{\"creationData\":{\"\
-        createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-10-23T19:19:15.4795231+00:00\"\
+        createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-11-26T23:16:02.2818795+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/disks\",\"location\":\"westus\",\"tags\":{\"tag1\":\"\
         d1\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        ,\"name\":\"d1\"}\r\n  },\r\n  \"name\": \"fd023cf2-63e4-457a-ad4f-66ea2436c4d0\"\
+        ,\"name\":\"d1\"}\r\n  },\r\n  \"name\": \"a6712d9f-1a2b-4f7d-996a-26f9a29e7a0c\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['721']
+      content-length: ['722']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:19:45 GMT']
+      date: ['Mon, 26 Nov 2018 23:16:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -124,7 +128,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249969']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49998,Microsoft.Compute/GetOperation30Min;249994']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -133,15 +137,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [disk create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --size-gb --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1?api-version=2018-06-01
   response:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Premium_LRS\",\r\n    \"\
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-10-23T19:19:15.4795231+00:00\",\r\n  \
+        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n  \
         \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -151,7 +156,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['617']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:19:45 GMT']
+      date: ['Mon, 26 Nov 2018 23:16:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -159,7 +164,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4998,Microsoft.Compute/LowCostGet30Min;19962']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4997,Microsoft.Compute/LowCostGet30Min;19989']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -168,8 +173,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [disk update]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --size-gb --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1?api-version=2018-06-01
@@ -177,7 +183,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Premium_LRS\",\r\n    \"\
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-10-23T19:19:15.4795231+00:00\",\r\n  \
+        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n  \
         \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -187,7 +193,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['617']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:19:47 GMT']
+      date: ['Mon, 26 Nov 2018 23:16:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -195,7 +201,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4996,Microsoft.Compute/LowCostGet30Min;19960']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4996,Microsoft.Compute/LowCostGet30Min;19988']
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "westus", "tags": {"tag1": "d1"}, "sku": {"name": "Standard_LRS"},
@@ -207,8 +213,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['156']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --size-gb --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1?api-version=2018-06-01
@@ -220,19 +227,19 @@ interactions:
         \ \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"name\"\
         : \"d1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/406b4b39-8095-41b7-9bf6-385d51c810bf?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/57ba24ad-5827-49e1-9d5b-a2f333607002?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['303']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:19:48 GMT']
+      date: ['Mon, 26 Nov 2018 23:16:35 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/406b4b39-8095-41b7-9bf6-385d51c810bf?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/57ba24ad-5827-49e1-9d5b-a2f333607002?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateUpdateDisks3Min;998,Microsoft.Compute/CreateUpdateDisks30Min;3995']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateUpdateDisks3Min;998,Microsoft.Compute/CreateUpdateDisks30Min;3998']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -241,26 +248,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [disk update]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --size-gb --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/406b4b39-8095-41b7-9bf6-385d51c810bf?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/57ba24ad-5827-49e1-9d5b-a2f333607002?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:19:48.1556513+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:19:48.3275421+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:16:35.0222809+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:16:35.1629586+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Standard_LRS\",\"tier\":\"Standard\"},\"properties\":{\"creationData\"\
-        :{\"createOption\":\"Empty\"},\"diskSizeGB\":10,\"timeCreated\":\"2018-10-23T19:19:15.4795231+00:00\"\
+        :{\"createOption\":\"Empty\"},\"diskSizeGB\":10,\"timeCreated\":\"2018-11-26T23:16:02.2818795+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/disks\",\"location\":\"westus\",\"tags\":{\"tag1\":\"\
         d1\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        ,\"name\":\"d1\"}\r\n  },\r\n  \"name\": \"406b4b39-8095-41b7-9bf6-385d51c810bf\"\
+        ,\"name\":\"d1\"}\r\n  },\r\n  \"name\": \"57ba24ad-5827-49e1-9d5b-a2f333607002\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['725']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:20:18 GMT']
+      date: ['Mon, 26 Nov 2018 23:17:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -268,7 +276,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49986,Microsoft.Compute/GetOperation30Min;249967']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49996,Microsoft.Compute/GetOperation30Min;249992']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -277,15 +285,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [disk update]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --size-gb --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1?api-version=2018-06-01
   response:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-10-23T19:19:15.4795231+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -295,7 +304,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['620']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:20:18 GMT']
+      date: ['Mon, 26 Nov 2018 23:17:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -303,7 +312,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4993,Microsoft.Compute/LowCostGet30Min;19958']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4993,Microsoft.Compute/LowCostGet30Min;19985']
     status: {code: 200, message: OK}
 - request:
     body: '{"access": "Read", "durationInSeconds": 10}'
@@ -314,25 +323,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['43']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --duration-in-seconds]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1/beginGetAccess?api-version=2018-06-01
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/c83af0a4-4214-4f53-94e4-ed6110ba5143?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1a503bb3-3b3b-496b-a0c8-3fb23461c2f8?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Tue, 23 Oct 2018 19:20:20 GMT']
+      date: ['Mon, 26 Nov 2018 23:17:08 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/c83af0a4-4214-4f53-94e4-ed6110ba5143?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1a503bb3-3b3b-496b-a0c8-3fb23461c2f8?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostDiskHydrate3Min;999,Microsoft.Compute/HighCostDiskHydrate30Min;4998']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostDiskHydrate3Min;999,Microsoft.Compute/HighCostDiskHydrate30Min;4999']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -342,21 +352,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [disk grant-access]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --duration-in-seconds]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/c83af0a4-4214-4f53-94e4-ed6110ba5143?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1a503bb3-3b3b-496b-a0c8-3fb23461c2f8?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:20:20.2315035+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:20:20.5752661+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:17:08.7729118+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:17:09.3198047+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\"\
-        : \"https://md-gm4v5p1x5v3l.blob.core.windows.net/lgx4p25l5hnf/abcd?sv=2017-04-17&sr=b&si=85259428-773a-44d9-b400-f1349e63680a&sig=cX67cFJRAXyehULVQ1speTANDIuLIfOQIweBo5KwLsk%3D\"\
-        \r\n}\r\n  },\r\n  \"name\": \"c83af0a4-4214-4f53-94e4-ed6110ba5143\"\r\n}"}
+        : \"https://md-jb0rsvcs5c2m.blob.core.windows.net/wc5brn3s2jfh/abcd?sv=2017-04-17&sr=b&si=46965bbd-3604-4a05-b24a-ccba74b55355&sig=kgPAyfYq%2FZetV7pLSFNc52Sicr7T3KmbuWP54wy1578%3D\"\
+        \r\n}\r\n  },\r\n  \"name\": \"1a503bb3-3b3b-496b-a0c8-3fb23461c2f8\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['421']
+      content-length: ['423']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:20:50 GMT']
+      date: ['Mon, 26 Nov 2018 23:17:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -364,7 +375,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249965']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49994,Microsoft.Compute/GetOperation30Min;249990']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -373,18 +384,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [disk grant-access]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --duration-in-seconds]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/c83af0a4-4214-4f53-94e4-ed6110ba5143?monitor=true&api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1a503bb3-3b3b-496b-a0c8-3fb23461c2f8?monitor=true&api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"accessSAS\": \"https://md-gm4v5p1x5v3l.blob.core.windows.net/lgx4p25l5hnf/abcd?sv=2017-04-17&sr=b&si=85259428-773a-44d9-b400-f1349e63680a&sig=cX67cFJRAXyehULVQ1speTANDIuLIfOQIweBo5KwLsk%3D\"\
+    body: {string: "{\r\n  \"accessSAS\": \"https://md-jb0rsvcs5c2m.blob.core.windows.net/wc5brn3s2jfh/abcd?sv=2017-04-17&sr=b&si=46965bbd-3604-4a05-b24a-ccba74b55355&sig=kgPAyfYq%2FZetV7pLSFNc52Sicr7T3KmbuWP54wy1578%3D\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['196']
+      content-length: ['198']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:20:52 GMT']
+      date: ['Mon, 26 Nov 2018 23:17:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -392,7 +404,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49987,Microsoft.Compute/GetOperation30Min;249964']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49993,Microsoft.Compute/GetOperation30Min;249989']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -402,18 +414,19 @@ interactions:
       CommandName: [disk create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-23T19:19:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:20:53 GMT']
+      date: ['Mon, 26 Nov 2018 23:17:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -430,8 +443,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['327']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d2?api-version=2018-06-01
@@ -443,18 +457,18 @@ interactions:
         : true\r\n  },\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"name\"\
         : \"d2\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/078efc03-08da-4ff7-b0eb-14381b3ba79a?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/16c3e784-8641-4706-8863-8780d29912a9?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['466']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:20:54 GMT']
+      date: ['Mon, 26 Nov 2018 23:17:40 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/078efc03-08da-4ff7-b0eb-14381b3ba79a?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/16c3e784-8641-4706-8863-8780d29912a9?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateUpdateDisks3Min;997,Microsoft.Compute/CreateUpdateDisks30Min;3994']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateUpdateDisks3Min;997,Microsoft.Compute/CreateUpdateDisks30Min;3997']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -464,27 +478,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [disk create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/078efc03-08da-4ff7-b0eb-14381b3ba79a?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/16c3e784-8641-4706-8863-8780d29912a9?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:20:54.9183705+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:20:55.6995937+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:17:40.9142569+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:17:42.1173836+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Premium_LRS\",\"tier\":\"Premium\"},\"properties\":{\"creationData\":{\"\
         createOption\":\"Copy\",\"sourceResourceId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        },\"diskSizeGB\":10,\"timeCreated\":\"2018-10-23T19:20:54.9183705+00:00\"\
+        },\"diskSizeGB\":10,\"timeCreated\":\"2018-11-26T23:17:40.9142569+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/disks\",\"location\":\"westus\",\"tags\":{},\"id\":\"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d2\"\
-        ,\"name\":\"d2\"}\r\n  },\r\n  \"name\": \"078efc03-08da-4ff7-b0eb-14381b3ba79a\"\
+        ,\"name\":\"d2\"}\r\n  },\r\n  \"name\": \"16c3e784-8641-4706-8863-8780d29912a9\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['912']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:21:24 GMT']
+      date: ['Mon, 26 Nov 2018 23:18:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -492,7 +507,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249962']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49991,Microsoft.Compute/GetOperation30Min;249987']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -501,8 +516,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [disk create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d2?api-version=2018-06-01
   response:
@@ -510,7 +526,7 @@ interactions:
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Copy\",\r\n      \"sourceResourceId\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        \r\n    },\r\n    \"diskSizeGB\": 10,\r\n    \"timeCreated\": \"2018-10-23T19:20:54.9183705+00:00\"\
+        \r\n    },\r\n    \"diskSizeGB\": 10,\r\n    \"timeCreated\": \"2018-11-26T23:17:40.9142569+00:00\"\
         ,\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d2\"\
@@ -519,7 +535,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['805']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:21:25 GMT']
+      date: ['Mon, 26 Nov 2018 23:18:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -527,7 +543,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4990,Microsoft.Compute/LowCostGet30Min;19955']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4990,Microsoft.Compute/LowCostGet30Min;19982']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -537,18 +553,19 @@ interactions:
       CommandName: [snapshot create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --size-gb --sku --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-23T19:19:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:21:27 GMT']
+      date: ['Mon, 26 Nov 2018 23:18:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -565,8 +582,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['154']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --size-gb --sku --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1?api-version=2018-06-01
@@ -577,18 +595,18 @@ interactions:
         : \"Updating\",\r\n    \"isArmResource\": true\r\n  },\r\n  \"location\":\
         \ \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/56b5646e-dc03-4dc5-9a8f-8a06759e8ec0?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/009b4254-7f40-4ebc-8a56-c767e61eac8a?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['284']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:21:28 GMT']
+      date: ['Mon, 26 Nov 2018 23:18:12 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/56b5646e-dc03-4dc5-9a8f-8a06759e8ec0?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/009b4254-7f40-4ebc-8a56-c767e61eac8a?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostSnapshotCreateHydrate3Min;239,Microsoft.Compute/HighCostSnapshotCreateHydrate30Min;1196']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostSnapshotCreateHydrate3Min;239,Microsoft.Compute/HighCostSnapshotCreateHydrate30Min;1199']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -598,26 +616,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [snapshot create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --size-gb --sku --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/56b5646e-dc03-4dc5-9a8f-8a06759e8ec0?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/009b4254-7f40-4ebc-8a56-c767e61eac8a?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:21:28.7631142+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:21:28.9349589+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:18:13.0030987+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:18:13.2062231+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Premium_LRS\",\"tier\":\"Premium\"},\"properties\":{\"creationData\":{\"\
-        createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-10-23T19:21:28.7631142+00:00\"\
+        createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-11-26T23:18:13.018721+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/snapshots\",\"location\":\"westus\",\"tags\":{\"tag1\"\
         :\"s1\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
-        ,\"name\":\"s1\"}\r\n  },\r\n  \"name\": \"56b5646e-dc03-4dc5-9a8f-8a06759e8ec0\"\
+        ,\"name\":\"s1\"}\r\n  },\r\n  \"name\": \"009b4254-7f40-4ebc-8a56-c767e61eac8a\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['730']
+      content-length: ['729']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:21:58 GMT']
+      date: ['Mon, 26 Nov 2018 23:18:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -625,7 +644,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49989,Microsoft.Compute/GetOperation30Min;249960']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49989,Microsoft.Compute/GetOperation30Min;249985']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -634,25 +653,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [snapshot create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --size-gb --sku --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1?api-version=2018-06-01
   response:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Premium_LRS\",\r\n    \"\
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-10-23T19:21:28.7631142+00:00\",\r\n  \
-        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
+        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['625']
+      content-length: ['624']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:22:00 GMT']
+      date: ['Mon, 26 Nov 2018 23:18:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -660,7 +680,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4987,Microsoft.Compute/LowCostGet30Min;19952']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4987,Microsoft.Compute/LowCostGet30Min;19979']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -669,8 +689,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [snapshot update]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1?api-version=2018-06-01
@@ -678,17 +699,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Premium_LRS\",\r\n    \"\
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-10-23T19:21:28.7631142+00:00\",\r\n  \
-        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
+        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['625']
+      content-length: ['624']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:22:01 GMT']
+      date: ['Mon, 26 Nov 2018 23:18:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -696,7 +717,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4986,Microsoft.Compute/LowCostGet30Min;19951']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4986,Microsoft.Compute/LowCostGet30Min;19978']
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "westus", "tags": {"tag1": "s1"}, "sku": {"name": "Standard_LRS"},
@@ -708,8 +729,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['155']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1?api-version=2018-06-01
@@ -721,18 +743,18 @@ interactions:
         \n  },\r\n  \"location\": \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"\
         s1\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/bac3fd16-9478-4812-9a53-2291cf15f865?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a0c89484-7762-4d34-a945-11d186486fe3?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['308']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:22:02 GMT']
+      date: ['Mon, 26 Nov 2018 23:18:45 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/bac3fd16-9478-4812-9a53-2291cf15f865?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a0c89484-7762-4d34-a945-11d186486fe3?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostSnapshotCreateHydrate3Min;238,Microsoft.Compute/HighCostSnapshotCreateHydrate30Min;1195']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostSnapshotCreateHydrate3Min;238,Microsoft.Compute/HighCostSnapshotCreateHydrate30Min;1198']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -742,26 +764,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [snapshot update]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/bac3fd16-9478-4812-9a53-2291cf15f865?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a0c89484-7762-4d34-a945-11d186486fe3?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:22:02.7064874+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:22:03.378325+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:18:45.3369822+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:18:45.9307032+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Standard_LRS\",\"tier\":\"Standard\"},\"properties\":{\"creationData\"\
-        :{\"createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-10-23T19:21:28.7631142+00:00\"\
+        :{\"createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-11-26T23:18:13.018721+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/snapshots\",\"location\":\"westus\",\"tags\":{\"tag1\"\
         :\"s1\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
-        ,\"name\":\"s1\"}\r\n  },\r\n  \"name\": \"bac3fd16-9478-4812-9a53-2291cf15f865\"\
+        ,\"name\":\"s1\"}\r\n  },\r\n  \"name\": \"a0c89484-7762-4d34-a945-11d186486fe3\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['731']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:22:32 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -769,7 +792,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49989,Microsoft.Compute/GetOperation30Min;249958']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249983']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -778,25 +801,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [snapshot update]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1?api-version=2018-06-01
   response:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-10-23T19:21:28.7631142+00:00\",\r\n  \
-        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
+        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['627']
+      content-length: ['626']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:22:33 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -804,7 +828,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4987,Microsoft.Compute/LowCostGet30Min;19948']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4986,Microsoft.Compute/LowCostGet30Min;19976']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -813,8 +837,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [snapshot create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/d1?api-version=2018-06-01
@@ -825,7 +850,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['209']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:22:34 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -839,8 +864,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [snapshot create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1?api-version=2018-06-01
@@ -848,7 +874,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-10-23T19:19:15.4795231+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"ActiveSAS\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -858,7 +884,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['619']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:22:35 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -866,7 +892,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4986,Microsoft.Compute/LowCostGet30Min;19947']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4985,Microsoft.Compute/LowCostGet30Min;19975']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -876,18 +902,19 @@ interactions:
       CommandName: [snapshot create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-23T19:19:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:22:36 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -904,8 +931,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['327']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2?api-version=2018-06-01
@@ -916,19 +944,19 @@ interactions:
         \r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"isArmResource\"\
         : true\r\n  },\r\n  \"location\": \"westus\",\r\n  \"tags\": {}\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/fae80acb-509b-4cc2-829e-0564b36fde99?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/2c82a5b8-e0b9-45f4-b974-4889c3c9db3b?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['449']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:22:37 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:17 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/fae80acb-509b-4cc2-829e-0564b36fde99?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/2c82a5b8-e0b9-45f4-b974-4889c3c9db3b?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostSnapshotCreateHydrate3Min;237,Microsoft.Compute/HighCostSnapshotCreateHydrate30Min;1194']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostSnapshotCreateHydrate3Min;237,Microsoft.Compute/HighCostSnapshotCreateHydrate30Min;1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -937,27 +965,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [snapshot create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/fae80acb-509b-4cc2-829e-0564b36fde99?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/2c82a5b8-e0b9-45f4-b974-4889c3c9db3b?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:22:37.3474103+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:22:37.8008434+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:19:17.9503536+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:19:18.6378728+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Premium_LRS\",\"tier\":\"Premium\"},\"properties\":{\"creationData\":{\"\
         createOption\":\"Copy\",\"sourceResourceId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        },\"diskSizeGB\":10,\"timeCreated\":\"2018-10-23T19:22:37.3474103+00:00\"\
+        },\"diskSizeGB\":10,\"timeCreated\":\"2018-11-26T23:19:17.9503536+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/snapshots\",\"location\":\"westus\",\"tags\":{},\"id\"\
         :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2\"\
-        ,\"name\":\"s2\"}\r\n  },\r\n  \"name\": \"fae80acb-509b-4cc2-829e-0564b36fde99\"\
+        ,\"name\":\"s2\"}\r\n  },\r\n  \"name\": \"2c82a5b8-e0b9-45f4-b974-4889c3c9db3b\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['920']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:07 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -965,7 +994,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49989,Microsoft.Compute/GetOperation30Min;249956']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249981']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -974,8 +1003,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [snapshot create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2?api-version=2018-06-01
   response:
@@ -983,7 +1013,7 @@ interactions:
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Copy\",\r\n      \"sourceResourceId\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        \r\n    },\r\n    \"diskSizeGB\": 10,\r\n    \"timeCreated\": \"2018-10-23T19:22:37.3474103+00:00\"\
+        \r\n    },\r\n    \"diskSizeGB\": 10,\r\n    \"timeCreated\": \"2018-11-26T23:19:17.9503536+00:00\"\
         ,\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2\"\
@@ -992,7 +1022,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['813']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:08 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1000,7 +1030,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4984,Microsoft.Compute/LowCostGet30Min;19942']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4985,Microsoft.Compute/LowCostGet30Min;19971']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1009,8 +1039,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/virtualMachines/s1?api-version=2018-10-01
@@ -1021,7 +1052,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['215']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:09 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1035,8 +1066,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1?api-version=2018-06-01
@@ -1044,17 +1076,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-10-23T19:21:28.7631142+00:00\",\r\n  \
-        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
+        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['627']
+      content-length: ['626']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:09 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1062,7 +1094,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4983,Microsoft.Compute/LowCostGet30Min;19941']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4984,Microsoft.Compute/LowCostGet30Min;19970']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1071,8 +1103,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/d1?api-version=2018-06-01
@@ -1083,7 +1116,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['209']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:10 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1097,8 +1130,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1?api-version=2018-06-01
@@ -1106,7 +1140,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-10-23T19:19:15.4795231+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"ActiveSAS\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -1116,7 +1150,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['619']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:10 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1124,7 +1158,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4982,Microsoft.Compute/LowCostGet30Min;19940']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4983,Microsoft.Compute/LowCostGet30Min;19969']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1134,18 +1168,19 @@ interactions:
       CommandName: [image create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-23T19:19:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:11 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1166,8 +1201,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['1016']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i1?api-version=2018-10-01
@@ -1192,17 +1228,17 @@ interactions:
         \n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i1\"\
         ,\r\n  \"name\": \"i1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/751d9d40-0403-459b-99eb-83adb0660a0f?api-version=2018-10-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c2e5e3d1-9c88-4603-9128-122e502530d6?api-version=2018-10-01']
       cache-control: [no-cache]
       content-length: ['1939']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:11 GMT']
+      date: ['Mon, 26 Nov 2018 23:19:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;39,Microsoft.Compute/CreateImages30Min;197']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;39,Microsoft.Compute/CreateImages30Min;194']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -1212,19 +1248,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/751d9d40-0403-459b-99eb-83adb0660a0f?api-version=2018-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c2e5e3d1-9c88-4603-9128-122e502530d6?api-version=2018-10-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:23:12.4555224+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:23:17.6636296+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"751d9d40-0403-459b-99eb-83adb0660a0f\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:19:51.5684595+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:19:56.7247493+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"c2e5e3d1-9c88-4603-9128-122e502530d6\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:43 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1232,7 +1269,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14998,Microsoft.Compute/GetOperation30Min;29990']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14998,Microsoft.Compute/GetOperation30Min;29995']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1241,8 +1278,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i1?api-version=2018-10-01
   response:
@@ -1272,7 +1310,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2053']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:43 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1280,7 +1318,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;357,Microsoft.Compute/GetImages30Min;1789']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;351,Microsoft.Compute/GetImages30Min;1773']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1289,8 +1327,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/virtualMachines/s1?api-version=2018-10-01
@@ -1301,7 +1340,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['215']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:44 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1315,8 +1354,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1?api-version=2018-06-01
@@ -1324,17 +1364,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-10-23T19:21:28.7631142+00:00\",\r\n  \
-        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
+        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['627']
+      content-length: ['626']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:45 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1342,7 +1382,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4976,Microsoft.Compute/LowCostGet30Min;19934']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4979,Microsoft.Compute/LowCostGet30Min;19969']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1351,8 +1391,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/d1?api-version=2018-06-01
@@ -1363,7 +1404,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['209']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:45 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1377,8 +1418,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1?api-version=2018-06-01
@@ -1386,7 +1428,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-10-23T19:19:15.4795231+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"ActiveSAS\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -1396,7 +1438,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['619']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:45 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1404,7 +1446,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4975,Microsoft.Compute/LowCostGet30Min;19933']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4978,Microsoft.Compute/LowCostGet30Min;19968']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1414,18 +1456,19 @@ interactions:
       CommandName: [image create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-23T19:19:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:46 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1447,8 +1490,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['1053']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i2?api-version=2018-10-01
@@ -1473,18 +1517,18 @@ interactions:
         \n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i2\"\
         ,\r\n  \"name\": \"i2\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/d993c90f-6cbb-4ca1-975e-3c826c4c2261?api-version=2018-10-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/7303aa80-1f1f-447c-b1bf-a6637d6d70da?api-version=2018-10-01']
       cache-control: [no-cache]
       content-length: ['1938']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:23:46 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;38,Microsoft.Compute/CreateImages30Min;196']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;38,Microsoft.Compute/CreateImages30Min;194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1493,19 +1537,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/d993c90f-6cbb-4ca1-975e-3c826c4c2261?api-version=2018-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/7303aa80-1f1f-447c-b1bf-a6637d6d70da?api-version=2018-10-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:23:47.2498329+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:23:52.4380917+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"d993c90f-6cbb-4ca1-975e-3c826c4c2261\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:20:26.5895247+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:20:31.7458015+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"7303aa80-1f1f-447c-b1bf-a6637d6d70da\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:17 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1513,7 +1558,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14996,Microsoft.Compute/GetOperation30Min;29988']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14996,Microsoft.Compute/GetOperation30Min;29993']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1522,8 +1567,9 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i2?api-version=2018-10-01
   response:
@@ -1553,7 +1599,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2052']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:18 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1561,7 +1607,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;352,Microsoft.Compute/GetImages30Min;1784']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;347,Microsoft.Compute/GetImages30Min;1768']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1570,8 +1616,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/virtualMachines/s1?api-version=2018-10-01
@@ -1582,7 +1630,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['215']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:20 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1596,8 +1644,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1?api-version=2018-06-01
@@ -1605,17 +1655,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-10-23T19:21:28.7631142+00:00\",\r\n  \
-        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
+        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['627']
+      content-length: ['626']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:20 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1623,7 +1673,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4972,Microsoft.Compute/LowCostGet30Min;19927']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4974,Microsoft.Compute/LowCostGet30Min;19963']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1632,8 +1682,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/d1?api-version=2018-06-01
@@ -1644,7 +1696,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['209']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:21 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1658,8 +1710,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1?api-version=2018-06-01
@@ -1667,7 +1721,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-10-23T19:19:15.4795231+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"ActiveSAS\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -1677,7 +1731,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['619']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:21 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1685,7 +1739,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4971,Microsoft.Compute/LowCostGet30Min;19926']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4973,Microsoft.Compute/LowCostGet30Min;19962']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1695,18 +1749,20 @@ interactions:
       CommandName: [image create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-23T19:19:08Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:21 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1717,8 +1773,8 @@ interactions:
     body: 'b''{"location": "westus", "tags": {"tag1": "i1"}, "properties": {"storageProfile":
       {"osDisk": {"osType": "Linux", "osState": "Generalized", "snapshot": {"id":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1"},
-      "storageAccountType": "Standard_LRS"}, "dataDisks": [{"lun": 0, "snapshot":
-      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2"}},
+      "caching": "ReadWrite", "storageAccountType": "Standard_LRS"}, "dataDisks":
+      [{"lun": 0, "snapshot": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2"}},
       {"lun": 1, "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1"}},
       {"lun": 2, "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d2"}}]}}}'''
     headers:
@@ -1726,10 +1782,12 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
-      Content-Length: ['1054']
+      Content-Length: ['1078']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i3?api-version=2018-10-01
@@ -1737,7 +1795,7 @@ interactions:
     body: {string: "{\r\n  \"properties\": {\r\n    \"storageProfile\": {\r\n    \
         \  \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"osState\"\
         : \"Generalized\",\r\n        \"snapshot\": {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
-        \r\n        },\r\n        \"caching\": \"None\",\r\n        \"storageAccountType\"\
+        \r\n        },\r\n        \"caching\": \"ReadWrite\",\r\n        \"storageAccountType\"\
         : \"Standard_LRS\"\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n\
         \          \"lun\": 0,\r\n          \"snapshot\": {\r\n            \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2\"\
@@ -1754,18 +1812,18 @@ interactions:
         \n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i3\"\
         ,\r\n  \"name\": \"i3\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/5b7477dc-5af5-41c8-aecd-652a4e736c89?api-version=2018-10-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c183c489-38b1-4d4f-a83c-c98f2a732943?api-version=2018-10-01']
       cache-control: [no-cache]
-      content-length: ['1939']
+      content-length: ['1944']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:22 GMT']
+      date: ['Mon, 26 Nov 2018 23:20:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;37,Microsoft.Compute/CreateImages30Min;195']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;37,Microsoft.Compute/CreateImages30Min;193']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1774,19 +1832,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/5b7477dc-5af5-41c8-aecd-652a4e736c89?api-version=2018-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c183c489-38b1-4d4f-a83c-c98f2a732943?api-version=2018-10-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-10-23T19:24:22.8685484+00:00\",\r\
-        \n  \"endTime\": \"2018-10-23T19:24:28.0404548+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"5b7477dc-5af5-41c8-aecd-652a4e736c89\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:21:00.1053372+00:00\",\r\
+        \n  \"endTime\": \"2018-11-26T23:21:05.2460515+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"c183c489-38b1-4d4f-a83c-c98f2a732943\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:53 GMT']
+      date: ['Mon, 26 Nov 2018 23:21:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1794,7 +1854,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14994,Microsoft.Compute/GetOperation30Min;29986']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14994,Microsoft.Compute/GetOperation30Min;29991']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1803,8 +1863,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.50]
+          computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i3?api-version=2018-10-01
   response:
@@ -1812,7 +1874,7 @@ interactions:
         \  \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"osState\"\
         : \"Generalized\",\r\n        \"diskSizeGB\": 1,\r\n        \"snapshot\":\
         \ {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
-        \r\n        },\r\n        \"caching\": \"None\",\r\n        \"storageAccountType\"\
+        \r\n        },\r\n        \"caching\": \"ReadWrite\",\r\n        \"storageAccountType\"\
         : \"Standard_LRS\"\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n\
         \          \"lun\": 0,\r\n          \"diskSizeGB\": 10,\r\n          \"snapshot\"\
         : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2\"\
@@ -1832,9 +1894,9 @@ interactions:
         ,\r\n  \"name\": \"i3\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2053']
+      content-length: ['2058']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 23 Oct 2018 19:24:53 GMT']
+      date: ['Mon, 26 Nov 2018 23:21:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1842,7 +1904,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;348,Microsoft.Compute/GetImages30Min;1780']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;341,Microsoft.Compute/GetImages30Min;1762']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1853,8 +1915,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--name --yes --no-wait]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.50]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
@@ -1863,9 +1926,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Tue, 23 Oct 2018 19:24:55 GMT']
+      date: ['Mon, 26 Nov 2018 23:21:32 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGTUFOQUdFRDo1RkRJU0tVNUY2VFRQRTNWTktXRE9IRzVRUHw4NEI3N0FGOTk1QkYxN0UwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGTUFOQUdFRDo1RkRJU0tCT0dTR1NXQ01WNlJSWjRPNVU3RXxFRjk5QkFCNzFGREQ2RDgyLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_managed_disk.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_managed_disk.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-11-26T23:15:58Z"}}'
+      "date": "2018-11-28T21:56:24Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -16,12 +16,12 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-28T21:56:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:15:59 GMT']
+      date: ['Wed, 28 Nov 2018 21:56:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -43,12 +43,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-28T21:56:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:16:01 GMT']
+      date: ['Wed, 28 Nov 2018 21:56:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -79,13 +79,13 @@ interactions:
         \ \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"name\"\
         : \"d1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a6712d9f-1a2b-4f7d-996a-26f9a29e7a0c?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/760aeae9-ee20-48e7-9293-93cb7469c34b?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['301']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:16:02 GMT']
+      date: ['Wed, 28 Nov 2018 21:56:29 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a6712d9f-1a2b-4f7d-996a-26f9a29e7a0c?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/760aeae9-ee20-48e7-9293-93cb7469c34b?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -104,23 +104,23 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a6712d9f-1a2b-4f7d-996a-26f9a29e7a0c?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/760aeae9-ee20-48e7-9293-93cb7469c34b?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:16:02.2662458+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:16:02.3912777+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T21:56:30.0003618+00:00\",\r\
+        \n  \"endTime\": \"2018-11-28T21:56:30.1566051+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Premium_LRS\",\"tier\":\"Premium\"},\"properties\":{\"creationData\":{\"\
-        createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-11-26T23:16:02.2818795+00:00\"\
+        createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-11-28T21:56:30.0159817+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/disks\",\"location\":\"westus\",\"tags\":{\"tag1\":\"\
         d1\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        ,\"name\":\"d1\"}\r\n  },\r\n  \"name\": \"a6712d9f-1a2b-4f7d-996a-26f9a29e7a0c\"\
+        ,\"name\":\"d1\"}\r\n  },\r\n  \"name\": \"760aeae9-ee20-48e7-9293-93cb7469c34b\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['722']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:16:32 GMT']
+      date: ['Wed, 28 Nov 2018 21:56:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -128,7 +128,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49998,Microsoft.Compute/GetOperation30Min;249994']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49998,Microsoft.Compute/GetOperation30Min;249998']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -146,7 +146,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Premium_LRS\",\r\n    \"\
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n  \
+        \ 1,\r\n    \"timeCreated\": \"2018-11-28T21:56:30.0159817+00:00\",\r\n  \
         \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -156,7 +156,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['617']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:16:33 GMT']
+      date: ['Wed, 28 Nov 2018 21:57:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -164,7 +164,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4997,Microsoft.Compute/LowCostGet30Min;19989']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4997,Microsoft.Compute/LowCostGet30Min;19997']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -183,7 +183,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Premium_LRS\",\r\n    \"\
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n  \
+        \ 1,\r\n    \"timeCreated\": \"2018-11-28T21:56:30.0159817+00:00\",\r\n  \
         \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -193,7 +193,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['617']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:16:34 GMT']
+      date: ['Wed, 28 Nov 2018 21:57:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -201,7 +201,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4996,Microsoft.Compute/LowCostGet30Min;19988']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4996,Microsoft.Compute/LowCostGet30Min;19996']
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "westus", "tags": {"tag1": "d1"}, "sku": {"name": "Standard_LRS"},
@@ -227,13 +227,13 @@ interactions:
         \ \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"name\"\
         : \"d1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/57ba24ad-5827-49e1-9d5b-a2f333607002?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/f802f96f-88f7-424e-82a3-cf0020d7e057?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['303']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:16:35 GMT']
+      date: ['Wed, 28 Nov 2018 21:57:02 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/57ba24ad-5827-49e1-9d5b-a2f333607002?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/f802f96f-88f7-424e-82a3-cf0020d7e057?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -252,23 +252,23 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/57ba24ad-5827-49e1-9d5b-a2f333607002?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/f802f96f-88f7-424e-82a3-cf0020d7e057?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:16:35.0222809+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:16:35.1629586+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T21:57:02.7985856+00:00\",\r\
+        \n  \"endTime\": \"2018-11-28T21:57:02.9079415+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Standard_LRS\",\"tier\":\"Standard\"},\"properties\":{\"creationData\"\
-        :{\"createOption\":\"Empty\"},\"diskSizeGB\":10,\"timeCreated\":\"2018-11-26T23:16:02.2818795+00:00\"\
+        :{\"createOption\":\"Empty\"},\"diskSizeGB\":10,\"timeCreated\":\"2018-11-28T21:56:30.0159817+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/disks\",\"location\":\"westus\",\"tags\":{\"tag1\":\"\
         d1\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        ,\"name\":\"d1\"}\r\n  },\r\n  \"name\": \"57ba24ad-5827-49e1-9d5b-a2f333607002\"\
+        ,\"name\":\"d1\"}\r\n  },\r\n  \"name\": \"f802f96f-88f7-424e-82a3-cf0020d7e057\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['725']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:17:06 GMT']
+      date: ['Wed, 28 Nov 2018 21:57:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -276,7 +276,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49996,Microsoft.Compute/GetOperation30Min;249992']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49996,Microsoft.Compute/GetOperation30Min;249996']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -294,7 +294,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-28T21:56:30.0159817+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -304,7 +304,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['620']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:17:07 GMT']
+      date: ['Wed, 28 Nov 2018 21:57:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -312,7 +312,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4993,Microsoft.Compute/LowCostGet30Min;19985']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4993,Microsoft.Compute/LowCostGet30Min;19993']
     status: {code: 200, message: OK}
 - request:
     body: '{"access": "Read", "durationInSeconds": 10}'
@@ -332,12 +332,12 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1a503bb3-3b3b-496b-a0c8-3fb23461c2f8?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/7e10cd51-ea2c-47c5-a696-f30ac74abffb?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 26 Nov 2018 23:17:08 GMT']
+      date: ['Wed, 28 Nov 2018 21:57:34 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1a503bb3-3b3b-496b-a0c8-3fb23461c2f8?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/7e10cd51-ea2c-47c5-a696-f30ac74abffb?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -356,18 +356,18 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1a503bb3-3b3b-496b-a0c8-3fb23461c2f8?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/7e10cd51-ea2c-47c5-a696-f30ac74abffb?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:17:08.7729118+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:17:09.3198047+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T21:57:34.646541+00:00\",\r\n\
+        \  \"endTime\": \"2018-11-28T21:57:36.0532168+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\"\
-        : \"https://md-jb0rsvcs5c2m.blob.core.windows.net/wc5brn3s2jfh/abcd?sv=2017-04-17&sr=b&si=46965bbd-3604-4a05-b24a-ccba74b55355&sig=kgPAyfYq%2FZetV7pLSFNc52Sicr7T3KmbuWP54wy1578%3D\"\
-        \r\n}\r\n  },\r\n  \"name\": \"1a503bb3-3b3b-496b-a0c8-3fb23461c2f8\"\r\n}"}
+        : \"https://md-jb0rsvcs5c2m.blob.core.windows.net/kkjhj2jqmlbx/abcd?sv=2017-04-17&sr=b&si=fd17abac-4d6e-4a83-b510-eaca901247de&sig=6UKHwU%2F80kfqvPp8K06xb8T1l5i2LHoNaVabd68o3XA%3D\"\
+        \r\n}\r\n  },\r\n  \"name\": \"7e10cd51-ea2c-47c5-a696-f30ac74abffb\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['423']
+      content-length: ['422']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:17:38 GMT']
+      date: ['Wed, 28 Nov 2018 21:58:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -375,7 +375,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49994,Microsoft.Compute/GetOperation30Min;249990']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49994,Microsoft.Compute/GetOperation30Min;249994']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -388,15 +388,15 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1a503bb3-3b3b-496b-a0c8-3fb23461c2f8?monitor=true&api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/7e10cd51-ea2c-47c5-a696-f30ac74abffb?monitor=true&api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"accessSAS\": \"https://md-jb0rsvcs5c2m.blob.core.windows.net/wc5brn3s2jfh/abcd?sv=2017-04-17&sr=b&si=46965bbd-3604-4a05-b24a-ccba74b55355&sig=kgPAyfYq%2FZetV7pLSFNc52Sicr7T3KmbuWP54wy1578%3D\"\
+    body: {string: "{\r\n  \"accessSAS\": \"https://md-jb0rsvcs5c2m.blob.core.windows.net/kkjhj2jqmlbx/abcd?sv=2017-04-17&sr=b&si=fd17abac-4d6e-4a83-b510-eaca901247de&sig=6UKHwU%2F80kfqvPp8K06xb8T1l5i2LHoNaVabd68o3XA%3D\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['198']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:17:39 GMT']
+      date: ['Wed, 28 Nov 2018 21:58:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -404,7 +404,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49993,Microsoft.Compute/GetOperation30Min;249989']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49993,Microsoft.Compute/GetOperation30Min;249993']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -421,12 +421,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-28T21:56:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:17:40 GMT']
+      date: ['Wed, 28 Nov 2018 21:58:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -457,13 +457,13 @@ interactions:
         : true\r\n  },\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"name\"\
         : \"d2\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/16c3e784-8641-4706-8863-8780d29912a9?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/6c8b7765-d9a8-487e-9321-f1428caca863?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['466']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:17:40 GMT']
+      date: ['Wed, 28 Nov 2018 21:58:06 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/16c3e784-8641-4706-8863-8780d29912a9?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/6c8b7765-d9a8-487e-9321-f1428caca863?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -482,24 +482,24 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/16c3e784-8641-4706-8863-8780d29912a9?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/6c8b7765-d9a8-487e-9321-f1428caca863?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:17:40.9142569+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:17:42.1173836+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T21:58:07.2415286+00:00\",\r\
+        \n  \"endTime\": \"2018-11-28T21:58:08.8509357+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Premium_LRS\",\"tier\":\"Premium\"},\"properties\":{\"creationData\":{\"\
         createOption\":\"Copy\",\"sourceResourceId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        },\"diskSizeGB\":10,\"timeCreated\":\"2018-11-26T23:17:40.9142569+00:00\"\
+        },\"diskSizeGB\":10,\"timeCreated\":\"2018-11-28T21:58:07.2571758+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/disks\",\"location\":\"westus\",\"tags\":{},\"id\":\"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d2\"\
-        ,\"name\":\"d2\"}\r\n  },\r\n  \"name\": \"16c3e784-8641-4706-8863-8780d29912a9\"\
+        ,\"name\":\"d2\"}\r\n  },\r\n  \"name\": \"6c8b7765-d9a8-487e-9321-f1428caca863\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['912']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:18:10 GMT']
+      date: ['Wed, 28 Nov 2018 21:58:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -507,7 +507,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49991,Microsoft.Compute/GetOperation30Min;249987']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49991,Microsoft.Compute/GetOperation30Min;249991']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -526,7 +526,7 @@ interactions:
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Copy\",\r\n      \"sourceResourceId\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        \r\n    },\r\n    \"diskSizeGB\": 10,\r\n    \"timeCreated\": \"2018-11-26T23:17:40.9142569+00:00\"\
+        \r\n    },\r\n    \"diskSizeGB\": 10,\r\n    \"timeCreated\": \"2018-11-28T21:58:07.2571758+00:00\"\
         ,\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d2\"\
@@ -535,7 +535,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['805']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:18:11 GMT']
+      date: ['Wed, 28 Nov 2018 21:58:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -543,7 +543,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4990,Microsoft.Compute/LowCostGet30Min;19982']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4990,Microsoft.Compute/LowCostGet30Min;19990']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -560,12 +560,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-28T21:56:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:18:11 GMT']
+      date: ['Wed, 28 Nov 2018 21:58:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -595,13 +595,13 @@ interactions:
         : \"Updating\",\r\n    \"isArmResource\": true\r\n  },\r\n  \"location\":\
         \ \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/009b4254-7f40-4ebc-8a56-c767e61eac8a?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1f8b0292-5e3b-4f12-8b92-69abc8bcfe58?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['284']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:18:12 GMT']
+      date: ['Wed, 28 Nov 2018 21:58:39 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/009b4254-7f40-4ebc-8a56-c767e61eac8a?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1f8b0292-5e3b-4f12-8b92-69abc8bcfe58?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -620,23 +620,23 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/009b4254-7f40-4ebc-8a56-c767e61eac8a?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/1f8b0292-5e3b-4f12-8b92-69abc8bcfe58?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:18:13.0030987+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:18:13.2062231+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T21:58:39.4293211+00:00\",\r\
+        \n  \"endTime\": \"2018-11-28T21:58:39.6793617+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Premium_LRS\",\"tier\":\"Premium\"},\"properties\":{\"creationData\":{\"\
-        createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-11-26T23:18:13.018721+00:00\"\
+        createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-11-28T21:58:39.4293211+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/snapshots\",\"location\":\"westus\",\"tags\":{\"tag1\"\
         :\"s1\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
-        ,\"name\":\"s1\"}\r\n  },\r\n  \"name\": \"009b4254-7f40-4ebc-8a56-c767e61eac8a\"\
+        ,\"name\":\"s1\"}\r\n  },\r\n  \"name\": \"1f8b0292-5e3b-4f12-8b92-69abc8bcfe58\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['729']
+      content-length: ['730']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:18:42 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -644,7 +644,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49989,Microsoft.Compute/GetOperation30Min;249985']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49989,Microsoft.Compute/GetOperation30Min;249989']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -662,17 +662,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Premium_LRS\",\r\n    \"\
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
-        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-28T21:58:39.4293211+00:00\",\r\n  \
+        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['624']
+      content-length: ['625']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:18:43 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -680,7 +680,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4987,Microsoft.Compute/LowCostGet30Min;19979']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4987,Microsoft.Compute/LowCostGet30Min;19987']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -699,17 +699,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Premium_LRS\",\r\n    \"\
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
-        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-28T21:58:39.4293211+00:00\",\r\n  \
+        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['624']
+      content-length: ['625']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:18:44 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -717,7 +717,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4986,Microsoft.Compute/LowCostGet30Min;19978']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4986,Microsoft.Compute/LowCostGet30Min;19986']
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "westus", "tags": {"tag1": "s1"}, "sku": {"name": "Standard_LRS"},
@@ -743,13 +743,13 @@ interactions:
         \n  },\r\n  \"location\": \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"\
         s1\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a0c89484-7762-4d34-a945-11d186486fe3?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/e5a4ccb7-baab-4b40-a9bf-7a542539a81b?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['308']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:18:45 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:11 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a0c89484-7762-4d34-a945-11d186486fe3?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/e5a4ccb7-baab-4b40-a9bf-7a542539a81b?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -768,23 +768,23 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/a0c89484-7762-4d34-a945-11d186486fe3?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/e5a4ccb7-baab-4b40-a9bf-7a542539a81b?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:18:45.3369822+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:18:45.9307032+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T21:59:11.7581337+00:00\",\r\
+        \n  \"endTime\": \"2018-11-28T21:59:12.445657+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Standard_LRS\",\"tier\":\"Standard\"},\"properties\":{\"creationData\"\
-        :{\"createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-11-26T23:18:13.018721+00:00\"\
+        :{\"createOption\":\"Empty\"},\"diskSizeGB\":1,\"timeCreated\":\"2018-11-28T21:58:39.4293211+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/snapshots\",\"location\":\"westus\",\"tags\":{\"tag1\"\
         :\"s1\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
-        ,\"name\":\"s1\"}\r\n  },\r\n  \"name\": \"a0c89484-7762-4d34-a945-11d186486fe3\"\
+        ,\"name\":\"s1\"}\r\n  },\r\n  \"name\": \"e5a4ccb7-baab-4b40-a9bf-7a542539a81b\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['731']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:15 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -792,7 +792,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249983']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249987']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -810,17 +810,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
-        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-28T21:58:39.4293211+00:00\",\r\n  \
+        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['626']
+      content-length: ['627']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:15 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -828,7 +828,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4986,Microsoft.Compute/LowCostGet30Min;19976']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4986,Microsoft.Compute/LowCostGet30Min;19984']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -850,7 +850,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['209']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:16 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -874,7 +874,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-28T21:56:30.0159817+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"ActiveSAS\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -884,7 +884,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['619']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:17 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -892,7 +892,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4985,Microsoft.Compute/LowCostGet30Min;19975']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4985,Microsoft.Compute/LowCostGet30Min;19983']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -909,12 +909,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-28T21:56:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:17 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -944,13 +944,13 @@ interactions:
         \r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"isArmResource\"\
         : true\r\n  },\r\n  \"location\": \"westus\",\r\n  \"tags\": {}\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/2c82a5b8-e0b9-45f4-b974-4889c3c9db3b?api-version=2018-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/3102e9cc-355d-4f25-99b8-0b03ee5ab8a5?api-version=2018-06-01']
       cache-control: [no-cache]
       content-length: ['449']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:17 GMT']
+      date: ['Wed, 28 Nov 2018 21:59:44 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/2c82a5b8-e0b9-45f4-b974-4889c3c9db3b?monitor=true&api-version=2018-06-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/3102e9cc-355d-4f25-99b8-0b03ee5ab8a5?monitor=true&api-version=2018-06-01']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -969,24 +969,24 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/2c82a5b8-e0b9-45f4-b974-4889c3c9db3b?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/DiskOperations/3102e9cc-355d-4f25-99b8-0b03ee5ab8a5?api-version=2018-06-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:19:17.9503536+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:19:18.6378728+00:00\",\r\n  \"status\": \"\
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T21:59:44.738718+00:00\",\r\n\
+        \  \"endTime\": \"2018-11-28T21:59:45.3168709+00:00\",\r\n  \"status\": \"\
         Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\"sku\":{\"name\"\
         :\"Premium_LRS\",\"tier\":\"Premium\"},\"properties\":{\"creationData\":{\"\
         createOption\":\"Copy\",\"sourceResourceId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        },\"diskSizeGB\":10,\"timeCreated\":\"2018-11-26T23:19:17.9503536+00:00\"\
+        },\"diskSizeGB\":10,\"timeCreated\":\"2018-11-28T21:59:44.7543221+00:00\"\
         ,\"provisioningState\":\"Succeeded\",\"diskState\":\"Unattached\"},\"type\"\
         :\"Microsoft.Compute/snapshots\",\"location\":\"westus\",\"tags\":{},\"id\"\
         :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2\"\
-        ,\"name\":\"s2\"}\r\n  },\r\n  \"name\": \"2c82a5b8-e0b9-45f4-b974-4889c3c9db3b\"\
+        ,\"name\":\"s2\"}\r\n  },\r\n  \"name\": \"3102e9cc-355d-4f25-99b8-0b03ee5ab8a5\"\
         \r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['920']
+      content-length: ['919']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:48 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -994,7 +994,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249981']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249985']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1013,7 +1013,7 @@ interactions:
         tier\": \"Premium\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Copy\",\r\n      \"sourceResourceId\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1\"\
-        \r\n    },\r\n    \"diskSizeGB\": 10,\r\n    \"timeCreated\": \"2018-11-26T23:19:17.9503536+00:00\"\
+        \r\n    },\r\n    \"diskSizeGB\": 10,\r\n    \"timeCreated\": \"2018-11-28T21:59:44.7543221+00:00\"\
         ,\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2\"\
@@ -1022,7 +1022,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['813']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:47 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1030,7 +1030,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4985,Microsoft.Compute/LowCostGet30Min;19971']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4985,Microsoft.Compute/LowCostGet30Min;19979']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1052,7 +1052,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['215']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:49 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1076,17 +1076,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
-        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-28T21:58:39.4293211+00:00\",\r\n  \
+        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['626']
+      content-length: ['627']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:49 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1094,7 +1094,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4984,Microsoft.Compute/LowCostGet30Min;19970']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4984,Microsoft.Compute/LowCostGet30Min;19978']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1116,7 +1116,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['209']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:49 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1140,7 +1140,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-28T21:56:30.0159817+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"ActiveSAS\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -1150,7 +1150,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['619']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:50 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1158,7 +1158,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4983,Microsoft.Compute/LowCostGet30Min;19969']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4983,Microsoft.Compute/LowCostGet30Min;19977']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1175,12 +1175,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-28T21:56:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:50 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1228,18 +1228,18 @@ interactions:
         \n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i1\"\
         ,\r\n  \"name\": \"i1\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c2e5e3d1-9c88-4603-9128-122e502530d6?api-version=2018-10-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/73087c6e-c606-49cc-a507-638aa0583b99?api-version=2018-10-01']
       cache-control: [no-cache]
       content-length: ['1939']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:19:51 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;39,Microsoft.Compute/CreateImages30Min;194']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;39,Microsoft.Compute/CreateImages30Min;199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1252,16 +1252,16 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c2e5e3d1-9c88-4603-9128-122e502530d6?api-version=2018-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/73087c6e-c606-49cc-a507-638aa0583b99?api-version=2018-10-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:19:51.5684595+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:19:56.7247493+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"c2e5e3d1-9c88-4603-9128-122e502530d6\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T22:00:19.1775464+00:00\",\r\
+        \n  \"endTime\": \"2018-11-28T22:00:24.3650616+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"73087c6e-c606-49cc-a507-638aa0583b99\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:21 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1269,7 +1269,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14998,Microsoft.Compute/GetOperation30Min;29995']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14998,Microsoft.Compute/GetOperation30Min;29998']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1310,7 +1310,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2053']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:22 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1318,7 +1318,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;351,Microsoft.Compute/GetImages30Min;1773']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;357,Microsoft.Compute/GetImages30Min;1797']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1327,7 +1327,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
-      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
@@ -1340,7 +1341,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['215']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:24 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1354,7 +1355,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
-      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
@@ -1364,17 +1366,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
-        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-28T21:58:39.4293211+00:00\",\r\n  \
+        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['626']
+      content-length: ['627']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:24 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1382,7 +1384,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4979,Microsoft.Compute/LowCostGet30Min;19969']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4979,Microsoft.Compute/LowCostGet30Min;19972']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1391,7 +1393,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
-      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
@@ -1404,7 +1407,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['209']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:24 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1418,7 +1421,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
-      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
@@ -1428,7 +1432,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-28T21:56:30.0159817+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"ActiveSAS\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -1438,7 +1442,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['619']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:24 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1446,7 +1450,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4978,Microsoft.Compute/LowCostGet30Min;19968']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4978,Microsoft.Compute/LowCostGet30Min;19971']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1456,19 +1460,20 @@ interactions:
       CommandName: [image create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-28T21:56:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:25 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1479,8 +1484,8 @@ interactions:
     body: 'b''{"location": "westus", "tags": {"tag1": "i1"}, "properties": {"storageProfile":
       {"osDisk": {"osType": "Linux", "osState": "Generalized", "snapshot": {"id":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1"},
-      "storageAccountType": "Premium_LRS"}, "dataDisks": [{"lun": 0, "snapshot": {"id":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2"}},
+      "caching": "None", "storageAccountType": "Premium_LRS"}, "dataDisks": [{"lun":
+      0, "snapshot": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s2"}},
       {"lun": 1, "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d1"}},
       {"lun": 2, "managedDisk": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/disks/d2"}}]}}}'''
     headers:
@@ -1488,9 +1493,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
-      Content-Length: ['1053']
+      Content-Length: ['1072']
       Content-Type: [application/json; charset=utf-8]
-      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
       accept-language: [en-US]
@@ -1517,18 +1523,18 @@ interactions:
         \n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i2\"\
         ,\r\n  \"name\": \"i2\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/7303aa80-1f1f-447c-b1bf-a6637d6d70da?api-version=2018-10-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/69b4828d-bb0f-4ee6-a41e-c4a3ce415361?api-version=2018-10-01']
       cache-control: [no-cache]
       content-length: ['1938']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:26 GMT']
+      date: ['Wed, 28 Nov 2018 22:00:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;38,Microsoft.Compute/CreateImages30Min;194']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;38,Microsoft.Compute/CreateImages30Min;198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1537,20 +1543,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
-      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/7303aa80-1f1f-447c-b1bf-a6637d6d70da?api-version=2018-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/69b4828d-bb0f-4ee6-a41e-c4a3ce415361?api-version=2018-10-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:20:26.5895247+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:20:31.7458015+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"7303aa80-1f1f-447c-b1bf-a6637d6d70da\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T22:00:52.9590288+00:00\",\r\
+        \n  \"endTime\": \"2018-11-28T22:00:58.1153216+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"69b4828d-bb0f-4ee6-a41e-c4a3ce415361\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:56 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1558,7 +1565,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14996,Microsoft.Compute/GetOperation30Min;29993']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14996,Microsoft.Compute/GetOperation30Min;29996']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1567,7 +1574,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [image create]
       Connection: [keep-alive]
-      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku]
+      ParameterSetName: [-g -n --source --data-disk-sources --os-type --tags --storage-sku
+          --os-disk-caching]
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
@@ -1599,7 +1607,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2052']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:56 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1607,7 +1615,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;347,Microsoft.Compute/GetImages30Min;1768']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;352,Microsoft.Compute/GetImages30Min;1792']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1630,7 +1638,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['215']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:57 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1655,17 +1663,17 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 1,\r\n    \"timeCreated\": \"2018-11-26T23:18:13.018721+00:00\",\r\n   \
-        \ \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
+        \ 1,\r\n    \"timeCreated\": \"2018-11-28T21:58:39.4293211+00:00\",\r\n  \
+        \  \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/snapshots\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"s1\"\r\n  },\r\n  \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/snapshots/s1\"\
         ,\r\n  \"name\": \"s1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['626']
+      content-length: ['627']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:58 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1673,7 +1681,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4974,Microsoft.Compute/LowCostGet30Min;19963']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4974,Microsoft.Compute/LowCostGet30Min;19966']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1696,7 +1704,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['209']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:58 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1721,7 +1729,7 @@ interactions:
     body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"\
         tier\": \"Standard\"\r\n  },\r\n  \"properties\": {\r\n    \"creationData\"\
         : {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\":\
-        \ 10,\r\n    \"timeCreated\": \"2018-11-26T23:16:02.2818795+00:00\",\r\n \
+        \ 10,\r\n    \"timeCreated\": \"2018-11-28T21:56:30.0159817+00:00\",\r\n \
         \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"ActiveSAS\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {\r\n    \"tag1\": \"d1\"\r\n  },\r\n  \"id\": \"\
@@ -1731,7 +1739,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['619']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:58 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1739,7 +1747,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4973,Microsoft.Compute/LowCostGet30Min;19962']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;4973,Microsoft.Compute/LowCostGet30Min;19965']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1757,12 +1765,12 @@ interactions:
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_managed_disk000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-26T23:15:58Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001","name":"cli_test_managed_disk000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-28T21:56:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:58 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1812,18 +1820,18 @@ interactions:
         \n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_managed_disk000001/providers/Microsoft.Compute/images/i3\"\
         ,\r\n  \"name\": \"i3\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c183c489-38b1-4d4f-a83c-c98f2a732943?api-version=2018-10-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/745fa29b-ed96-4257-9564-8a01333a9fea?api-version=2018-10-01']
       cache-control: [no-cache]
       content-length: ['1944']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:20:59 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;37,Microsoft.Compute/CreateImages30Min;193']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/CreateImages3Min;37,Microsoft.Compute/CreateImages30Min;197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1837,16 +1845,16 @@ interactions:
       User-Agent: [python/3.6.5 (Darwin-17.7.0-x86_64-i386-64bit) msrest/0.6.0 msrest_azure/0.4.34
           computemanagementclient/4.3.1 Azure-SDK-For-Python AZURECLI/2.0.52]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c183c489-38b1-4d4f-a83c-c98f2a732943?api-version=2018-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/745fa29b-ed96-4257-9564-8a01333a9fea?api-version=2018-10-01
   response:
-    body: {string: "{\r\n  \"startTime\": \"2018-11-26T23:21:00.1053372+00:00\",\r\
-        \n  \"endTime\": \"2018-11-26T23:21:05.2460515+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"c183c489-38b1-4d4f-a83c-c98f2a732943\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2018-11-28T22:01:27.8967699+00:00\",\r\
+        \n  \"endTime\": \"2018-11-28T22:01:33.0686751+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"745fa29b-ed96-4257-9564-8a01333a9fea\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:21:30 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1854,7 +1862,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14994,Microsoft.Compute/GetOperation30Min;29991']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetOperation3Min;14994,Microsoft.Compute/GetOperation30Min;29994']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1896,7 +1904,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2058']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 26 Nov 2018 23:21:30 GMT']
+      date: ['Wed, 28 Nov 2018 22:01:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1904,7 +1912,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;341,Microsoft.Compute/GetImages30Min;1762']
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/GetImages3Min;348,Microsoft.Compute/GetImages30Min;1788']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1926,9 +1934,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 26 Nov 2018 23:21:32 GMT']
+      date: ['Wed, 28 Nov 2018 22:02:00 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGTUFOQUdFRDo1RkRJU0tCT0dTR1NXQ01WNlJSWjRPNVU3RXxFRjk5QkFCNzFGREQ2RDgyLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGTUFOQUdFRDo1RkRJU0s1SlhBNFFCTUFSR1pEVldZSzZST3xFNjU5MkM1QTBERTQ0MTc5LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -611,7 +611,7 @@ class VMManagedDiskScenarioTest(ScenarioTest):
             self.check('tags.tag1', 'i1')
         ])
 
-        # test that images can be created with different storage skus
+        # test that images can be created with different storage skus and os disk caching settings.
         self.cmd('image create -g {rg} -n {image_2} --source {snapshot1} --data-disk-sources {disk1} {snapshot2_id} {disk2_id}'
                  ' --os-type Linux --tags tag1=i1 --storage-sku Premium_LRS',
                  checks=[
@@ -621,12 +621,16 @@ class VMManagedDiskScenarioTest(ScenarioTest):
                      self.check('length(storageProfile.dataDisks)', 3),
                      self.check('storageProfile.dataDisks[0].lun', 0),
                      self.check('storageProfile.dataDisks[1].lun', 1),
+                     self.check('storageProfile.osDisk.caching', 'None'),
                      self.check('tags.tag1', 'i1')
                  ])
 
         self.cmd('image create -g {rg} -n {image_3} --source {snapshot1} --data-disk-sources {disk1} {snapshot2_id} {disk2_id}'
-                 ' --os-type Linux --tags tag1=i1 --storage-sku Standard_LRS',
-                 checks=self.check('storageProfile.osDisk.storageAccountType', 'Standard_LRS'))
+                 ' --os-type Linux --tags tag1=i1 --storage-sku Standard_LRS --os-disk-caching ReadWrite',
+                 checks=[
+                     self.check('storageProfile.osDisk.storageAccountType', 'Standard_LRS'),
+                     self.check('storageProfile.osDisk.caching', 'ReadWrite')
+                 ])
 
 
 class VMWriteAcceleratorScenarioTest(ScenarioTest):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -613,7 +613,7 @@ class VMManagedDiskScenarioTest(ScenarioTest):
 
         # test that images can be created with different storage skus and os disk caching settings.
         self.cmd('image create -g {rg} -n {image_2} --source {snapshot1} --data-disk-sources {disk1} {snapshot2_id} {disk2_id}'
-                 ' --os-type Linux --tags tag1=i1 --storage-sku Premium_LRS',
+                 ' --os-type Linux --tags tag1=i1 --storage-sku Premium_LRS --os-disk-caching None',
                  checks=[
                      self.check('storageProfile.osDisk.storageAccountType', 'Premium_LRS'),
                      self.check('storageProfile.osDisk.osType', 'Linux'),


### PR DESCRIPTION
This parameter is used if the source is not a vm (i.e source is is disk blob, managed os disk or os snapshot). It is not currently possible to modify the os disk caching or any attribute of the os disk when creating an image from a VM. See #7648.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azZure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
