### PR TITLE
Fix: Traceback when creating a budget on a resource group

### DIFF
--- a/src/command_modules/azure-cli-consumption/azure/cli/command_modules/consumption/custom.py
+++ b/src/command_modules/azure-cli-consumption/azure/cli/command_modules/consumption/custom.py
@@ -108,7 +108,7 @@ def cli_consumption_create_budget(client, budget_name, category, amount, time_gr
     filters = client.models.Filters(resource_groups=resource_groups, resources=resources, meters=meters)
     parameters = client.models.Budget(category=category, amount=amount, time_grain=time_grain, time_period=time_period, filters=filters, notifications=None)
     if resource_group_name:
-        return client.create_or_update(resource_group_name, budget_name, parameters)
+        return client.create_or_update_by_resource_group_name(resource_group_name, budget_name, parameters)
     return client.create_or_update(budget_name, parameters)
 
 


### PR DESCRIPTION
When creating a budget on a resource group, the wrong function was being called which was causing a stacktrace at runtime. It's now fixed by calling the correct function create_or_update_by_resource_group_name().

This fixes issue: https://github.com/Azure/azure-cli/issues/7775

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
