### PR TITLE
Disable version check from CI

### DIFF
--- a/scripts/ci/precheck_header.sh
+++ b/scripts/ci/precheck_header.sh
@@ -14,12 +14,12 @@ echo "Verify readme history"
 python -m automation.tests.verify_readme_history
 
 # Only verify package version or PRs to Azure/azure-cli (not other forks)
-if [ $TRAVIS_EVENT_TYPE == "pull_request" ] && [ $TRAVIS_REPO_SLUG == "Azure/azure-cli" ]; then
-    echo "Verify package versions"
-    latestCliReleaseTag=$(git describe --tags `git rev-list --tags='azure-cli-*' --max-count=1`)
-    latestCliReleaseDir=$(mktemp -d)
-    echo "Latest CLI release tag $latestCliReleaseTag"
-    git clone -c advice.detachedHead=False https://github.com/$TRAVIS_REPO_SLUG --branch $latestCliReleaseTag $latestCliReleaseDir
-    python -m automation.tests.verify_package_versions --base-repo $latestCliReleaseDir --base-tag $latestCliReleaseTag
-fi
+# if [ $TRAVIS_EVENT_TYPE == "pull_request" ] && [ $TRAVIS_REPO_SLUG == "Azure/azure-cli" ]; then
+#     echo "Verify package versions"
+#     latestCliReleaseTag=$(git describe --tags `git rev-list --tags='azure-cli-*' --max-count=1`)
+#     latestCliReleaseDir=$(mktemp -d)
+#     echo "Latest CLI release tag $latestCliReleaseTag"
+#     git clone -c advice.detachedHead=False https://github.com/$TRAVIS_REPO_SLUG --branch $latestCliReleaseTag $latestCliReleaseDir
+#     python -m automation.tests.verify_package_versions --base-repo $latestCliReleaseDir --base-tag $latestCliReleaseTag
+# fi
 


### PR DESCRIPTION
First step in #7834. This change will allow us to immediately start accepting 3rd party contributions without worrying about them having to bump the version.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [N/A] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
