### PR TITLE
[output] added --mute to mute warnings and result output.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -7,6 +7,7 @@ import knack.output
 from knack.events import EVENT_INVOKER_POST_PARSE_ARGS
 from azure.cli.core.azlogging import AzCliLogging
 
+
 class AzOutputProducer(knack.output.OutputProducer):
     def __init__(self, cli_ctx=None):
         super(AzOutputProducer, self).__init__(cli_ctx)

--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -4,20 +4,34 @@
 # --------------------------------------------------------------------------------------------
 
 import knack.output
-
+from knack.events import EVENT_INVOKER_POST_PARSE_ARGS
+from azure.cli.core.azlogging import AzCliLogging
 
 class AzOutputProducer(knack.output.OutputProducer):
     def __init__(self, cli_ctx=None):
         super(AzOutputProducer, self).__init__(cli_ctx)
         super(AzOutputProducer, self)._FORMAT_DICT['yaml'] = self.format_yaml
+        self.cli_ctx.register_event(EVENT_INVOKER_POST_PARSE_ARGS, AzOutputProducer.handle_mute_argument)
+        self.is_muted = False
+
+    def out(self, obj, formatter=None, out_file=None):  # pylint: disable=no-self-use
+        if not self.is_muted:
+            super(AzOutputProducer, self).out(obj, formatter=formatter, out_file=out_file)
+
+    def check_valid_format_type(self, format_type):
+        return format_type in self._FORMAT_DICT
 
     @staticmethod
     def format_yaml(obj):
         import yaml
         return yaml.safe_dump(obj.result, default_flow_style=False)
 
-    def check_valid_format_type(self, format_type):
-        return format_type in self._FORMAT_DICT
+    @staticmethod
+    def handle_mute_argument(cli_ctx, **kwargs):
+        args = kwargs.get('args')
+        # check if the output producer should be muted
+        if getattr(args, AzCliLogging.MUTE_ARG_DEST, False):
+            cli_ctx.output.is_muted = True
 
 
 def get_output_format(cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -23,11 +23,46 @@ omitted     Warning     Debug       Critical    Debug
 
 """
 
+import logging
 from knack.log import CLILogging
+from knack.log import CLI_LOGGER_NAME as KNACK_CLI_LOGGER_NAME
+from knack.events import EVENT_PARSER_GLOBAL_CREATE
 
 CLI_LOGGER_NAME = 'az'
 
 
 class AzCliLogging(CLILogging):
+    MUTE_FLAG = '--mute'    # note: easier to expose flag than to look for --output none do we prefer mute or silent?
+    MUTE_ARG_DEST = '_output_verbosity_mute'
+    @staticmethod
+    def on_global_arguments(_, **kwargs):
+        arg_group = kwargs.get('arg_group')
+        # The arguments for verbosity don't get parsed by argparse but we add it here for help.
+        arg_group.add_argument(AzCliLogging.MUTE_FLAG, dest=AzCliLogging.MUTE_ARG_DEST, action='store_true',
+                               help='Mute all console output, except progress reporting and errors.')
 
-    pass
+    def __init__(self, name, cli_ctx=None):
+        super(AzCliLogging, self).__init__(name, cli_ctx=cli_ctx)
+        self.console_log_configs = AzCliLogging._get_console_log_configs()
+        self.cli_ctx.register_event(EVENT_PARSER_GLOBAL_CREATE, AzCliLogging.on_global_arguments)
+
+
+    def _determine_verbose_level(self, args):
+        for arg in args:
+            if arg == AzCliLogging.MUTE_FLAG:
+                return 0
+        verbose_level= super(AzCliLogging, self)._determine_verbose_level(args)
+        # account for introducing lower verbosity in console log configs
+        return min(verbose_level + 1, len(self.console_log_configs) - 1)
+
+    @staticmethod
+    def _get_console_log_configs():
+        log_configs = CLILogging._get_console_log_configs()
+        new_log_configs = [
+            # lower verbosity than knack's default to support `--output None`
+            {
+                KNACK_CLI_LOGGER_NAME: logging.ERROR,
+                'root': logging.CRITICAL
+            }]
+        new_log_configs.extend(log_configs)
+        return new_log_configs

--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -34,6 +34,7 @@ CLI_LOGGER_NAME = 'az'
 class AzCliLogging(CLILogging):
     MUTE_FLAG = '--mute'    # note: easier to expose flag than to look for --output none do we prefer mute or silent?
     MUTE_ARG_DEST = '_output_verbosity_mute'
+
     @staticmethod
     def on_global_arguments(_, **kwargs):
         arg_group = kwargs.get('arg_group')
@@ -46,12 +47,11 @@ class AzCliLogging(CLILogging):
         self.console_log_configs = AzCliLogging._get_console_log_configs()
         self.cli_ctx.register_event(EVENT_PARSER_GLOBAL_CREATE, AzCliLogging.on_global_arguments)
 
-
     def _determine_verbose_level(self, args):
         for arg in args:
             if arg == AzCliLogging.MUTE_FLAG:
                 return 0
-        verbose_level= super(AzCliLogging, self)._determine_verbose_level(args)
+        verbose_level = super(AzCliLogging, self)._determine_verbose_level(args)
         # account for introducing lower verbosity in console log configs
         return min(verbose_level + 1, len(self.console_log_configs) - 1)
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -328,11 +328,11 @@ class AzCliCommandInvoker(CommandInvoker):
             raise ex
         elif exceptions:
             for exception, id_arg in exceptions:
-                logger.warning('%s: "%s"', id_arg, str(exception))
+                logger.error('%s: "%s"', id_arg, str(exception))
             if not results:
                 return CommandResultItem(None, exit_code=1, error=CLIError('Encountered more than one exception.'))
             else:
-                logger.warning('Encountered more than one exception.')
+                logger.error('Encountered more than one exception.')
 
         if results and len(results) == 1:
             results = results[0]


### PR DESCRIPTION
Closes #5667.

Note: should probably rename this to --quiet or --silent.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
