### PR TITLE
Fix 7973 - Call SubResource correctly in list comprehension

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1984,7 +1984,7 @@ def set_lb_outbound_rule(instance, cmd, parent, item_name, protocol=None, outbou
     _set_param(instance, 'backend_address_pool', SubResource(id=backend_address_pool)
                if backend_address_pool else None)
     _set_param(instance, 'frontend_ip_configurations',
-               [SubResource(x) for x in frontend_ip_configurations] if frontend_ip_configurations else None)
+               [SubResource(id=x) for x in frontend_ip_configurations] if frontend_ip_configurations else None)
 
     return parent
 


### PR DESCRIPTION
Call `SubResource(id=x)` instead of `SubResource(x)` in list comprehension, since the latter introduced a `TypeError` and prevented `az network lb outbound-rule update` from being used with the `--frontend-ip-configs` flag

This fixes GH-7973