### PR TITLE
Fixing Dockerfile nits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-FROM python:3.6.4-alpine3.7
+ARG PYTHON_VERSION="3.6.4"
+
+FROM python:${PYTHON_VERSION}-alpine3.7
 
 ARG CLI_VERSION
 
 # Metadata as defined at http://label-schema.org
 ARG BUILD_DATE
-
-ENV JP_VERSION="0.1.3"
 
 LABEL maintainer="Microsoft" \
       org.label-schema.schema-version="1.0" \
@@ -25,9 +25,6 @@ LABEL maintainer="Microsoft" \
       org.label-schema.vcs-url="https://github.com/Azure/azure-cli.git" \
       org.label-schema.docker.cmd="docker run -v \${HOME}/.azure:/root/.azure -it microsoft/azure-cli:$CLI_VERSION"
 
-WORKDIR azure-cli
-COPY . /azure-cli
-
 # bash gcc make openssl-dev libffi-dev musl-dev - dependencies required for CLI
 # openssh - included for ssh-keygen
 # ca-certificates
@@ -36,16 +33,23 @@ COPY . /azure-cli
 # jq - we include jq as a useful tool
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool
+RUN apk add --no-cache bash openssh ca-certificates jq curl openssl git \
+ && apk add --no-cache --virtual .build-deps gcc make openssl-dev libffi-dev musl-dev \
+ && update-ca-certificates
+
+ARG JP_VERSION="0.1.3"
+
+RUN curl https://github.com/jmespath/jp/releases/download/${JP_VERSION}/jp-linux-amd64 -o /usr/local/bin/jp \
+ && chmod +x /usr/local/bin/jp \
+ && pip install --no-cache-dir --upgrade jmespath-terminal
+
+WORKDIR azure-cli
+COPY . /azure-cli
+
 # 1. Build packages and store in tmp dir
 # 2. Install the cli and the other command modules that weren't included
 # 3. Temporary fix - install azure-nspkg to remove import of pkg_resources in azure/__init__.py (to improve performance)
-RUN apk add --no-cache bash openssh ca-certificates jq curl openssl git \
- && apk add --no-cache --virtual .build-deps gcc make openssl-dev libffi-dev musl-dev \
- && update-ca-certificates \
- && curl https://github.com/jmespath/jp/releases/download/${JP_VERSION}/jp-linux-amd64 -o /usr/local/bin/jp \
- && chmod +x /usr/local/bin/jp \
- && pip install --no-cache-dir --upgrade jmespath-terminal \
- && /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
+RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
     for d in src/azure-cli src/azure-cli-telemetry src/azure-cli-core src/azure-cli-nspkg src/azure-cli-command_modules-nspkg src/command_modules/azure-cli-*/; \
     do cd $d; echo $d; python setup.py bdist_wheel -d $TMP_PKG_DIR; cd -; \
     done; \
@@ -62,8 +66,11 @@ RUN apk add --no-cache bash openssh ca-certificates jq curl openssl git \
         | sort -u \
     )" \
  && apk add --virtual .rundeps $runDeps \
- && apk del .build-deps 
+ && apk del .build-deps
 
 WORKDIR /
+
+# Remove CLI source code from the final image.
+RUN rm -rf ./azure-cli
 
 CMD bash

--- a/Dockerfile.spot
+++ b/Dockerfile.spot
@@ -7,9 +7,19 @@
 # This allows Spots to be created directly from PRs.
 # The major difference between Dockerfile.spot and Dockerfile is the latter depends on alpine and this one does not.
 
-FROM python:3.6.4
+ARG PYTHON_VERSION="3.6.4"
 
-ENV JP_VERSION="0.1.3"
+FROM python:$PYTHON_VERSION
+
+RUN apt-get install -y ca-certificates curl openssl git \
+ && apt-get install -y gcc make libffi-dev \
+ && update-ca-certificates
+
+ARG JP_VERSION="0.1.3"
+
+RUN curl https://github.com/jmespath/jp/releases/download/${JP_VERSION}/jp-linux-amd64 -o /usr/local/bin/jp \
+ && chmod +x /usr/local/bin/jp \
+ && pip install --no-cache-dir --upgrade jmespath-terminal
 
 WORKDIR azure-cli
 COPY . /azure-cli
@@ -24,13 +34,7 @@ COPY . /azure-cli
 # 1. Build packages and store in tmp dir
 # 2. Install the cli and the other command modules that weren't included
 # 3. Temporary fix - install azure-nspkg to remove import of pkg_resources in azure/__init__.py (to improve performance)
-RUN apt-get install -y ca-certificates curl openssl git \
- && apt-get install -y gcc make libffi-dev \
- && update-ca-certificates \
- && curl https://github.com/jmespath/jp/releases/download/${JP_VERSION}/jp-linux-amd64 -o /usr/local/bin/jp \
- && chmod +x /usr/local/bin/jp \
- && pip install --no-cache-dir --upgrade jmespath-terminal \
- && /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
+RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
     for d in src/azure-cli src/azure-cli-core src/azure-cli-nspkg src/azure-cli-command_modules-nspkg src/command_modules/azure-cli-*/; \
     do cd $d; echo $d; python setup.py bdist_wheel -d $TMP_PKG_DIR; cd -; \
     done; \
@@ -41,5 +45,7 @@ RUN apt-get install -y ca-certificates curl openssl git \
  && cat /azure-cli/az.completion > ~/.bashrc
 
 WORKDIR /
+
+RUN rm -rf azure-cli
 
 CMD bash


### PR DESCRIPTION
Tweaking some of the Dockerfiles in the root of this repository so that:
- We can always inject the desired version of python by providing the flag `--build-arg PYTHON_VERSION="3.7.1"` when running a `docker build`.
- Structuring dependencies in such a way that more will be cached between docker builds. Should speed up local docker build times significantly during inner-dev-loop.