### PR TITLE
Dockerize Linux Builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 *
 # Make an exception for azure-cli source code
 !src/*
+# Make an exception for release scripts
+!scripts/*
 # Make an exception for private SDKs if they exist
 !privates/*
 # Make an exception for tab completion script

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ MANIFEST
 build_scripts/windows/out
 cli-build-*/
 *.rpm
+bin/docker/*.tar.gz
 
 # Result of running python setup.py install/pip install -e
 RECORD.txt

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 MANIFEST
 build_scripts/windows/out
 cli-build-*/
+*.rpm
 
 # Result of running python setup.py install/pip install -e
 RECORD.txt

--- a/scripts/release/debian/Dockerfile
+++ b/scripts/release/debian/Dockerfile
@@ -1,0 +1,47 @@
+ARG base_image=ubuntu:xenial
+FROM ${base_image} AS build-env
+
+# Update APT packages
+RUN apt-get update
+RUN apt-get install -y libssl-dev libffi-dev python3-dev debhelper zlib1g-dev wget
+
+# Download Python source code
+ARG python_version="3.6.5"
+ENV PYTHON_SRC_DIR=/usr/src/python
+RUN mkdir -p ${PYTHON_SRC_DIR} && \
+    wget -qO- https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz \
+    | tar -xz -C "${PYTHON_SRC_DIR}"
+
+WORKDIR /azure-cli
+RUN ${PYTHON_SRC_DIR}/*/configure --srcdir ${PYTHON_SRC_DIR}/* --prefix $(pwd)/python_env &&\
+    make && \
+    make install && \
+    ln /azure-cli/python_env/bin/python3 /azure-cli/python_env/bin/python && \
+    ln /azure-cli/python_env/bin/pip3 /azure-cli/python_env/bin/pip
+
+ENV PATH=/azure-cli/python_env/bin:$PATH
+
+RUN pip install wheel
+
+COPY . .
+
+RUN mkdir -p ./bin/pypi && \
+    BUILD_STAGINGDIRECTORY=/azure-cli/bin/pypi ./scripts/release/pypi/build.sh && \
+    if [ -d ./privates ]; then find ./privates -name '*.whl' | xargs pip install; fi && \
+    find ./bin/pypi -name '*.whl' | xargs pip install && \
+    pip install --force-reinstall --upgrade azure-nspkg azure-mgmt-nspkg
+
+ARG cli_version=0.0.0-dev
+ARG cli_version_revision=1
+
+RUN mkdir -p ./debian && \
+    CLI_VERSION=${cli_version} CLI_VERSION_REVISION=${cli_version_revision} ./scripts/release/debian/prepare.sh ./debian ./az.completion ./ && \
+    dpkg-buildpackage -us -uc && \
+    cp /azure-cli_${cli_version}-${cli_version_revision}_all.deb /azure-cli_all.deb
+
+FROM $base_image AS execution-env
+
+COPY --from=build-env /azure-cli_all.deb /azure-cli_all.deb
+
+RUN dpkg -i /azure-cli_all.deb && \
+    rm /azure-cli_all.deb

--- a/scripts/release/debian/README.md
+++ b/scripts/release/debian/README.md
@@ -1,5 +1,22 @@
-Debian Packaging
+# Debian Packaging
 ================
+
+Building the Debian package
+---------------------------
+
+On a machine with Docker, execute the following command from the root directory of this repository:
+
+``` bash
+docker build --target build-env -f ./scripts/release/debian/Dockerfile -t microsoft/azure-cli:ubuntu-builder .
+```
+
+After several minutes, this will have created a Docker image named `microsoft/azure-cli:ubuntu-builder` containing an
+unsigned `.deb` built from the current contents of your azure-cli directory. To extract the build product from the image
+you can run the following command:
+
+``` bash
+docker run microsoft/azure-cli:ubuntu-builder cat /azure-cli/debian/
+```
 
 The script only runs in container environment.
 

--- a/scripts/release/rpm/Dockerfile
+++ b/scripts/release/rpm/Dockerfile
@@ -1,0 +1,19 @@
+ARG base_image=centos:centos7
+
+FROM $base_image AS build-env
+ARG cli_version=dev
+
+RUN yum install -y wget rpm-build gcc libffi-devel python-devel openssl-devel make bash coreutils diffutils patch
+
+WORKDIR /azure-cli
+
+COPY . .
+
+RUN REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
+    cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.el7.x86_64.rpm /azure-cli-dev.rpm
+
+FROM $base_image AS execution-env
+
+COPY --from=build-env /azure-cli-dev.rpm ./
+RUN rpm -i ./azure-cli-dev.rpm && \
+    az --version

--- a/scripts/release/rpm/Dockerfile
+++ b/scripts/release/rpm/Dockerfile
@@ -3,13 +3,14 @@ ARG base_image=centos:centos7
 FROM $base_image AS build-env
 ARG cli_version=dev
 
-RUN yum install -y wget rpm-build gcc libffi-devel python-devel openssl-devel make bash coreutils diffutils patch
+RUN yum install -y wget rpm-build gcc libffi-devel python-devel openssl-devel make bash coreutils diffutils patch dos2unix
 
 WORKDIR /azure-cli
 
 COPY . .
 
-RUN REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
+RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
+    REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.el7.x86_64.rpm /azure-cli-dev.rpm
 
 FROM $base_image AS execution-env

--- a/scripts/release/rpm/README.md
+++ b/scripts/release/rpm/README.md
@@ -4,27 +4,55 @@ RPM Packaging
 Building the RPM package
 ------------------------
 
-On a build machine (e.g. new CentOS 7 VM) run the following.
+On a machine with Docker, execute the following command from the root directory of this repository:
 
-Install dependencies required to build:
-Required for rpm build tools & required to build the CLI.
-```
-sudo yum install -y gcc git rpm-build rpm-devel rpmlint make bash coreutils diffutils patch rpmdevtools python libffi-devel python-devel openssl-devel
+``` bash
+docker build --target build-env -f ./scripts/release/rpm/Dockerfile -t microsoft/azure-cli:centos7-builder .
 ```
 
-Build example:
-Note: use the full path to the repo path, not a relative path.
+After several minutes, this will have created a Docker image named `microsoft/azure-cli:centos7-builder` containing an
+unsigned `.rpm` built from the current contents of your azure-cli directory. To extract the build product from the image
+you can run the following command:
+
+``` bash
+docker run microsoft/azure-cli:centos7-builder cat /root/rpmbuild/RPMS/x86_64/azure-cli-dev-1.el7.x86_64.rpm > ./bin/azure-cli-dev-1.el7.x86_64.rpm
 ```
-git clone https://github.com/azure/azure-cli
-cd azure-cli
-export CLI_VERSION=2.0.16
-export REPO_PATH=$(pwd)
-rpmbuild -v -bb --clean build_scripts/rpm/azure-cli.spec
-```
+
+This launches a container running from the image built and tagged by the previous command, prints the contents of the
+built package to standard out, and pipes it to a file on your host machine.
+
+### Additional Build Flags
+
+`--build-arg cli_version={your version string}`
+
+This will allow you to name your build. If not specified, the value "dev" is assumed.
+
+`--build-arg base_image={docker image name}`
+
+RPMs must be built using a Red Hat distro or derivative. By default, this build uses CentOS7, but one could easily tweak
+it to include slightly different packages for distribution.
+
+### Verification
+
+
+
+Run the RPM package
+-------------------
+
+On a machine with Docker, execute the following command from the root directory of this repository:
+
+``` bash
+docker build -f ./scripts/release/rpm/Dockerfile -t microsoft/azure-cli:centos7 .
+``` 
+
+If you had previously followed this instructions above for building an RPM package, this should finish very quickly.
+Otherwise, it'll take a few minutes to create an image with a copy of the azure-cli installed.
+> Note: The image that is created by this command does not contain the source code of the azure-cli.
 
 Verification
 ------------
 
+Install the RPM:
 ```
 sudo rpm -i RPMS/*/azure-cli-2.0.16-1.noarch.rpm
 az --version
@@ -48,6 +76,6 @@ sudo rpm -e azure-cli
 Links
 -----
 
-https://fedoraproject.org/wiki/How_to_create_an_RPM_package
+- [Fedora Project: How to Create an RPM Package](https://fedoraproject.org/wiki/How_to_create_an_RPM_package)
+- [Fedora Project: Packaging RPM Macros](https://fedoraproject.org/wiki/Packaging:RPMMacros?rd=Packaging/RPMMacros)
 
-https://fedoraproject.org/wiki/Packaging:RPMMacros?rd=Packaging/RPMMacros

--- a/scripts/release/rpm/README.md
+++ b/scripts/release/rpm/README.md
@@ -1,8 +1,6 @@
-RPM Packaging
-================
+# RPM Packaging
 
-Building the RPM package
-------------------------
+## Building the RPM package
 
 On a machine with Docker, execute the following command from the root directory of this repository:
 
@@ -33,8 +31,6 @@ RPMs must be built using a Red Hat distro or derivative. By default, this build 
 it to include slightly different packages for distribution.
 
 ### Verification
-
-
 
 Run the RPM package
 -------------------

--- a/scripts/release/rpm/pipeline.sh
+++ b/scripts/release/rpm/pipeline.sh
@@ -14,15 +14,14 @@ docker build \
     --build-arg cli_version=${CLI_VERSION} \
     -f ./scripts/release/rpm/Dockerfile \
     -t microsoft/azure-cli:centos7-builder \
-    . &
+    .
 
 # Continue the previous build, and create a container that has the current azure-cli build but not the source code.
 docker build \
     --build-arg cli_version=${CLI_VERSION} \
     -f ./scripts/release/rpm/Dockerfile \
     -t microsoft/azure-cli:centos7 \
-    . &
-wait
+    .
 
 # Extract the built RPM so that it can be distributed independently.
 docker run \

--- a/scripts/release/rpm/pipeline.sh
+++ b/scripts/release/rpm/pipeline.sh
@@ -14,14 +14,15 @@ docker build \
     --build-arg cli_version=${CLI_VERSION} \
     -f ./scripts/release/rpm/Dockerfile \
     -t microsoft/azure-cli:centos7-builder \
-    .
+    . &
 
 # Continue the previous build, and create a container that has the current azure-cli build but not the source code.
 docker build \
     --build-arg cli_version=${CLI_VERSION} \
     -f ./scripts/release/rpm/Dockerfile \
     -t microsoft/azure-cli:centos7 \
-    .
+    . &
+wait
 
 # Extract the built RPM so that it can be distributed independently.
 docker run \

--- a/scripts/release/rpm/pipeline.sh
+++ b/scripts/release/rpm/pipeline.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 
-# Build APT package in an Azure Container Instances
-# This script assumes the Azure CLI is installed and logged in.
+# Build an RPM containing the Azure CLI at a paritcular
 
 set -exv
 
 CLI_VERSION=`cat src/azure-cli/azure/cli/__init__.py | grep __version__ | sed s/' '//g | sed s/'__version__='// |  sed s/\"//g`
 
-docker run --rm \
-           -v "$BUILD_SOURCESDIRECTORY":/mnt/repo \
-           -v "$BUILD_STAGINGDIRECTORY":/mnt/output \
-           -e CLI_VERSION=$CLI_VERSION \
-           centos:7 \
-           /mnt/repo/scripts/release/rpm/build.sh
+docker build \
+    --target build-env \
+    --build-arg cli_version=${CLI_VERSION} \
+    -f ./scripts/release/rpm/Dockerfile \
+    -t microsoft/azure-cli:centos7-builder \
+    .
+
+docker run \
+    microsoft/azure-cli:centos7-builder \
+    cat /root/rpmbuild/RPMS/x86_64/azure-cli-${CLI_VERSION}-1.el7.x86_64.rpm \
+    > ${BUILD_STAGINDIRECTORY}/azure-cli-${CLI_VERSION}-1.el7.x86_64.rpm

--- a/scripts/release/rpm/pipeline.sh
+++ b/scripts/release/rpm/pipeline.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
-# Build an RPM containing the Azure CLI at a paritcular
+# Build assets related to Linux Distributions that use RPM/yum for installation.
 
 set -exv
 
+: "${BUILD_STAGINGDIRECTORY:?BUILD_STAGINGDIRECTORY environment variable not set.}"
+
 CLI_VERSION=`cat src/azure-cli/azure/cli/__init__.py | grep __version__ | sed s/' '//g | sed s/'__version__='// |  sed s/\"//g`
 
+# Create a container image that includes the source code and a built RPM using this file.
 docker build \
     --target build-env \
     --build-arg cli_version=${CLI_VERSION} \
@@ -13,7 +16,24 @@ docker build \
     -t microsoft/azure-cli:centos7-builder \
     .
 
+# Continue the previous build, and create a container that has the current azure-cli build but not the source code.
+docker build \
+    --build-arg cli_version=${CLI_VERSION} \
+    -f ./scripts/release/rpm/Dockerfile \
+    -t microsoft/azure-cli:centos7 \
+    .
+
+# Extract the built RPM so that it can be distributed independently.
 docker run \
     microsoft/azure-cli:centos7-builder \
     cat /root/rpmbuild/RPMS/x86_64/azure-cli-${CLI_VERSION}-1.el7.x86_64.rpm \
-    > ${BUILD_STAGINDIRECTORY}/azure-cli-${CLI_VERSION}-1.el7.x86_64.rpm
+    > ${BUILD_STAGINGDIRECTORY}/azure-cli-${CLI_VERSION}-1.el7.x86_64.rpm
+
+# Save these too a staging directory so that later build phases can choose to save them as Artifacts or publish them to
+# a registry.
+#
+# The products of `docker save` can be rehydrated using `docker load`.
+mkdir -p ${BUILD_STAGINGDIRECTORY}/docker
+docker save microsoft/azure-cli:centos7-builder | gzip > ${BUILD_STAGINGDIRECTORY}/docker/microsoft_azure-cli_centos7-builder.tar.gz &
+docker save microsoft/azure-cli:centos7 | gzip > ${BUILD_STAGINGDIRECTORY}/docker/microsoft_azure-cli_centos7.tar.gz &
+wait


### PR DESCRIPTION
Before these changes, we had scripts defined that would allow us to use containers to execute builds. With my changes, the two are married together, so that the build is defined as part of the container definition. This is the first step in looking to enable any interested party in issuing a command like the following to experiment with changes made in any given PR:

``` bash
docker run -it microsoft/azure-cli:pr7996
```