### PR TITLE
Updates ACR help commands for task create and build

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
@@ -426,15 +426,18 @@ helps['acr task create'] = """
     type: command
     short-summary: Creates a series of steps for building, testing and OS & Framework patching containers. Tasks support triggers from git commits and base image updates.
     examples:
-        - name: Create a task using a public repository that builds hello-world, without triggers
+        - name: Create a Linux task from a public GitHub repository which builds the hello-world image without triggers
           text: >
             az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git -f Dockerfile --commit-trigger-enabled false --pull-request-trigger-enabled false
-        - name: Create a task using a private repository that builds hello-world, without triggers
+        - name: Create a Linux task using a private GitHub repository which builds the hello-world image without triggers
           text: >
             az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git -f Dockerfile --commit-trigger-enabled false --pull-request-trigger-enabled false --git-access-token 0000000000000000000000000000000000000000
-        - name: Create a task that builds hello-world, with git commit webhook based triggers
+        - name: Create a Linux task from a public GitHub repository which builds the hello-world image with a git commit trigger
           text: >
             az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git -f Dockerfile --git-access-token 0000000000000000000000000000000000000000
+        - name: Create a Windows task from a public GitHub repository which builds the Azure Container Builder image.
+          text: >
+            az acr task create -t acb:{{.Run.ID}} -n acb-win -r MyRegistry -c https://github.com/Azure/acr-builder.git -f Windows.Dockerfile --commit-trigger-enabled false --pull-request-trigger-enabled false --os Windows
 """
 
 helps['acr task show'] = """
@@ -551,20 +554,23 @@ helps['acr task logs'] = """
 
 helps['acr build'] = """
     type: command
-    short-summary: Queues a quick build, providing streamed logs for an Azure Container Registry.
+    short-summary: Queues a quick build, providing streaming logs for an Azure Container Registry.
     examples:
-        - name: Queue a local context (folder), pushed to ACR when complete, with streaming logs.
+        - name: Queue a local context as a Linux build, tag it, and push it to the registry.
           text: >
             az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry .
-        - name: Queue a local context, pushed to ACR without streaming logs.
+        - name: Queue a local context as a Linux build, tag it, and push it to the registry without streaming logs.
           text: >
             az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry --no-logs .
-        - name: Queue a local context to validate a build is successful, without pushing to the registry using the --no-push parameter.
+        - name: Queue a local context as a Linux build without pushing it to the registry.
           text: >
             az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry --no-push .
-        - name: Queue a local context to validate a build is successful, without pushing to the registry. Removing the -t parameter defaults to --no-push
+        - name: Queue a local context as a Linux build without pushing it to the registry.
           text: >
             az acr build -r MyRegistry .
+        - name: Queue a remote GitHub context as a Windows build, tag it, and push it to the registry.
+          text: >
+            az acr build -r MyRegistry https://github.com/Azure/acr-builder.git -f Windows.Dockerfile --os Windows
 """
 
 helps['acr build-task create'] = """


### PR DESCRIPTION
- Updates ACR help commands for task create and build to include a Windows example.

Closes #6870 (`build task` is deprecated at this point, so I'm leaving the docs as-is, in favor of `task`)

/cc @northtyphoon @djyou @ankurkhemani 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
