### PR TITLE
doc: fix a wrong example in "ad app permission grant"

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -188,7 +188,7 @@ helps['ad app permission grant'] = """
     short-summary: Grant the app an API permission
     examples:
         - name: Grant a native application with permissions to access an existing API with TTL of 2 years
-          text: az ad app permission grant --id e042ec79-34cd-498f-9d9f-1234234 --app-id a0322f79-57df-498f-9d9f-12678 --expires 2
+          text: az ad app permission grant --id e042ec79-34cd-498f-9d9f-1234234 --api a0322f79-57df-498f-9d9f-12678 --expires 2
 """
 helps['ad app permission list'] = """
     type: command


### PR DESCRIPTION
Fix #7925 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
