### PR TITLE
ACR: Include the original error from log SAS URL upload

### DIFF
--- a/src/command_modules/azure-cli-acr/HISTORY.rst
+++ b/src/command_modules/azure-cli-acr/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.1.12
+++++++
+* Minor fixes.
+
 2.1.11
 ++++++
 * Add support for image import from external Container Registries.

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_archive_utils.py
@@ -42,19 +42,16 @@ def upload_source_code(client,
     logger.warning("Uploading archived source code from '%s'...", tar_file_path)
     upload_url = None
     relative_path = None
-    error_message = "Could not get SAS URL to upload."
     try:
         source_upload_location = client.get_build_source_upload_url(
             resource_group_name, registry_name)
         upload_url = source_upload_location.upload_url
         relative_path = source_upload_location.relative_path
     except (AttributeError, CloudError) as e:
-        logger.debug("%s Exception: %s", error_message, e)
-        raise CLIError(error_message)
+        raise CLIError("Failed to get a SAS URL to upload context. Error: {}".format(e.message))
 
     if not upload_url:
-        logger.debug("%s Empty source upload URL.", error_message)
-        raise CLIError(error_message)
+        raise CLIError("Failed to get a SAS URL to upload context.")
 
     account_name, endpoint_suffix, container_name, blob_name, sas_token = get_blob_info(upload_url)
     BlockBlobService(account_name=account_name,

--- a/src/command_modules/azure-cli-acr/setup.py
+++ b/src/command_modules/azure-cli-acr/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.1.11"
+VERSION = "2.1.12"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/8140

@djyou @northtyphoon 

@tjprescott not sure what exactly the guidelines here are for handling errors. Seems to be inconsistent in the code base for `CloudError`. I don't see much harm in treating 5xx and 4xx errors here the same and displaying them to users, since the message itself will contain the relevant information. We could also simply remove the catch for `CloudError` altogether.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
