### PR TITLE
Moved get_default_admin_username from vm to core

### DIFF
--- a/doc/sphinx/azhelpgen/azhelpgen.py
+++ b/doc/sphinx/azhelpgen/azhelpgen.py
@@ -5,6 +5,7 @@
 
 import argparse
 import json
+from mock import patch
 from os.path import expanduser
 from docutils import nodes
 from docutils.statemachine import ViewList
@@ -32,7 +33,8 @@ class AzHelpGenDirective(Directive):
                invocation_cls=AzCliCommandInvoker,
                parser_cls=AzCliCommandParser,
                help_cls=AzCliHelp)
-        create_invoker_and_load_cmds_and_args(az_cli)
+        with patch('getpass.getuser', return_value='your_system_user_login_name'):
+            create_invoker_and_load_cmds_and_args(az_cli)
         help_files = get_all_help(az_cli)
 
         doc_source_map = _load_doc_source_map()

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 import sys
 import json
+import getpass
 import base64
 import binascii
 import six
@@ -344,3 +345,10 @@ def reload_module(module):
     except ImportError:
         pass  # for python 2
     reload(sys.modules[module])
+
+
+def get_default_admin_username():
+    try:
+        return getpass.getuser()
+    except KeyError:
+        return None

--- a/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/custom.py
+++ b/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/custom.py
@@ -295,7 +295,7 @@ def _update_user_account_settings(params, admin_user_name, ssh_key, password):
         parent.user_account_settings = models.UserAccountSettings(admin_user_name=None)
     # Get effective user name, password and key trying them in the following order: provided via command line,
     # provided in the config file, current user name and his default public ssh key.
-    effective_user_name = admin_user_name or parent.user_account_settings.admin_user_name or get_default_admin_username()
+    effective_user_name = admin_user_name or parent.user_account_settings.admin_user_name or get_default_admin_username() # pylint: disable=line-too-long
     effective_password = password or parent.user_account_settings.admin_user_password
     # Use default ssh public key only if no password is configured.
     effective_key = (ssh_key or parent.user_account_settings.admin_user_ssh_public_key or

--- a/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/custom.py
+++ b/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/custom.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 import collections
 import copy
 import datetime
-import getpass
 import json
 import os
 import signal
@@ -31,6 +30,7 @@ from msrestazure.tools import is_valid_resource_id, parse_resource_id
 from six.moves import urllib_parse
 
 from azure.cli.core import keys
+from azure.cli.core.util import get_default_admin_username
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.profiles import ResourceType, get_sdk
 import azure.mgmt.batchai.models as models
@@ -295,7 +295,7 @@ def _update_user_account_settings(params, admin_user_name, ssh_key, password):
         parent.user_account_settings = models.UserAccountSettings(admin_user_name=None)
     # Get effective user name, password and key trying them in the following order: provided via command line,
     # provided in the config file, current user name and his default public ssh key.
-    effective_user_name = admin_user_name or parent.user_account_settings.admin_user_name or getpass.getuser()
+    effective_user_name = admin_user_name or parent.user_account_settings.admin_user_name or get_default_admin_username()
     effective_password = password or parent.user_account_settings.admin_user_password
     # Use default ssh public key only if no password is configured.
     effective_key = (ssh_key or parent.user_account_settings.admin_user_ssh_public_key or

--- a/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/custom.py
+++ b/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/custom.py
@@ -295,7 +295,7 @@ def _update_user_account_settings(params, admin_user_name, ssh_key, password):
         parent.user_account_settings = models.UserAccountSettings(admin_user_name=None)
     # Get effective user name, password and key trying them in the following order: provided via command line,
     # provided in the config file, current user name and his default public ssh key.
-    effective_user_name = admin_user_name or parent.user_account_settings.admin_user_name or get_default_admin_username() # pylint: disable=line-too-long
+    effective_user_name = admin_user_name or parent.user_account_settings.admin_user_name or get_default_admin_username()  # pylint: disable=line-too-long
     effective_password = password or parent.user_account_settings.admin_user_password
     # Use default ssh public key only if no password is configured.
     effective_key = (ssh_key or parent.user_account_settings.admin_user_ssh_public_key or

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/custom.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/custom.py
@@ -3,10 +3,10 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import getpass
-
+from azure.cli.core.util import get_default_admin_username
 
 # pylint: disable=too-many-locals, unused-argument, too-many-statements
+
 
 def create_custom_image(client, resource_group_name, lab_name, name, source_vm_id, os_type, os_state,
                         author=None, description=None):
@@ -29,7 +29,7 @@ def create_custom_image(client, resource_group_name, lab_name, name, source_vm_i
 
 
 def create_lab_vm(client, resource_group_name, lab_name, name, notes=None, image=None, image_type=None,
-                  size=None, admin_username=getpass.getuser(), admin_password=None,
+                  size=None, admin_username=get_default_admin_username(), admin_password=None,
                   ssh_key=None, authentication_type='password',
                   vnet_name=None, subnet=None, disallow_public_ip_address=None, artifacts=None,
                   location=None, tags=None, custom_image_id=None, lab_virtual_network_id=None,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -9,6 +9,7 @@ from argcomplete.completers import FilesCompleter
 from knack.arguments import CLIArgumentType
 
 from azure.cli.core.profiles import ResourceType
+from azure.cli.core.util import get_default_admin_username
 from azure.cli.core.commands.validators import (
     get_default_location_from_resource_group, validate_file_or_dict)
 from azure.cli.core.commands.parameters import (
@@ -411,7 +412,7 @@ def load_arguments(self, _):
 
         with self.argument_context(scope, arg_group='Authentication') as c:
             c.argument('generate_ssh_keys', action='store_true', help='Generate SSH public and private key files if missing. The keys will be stored in the ~/.ssh directory')
-            c.argument('admin_username', help='Username for the VM.', default=_get_default_admin_username())
+            c.argument('admin_username', help='Username for the VM.', default=get_default_admin_username())
             c.argument('admin_password', help="Password for the VM if authentication type is 'Password'.")
             c.argument('ssh_key_value', help='SSH public key or public key file path.', completer=FilesCompleter(), type=file_type)
             c.argument('ssh_dest_key_path', help='Destination file path on the VM for the SSH key.')
@@ -578,11 +579,3 @@ def load_arguments(self, _):
             c.argument('target_regions', nargs='*', validator=process_gallery_image_version_namespace,
                        help='space separated region list, use "<region>=<replicate count>" to apply region specific replicate count')
     # endregion
-
-
-def _get_default_admin_username():
-    import getpass
-    try:
-        return getpass.getuser()
-    except KeyError:
-        return None


### PR DESCRIPTION
Moved get_default_admin_username from vm to core. Updated usages of getpass.getusername to use get_default_admin_username which catches getuser's exception.

Fixes #2100 and when completed will fix #7711.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
