### PR TITLE
[Storage] add ability to update version of logging for storage services

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.2.7
 +++++
-* Minor fixes.
+* `storage logging update`- Add ability to update log schema version for storage services.
 
 2.2.6
 +++++

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -701,6 +701,8 @@ helps['storage logging update'] = """
           short-summary: 'The operations for which to enable logging: (r)ead (w)rite (d)elete. Can be combined.'
         - name: --retention
           short-summary: Number of days for which to retain logs. 0 to disable.
+        - name: --version
+          short-summary: Version of the logging schema.
 """
 
 helps['storage message'] = """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -185,6 +185,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                 required=True)
         c.argument('log', validator=get_char_options_validator('rwd', 'log'))
         c.argument('retention', type=int)
+        c.argument('version', type=float)
 
     with self.argument_context('storage metrics show') as c:
         c.extra('services', validator=get_char_options_validator('bfqt', 'services'), default='bfqt')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/logging.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/operations/logging.py
@@ -4,9 +4,9 @@
 # --------------------------------------------------------------------------------------------
 
 
-def set_logging(client, log, retention, timeout=None):
+def set_logging(client, log, retention, timeout=None, version=None):
     for s in client:
-        s.set_logging('r' in log, 'w' in log, 'd' in log, retention, timeout)
+        s.set_logging('r' in log, 'w' in log, 'd' in log, retention, timeout=timeout, version=version)
 
 
 def get_logging(client, timeout=None):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/services_wrapper.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/services_wrapper.py
@@ -28,12 +28,14 @@ class ServiceProperties(object):
     def get_logging(self, timeout=None):
         return self.get_service_properties()(timeout=timeout).__dict__['logging']
 
-    def set_logging(self, read, write, delete, retention, timeout=None):
+    def set_logging(self, read, write, delete, retention, timeout=None, version=None):
         t_logging, t_retention_policy = get_sdk(self.cli_ctx, ResourceType.DATA_STORAGE, 'Logging', 'RetentionPolicy',
                                                 mod='common.models')
 
         retention_policy = t_retention_policy(enabled=retention != 0, days=retention)
         logging = t_logging(delete, read, write, retention_policy)
+        if version:
+            logging.version = str(version)
         return self.set_service_properties()(logging=logging, timeout=timeout)
 
     def get_cors(self, timeout=None):


### PR DESCRIPTION
---
Change is needed to support changes in displaying diagnostics logs, in new versions (newest, 2.0).

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

