### PR TITLE
Normalize line-endings using dos2unix attempt 2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
 
 WORKDIR /
 
-# Remove CLI source code from the final image.
-RUN rm -rf ./azure-cli
+# Remove CLI source code from the final image and normalize line endings.
+RUN rm -rf ./azure-cli && \
+    dos2unix /root/.bashrc /usr/local/bin/az
 
 CMD bash


### PR DESCRIPTION
Instead of using pipes, use the simpler syntax, where one just passes file names to the tool directly. Hopefully this should avoid the mess that was introduced before and caused #8087.

Fixes #8050 
