### PR TITLE
Revert "Convert line-endings in generated bash scripts. (#8056)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
     all_modules=`find $TMP_PKG_DIR -name "*.whl"`; \
     pip install --no-cache-dir $all_modules; \
     pip install --no-cache-dir --force-reinstall --upgrade azure-nspkg azure-mgmt-nspkg;' \
- && cat /azure-cli/az.completion | dos2unix > ~/.bashrc \
+ && cat /azure-cli/az.completion > ~/.bashrc \
  && runDeps="$( \
     scanelf --needed --nobanner --recursive /usr/local \
         | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
@@ -66,8 +66,7 @@ RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
         | sort -u \
     )" \
  && apk add --virtual .rundeps $runDeps \
- && apk del .build-deps \
- && cat /usr/local/bin/az | dos2unix > /usr/local/bin/az
+ && apk del .build-deps
 
 WORKDIR /
 


### PR DESCRIPTION
This reverts commit 8c89211372638a0106c4d961e91907dfa9b53c8d.

Investigation is not complete yet, but #8087 doesn't repro when this is reverted. This means that #8050 will need to be reopened.
