### PR TITLE
Put a check to see long_summary exists or not before trying to access…

### DIFF
--- a/src/command_modules/azure-cli-find/azure/cli/command_modules/find/custom.py
+++ b/src/command_modules/azure-cli-find/azure/cli/command_modules/find/custom.py
@@ -76,7 +76,7 @@ def _print_hit(hit):
 
     print('`az {0}`'.format(hit['cmd_name']))
     print_para('short_summary')
-    if hit['long_summary']:
+    if 'long_summary' in hit and hit['long_summary']:
         print_para('long_summary')
     print('')
 


### PR DESCRIPTION
… long_summary.

Issue happens when help declaration has long-summary but does not have any value for it

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
