### PR TITLE
[AKS] mark `az acs` commands as deprecated 

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 2.3.13
 ++++++
 * Remove "(PREVIEW)" from AAD arguments to "az aks create"
+* Mark "az acs" commands as deprecated (the ACS service will retire on January 31, 2020)
 
 2.3.12
 ++++++

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -17,6 +17,10 @@ AKS_SERVICE_PRINCIPAL_CACHE = os.path.join('$HOME', '.azure', 'aksServicePrincip
 helps['acs'] = """
      type: group
      short-summary: Manage Azure Container Services.
+     long-summary: |
+         ACS will be retired as a standalone service on January 31, 2020.
+
+         If you use the Kubernetes orchestrator, please migrate to AKS by January 31, 2020.
 """
 
 helps['acs browse'] = """

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -29,7 +29,11 @@ def load_command_table(self, _):
     )
 
     # ACS base commands
-    with self.command_group('acs', container_services_sdk, client_factory=cf_container_services) as g:
+    # TODO: When the first azure-cli release after January 31, 2020 is planned, add
+    # `expiration=<CLI core version>` to the `self.deprecate()` args below.
+    deprecate_info = self.deprecate(redirect='aks')
+    with self.command_group('acs', container_services_sdk, deprecate_info=deprecate_info,
+                            client_factory=cf_container_services) as g:
         g.custom_command('browse', 'acs_browse')
         g.custom_command('create', 'acs_create', supports_no_wait=True,
                          table_transformer=deployment_validate_table_format)


### PR DESCRIPTION
ACS will be retired as a standalone service on January 31, 2020.

The changes in this PR lead to this output:

```console
$ az acs -h

Group
    az acs : Manage Azure Container Services.
        ACS will be retired as a standalone service on January 31, 2020.

        If you use the Kubernetes orchestrator, please migrate to AKS by January 31, 2020. This
        command group has been deprecated and will be removed in a future release. Use 'aks'
        instead.

Subgroups:
    dcos           : Commands to manage a DC/OS-orchestrated Azure Container Service.
    kubernetes     : Commands to manage a Kubernetes-orchestrated Azure Container Service.

Commands:
    browse         : Show the dashboard for a service container's orchestrator in a web browser.
    create         : Create a new container service.
    ...
$ az acs create -h

Command
    az acs create : Create a new container service.
        This command is implicitly deprecated because command group 'acs' is deprecated and
        will be removed in a future release. Use 'aks' instead.

Arguments
    --name -n                 [Required] : Name of the container service. You can configure the
                                           default using `az configure --defaults acs=<name>`.
    --resource-group -g       [Required] : Name of resource group. You can configure the default
                                           group using `az configure --defaults group=<name>`.
    ...
```
When we know what the first `az` CLI release will be after the retirement date, we can add a parameter that will clarify this to users.

cc: @jakepearson @seanmck

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
