### PR TITLE
Convert line-endings in generated bash scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
     all_modules=`find $TMP_PKG_DIR -name "*.whl"`; \
     pip install --no-cache-dir $all_modules; \
     pip install --no-cache-dir --force-reinstall --upgrade azure-nspkg azure-mgmt-nspkg;' \
- && cat /azure-cli/az.completion > ~/.bashrc \
+ && cat /azure-cli/az.completion | dos2unix > ~/.bashrc \
  && runDeps="$( \
     scanelf --needed --nobanner --recursive /usr/local \
         | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
@@ -66,7 +66,8 @@ RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
         | sort -u \
     )" \
  && apk add --virtual .rundeps $runDeps \
- && apk del .build-deps
+ && apk del .build-deps \
+ && cat /usr/local/bin/az | dos2unix > /usr/local/bin/az
 
 WORKDIR /
 


### PR DESCRIPTION
Fixes #8050

The underlying problem is that we can't control how people have configured their line-endings when developing on Windows. Git, for example, has an option to always checkout Windows line endings and checkin Unix line endings. To account for folks wanting to build images from Docker for Windows, we can protect them by passing anything we write from the local repository through the utility "dos2unix" which is so prevalent it's even in Alpine Linux.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
