### PR TITLE
EventHubs help fixes

### DIFF
--- a/src/command_modules/azure-cli-eventhubs/azure/cli/command_modules/eventhubs/_help.py
+++ b/src/command_modules/azure-cli-eventhubs/azure/cli/command_modules/eventhubs/_help.py
@@ -75,7 +75,7 @@ helps['eventhubs namespace create'] = """
     examples:
         - name: Creates a new namespace.
           text: az eventhubs namespace create --resource-group myresourcegroup --name mynamespace --location westus
-           --tags tag1=value1 tag2=value2 --sku Standard --is-auto-inflate-enabled False --maximum-throughput-units 30
+           --tags tag1=value1 tag2=value2 --sku Standard --enable-auto-inflate-enabled False --maximum-throughput-units 30
 """
 
 helps['eventhubs namespace update'] = """
@@ -83,7 +83,7 @@ helps['eventhubs namespace update'] = """
     short-summary: Updates the Event Hubs Namespace
     examples:
         - name: Update a new namespace.
-          text: az eventhubs namespace update --resource-group myresourcegroup --name mynamespace --tags tag=value --is-auto-inflate-enabled True
+          text: az eventhubs namespace update --resource-group myresourcegroup --name mynamespace --tags tag=value --enable-auto-inflate-enabled True
 """
 
 helps['eventhubs namespace show'] = """
@@ -174,7 +174,7 @@ helps['eventhubs eventhub create'] = """
     short-summary: Creates the Event Hubs Eventhub
     examples:
         - name: Create a new Eventhub.
-          text: az eventhubs eventhub create --resource-group myresourcegroup --namespace-name mynamespace --name myeventhub --message-retention 4 ---partition-count 15
+          text: az eventhubs eventhub create --resource-group myresourcegroup --namespace-name mynamespace --name myeventhub --message-retention 4 --partition-count 15
 """
 
 helps['eventhubs eventhub update'] = """
@@ -182,7 +182,7 @@ helps['eventhubs eventhub update'] = """
     short-summary: Updates the Event Hubs Eventhub
     examples:
         - name: Updates a new Eventhub.
-          text: az eventhubs eventhub update --resource-group myresourcegroup --namespace-name mynamespace --name myeventhub --message-retention 3 ---partition-count 12
+          text: az eventhubs eventhub update --resource-group myresourcegroup --namespace-name mynamespace --name myeventhub --message-retention 3 --partition-count 12
 """
 
 helps['eventhubs eventhub show'] = """

--- a/src/command_modules/azure-cli-eventhubs/azure/cli/command_modules/eventhubs/_help.py
+++ b/src/command_modules/azure-cli-eventhubs/azure/cli/command_modules/eventhubs/_help.py
@@ -75,7 +75,7 @@ helps['eventhubs namespace create'] = """
     examples:
         - name: Creates a new namespace.
           text: az eventhubs namespace create --resource-group myresourcegroup --name mynamespace --location westus
-           --tags tag1=value1 tag2=value2 --sku Standard --enable-auto-inflate-enabled False --maximum-throughput-units 30
+           --tags tag1=value1 tag2=value2 --sku Standard --enable-auto-inflate False --maximum-throughput-units 30
 """
 
 helps['eventhubs namespace update'] = """
@@ -83,7 +83,7 @@ helps['eventhubs namespace update'] = """
     short-summary: Updates the Event Hubs Namespace
     examples:
         - name: Update a new namespace.
-          text: az eventhubs namespace update --resource-group myresourcegroup --name mynamespace --tags tag=value --enable-auto-inflate-enabled True
+          text: az eventhubs namespace update --resource-group myresourcegroup --name mynamespace --tags tag=value --enable-auto-inflate True
 """
 
 helps['eventhubs namespace show'] = """


### PR DESCRIPTION
Fixes #7937. Fixes #7938.

This is also testing that help text PRs made from the GitHub UI are not blocked by our CI.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
