### PR TITLE
Adding virtual-node to the help message for aks create and enable-addons

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -221,6 +221,7 @@ helps['aks create'] = """
             These addons are available:
                 http_application_routing - configure ingress with automatic public DNS name creation.
                 monitoring - turn on Log Analytics monitoring. Uses the Log Analytics Default Workspace if it exists, else creates one. Specify "--workspace-resource-id" to use an existing workspace.
+                virtual-node - enable AKS Virtual Node (PREVIEW). Requires --subnet_name to provide the name of an existing subnet for the Virtual Node to use.
         - name: --disable-rbac
           type: bool
           short-summary: Disable Kubernetes Role-Based Access Control.
@@ -291,6 +292,7 @@ helps['aks enable-addons'] = """
       These addons are available:
           http_application_routing - configure ingress with automatic public DNS name creation.
           monitoring - turn on Log Analytics monitoring. Requires "--workspace-resource-id".
+          virtual-node - enable AKS Virtual Node (PREVIEW). Requires --subnet_name to provide the name of an existing subnet for the Virtual Node to use.
     parameters:
         - name: --addons -a
           type: string


### PR DESCRIPTION
This PR updates the help commands for `az aks create` and `az aks enable-addons` to show the virtual-node addon in the relevant help section. 

HISTORY.rst isn't updated, as this is just an update to the help output. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
