### PR TITLE
--secrets "keyVaultSecret" when using az vm create

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -20,7 +20,7 @@ from azure.cli.command_modules.vm._completers import (
     get_urn_aliases_completion_list, get_vm_size_completion_list, get_vm_run_command_completion_list)
 from azure.cli.command_modules.vm._validators import (
     validate_nsg_name, validate_vm_nics, validate_vm_nic, validate_vm_disk, validate_vmss_disk,
-    validate_asg_names_or_ids, validate_keyvault, process_gallery_image_version_namespace, _validate_secrets)
+    validate_asg_names_or_ids, validate_keyvault, process_gallery_image_version_namespace)  #_validate_secrets)
 from ._vm_utils import MSI_LOCAL_ID
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -32,7 +32,6 @@ def load_arguments(self, _):
     # REUSABLE ARGUMENT DEFINITIONS
     name_arg_type = CLIArgumentType(options_list=['--name', '-n'], metavar='NAME')
     multi_ids_type = CLIArgumentType(nargs='+')
-    multi_ids_type = CLIArgumentType
     existing_vm_name = CLIArgumentType(overrides=name_arg_type,
                                        configured_default='vm',
                                        help="The name of the Virtual Machine. You can configure the default using `az configure --defaults vm=<name>`",


### PR DESCRIPTION
Line 23 added _validate_secrets at importer
Line 173 added secrets parameter
Line 222-223 Left the original and added new commented secrets parameter below
Line 416-417 Left the original and added new commented secrets parameter below

The Secrets parameter importer below was created by using the examples in Lines 222 and 416, let's go step by step:

c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`',  validator=_validate_secrets)

'secrets' the argument name
multi_ids_type --> No idea what it does, but 222 and 416 both had it.
options_list=['--secrets', '-s'] the optional name for the parameter
help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`' The help!
type=file_type No idea what this is but unlike multi_ids_type 222 didn't have it and 416 did, so I decided to remove it
completer=FilesCompleter()  No idea what this is but unlike multi_ids_type 222 didn't have it and 416 did, so I decided to remove it
validator=_validate_secrets The ONLY thing I added

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
