### PR TITLE
[AKS] fix for lowercase logAnalyticsWorkspaceResourceID key 

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.3.14
+++++++
+* Minor fixes
+
 2.3.13
 ++++++
 * Add Virtual Nodes Preview

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1930,6 +1930,10 @@ def _ensure_default_log_analytics_workspace_for_monitoring(cmd, subscription_id,
 
 
 def _ensure_container_insights_for_monitoring(cmd, addon):
+    # Workaround for this addon key which has been seen lowercased in the wild.
+    if 'loganalyticsworkspaceresourceid' in addon.config:
+        addon.config['logAnalyticsWorkspaceResourceID'] = addon.config.pop('loganalyticsworkspaceresourceid')
+
     workspace_resource_id = addon.config['logAnalyticsWorkspaceResourceID']
 
     workspace_resource_id = workspace_resource_id.strip()

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.3.13"
+VERSION = "2.3.14"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes an issue where this addon config key is unexpectedly lowercased, which causes a `KeyError` we've seen happen a couple times.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
