### PR TITLE
[VM/SS] stop.  Clarify VM/SS stop's usage. 

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -349,6 +349,7 @@ helps['vmss start'] = """
 helps['vmss stop'] = """
     type: command
     short-summary: Power off (stop) VMs within a VMSS.
+    long-summary: The VMs will continue to be billed. To deallocate VMs within a VMSS, see "az vmss deallocate"
 """
 
 helps['vmss update'] = """
@@ -1221,9 +1222,10 @@ helps['vm start'] = """
 
 helps['vm stop'] = """
     type: command
-    short-summary: Stop a running VM.
+    short-summary: Power off (stop) a running VM.
+    long-summary: The VM will continue to be billed. To deallocate a VM, see "az vm deallocate"
     examples:
-        - name: Stop a running VM.
+        - name: Power off (stop) a running VM.
           text: az vm stop -g MyResourceGroup -n MyVm
 {0}
 """.format(vm_ids_example.format('Stop all VMs in a resource group.', 'vm stop'))

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -349,7 +349,7 @@ helps['vmss start'] = """
 helps['vmss stop'] = """
     type: command
     short-summary: Power off (stop) VMs within a VMSS.
-    long-summary: The VMs will continue to be billed. To deallocate VMs within a VMSS, see "az vmss deallocate"
+    long-summary: The VMs will continue to be billed. To avoid this, you can deallocate VM instances within a VMSS through "az vmss deallocate"
 """
 
 helps['vmss update'] = """
@@ -1223,7 +1223,7 @@ helps['vm start'] = """
 helps['vm stop'] = """
     type: command
     short-summary: Power off (stop) a running VM.
-    long-summary: The VM will continue to be billed. To deallocate a VM, see "az vm deallocate"
+    long-summary: The VM will continue to be billed. To avoid this, you can deallocate the VM through "az vm deallocate"
     examples:
         - name: Power off (stop) a running VM.
           text: az vm stop -g MyResourceGroup -n MyVm

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -1364,3 +1364,12 @@ def process_gallery_image_version_namespace(cmd, namespace):
                 regions_info.append(TargetRegion(name=parts[0], regional_replica_count=replica_count))
         namespace.target_regions = regions_info
 # endregion
+
+
+def process_vm_vmss_stop(cmd, _):
+    if "vmss" in cmd.name:
+        logger.warning("About to power off the VMSS instances...\nThey will continue to be billed. "
+                       "To deallocate VMSS instances, run: az vmss deallocate.")
+    else:
+        logger.warning("About to power off the specified VM...\nIt will continue to be billed. "
+                       "To deallocate a VM, run: az vm deallocate.")

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -1366,7 +1366,7 @@ def process_gallery_image_version_namespace(cmd, namespace):
 # endregion
 
 
-def process_vm_vmss_stop(cmd, _):
+def process_vm_vmss_stop(cmd, namespace):  # pylint: disable=unused-argument
     if "vmss" in cmd.name:
         logger.warning("About to power off the VMSS instances...\nThey will continue to be billed. "
                        "To deallocate VMSS instances, run: az vmss deallocate.")

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -20,7 +20,7 @@ from azure.cli.command_modules.vm._format import (
 from azure.cli.command_modules.vm._validators import (
     process_vm_create_namespace, process_vmss_create_namespace, process_image_create_namespace,
     process_disk_or_snapshot_create_namespace, process_disk_encryption_namespace, process_assign_identity_namespace,
-    process_msi_namespace, process_remove_identity_namespace, process_vm_secret_format)
+    process_msi_namespace, process_remove_identity_namespace, process_vm_secret_format, process_vm_vmss_stop)
 
 from azure.cli.core.commands import DeploymentOutputLongRunningOperation, CliCommandType
 from azure.cli.core.commands.arm import deployment_validate_table_format, handle_template_based_exception
@@ -197,7 +197,7 @@ def load_command_table(self, _):
         g.custom_command('restart', 'restart_vm', supports_no_wait=True)
         g.custom_show_command('show', 'show_vm', table_transformer=transform_vm)
         g.command('start', 'start', supports_no_wait=True)
-        g.command('stop', 'power_off', supports_no_wait=True)
+        g.command('stop', 'power_off', supports_no_wait=True, validator=process_vm_vmss_stop)
         g.generic_update_command('update', setter_name='update_vm', setter_type=compute_custom, supports_no_wait=True)
         g.wait_command('wait', getter_name='get_instance_view', getter_type=compute_custom)
 
@@ -297,7 +297,7 @@ def load_command_table(self, _):
         g.custom_command('scale', 'scale_vmss', supports_no_wait=True)
         g.custom_show_command('show', 'show_vmss', table_transformer=get_vmss_table_output_transformer(self, False))
         g.custom_command('start', 'start_vmss', supports_no_wait=True)
-        g.custom_command('stop', 'stop_vmss', supports_no_wait=True)
+        g.custom_command('stop', 'stop_vmss', supports_no_wait=True, validator=process_vm_vmss_stop)
         g.generic_update_command('update', getter_name='get_vmss', setter_name='update_vmss', supports_no_wait=True, command_type=compute_custom)
         g.custom_command('update-instances', 'update_vmss_instances', supports_no_wait=True)
         g.wait_command('wait', getter_name='get_vmss', getter_type=compute_custom)


### PR DESCRIPTION
Updated help.
Added logger warning to inform users that `az vm/ss stop` does not deallocate the VM.

Closes #3026 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
