### PR TITLE
Support dev extensions

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -171,7 +171,7 @@ class MainCommandsLoader(CLICommandsLoader):
                 module_commands = set(self.command_table.keys())
                 for ext in allowed_extensions:
                     ext_name = ext.name
-                    ext_dir = get_extension_path(ext_name)
+                    ext_dir = ext.path or get_extension_path(ext_name)
                     sys.path.append(ext_dir)
                     try:
                         ext_mod = get_extension_modname(ext_name, ext_dir=ext_dir)

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -14,12 +14,15 @@ from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
 
 az_config = CLIConfig(config_dir=GLOBAL_CONFIG_DIR, config_env_var_prefix=ENV_VAR_PREFIX)
 _CUSTOM_EXT_DIR = az_config.get('extension', 'dir', None)
+_DEV_EXTENSION_SOURCES = az_config.get('extension', 'dev_sources', None)
 EXTENSIONS_DIR = os.path.expanduser(_CUSTOM_EXT_DIR) if _CUSTOM_EXT_DIR else os.path.join(GLOBAL_CONFIG_DIR,
                                                                                           'cliextensions')
+DEV_EXTENSION_SOURCES = _DEV_EXTENSION_SOURCES.split(',') if _DEV_EXTENSION_SOURCES else []
 
 EXTENSIONS_MOD_PREFIX = 'azext_'
 
 WHL_METADATA_FILENAME = 'metadata.json'
+EGG_INFO_METADATA_FILE_NAME = 'PKG-INFO'  # used for dev packages
 AZEXT_METADATA_FILENAME = 'azext_metadata.json'
 
 EXT_METADATA_MINCLICOREVERSION = 'azext.minCliCoreVersion'
@@ -40,9 +43,10 @@ class ExtensionNotInstalledException(Exception):
 
 class Extension(object):
 
-    def __init__(self, name, ext_type):
+    def __init__(self, name, ext_type, path=None):
         self.name = name
         self.ext_type = ext_type
+        self.path = path
         self._version = None
         self._metadata = None
         self._preview = None
@@ -97,29 +101,31 @@ class Extension(object):
 
 class WheelExtension(Extension):
 
-    def __init__(self, name):
-        super(WheelExtension, self).__init__(name, 'whl')
+    def __init__(self, name, path):
+        super(WheelExtension, self).__init__(name, 'whl', path)
 
     def get_version(self):
         return self.metadata.get('version')
 
     def get_metadata(self):
         from wheel.install import WHEEL_INFO_RE
+
         if not extension_exists(self.name):
             return None
         metadata = {}
-        ext_dir = get_extension_path(self.name)
+        ext_dir = self.path or get_extension_path(self.name)
         dist_info_dirs = [f for f in os.listdir(ext_dir) if f.endswith('.dist-info')]
         azext_metadata = WheelExtension.get_azext_metadata(ext_dir)
         if azext_metadata:
             metadata.update(azext_metadata)
+
         for dist_info_dirname in dist_info_dirs:
             parsed_dist_info_dir = WHEEL_INFO_RE(dist_info_dirname)
             if parsed_dist_info_dir and parsed_dist_info_dir.groupdict().get('name') == self.name.replace('-', '_'):
                 whl_metadata_filepath = os.path.join(ext_dir, dist_info_dirname, WHL_METADATA_FILENAME)
-                if os.path.isfile(whl_metadata_filepath):
-                    with open(whl_metadata_filepath) as f:
-                        metadata.update(json.load(f))
+                with open(whl_metadata_filepath) as f:
+                    metadata.update(json.loads(f.read()))
+
         return metadata
 
     @staticmethod
@@ -137,17 +143,93 @@ class WheelExtension(Extension):
         """
         Returns all wheel-based extensions.
         """
+        from glob import glob
         exts = []
         if os.path.isdir(EXTENSIONS_DIR):
             for ext_name in os.listdir(EXTENSIONS_DIR):
-                ext_path = get_extension_path(ext_name)
-                if os.path.isdir(ext_path) and \
-                        next((f for f in os.listdir(ext_path) if f.endswith(('.dist-info', '.egg-info'))), None):
-                    exts.append(WheelExtension(ext_name))
+                ext_path = os.path.join(EXTENSIONS_DIR, ext_name)
+                pattern = os.path.join(ext_path, '*.dist-info')
+                if os.path.isdir(ext_path) and glob(pattern):
+                    exts.append(WheelExtension(ext_name, get_extension_path(ext_name)))
         return exts
 
 
-EXTENSION_TYPES = [WheelExtension]
+class DevExtension(Extension):
+    def __init__(self, name, path):
+        super(DevExtension, self).__init__(name, 'dev', path)
+
+    def get_version(self):
+        return self.metadata.get('version')
+
+    def get_metadata(self):
+
+        if not extension_exists(self.name):
+            return None
+        metadata = {}
+        ext_dir = self.path
+        egg_info_dirs = [f for f in os.listdir(ext_dir) if f.endswith('.egg-info')]
+        azext_metadata = DevExtension.get_azext_metadata(ext_dir)
+        if azext_metadata:
+            metadata.update(azext_metadata)
+
+        def _apply_egginfo_metadata(filename):
+            # extract version info for dev extensions from PKG-INFO
+            if os.path.isfile(filename):
+                with open(filename) as f:
+                    for line in f.readlines():
+                        try:
+                            key, val = line.split(':', 1)
+                            key = key.lower()
+                            if key == 'version':
+                                metadata[key] = '{}'.format(val.strip())
+                        except ValueError:
+                            continue
+
+        for egg_info_dirname in egg_info_dirs:
+            egg_metadata_filepath = os.path.join(ext_dir, egg_info_dirname, EGG_INFO_METADATA_FILE_NAME)
+            _apply_egginfo_metadata(egg_metadata_filepath)
+
+        return metadata
+
+    @staticmethod
+    def get_azext_metadata(ext_dir):
+        azext_metadata = None
+        ext_modname = get_extension_modname(ext_dir=ext_dir)
+        azext_metadata_filepath = os.path.join(ext_dir, ext_modname, AZEXT_METADATA_FILENAME)
+        if os.path.isfile(azext_metadata_filepath):
+            with open(azext_metadata_filepath) as f:
+                azext_metadata = json.load(f)
+        return azext_metadata
+
+    @staticmethod
+    def get_all():
+        """
+        Returns all dev extensions.
+        """
+        from glob import glob
+        exts = []
+
+        def _collect(path, depth=0, max_depth=3):
+            if not os.path.isdir(path) or depth == max_depth or os.path.split(path)[-1].startswith('.'):
+                return
+            pattern = os.path.join(path, '*.egg-info')
+            match = glob(pattern)
+            if match:
+                ext_path = os.path.dirname(match[0])
+                ext_name = os.path.split(ext_path)[-1]
+                exts.append(DevExtension(ext_name, ext_path))
+            else:
+                for item in os.listdir(path):
+                    _collect(os.path.join(path, item), depth + 1, max_depth)
+        # always check extension dir for dev extensions since that is where
+        # they previously were located
+        _collect(EXTENSIONS_DIR)
+        for source in DEV_EXTENSION_SOURCES:
+            _collect(source)
+        return exts
+
+
+EXTENSION_TYPES = [WheelExtension, DevExtension]
 
 
 def ext_compat_with_cli(azext_metadata):
@@ -179,29 +261,34 @@ def get_extension_path(ext_name):
     return os.path.join(EXTENSIONS_DIR, ext_name)
 
 
-def get_extensions():
+def get_extensions(ext_type=None):
     logger.debug("Extensions directory: '%s'", EXTENSIONS_DIR)
     extensions = []
-    for ext_type in EXTENSION_TYPES:
-        extensions.extend([ext for ext in ext_type.get_all()])
+    if not ext_type:
+        ext_type = EXTENSION_TYPES
+    elif not isinstance(ext_type, list):
+        ext_type = [ext_type]
+    for t in ext_type:
+        extensions.extend([ext for ext in t.get_all()])
     return extensions
 
 
-def get_extension(ext_name):
-    ext = next((ext for ext in get_extensions() if ext.name == ext_name), None)
+def get_extension(ext_name, ext_type=None):
+    ext = next((ext for ext in get_extensions(ext_type=ext_type) if ext.name == ext_name), None)
     if ext is None:
         raise ExtensionNotInstalledException(ext_name)
     return ext
 
 
-def extension_exists(ext_name):
-    ext = next((ext for ext in get_extensions() if ext.name == ext_name), None)
+def extension_exists(ext_name, ext_type=None):
+    exts = get_extensions(ext_type=ext_type)
+    ext = next((ext for ext in exts if ext.name == ext_name), None)
     return ext is not None
 
 
-def get_extension_names():
+def get_extension_names(ext_type=None):
     """
     Helper method to only get extension names.
     Returns the extension names of extensions installed in the extensions directory.
     """
-    return [ext.name for ext in get_extensions()]
+    return [ext.name for ext in get_extensions(ext_type=ext_type)]

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -161,7 +161,7 @@ class TestExtensionCommands(unittest.TestCase):
             with mock.patch('azure.cli.core.extension.operations.logger') as mock_logger:
                 add_extension(extension_name=MY_EXT_NAME)
                 call_args = mock_logger.warning.call_args
-                self.assertEqual("The extension '%s' already exists.", call_args[0][0])
+                self.assertEqual("Extension '%s' is already installed.", call_args[0][0])
                 self.assertEqual(MY_EXT_NAME, call_args[0][1])
                 self.assertEqual(mock_logger.warning.call_count, 1)
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -152,9 +152,9 @@ class TestCommandRegistration(unittest.TestCase):
         return ext_name
 
     def _mock_get_extensions():
-        MockExtension = namedtuple('Extension', ['name', 'preview'])
-        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False),
-                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False)]
+        MockExtension = namedtuple('Extension', ['name', 'preview', 'path'])
+        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, path=None),
+                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, path=None)]
 
     def _mock_load_command_loader(loader, args, name, prefix):
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_extension.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_extension.py
@@ -58,50 +58,50 @@ class TestExtensions(TestExtensionsBase):
     def test_no_extensions_dir(self):
         """ Extensions directory doesn't exist """
         shutil.rmtree(self.ext_dir)
-        actual = get_extensions()
+        actual = get_extensions(ext_type=WheelExtension)
         self.assertEqual(len(actual), 0)
 
     def test_no_extensions_in_dir(self):
         """ Directory exists but there are no extensions """
-        actual = get_extensions()
+        actual = get_extensions(ext_type=WheelExtension)
         self.assertEqual(len(actual), 0)
 
     def test_other_files_in_extensions_dir(self):
         tempfile.mkstemp(dir=self.ext_dir)
-        actual = get_extensions()
+        actual = get_extensions(ext_type=WheelExtension)
         self.assertEqual(len(actual), 0)
 
     def test_extension_list(self):
         _install_test_extension1()
-        actual = get_extensions()
+        actual = get_extensions(ext_type=WheelExtension)
         self.assertEqual(len(actual), 1)
 
     def test_extension_exists(self):
         _install_test_extension1()
-        actual = extension_exists(EXT_NAME)
+        actual = extension_exists(EXT_NAME, ext_type=WheelExtension)
         self.assertTrue(actual)
 
     def test_extension_not_exists(self):
-        actual = extension_exists(EXT_NAME)
+        actual = extension_exists(EXT_NAME, ext_type=WheelExtension)
         self.assertFalse(actual)
 
     def test_extension_not_exists_2(self):
         _install_test_extension1()
-        actual = extension_exists('notanextension')
+        actual = extension_exists('notanextension', ext_type=WheelExtension)
         self.assertFalse(actual)
 
     def test_get_extension(self):
         _install_test_extension1()
-        actual = get_extension(EXT_NAME)
+        actual = get_extension(EXT_NAME, ext_type=WheelExtension)
         self.assertEqual(actual.name, EXT_NAME)
 
     def test_get_extension_not_installed(self):
         with self.assertRaises(ExtensionNotInstalledException):
-            get_extension(EXT_NAME)
+            get_extension(EXT_NAME, ext_type=WheelExtension)
 
     def test_get_extension_names(self):
         _install_test_extension1()
-        actual = get_extension_names()
+        actual = get_extension_names(ext_type=WheelExtension)
         self.assertEqual(len(actual), 1)
         self.assertEqual(actual[0], EXT_NAME)
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -144,9 +144,9 @@ class TestParser(unittest.TestCase):
         return ext_name
 
     def _mock_get_extensions():
-        MockExtension = namedtuple('Extension', ['name', 'preview'])
-        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False),
-                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False)]
+        MockExtension = namedtuple('Extension', ['name', 'preview', 'path'])
+        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, path=None),
+                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, path=None)]
 
     def _mock_load_command_loader(loader, args, name, prefix):
         from enum import Enum

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -72,7 +72,7 @@ def get_installed_cli_distributions():
 
 def get_az_version_string():
     import platform
-    from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR
+    from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR, DEV_EXTENSION_SOURCES
 
     output = six.StringIO()
     installed_dists = get_installed_cli_distributions()
@@ -83,31 +83,40 @@ def get_az_version_string():
             cli_info = {'name': dist.key, 'version': dist.version}
             break
 
+    def _print(val=''):
+        print(val, file=output)
+
     if cli_info:
-        print('{} ({})'.format(cli_info['name'], cli_info['version']), file=output)
+        _print('{} ({})'.format(cli_info['name'], cli_info['version']))
 
     component_version_info = sorted([{'name': dist.key.replace(COMPONENT_PREFIX, ''),
                                       'version': dist.version}
                                      for dist in installed_dists
                                      if dist.key.startswith(COMPONENT_PREFIX)],
                                     key=lambda x: x['name'])
-    print(file=output)
-    print('\n'.join(['{} ({})'.format(c['name'], c['version']) for c in component_version_info]),
-          file=output)
-    print(file=output)
+    _print()
+    _print('\n'.join(['{} ({})'.format(c['name'], c['version']) for c in component_version_info]))
+    _print()
     extensions = get_extensions()
     if extensions:
-        print('Extensions:', file=output)
-        print('\n'.join(['{} ({})'.format(c.name, c.version) for c in extensions]),
-              file=output)
-        print(file=output)
-    print("Python location '{}'".format(sys.executable), file=output)
-    print("Extensions directory '{}'".format(EXTENSIONS_DIR), file=output)
-    print(file=output)
-    print('Python ({}) {}'.format(platform.system(), sys.version), file=output)
-    print(file=output)
-    print('Legal docs and information: aka.ms/AzureCliLegal', file=output)
-    print(file=output)
+        _print('Extensions:')
+        for ext in extensions:
+            if ext.ext_type == 'dev':
+                _print('{} ({}) [{}]'.format(ext.name, ext.version, ext.path))
+            else:
+                _print('{} ({})'.format(ext.name, ext.version))
+        _print()
+    _print("Python location '{}'".format(sys.executable))
+    _print("Extensions directory '{}'".format(EXTENSIONS_DIR))
+    if DEV_EXTENSION_SOURCES:
+        _print("Development extension sources:")
+        for source in DEV_EXTENSION_SOURCES:
+            _print('    {}'.format(source))
+    _print()
+    _print('Python ({}) {}'.format(platform.system(), sys.version))
+    _print()
+    _print('Legal docs and information: aka.ms/AzureCliLegal')
+    _print()
     version_string = output.getvalue()
     return version_string
 


### PR DESCRIPTION
Changes to the core CLI needed to better support extension development scenarios alongside production scenarios.

Collects sources of development extensions (identified by egg-info instead of dist-info) from a config entry or ENV variable called AZURE_EXTENSION_DEV_SOURCES which accepts a comma-separated list. These core changes will be leveraged in the new `azdev` to streamline development tasks for extension developers.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
