### PR TITLE
Cosmos DB allow users to enable multi master on update

### DIFF
--- a/src/command_modules/azure-cli-cosmosdb/HISTORY.rst
+++ b/src/command_modules/azure-cli-cosmosdb/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 0.2.6 
 +++++ 
-* Added support for updating account to multi-master
+* Added support for updating account from multi-master to single-master
 
 0.2.5
 +++++

--- a/src/command_modules/azure-cli-cosmosdb/HISTORY.rst
+++ b/src/command_modules/azure-cli-cosmosdb/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.2.6 
++++++ 
+* Added support for updating account to multi-master
+
 0.2.5
 +++++
 * Use latest azure-mgmt-cosmosdb pypi package (0.5.2)

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_client_factory.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_client_factory.py
@@ -54,6 +54,9 @@ def cf_cosmosdb_document(cli_ctx, kwargs):
             database_account = cf_cosmosdb(cli_ctx).database_accounts.get(resource_group, name)
             url_connection = database_account.document_endpoint
 
+        if name and not url_connection:
+            url_connection = 'https://{}.documents.azure.com:443'.format(name)
+
         if not key and not url_connection:
             raise CLIError(MISSING_CREDENTIALS_ERROR_MESSAGE)
         auth = {'masterKey': key}

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_params.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_params.py
@@ -38,6 +38,7 @@ def load_arguments(self, _):
             c.argument('capabilities', nargs='+', validator=validate_capabilities, help='set custom capabilities on the Cosmos DB database account.')
             c.argument('enable_virtual_network', arg_type=get_three_state_flag(), help='Enables virtual network on the Cosmos DB database account')
             c.argument('virtual_network_rules', nargs='+', validator=validate_virtual_network_rules, help='ACL\'s for virtual network')
+            c.argument('enable_multiple_write_locations', arg_type=get_three_state_flag(), help="Enable Multiple Write Locations")
 
     with self.argument_context('cosmosdb regenerate-key') as c:
         c.argument('key_kind', arg_type=get_enum_type(KeyKind))
@@ -51,6 +52,3 @@ def load_arguments(self, _):
         c.argument('partition_key_path', help='Partition Key Path, e.g., \'/properties/name\'')
         c.argument('indexing_policy', type=shell_safe_json_parse, completer=FilesCompleter(), help='Indexing Policy, you can enter it as a string or as a file, e.g., --indexing-policy @policy-file.json)')
         c.argument('default_ttl', type=int, help='Default TTL')
-
-    with self.argument_context('cosmosdb create') as c:
-        c.argument('enable_multiple_write_locations', arg_type=get_three_state_flag(), help="Enable Multiple Write Locations")

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+
 from knack.log import get_logger
 from knack.util import CLIError
 
@@ -186,6 +188,11 @@ def cli_cosmosdb_update(client,
 
     if enable_multiple_write_locations is None:
         enable_multiple_write_locations = existing.enable_multiple_write_locations
+    elif enable_multiple_write_locations != existing.enable_multiple_write_locations and \
+            enable_multiple_write_locations:
+        raise CLIError("Cannot convert account from single master to multi master")
+    elif enable_multiple_write_locations != existing.enable_multiple_write_locations:
+        print("This operation will take 24 hours to complete")
 
     params = DatabaseAccountCreateUpdateParameters(
         location=existing.location,

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
@@ -88,6 +88,7 @@ def cli_cosmosdb_create(cmd, client,
     return docdb_account
 
 
+# pylint: disable=too-many-branches
 def cli_cosmosdb_update(client,
                         resource_group_name,
                         account_name,
@@ -135,7 +136,8 @@ def cli_cosmosdb_update(client,
                 ip_range_filter is None and \
                 enable_automatic_failover is None and \
                 enable_virtual_network is None and \
-                virtual_network_rules is None:
+                virtual_network_rules is None and \
+                enable_multiple_write_locations is None:
             async_docdb_create = client.patch(resource_group_name, account_name, tags=tags, capabilities=capabilities)
             docdb_account = async_docdb_create.result()
             docdb_account = client.get(resource_group_name, account_name)

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 from knack.log import get_logger
 from knack.util import CLIError
 
@@ -192,7 +190,7 @@ def cli_cosmosdb_update(client,
             enable_multiple_write_locations:
         raise CLIError("Cannot convert account from single master to multi master")
     elif enable_multiple_write_locations != existing.enable_multiple_write_locations:
-        print("This operation will take 24 hours to complete")
+        logger.warning("Updating the account from multi master to single master will take 24 hours to complete.")
 
     params = DatabaseAccountCreateUpdateParameters(
         location=existing.location,

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
@@ -100,7 +100,8 @@ def cli_cosmosdb_update(client,
                         enable_automatic_failover=None,
                         capabilities=None,
                         enable_virtual_network=None,
-                        virtual_network_rules=None):
+                        virtual_network_rules=None,
+                        enable_multiple_write_locations=None):
     """Update an existing Azure Cosmos DB database account. """
     existing = client.get(resource_group_name, account_name)
 
@@ -114,7 +115,8 @@ def cli_cosmosdb_update(client,
                 ip_range_filter is not None or \
                 enable_automatic_failover is not None or \
                 enable_virtual_network is not None or \
-                virtual_network_rules is not None:
+                virtual_network_rules is not None or \
+                enable_multiple_write_locations is not None:
             raise CLIError("Cannot set capabilities and update properties at the same time. {0}".format(locations))
 
         else:
@@ -182,6 +184,9 @@ def cli_cosmosdb_update(client,
     if tags is None:
         tags = existing.tags
 
+    if enable_multiple_write_locations is None:
+        enable_multiple_write_locations = existing.enable_multiple_write_locations
+
     params = DatabaseAccountCreateUpdateParameters(
         location=existing.location,
         locations=locations,
@@ -192,7 +197,8 @@ def cli_cosmosdb_update(client,
         enable_automatic_failover=enable_automatic_failover,
         capabilities=existing.capabilities,
         is_virtual_network_filter_enabled=enable_virtual_network,
-        virtual_network_rules=virtual_network_rules)
+        virtual_network_rules=virtual_network_rules,
+        enable_multiple_write_locations=enable_multiple_write_locations)
 
     async_docdb_create = client.create_or_update(resource_group_name, account_name, params)
     docdb_account = async_docdb_create.result()

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_keys_database_account.yaml
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_keys_database_account.yaml
@@ -1,29 +1,31 @@
 interactions:
 - request:
-    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2018-10-11T00:11:55Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [group create]
       Connection: [keep-alive]
-      Content-Length: ['50']
+      Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_account000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-11T00:11:55Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['328']
+      content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 07 Feb 2018 07:40:32 GMT']
+      date: ['Thu, 11 Oct 2018 00:11:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -34,27 +36,29 @@ interactions:
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_account000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-11T00:11:55Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['328']
+      content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 07 Feb 2018 07:40:33 GMT']
+      date: ['Thu, 11 Oct 2018 00:11:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"databaseAccountOfferType": "Standard", "locations": [{"failoverPriority":
-      0, "locationName": "westus"}]}, "kind": "GlobalDocumentDB", "location": "westus"}'
+    body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
+      [{"locationName": "westus", "failoverPriority": 0}], "databaseAccountOfferType":
+      "Standard"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -62,30 +66,31 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['172']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2015-04-08
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Initializing","ipRangeFilter":"","enableAutomaticFailover":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Initializing","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","provisioningState":"Initializing","failoverPriority":0}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","provisioningState":"Initializing","failoverPriority":0}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
         US","failoverPriority":0}],"capabilities":[]}}'}
     headers:
       cache-control: ['no-store, no-cache']
-      content-length: ['1187']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km?api-version=2015-04-08']
+      content-length: ['1224']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:40:35 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:11:59 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: Ok}
 - request:
@@ -95,23 +100,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:41:05 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:12:30 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -120,23 +126,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:41:36 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:13:00 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -145,23 +152,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:42:07 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:13:30 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -170,23 +178,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:42:37 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:14:00 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -195,23 +204,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:43:07 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:14:30 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -220,23 +230,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:43:38 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:15:01 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -245,24 +256,155 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Thu, 11 Oct 2018 00:15:30 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Thu, 11 Oct 2018 00:16:02 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Thu, 11 Oct 2018 00:16:32 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Thu, 11 Oct 2018 00:17:02 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Thu, 11 Oct 2018 00:17:32 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
   response:
     body: {string: '{"status":"Succeeded","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['33']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:44:08 GMT']
+      date: ['Thu, 11 Oct 2018 00:18:03 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -271,30 +413,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2015-04-08
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
         US","failoverPriority":0}],"capabilities":[]}}'}
     headers:
       cache-control: ['no-store, no-cache']
-      content-length: ['1477']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km?api-version=2015-04-08']
+      content-length: ['1514']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:44:08 GMT']
+      date: ['Thu, 11 Oct 2018 00:18:03 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -304,25 +446,25 @@ interactions:
       CommandName: [cosmosdb list-keys]
       Connection: [keep-alive]
       Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"0O1imT56C10jEX3567TqtR1JZRfKtJzEYxTFEMnd20s1Fkn31A1VFZ4Ppo4ADRB0obJqgsfOHIDBKLxys1F8EA==","secondaryMasterKey":"9G3VGFGnBLcDpLygxIWAbqnFnLU1mg0A8a1LFcjmgftrTFgPWTY55HWGMmsE6MzAfWsw5u6ErBa5LCMfRcn3AA==","primaryReadonlyMasterKey":"AgK92QdiWAkA21yK7YHr06LejEEDthkDSiSjyfTISKnoUBBypJDR28wd9YoFa5al5duWMI7xX6zN7YX29wMbsA==","secondaryReadonlyMasterKey":"CS9W5rkkBTSMCQOk2k2PJ9PMVqwUPS0bhwcPo0TXoguI7Acyd5SITNdfzxsdCAdWbwx9eYGEzH4WvOE7EkwA7g=="}'}
+    body: {string: '{"primaryMasterKey":"VDymGsu2lyNwW0fVpP5E5Ra6ql0z8T1bmPEMbF9D6h7mzXjNTGCFporIE4DP7r6ibIMVVcR0f0ZNv7IZl6TYeQ==","secondaryMasterKey":"vqLRdRyjiavQ5WVgL7YfiBpQYjS6o3o0zPQO7AGQ4ovSdGf11bSzU8q6qKHYQTgb7fRDS5jdhgdf1hma0l7UFg==","primaryReadonlyMasterKey":"Dm32t2gs6dt67eoubTZY0EhO85kMZ9kW7KYGs4ZqbOcd5a5sElpO0k6COLRoNqwCZLjfXO0j9FK2y7wE35gpAw==","secondaryReadonlyMasterKey":"NF0Jh8jPafkHtCbysc81chJYv7jVQ2kJ0OYzTyaDIjFXoUNH9Iaql1dCdodpnuNAgeEpNbeps8dyfHUYI53cGQ=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:44:08 GMT']
+      date: ['Thu, 11 Oct 2018 00:18:04 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: Ok}
 - request:
@@ -334,8 +476,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey?api-version=2015-04-08
@@ -345,12 +487,13 @@ interactions:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:44:11 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:18:07 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/505c1dbb-4911-4060-8e6b-7211d937790d?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -360,49 +503,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb regenerate-key]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/505c1dbb-4911-4060-8e6b-7211d937790d?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
-    headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:44:40 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb regenerate-key]
-      Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08
-  response:
-    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"9G3VGFGnBLcDpLygxIWAbqnFnLU1mg0A8a1LFcjmgftrTFgPWTY55HWGMmsE6MzAfWsw5u6ErBa5LCMfRcn3AA==","primaryReadonlyMasterKey":"AgK92QdiWAkA21yK7YHr06LejEEDthkDSiSjyfTISKnoUBBypJDR28wd9YoFa5al5duWMI7xX6zN7YX29wMbsA==","secondaryReadonlyMasterKey":"CS9W5rkkBTSMCQOk2k2PJ9PMVqwUPS0bhwcPo0TXoguI7Acyd5SITNdfzxsdCAdWbwx9eYGEzH4WvOE7EkwA7g=="}'}
+    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"vqLRdRyjiavQ5WVgL7YfiBpQYjS6o3o0zPQO7AGQ4ovSdGf11bSzU8q6qKHYQTgb7fRDS5jdhgdf1hma0l7UFg==","primaryReadonlyMasterKey":"Dm32t2gs6dt67eoubTZY0EhO85kMZ9kW7KYGs4ZqbOcd5a5sElpO0k6COLRoNqwCZLjfXO0j9FK2y7wE35gpAw==","secondaryReadonlyMasterKey":"NF0Jh8jPafkHtCbysc81chJYv7jVQ2kJ0OYzTyaDIjFXoUNH9Iaql1dCdodpnuNAgeEpNbeps8dyfHUYI53cGQ=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/regenerateKey/operationResults/505c1dbb-4911-4060-8e6b-7211d937790d?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:45:11 GMT']
+      date: ['Thu, 11 Oct 2018 00:18:38 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: '{"keyKind": "primaryReadonly"}'
@@ -413,8 +532,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['30']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey?api-version=2015-04-08
@@ -424,12 +543,13 @@ interactions:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:45:14 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:18:40 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/7bd54baa-55c2-4d54-ac93-64939bdfa1c8?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -439,49 +559,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb regenerate-key]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/7bd54baa-55c2-4d54-ac93-64939bdfa1c8?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
-    headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:45:44 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb regenerate-key]
-      Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08
-  response:
-    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"9G3VGFGnBLcDpLygxIWAbqnFnLU1mg0A8a1LFcjmgftrTFgPWTY55HWGMmsE6MzAfWsw5u6ErBa5LCMfRcn3AA==","primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"CS9W5rkkBTSMCQOk2k2PJ9PMVqwUPS0bhwcPo0TXoguI7Acyd5SITNdfzxsdCAdWbwx9eYGEzH4WvOE7EkwA7g=="}'}
+    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"vqLRdRyjiavQ5WVgL7YfiBpQYjS6o3o0zPQO7AGQ4ovSdGf11bSzU8q6qKHYQTgb7fRDS5jdhgdf1hma0l7UFg==","primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"NF0Jh8jPafkHtCbysc81chJYv7jVQ2kJ0OYzTyaDIjFXoUNH9Iaql1dCdodpnuNAgeEpNbeps8dyfHUYI53cGQ=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/regenerateKey/operationResults/7bd54baa-55c2-4d54-ac93-64939bdfa1c8?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:46:14 GMT']
+      date: ['Thu, 11 Oct 2018 00:19:10 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: '{"keyKind": "secondary"}'
@@ -492,8 +588,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['24']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey?api-version=2015-04-08
@@ -503,13 +599,14 @@ interactions:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:46:17 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:19:12 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/65241523-8ad8-4859-aa04-8a8498a25337?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -518,49 +615,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb regenerate-key]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/65241523-8ad8-4859-aa04-8a8498a25337?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
-    headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:46:47 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb regenerate-key]
-      Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08
-  response:
-    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"QgrWn4O2UBPOpE0DFbA5CqUVKiIzojDwi9S9bQI6dCnZB4mYvLj10wcicWBrwjS5uXiY61vvSJjEouI2I9kxUw==","primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"CS9W5rkkBTSMCQOk2k2PJ9PMVqwUPS0bhwcPo0TXoguI7Acyd5SITNdfzxsdCAdWbwx9eYGEzH4WvOE7EkwA7g=="}'}
+    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"00a7B07G0ZXYf4z99hO9iTg3pf0Bni0VzTexv7nhrap2KErCKmZNJC6YMH9J31DDqbuL9K2nxWrpJqRcPNfWOA==","primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"NF0Jh8jPafkHtCbysc81chJYv7jVQ2kJ0OYzTyaDIjFXoUNH9Iaql1dCdodpnuNAgeEpNbeps8dyfHUYI53cGQ=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/regenerateKey/operationResults/65241523-8ad8-4859-aa04-8a8498a25337?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:47:18 GMT']
+      date: ['Thu, 11 Oct 2018 00:19:43 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: '{"keyKind": "secondaryReadonly"}'
@@ -571,8 +644,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['32']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey?api-version=2015-04-08
@@ -582,12 +655,13 @@ interactions:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:47:19 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08']
+      date: ['Thu, 11 Oct 2018 00:19:45 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/b19d68e5-0213-43d1-b814-1e54aa177ba4?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
@@ -597,49 +671,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb regenerate-key]
       Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/b19d68e5-0213-43d1-b814-1e54aa177ba4?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
-    headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:47:50 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-gatewayversion: [version=1.20.0.0]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb regenerate-key]
-      Connection: [keep-alive]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08
-  response:
-    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"QgrWn4O2UBPOpE0DFbA5CqUVKiIzojDwi9S9bQI6dCnZB4mYvLj10wcicWBrwjS5uXiY61vvSJjEouI2I9kxUw==","primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"VeGykmTjFOuEWkZVpcBJHdFNeFZ6JQjDFKHTUqZubbwPhAREwLzrygHR5HaM3GOYC9P1uBjX4S08fWCOjBFUGA=="}'}
+    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"00a7B07G0ZXYf4z99hO9iTg3pf0Bni0VzTexv7nhrap2KErCKmZNJC6YMH9J31DDqbuL9K2nxWrpJqRcPNfWOA==","primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"4wt3IGiXb477qsFkSqmz0tjo39MJI7Ynu5TSl3mQ5mUPPefrelL74owtZ8HIRFfvvj3T0by3xitgSYodEIPwtQ=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/regenerateKey/operationResults/b19d68e5-0213-43d1-b814-1e54aa177ba4?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:48:20 GMT']
+      date: ['Thu, 11 Oct 2018 00:20:15 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -649,26 +699,26 @@ interactions:
       CommandName: [cosmosdb list-keys]
       Connection: [keep-alive]
       Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"QgrWn4O2UBPOpE0DFbA5CqUVKiIzojDwi9S9bQI6dCnZB4mYvLj10wcicWBrwjS5uXiY61vvSJjEouI2I9kxUw==","primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"VeGykmTjFOuEWkZVpcBJHdFNeFZ6JQjDFKHTUqZubbwPhAREwLzrygHR5HaM3GOYC9P1uBjX4S08fWCOjBFUGA=="}'}
+    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"00a7B07G0ZXYf4z99hO9iTg3pf0Bni0VzTexv7nhrap2KErCKmZNJC6YMH9J31DDqbuL9K2nxWrpJqRcPNfWOA==","primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"4wt3IGiXb477qsFkSqmz0tjo39MJI7Ynu5TSl3mQ5mUPPefrelL74owtZ8HIRFfvvj3T0by3xitgSYodEIPwtQ=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:48:21 GMT']
+      date: ['Thu, 11 Oct 2018 00:20:17 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -677,26 +727,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb list-read-only-keys]
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+      Content-Length: ['0']
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
       accept-language: [en-US]
-    method: GET
+    method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/readonlykeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"VeGykmTjFOuEWkZVpcBJHdFNeFZ6JQjDFKHTUqZubbwPhAREwLzrygHR5HaM3GOYC9P1uBjX4S08fWCOjBFUGA=="}'}
+    body: {string: '{"primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"4wt3IGiXb477qsFkSqmz0tjo39MJI7Ynu5TSl3mQ5mUPPefrelL74owtZ8HIRFfvvj3T0by3xitgSYodEIPwtQ=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['239']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/readonlykeys?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Wed, 07 Feb 2018 07:48:21 GMT']
+      date: ['Thu, 11 Oct 2018 00:20:17 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-gatewayversion: [version=1.20.0.0]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -707,9 +758,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
-          AZURECLI/2.0.27]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
+          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.47]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_account000001?api-version=2018-05-01
@@ -718,11 +769,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 07 Feb 2018 07:48:22 GMT']
+      date: ['Thu, 11 Oct 2018 00:20:18 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQ09TTU9TREI6NUZBQ0NPVU5UUlNYSUlCVlAzSjZVNkRHUnxENjA0NDY1MTE5RDA3QTMwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQ09TTU9TREI6NUZBQ0NPVU5URjdDQ0hFM0lQUzZEWlNYSHxGNEFBNjA1NTJGRTk5MkJELVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_keys_database_account.yaml
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_keys_database_account.yaml
@@ -1,31 +1,29 @@
 interactions:
 - request:
-    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-10-11T00:11:55Z"}}'
+    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [group create]
       Connection: [keep-alive]
-      Content-Length: ['110']
+      Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.27]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_account000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-11T00:11:55Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['384']
+      content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 Oct 2018 00:11:57 GMT']
+      date: ['Wed, 07 Feb 2018 07:40:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -36,29 +34,27 @@ interactions:
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.27]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_account000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-10-11T00:11:55Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['384']
+      content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 Oct 2018 00:11:57 GMT']
+      date: ['Wed, 07 Feb 2018 07:40:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
-      [{"locationName": "westus", "failoverPriority": 0}], "databaseAccountOfferType":
-      "Standard"}}'
+    body: '{"properties": {"databaseAccountOfferType": "Standard", "locations": [{"failoverPriority":
+      0, "locationName": "westus"}]}, "kind": "GlobalDocumentDB", "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -66,31 +62,30 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['172']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2015-04-08
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Initializing","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Initializing","ipRangeFilter":"","enableAutomaticFailover":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","provisioningState":"Initializing","failoverPriority":0}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","provisioningState":"Initializing","failoverPriority":0}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
         US","failoverPriority":0}],"capabilities":[]}}'}
     headers:
       cache-control: ['no-store, no-cache']
-      content-length: ['1224']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w?api-version=2015-04-08']
+      content-length: ['1187']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:11:59 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:40:35 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: Ok}
 - request:
@@ -100,24 +95,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:12:30 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:41:05 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -126,24 +120,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:13:00 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:41:36 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -152,24 +145,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:13:30 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:42:07 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -178,24 +170,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:14:00 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:42:37 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -204,24 +195,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:14:30 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:43:07 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -230,24 +220,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
   response:
     body: {string: '{"status":"Dequeued","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:15:01 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:43:38 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -256,155 +245,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
-  response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
-    headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:15:30 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
-  response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
-    headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:16:02 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
-  response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
-    headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:16:32 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
-  response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
-    headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:17:02 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
-  response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
-    headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:17:32 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08
   response:
     body: {string: '{"status":"Succeeded","error":{}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['33']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/operationResults/589fc4d1-9304-45f6-b021-028050421d2f?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/operationResults/2c589aed-d7f6-41b4-8009-65b2845aa391?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:18:03 GMT']
+      date: ['Wed, 07 Feb 2018 07:44:08 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -413,30 +271,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb create]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2015-04-08
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
         US","failoverPriority":0}],"capabilities":[]}}'}
     headers:
       cache-control: ['no-store, no-cache']
-      content-length: ['1514']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w?api-version=2015-04-08']
+      content-length: ['1477']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:18:03 GMT']
+      date: ['Wed, 07 Feb 2018 07:44:08 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -446,25 +304,25 @@ interactions:
       CommandName: [cosmosdb list-keys]
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"VDymGsu2lyNwW0fVpP5E5Ra6ql0z8T1bmPEMbF9D6h7mzXjNTGCFporIE4DP7r6ibIMVVcR0f0ZNv7IZl6TYeQ==","secondaryMasterKey":"vqLRdRyjiavQ5WVgL7YfiBpQYjS6o3o0zPQO7AGQ4ovSdGf11bSzU8q6qKHYQTgb7fRDS5jdhgdf1hma0l7UFg==","primaryReadonlyMasterKey":"Dm32t2gs6dt67eoubTZY0EhO85kMZ9kW7KYGs4ZqbOcd5a5sElpO0k6COLRoNqwCZLjfXO0j9FK2y7wE35gpAw==","secondaryReadonlyMasterKey":"NF0Jh8jPafkHtCbysc81chJYv7jVQ2kJ0OYzTyaDIjFXoUNH9Iaql1dCdodpnuNAgeEpNbeps8dyfHUYI53cGQ=="}'}
+    body: {string: '{"primaryMasterKey":"0O1imT56C10jEX3567TqtR1JZRfKtJzEYxTFEMnd20s1Fkn31A1VFZ4Ppo4ADRB0obJqgsfOHIDBKLxys1F8EA==","secondaryMasterKey":"9G3VGFGnBLcDpLygxIWAbqnFnLU1mg0A8a1LFcjmgftrTFgPWTY55HWGMmsE6MzAfWsw5u6ErBa5LCMfRcn3AA==","primaryReadonlyMasterKey":"AgK92QdiWAkA21yK7YHr06LejEEDthkDSiSjyfTISKnoUBBypJDR28wd9YoFa5al5duWMI7xX6zN7YX29wMbsA==","secondaryReadonlyMasterKey":"CS9W5rkkBTSMCQOk2k2PJ9PMVqwUPS0bhwcPo0TXoguI7Acyd5SITNdfzxsdCAdWbwx9eYGEzH4WvOE7EkwA7g=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:18:04 GMT']
+      date: ['Wed, 07 Feb 2018 07:44:08 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: Ok}
 - request:
@@ -476,8 +334,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey?api-version=2015-04-08
@@ -487,13 +345,12 @@ interactions:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:18:07 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/505c1dbb-4911-4060-8e6b-7211d937790d?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:44:11 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -503,25 +360,49 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb regenerate-key]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/505c1dbb-4911-4060-8e6b-7211d937790d?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"vqLRdRyjiavQ5WVgL7YfiBpQYjS6o3o0zPQO7AGQ4ovSdGf11bSzU8q6qKHYQTgb7fRDS5jdhgdf1hma0l7UFg==","primaryReadonlyMasterKey":"Dm32t2gs6dt67eoubTZY0EhO85kMZ9kW7KYGs4ZqbOcd5a5sElpO0k6COLRoNqwCZLjfXO0j9FK2y7wE35gpAw==","secondaryReadonlyMasterKey":"NF0Jh8jPafkHtCbysc81chJYv7jVQ2kJ0OYzTyaDIjFXoUNH9Iaql1dCdodpnuNAgeEpNbeps8dyfHUYI53cGQ=="}'}
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Wed, 07 Feb 2018 07:44:40 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-gatewayversion: [version=1.20.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb regenerate-key]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08
+  response:
+    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"9G3VGFGnBLcDpLygxIWAbqnFnLU1mg0A8a1LFcjmgftrTFgPWTY55HWGMmsE6MzAfWsw5u6ErBa5LCMfRcn3AA==","primaryReadonlyMasterKey":"AgK92QdiWAkA21yK7YHr06LejEEDthkDSiSjyfTISKnoUBBypJDR28wd9YoFa5al5duWMI7xX6zN7YX29wMbsA==","secondaryReadonlyMasterKey":"CS9W5rkkBTSMCQOk2k2PJ9PMVqwUPS0bhwcPo0TXoguI7Acyd5SITNdfzxsdCAdWbwx9eYGEzH4WvOE7EkwA7g=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/regenerateKey/operationResults/505c1dbb-4911-4060-8e6b-7211d937790d?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/8b3f117c-d779-4488-a0b8-8dfa517282a7?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:18:38 GMT']
+      date: ['Wed, 07 Feb 2018 07:45:11 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: '{"keyKind": "primaryReadonly"}'
@@ -532,8 +413,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['30']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey?api-version=2015-04-08
@@ -543,13 +424,12 @@ interactions:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:18:40 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/7bd54baa-55c2-4d54-ac93-64939bdfa1c8?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:45:14 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -559,25 +439,49 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb regenerate-key]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/7bd54baa-55c2-4d54-ac93-64939bdfa1c8?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"vqLRdRyjiavQ5WVgL7YfiBpQYjS6o3o0zPQO7AGQ4ovSdGf11bSzU8q6qKHYQTgb7fRDS5jdhgdf1hma0l7UFg==","primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"NF0Jh8jPafkHtCbysc81chJYv7jVQ2kJ0OYzTyaDIjFXoUNH9Iaql1dCdodpnuNAgeEpNbeps8dyfHUYI53cGQ=="}'}
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Wed, 07 Feb 2018 07:45:44 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-gatewayversion: [version=1.20.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb regenerate-key]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08
+  response:
+    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"9G3VGFGnBLcDpLygxIWAbqnFnLU1mg0A8a1LFcjmgftrTFgPWTY55HWGMmsE6MzAfWsw5u6ErBa5LCMfRcn3AA==","primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"CS9W5rkkBTSMCQOk2k2PJ9PMVqwUPS0bhwcPo0TXoguI7Acyd5SITNdfzxsdCAdWbwx9eYGEzH4WvOE7EkwA7g=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/regenerateKey/operationResults/7bd54baa-55c2-4d54-ac93-64939bdfa1c8?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/749d49d8-104c-41b6-a5c1-ecb88974068d?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:19:10 GMT']
+      date: ['Wed, 07 Feb 2018 07:46:14 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: '{"keyKind": "secondary"}'
@@ -588,8 +492,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['24']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey?api-version=2015-04-08
@@ -599,14 +503,13 @@ interactions:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:19:12 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/65241523-8ad8-4859-aa04-8a8498a25337?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:46:17 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-gatewayversion: [version=1.20.0.0]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -615,25 +518,49 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb regenerate-key]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/65241523-8ad8-4859-aa04-8a8498a25337?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"00a7B07G0ZXYf4z99hO9iTg3pf0Bni0VzTexv7nhrap2KErCKmZNJC6YMH9J31DDqbuL9K2nxWrpJqRcPNfWOA==","primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"NF0Jh8jPafkHtCbysc81chJYv7jVQ2kJ0OYzTyaDIjFXoUNH9Iaql1dCdodpnuNAgeEpNbeps8dyfHUYI53cGQ=="}'}
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Wed, 07 Feb 2018 07:46:47 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-gatewayversion: [version=1.20.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb regenerate-key]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08
+  response:
+    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"QgrWn4O2UBPOpE0DFbA5CqUVKiIzojDwi9S9bQI6dCnZB4mYvLj10wcicWBrwjS5uXiY61vvSJjEouI2I9kxUw==","primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"CS9W5rkkBTSMCQOk2k2PJ9PMVqwUPS0bhwcPo0TXoguI7Acyd5SITNdfzxsdCAdWbwx9eYGEzH4WvOE7EkwA7g=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/regenerateKey/operationResults/65241523-8ad8-4859-aa04-8a8498a25337?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/9db8a153-3d28-4214-9220-454cee96008d?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:19:43 GMT']
+      date: ['Wed, 07 Feb 2018 07:47:18 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: '{"keyKind": "secondaryReadonly"}'
@@ -644,8 +571,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['32']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey?api-version=2015-04-08
@@ -655,13 +582,12 @@ interactions:
       cache-control: ['no-store, no-cache']
       content-length: ['32']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:19:45 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/b19d68e5-0213-43d1-b814-1e54aa177ba4?api-version=2015-04-08']
+      date: ['Wed, 07 Feb 2018 07:47:19 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
@@ -671,25 +597,49 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb regenerate-key]
       Connection: [keep-alive]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/b19d68e5-0213-43d1-b814-1e54aa177ba4?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"00a7B07G0ZXYf4z99hO9iTg3pf0Bni0VzTexv7nhrap2KErCKmZNJC6YMH9J31DDqbuL9K2nxWrpJqRcPNfWOA==","primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"4wt3IGiXb477qsFkSqmz0tjo39MJI7Ynu5TSl3mQ5mUPPefrelL74owtZ8HIRFfvvj3T0by3xitgSYodEIPwtQ=="}'}
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Wed, 07 Feb 2018 07:47:50 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-gatewayversion: [version=1.20.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb regenerate-key]
+      Connection: [keep-alive]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08
+  response:
+    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"QgrWn4O2UBPOpE0DFbA5CqUVKiIzojDwi9S9bQI6dCnZB4mYvLj10wcicWBrwjS5uXiY61vvSJjEouI2I9kxUw==","primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"VeGykmTjFOuEWkZVpcBJHdFNeFZ6JQjDFKHTUqZubbwPhAREwLzrygHR5HaM3GOYC9P1uBjX4S08fWCOjBFUGA=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/5ccfb4a3-650b-4efd-afaf-0813c8197672/resourceGroups/cli_test_cosmosdb_accountf7cche3ips6dzsxhgaf4rnt2vgkmwyivvoxuhbrekv76a6fdcm/providers/Microsoft.DocumentDB/databaseAccounts/clirhiymmup6qwlqznuhmccbpgxfp4gw7ffjn52w/regenerateKey/operationResults/b19d68e5-0213-43d1-b814-1e54aa177ba4?api-version=2015-04-08']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/regenerateKey/operationResults/46bcb503-2dd4-47aa-a657-f8e29afdec90?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:20:15 GMT']
+      date: ['Wed, 07 Feb 2018 07:48:20 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -699,26 +649,26 @@ interactions:
       CommandName: [cosmosdb list-keys]
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"44LQmTLtLcMTb2HIbfAGJk6zG7zQS6JG9cTHkeBOP1W7DGRanvOWLwDbXobGQRQCyh1shr6rbictPLHQKzhtUw==","secondaryMasterKey":"00a7B07G0ZXYf4z99hO9iTg3pf0Bni0VzTexv7nhrap2KErCKmZNJC6YMH9J31DDqbuL9K2nxWrpJqRcPNfWOA==","primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"4wt3IGiXb477qsFkSqmz0tjo39MJI7Ynu5TSl3mQ5mUPPefrelL74owtZ8HIRFfvvj3T0by3xitgSYodEIPwtQ=="}'}
+    body: {string: '{"primaryMasterKey":"5okFYozaDXFd63aZ91c5RAke8fMCwikojpTKG3nGEa7j4WjRTMFFiYamyvNexIpyOpHv3Luvmm6oo0Tqjhwe8g==","secondaryMasterKey":"QgrWn4O2UBPOpE0DFbA5CqUVKiIzojDwi9S9bQI6dCnZB4mYvLj10wcicWBrwjS5uXiY61vvSJjEouI2I9kxUw==","primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"VeGykmTjFOuEWkZVpcBJHdFNeFZ6JQjDFKHTUqZubbwPhAREwLzrygHR5HaM3GOYC9P1uBjX4S08fWCOjBFUGA=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['461']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:20:17 GMT']
+      date: ['Wed, 07 Feb 2018 07:48:21 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-gatewayversion: [version=1.20.0.0]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -727,27 +677,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [cosmosdb list-read-only-keys]
       Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.0 Azure-SDK-For-Python AZURECLI/2.0.47]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 azure-mgmt-cosmosdb/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.27]
       accept-language: [en-US]
-    method: POST
+    method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/readonlykeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryReadonlyMasterKey":"Up7nYeb50D2Ol85VKZvd27HaMtzbLJdLX99KYcculXQ3bJWFs2LMe0YDx9jzzOykaSpBfr0Slyr21zjVnN9nFw==","secondaryReadonlyMasterKey":"4wt3IGiXb477qsFkSqmz0tjo39MJI7Ynu5TSl3mQ5mUPPefrelL74owtZ8HIRFfvvj3T0by3xitgSYodEIPwtQ=="}'}
+    body: {string: '{"primaryReadonlyMasterKey":"NeDyjkCO4uzYWUXTERPlnmjOnpWtBcKwEPedIW7WNR7wHQEEvrZ9po3nI7gFfshWiNZHs6h7YdfwelfMOVSNQw==","secondaryReadonlyMasterKey":"VeGykmTjFOuEWkZVpcBJHdFNeFZ6JQjDFKHTUqZubbwPhAREwLzrygHR5HaM3GOYC9P1uBjX4S08fWCOjBFUGA=="}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['239']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/36dfc234-9a2d-4f33-be43-db6e321dbc2b/resourceGroups/cli_test_cosmosdb_accountrsxiibvp3j6u6dgrfqy6zapbfbd5xcjvmzwcu2nqhxjbwt4o44/providers/Microsoft.DocumentDB/databaseAccounts/cliikpuw4xtoz7t4tzmv4q2mv7j6lb5ltuol76km/readonlykeys?api-version=2015-04-08']
       content-type: [application/json]
-      date: ['Thu, 11 Oct 2018 00:20:17 GMT']
+      date: ['Wed, 07 Feb 2018 07:48:21 GMT']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.1.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-gatewayversion: [version=1.20.0.0]
     status: {code: 200, message: Ok}
 - request:
     body: null
@@ -758,9 +707,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.5
-          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.47]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.16299-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.21 resourcemanagementclient/1.2.1 Azure-SDK-For-Python
+          AZURECLI/2.0.27]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_account000001?api-version=2018-05-01
@@ -769,12 +718,11 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 11 Oct 2018 00:20:18 GMT']
+      date: ['Wed, 07 Feb 2018 07:48:22 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQ09TTU9TREI6NUZBQ0NPVU5URjdDQ0hFM0lQUzZEWlNYSHxGNEFBNjA1NTJGRTk5MkJELVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQ09TTU9TREI6NUZBQ0NPVU5UUlNYSUlCVlAzSjZVNkRHUnxENjA0NDY1MTE5RDA3QTMwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_list_databases.yaml
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_list_databases.yaml
@@ -1,0 +1,930 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2018-11-27T20:45:19Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.51]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_account000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-27T20:45:19Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Nov 2018 20:45:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.51]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_account000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001","name":"cli_test_cosmosdb_account000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-27T20:45:19Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Nov 2018 20:45:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
+      [{"locationName": "westus", "failoverPriority": 0}], "databaseAccountOfferType":
+      "Standard"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      Content-Length: ['172']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2015-04-08
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Initializing","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","provisioningState":"Initializing","failoverPriority":0}],"readLocations":[{"id":"cli000002-westus","locationName":"West
+        US","provisioningState":"Initializing","failoverPriority":0}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
+        US","failoverPriority":0}],"capabilities":[]}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['1248']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:45:23 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:45:54 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:46:23 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:46:54 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:47:24 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:47:55 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:48:25 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:48:55 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:49:26 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:49:56 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:50:27 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:50:57 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:51:27 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:51:58 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Dequeued","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['32']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:52:28 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08
+  response:
+    body: {string: '{"status":"Succeeded","error":{}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['33']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7/operationResults/0dd74116-f83d-47e0-a26d-cf72241999a3?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:52:58 GMT']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2015-04-08
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"readLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
+        US","failoverPriority":0}],"capabilities":[]}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['1538']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:52:59 GMT']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb list-keys]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/listKeys?api-version=2015-04-08
+  response:
+    body: {string: '{"primaryMasterKey":"ZpXsr1IHbv04SkCifL908iU8YL5ZTLlzzgSO5cB6g9tEhU0gzRJise6bg4xuV4sdd4Vt37QHTgOZ4gXNa1yTzw==","secondaryMasterKey":"pbShxuQuZTHn5PQqpUi4nDW51B2vshS9fsXtqA6phKDG0I0FmF7fOEUF0bwtOOVXkQzIY1tNLLSHsvebnAEDcA==","primaryReadonlyMasterKey":"2xiMfIx8fBxcC0jZvKikVFKHbUfIFYvwhS0zzmDaLSxj9jVknfZSFWsmHEQTAHu1eUdtPCteVvlNMVj58hlxKA==","secondaryReadonlyMasterKey":"oPM9YPOyJSBoWoiAVVmseUMjYJ0EnpmzFLXUI0ZqJKUW8UXqFi5K612ZKbdTQKP6nBbY7JTfYn4GZzNGZkfUDg=="}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['461']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:00 GMT']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb show]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2015-04-08
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"readLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
+        US","failoverPriority":0}],"capabilities":[]}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['1538']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:00 GMT']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb database list]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/listKeys?api-version=2015-04-08
+  response:
+    body: {string: '{"primaryMasterKey":"ZpXsr1IHbv04SkCifL908iU8YL5ZTLlzzgSO5cB6g9tEhU0gzRJise6bg4xuV4sdd4Vt37QHTgOZ4gXNa1yTzw==","secondaryMasterKey":"pbShxuQuZTHn5PQqpUi4nDW51B2vshS9fsXtqA6phKDG0I0FmF7fOEUF0bwtOOVXkQzIY1tNLLSHsvebnAEDcA==","primaryReadonlyMasterKey":"2xiMfIx8fBxcC0jZvKikVFKHbUfIFYvwhS0zzmDaLSxj9jVknfZSFWsmHEQTAHu1eUdtPCteVvlNMVj58hlxKA==","secondaryReadonlyMasterKey":"oPM9YPOyJSBoWoiAVVmseUMjYJ0EnpmzFLXUI0ZqJKUW8UXqFi5K612ZKbdTQKP6nBbY7JTfYn4GZzNGZkfUDg=="}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['461']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:01 GMT']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [cosmosdb database list]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.51]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2015-04-08
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"readLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
+        US","failoverPriority":0}],"capabilities":[]}}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['1538']
+      content-location: ['https://management.documents.azure.com:450/subscriptions/a96b0a28-b2fc-4595-9709-2ba61bfbd1e4/resourceGroups/cli_test_cosmosdb_account7cjqkcurulnmp3kaktw6x2ikhvo2fdqxqxh4nzozap3epcqkpk/providers/Microsoft.DocumentDB/databaseAccounts/clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7?api-version=2015-04-08']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:01 GMT']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-gatewayversion: [version=2.1.0.0]
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Cache-Control: [no-cache]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Windows/10 Python/3.7.0 documentdb-python-sdk/2.3.3 AZURECLI/2.0.51]
+      x-ms-consistency-level: [Session]
+      x-ms-date: ['Tue, 27 Nov 2018 20:53:01 GMT']
+      x-ms-documentdb-query-iscontinuationexpected: ['False']
+      x-ms-session-token: ['']
+      x-ms-version: ['2017-11-15']
+    method: GET
+    uri: https://cli000002.documents.azure.com/
+  response:
+    body: {string: '{"_self":"","id":"cli000002","_rid":"cli000002.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+        US","databaseAccountEndpoint":"https://cli000002-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
+        US","databaseAccountEndpoint":"https://cli000002-westus.documents.azure.com:443/"}],"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowOffsetLimitClause\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-location: ['https://clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7.documents.azure.com/']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:01 GMT']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-ms-databaseaccount-consumed-mb: ['0']
+      x-ms-databaseaccount-provisioned-mb: ['0']
+      x-ms-databaseaccount-reserved-mb: ['0']
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-max-media-storage-usage-mb: ['2048']
+      x-ms-media-storage-usage-mb: ['0']
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Cache-Control: [no-cache]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Windows/10 Python/3.7.0 documentdb-python-sdk/2.3.3 AZURECLI/2.0.51]
+      x-ms-consistency-level: [Session]
+      x-ms-date: ['Tue, 27 Nov 2018 20:53:02 GMT']
+      x-ms-documentdb-query-iscontinuationexpected: ['False']
+      x-ms-version: ['2017-11-15']
+    method: GET
+    uri: https://cli000002-westus.documents.azure.com/dbs
+  response:
+    body: {string: '{"_rid":"","Databases":[],"_count":0}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-location: ['https://clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7-westus.documents.azure.com/dbs']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:02 GMT']
+      lsn: ['3']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-ms-activity-id: [02447a43-541b-4886-86f8-75830f6e69e5]
+      x-ms-cosmos-llsn: ['3']
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-global-committed-lsn: ['3']
+      x-ms-item-count: ['0']
+      x-ms-last-state-change-utc: ['Tue, 27 Nov 2018 11:31:43.941 GMT']
+      x-ms-number-of-read-regions: ['0']
+      x-ms-request-charge: ['2']
+      x-ms-resource-quota: [databases=100;collections=5000;users=500000;permissions=2000000;]
+      x-ms-resource-usage: [databases=0;collections=0;users=0;permissions=0;]
+      x-ms-schemaversion: ['1.6']
+      x-ms-serviceversion: [version=2.1.0.0]
+      x-ms-session-token: ['0:3']
+      x-ms-transport-request-id: ['272']
+      x-ms-xp-role: ['2']
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Cache-Control: [no-cache]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Windows/10 Python/3.7.0 documentdb-python-sdk/2.3.3 AZURECLI/2.0.51]
+      x-ms-consistency-level: [Session]
+      x-ms-date: ['Tue, 27 Nov 2018 20:53:02 GMT']
+      x-ms-documentdb-query-iscontinuationexpected: ['False']
+      x-ms-session-token: ['']
+      x-ms-version: ['2017-11-15']
+    method: GET
+    uri: https://cli000002.documents.azure.com/
+  response:
+    body: {string: '{"_self":"","id":"cli000002","_rid":"cli000002.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+        US","databaseAccountEndpoint":"https://cli000002-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
+        US","databaseAccountEndpoint":"https://cli000002-westus.documents.azure.com:443/"}],"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowOffsetLimitClause\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-location: ['https://clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7.documents.azure.com/']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:02 GMT']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-ms-databaseaccount-consumed-mb: ['0']
+      x-ms-databaseaccount-provisioned-mb: ['0']
+      x-ms-databaseaccount-reserved-mb: ['0']
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-max-media-storage-usage-mb: ['2048']
+      x-ms-media-storage-usage-mb: ['0']
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Cache-Control: [no-cache]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Windows/10 Python/3.7.0 documentdb-python-sdk/2.3.3 AZURECLI/2.0.51]
+      x-ms-consistency-level: [Session]
+      x-ms-date: ['Tue, 27 Nov 2018 20:53:03 GMT']
+      x-ms-documentdb-query-iscontinuationexpected: ['False']
+      x-ms-version: ['2017-11-15']
+    method: GET
+    uri: https://cli000002-westus.documents.azure.com/dbs
+  response:
+    body: {string: '{"_rid":"","Databases":[],"_count":0}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-location: ['https://clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7-westus.documents.azure.com/dbs']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:02 GMT']
+      lsn: ['3']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-ms-activity-id: [2f7607ca-d5de-46b1-b55d-28115b3ad9f5]
+      x-ms-cosmos-llsn: ['3']
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-global-committed-lsn: ['3']
+      x-ms-item-count: ['0']
+      x-ms-last-state-change-utc: ['Tue, 27 Nov 2018 18:14:25.341 GMT']
+      x-ms-number-of-read-regions: ['0']
+      x-ms-request-charge: ['2']
+      x-ms-resource-quota: [databases=100;collections=5000;users=500000;permissions=2000000;]
+      x-ms-resource-usage: [databases=0;collections=0;users=0;permissions=0;]
+      x-ms-schemaversion: ['1.6']
+      x-ms-serviceversion: [version=2.1.0.0]
+      x-ms-session-token: ['0:3']
+      x-ms-transport-request-id: ['493']
+      x-ms-xp-role: ['1']
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Cache-Control: [no-cache]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Windows/10 Python/3.7.0 documentdb-python-sdk/2.3.3 AZURECLI/2.0.51]
+      x-ms-consistency-level: [Session]
+      x-ms-date: ['Tue, 27 Nov 2018 20:53:03 GMT']
+      x-ms-documentdb-query-iscontinuationexpected: ['False']
+      x-ms-session-token: ['']
+      x-ms-version: ['2017-11-15']
+    method: GET
+    uri: https://cli000002.documents.azure.com/
+  response:
+    body: {string: '{"_self":"","id":"cli000002","_rid":"cli000002.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+        US","databaseAccountEndpoint":"https://cli000002-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
+        US","databaseAccountEndpoint":"https://cli000002-westus.documents.azure.com:443/"}],"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowOffsetLimitClause\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-location: ['https://clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7.documents.azure.com/']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:02 GMT']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-ms-databaseaccount-consumed-mb: ['0']
+      x-ms-databaseaccount-provisioned-mb: ['0']
+      x-ms-databaseaccount-reserved-mb: ['0']
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-max-media-storage-usage-mb: ['2048']
+      x-ms-media-storage-usage-mb: ['0']
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Cache-Control: [no-cache]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Windows/10 Python/3.7.0 documentdb-python-sdk/2.3.3 AZURECLI/2.0.51]
+      x-ms-consistency-level: [Session]
+      x-ms-date: ['Tue, 27 Nov 2018 20:53:03 GMT']
+      x-ms-documentdb-query-iscontinuationexpected: ['False']
+      x-ms-version: ['2017-11-15']
+    method: GET
+    uri: https://cli000002-westus.documents.azure.com/dbs
+  response:
+    body: {string: '{"_rid":"","Databases":[],"_count":0}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-location: ['https://clik6pgepc6dcukgz6frrpfqvphxvhhiofl2ajq7-westus.documents.azure.com/dbs']
+      content-type: [application/json]
+      date: ['Tue, 27 Nov 2018 20:53:03 GMT']
+      lsn: ['3']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-ms-activity-id: [e05c532e-4fef-4c5d-a6be-abe99580e6ad]
+      x-ms-cosmos-llsn: ['3']
+      x-ms-gatewayversion: [version=2.1.0.0]
+      x-ms-global-committed-lsn: ['3']
+      x-ms-item-count: ['0']
+      x-ms-last-state-change-utc: ['Tue, 27 Nov 2018 11:31:43.941 GMT']
+      x-ms-number-of-read-regions: ['0']
+      x-ms-request-charge: ['2']
+      x-ms-resource-quota: [databases=100;collections=5000;users=500000;permissions=2000000;]
+      x-ms-resource-usage: [databases=0;collections=0;users=0;permissions=0;]
+      x-ms-schemaversion: ['1.6']
+      x-ms-serviceversion: [version=2.1.0.0]
+      x-ms-session-token: ['0:3']
+      x-ms-transport-request-id: ['166']
+      x-ms-xp-role: ['2']
+    status: {code: 200, message: Ok}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
+          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
+          AZURECLI/2.0.51]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_account000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Tue, 27 Nov 2018 20:53:03 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQ09TTU9TREI6NUZBQ0NPVU5UN0NKUUtDVVJVTE5NUDNLQXxCMUI4Nzg1RjhENzhEMUE0LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
@@ -171,3 +171,23 @@ class CosmosDBTests(ScenarioTest):
             self.check('enableMultipleWriteLocations', True),
             self.check('consistencyPolicy.defaultConsistencyLevel', 'ConsistentPrefix'),
         ]).get_output_in_json()
+
+    @ResourceGroupPreparer(name_prefix='cli_test_cosmosdb_account')
+    def test_list_databases(self, resource_group):
+
+        self.kwargs.update({
+            'acc': self.create_random_name(prefix='cli', length=40)
+        })
+
+        self.cmd('az cosmosdb create -n {acc} -g {rg}')
+        keys = self.cmd('az cosmosdb list-keys -n {acc} -g {rg}').get_output_in_json()
+        account = self.cmd('az cosmosdb show -n {acc} -g {rg}').get_output_in_json()
+
+        self.kwargs.update({
+            'primary_master_key': keys["primaryMasterKey"],
+            'url': account['documentEndpoint']
+        })
+
+        self.cmd('az cosmosdb database list -n {acc} -g {rg}')
+        self.cmd('az cosmosdb database list -n {acc} --key {primary_master_key}')
+        self.cmd('az cosmosdb database list --url-connection {url} --key {primary_master_key}')

--- a/src/command_modules/azure-cli-cosmosdb/setup.py
+++ b/src/command_modules/azure-cli-cosmosdb/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.2.5"
+VERSION = "0.2.6"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
It allows users to switch their account from multi-master to single master and vice-versa. This change fixes a bug that prevents existing multi-master accounts from updating.

It also includes a fix to a problem that prevented using the database account name and account key when performing database operations.

These changes address the following open issues:

https://github.com/Azure/azure-cli/issues/7969
https://github.com/Azure/azure-cli/issues/7396
https://github.com/Azure/azure-cli/issues/6770
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
