### PR TITLE
Update _help.py

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -230,11 +230,11 @@ helps['aks create'] = """
           short-summary: "Enable Kubernetes Role-Based Access Control. Default: enabled."
         - name: --max-pods -m
           type: int
-          short-summary: The maximum number of pods deployable to a node.
+          short-summary: The maximum number of pods deployable to a node. If not specified, defaults to 110, or 30 for advanced networking configurations.
           long-summary: If not specified, defaults to 110, or 30 for advanced networking configurations.
         - name: --network-plugin
           type: string
-          short-summary: The Kubernetes network plugin to use.
+          short-summary: The Kubernetes network plugin to use. Specify "azure" for advanced networking configurations. Defaults to "kubenet".
           long-summary: Specify "azure" for advanced networking configurations. Defaults to "kubenet".
         - name: --network-policy
           type: string


### PR DESCRIPTION
As far as I can tell the short-summary is what is used for the docs.microsoft.com help page.
This means that I cannot see what the default value for --max-pods is or what the allowed values for --network-plugin is.
This is not so nice :-)
I have copied information from long-summary to short-summary.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
