### PR TITLE
[AKS] Don't require name to scale if there's a single nodepool

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * Remove "(PREVIEW)" from AAD arguments to "az aks create"
 * Mark "az acs" commands as deprecated (the ACS service will retire on January 31, 2020)
 * Add support of Network Policy when creating new AKS clusters
+* Don't require --nodepool-name in "az aks scale" if there's only one nodepool
 
 2.3.12
 ++++++

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -216,7 +216,7 @@ def load_arguments(self, _):
         c.argument('kubernetes_version', completer=get_k8s_upgrades_completion_list)
 
     with self.argument_context('aks scale') as c:
-        c.argument('nodepool_name', type=str, default='nodepool1',
+        c.argument('nodepool_name', type=str,
                    help='Node pool name, upto 12 alphanumeric characters', validator=validate_nodepool_name)
 
     with self.argument_context('aks upgrade-connector') as c:

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_validators.py
@@ -87,15 +87,12 @@ def validate_k8s_version(namespace):
 
 
 def validate_nodepool_name(namespace):
-    """Validates a nodepool name to be non empty,atmost 12 characters,alphanumeric only"""
-    if not namespace.nodepool_name:
-        raise CLIError('--nodepool-name cannot be empty')
-
-    if len(namespace.nodepool_name) > 12:
-        raise CLIError('--nodepool-name can contain atmost 12 characters')
-
-    if not namespace.nodepool_name.isalnum():
-        raise CLIError('--nodepool-name should only contain alphanumeric characters')
+    """Validates a nodepool name to be at most 12 characters, alphanumeric only."""
+    if namespace.nodepool_name != "":
+        if len(namespace.nodepool_name) > 12:
+            raise CLIError('--nodepool-name can contain atmost 12 characters')
+        if not namespace.nodepool_name.isalnum():
+            raise CLIError('--nodepool-name should only contain alphanumeric characters')
 
 
 def validate_k8s_client_version(namespace):


### PR DESCRIPTION
This fixes a bug where if the AKS node pool didn't have the expected "nodepool1" name, an `az aks scale` operation would fail silently.

cc: @shanepeckham @zqingqing1

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
