### PR TITLE
Remove Publishing Steps from Build Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,6 @@
 resources:
 - repo: self
 
-variables:
-- group: staging-storage-account
-
 phases:
 - phase: ExtractMetadata
   displayName: Extract Metadata
@@ -613,72 +610,6 @@ phases:
            docker run --rm -v $SYSTEM_ARTIFACTSDIRECTORY/debian:/mnt/artifacts ${BASE_IMAGES[$i]} /bin/bash -c "apt-get update && apt-get install -y libssl1.1 apt-transport-https && dpkg -i /mnt/artifacts/azure-cli_$CLI_VERSION-1~${DISTROS[$i]}_all.deb && time az self-test && time az --version && sleep 5"
        done
     displayName: 'Bash Script'
-
-
-- phase: PublishArtifacts
-  displayName: Publish Artifacts to Azure Storage
-
-  dependsOn:
-   - TestHomebrewFormula
-   - TestPythonWheel
-   - TestYumPackage
-   - TestLinuxPackages
-   - TestDockerImage
-   - BuildWindowsMSI
-  condition: succeeded()
-  queue:
-    name: Hosted
-    demands: azureps
-
-  steps:
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Metadata Artifacts'
-    inputs:
-      artifactName: metadata
-
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download PyPI Build Artifacts'
-    inputs:
-      artifactName: pypi
-
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download MSI Build Artifacts'
-    inputs:
-      artifactName: MSI
-
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Debian Build Artifacts'
-    inputs:
-      artifactName: debian
-
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download RPM Build Artifacts'
-    inputs:
-      artifactName: yum
-
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Docker Build Artifacts'
-    inputs:
-      artifactName: Docker
-
-
-  - task: AzureFileCopy@1
-    displayName: 'AzureBlob File Copy'
-    inputs:
-      sourcePath: '$(System.ArtifactsDirectory)'
-      azureConnectionType: 'ConnectedServiceNameARM'
-      azureSubscription: 'SDKInfrastructureSP'
-      destination: AzureBlob
-      storage: azureclistage
-      containerName: archive-devops
-      blobPrefix: '$(Build.BuildNumber)'
-
-
 
 - phase: BuildUbuntuCosmic
   displayName: Build Ubuntu Cosmic

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,49 +24,6 @@ phases:
     inputs:
       ArtifactName: metadata
 
-- phase: CompressSource
-  displayName: Compress Source
-
-  dependsOn: ExtractMetadata
-  condition: succeeded()
-  queue:
-    name: Hosted
-
-  steps:
-  - task: ArchiveFiles@2
-    displayName: 'Create zip of source'
-    inputs:
-      rootFolderOrFile: '$(Build.SourcesDirectory)'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/azure-cli_$(Build.BuildId).zip'
-  - task: AzureFileCopy@1
-    displayName: 'Copy source zip to Azure Blob'
-    inputs:
-      sourcePath: '$(Build.ArtifactStagingDirectory)/azure-cli_$(Build.BuildId).zip'
-      azureConnectionType: 'ConnectedServiceNameARM'
-      azureSubscription: 'SDKInfrastructureSP'
-      destination: AzureBlob
-      storage: azureclistage
-      containerName: archive-devops
-      blobPrefix: '$(Build.BuildNumber)'
-  - task: ArchiveFiles@2
-    displayName: 'Create tarball of source'
-    inputs:
-      rootFolderOrFile: '$(Build.SourcesDirectory)'
-      archiveType: tar
-      tarCompression: gz
-      archiveFile: '$(Build.ArtifactStagingDirectory)/azure-cli_$(Build.BuildId).tar.gz'
-  - task: AzureFileCopy@1
-    displayName: 'AzureBlob File Copy'
-    inputs:
-      sourcePath: '$(Build.ArtifactStagingDirectory)/azure-cli_$(Build.BuildId).tar.gz'
-      azureConnectionType: 'ConnectedServiceNameARM'
-      azureSubscription: 'SDKInfrastructureSP'
-      destination: AzureBlob
-      storage: azureclistage
-      containerName: archive-devops
-      blobPrefix: '$(Build.BuildNumber)'
-
-
 - phase: BuildWindowsMSI
   displayName: Build Windows MSI
 
@@ -257,6 +214,7 @@ phases:
        set -evx
 
        CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+       HOMEBREW_UPSTREAM_URL=`curl -Ls -o /dev/null -w %{url_effective} https://api.github.com/repos/Azure/azure-cli/tarball/$BUILD_SOURCEVERSION`
 
        docker_files=$(cd $BUILD_SOURCESDIRECTORY/scripts/release/homebrew/docker; pwd)
        pypi_files=$(cd $BUILD_ARTIFACTSTAGINGDIRECTORY/pypi; pwd)
@@ -277,8 +235,6 @@ phases:
        docker cp azurecli:azure-cli.rb $BUILD_ARTIFACTSTAGINGDIRECTORY/azure-cli.rb
        docker rm --force azurecli
     displayName: 'Build homebrew formula'
-    env:
-      HOMEBREW_UPSTREAM_URL: 'https://azureclistage.blob.core.windows.net/archive-devops/$(Build.BuildNumber)/azure-cli_$(Build.BuildID).tar.gz'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: homebrew'

--- a/scripts/release/homebrew/docker/formula_generate.py
+++ b/scripts/release/homebrew/docker/formula_generate.py
@@ -13,6 +13,7 @@ import jinja2
 from poet.poet import make_graph, RESOURCE_TEMPLATE
 
 TEMPLATE_FILE_NAME='formula_template.txt'
+CLI_VERSION=os.environ['CLI_VERSION']
 HOMEBREW_UPSTREAM_URL=os.environ['HOMEBREW_UPSTREAM_URL']
 HOMEBREW_FORMULAR_LATEST="https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/azure-cli.rb"
 
@@ -26,6 +27,7 @@ def main():
 
     template = jinja2.Template(template_content)
     content = template.render(
+        cli_version=CLI_VERSION,
         upstream_url=HOMEBREW_UPSTREAM_URL,
         upstream_sha=compute_sha256(HOMEBREW_UPSTREAM_URL),
         resources=collect_resources(),

--- a/scripts/release/homebrew/docker/formula_template.txt
+++ b/scripts/release/homebrew/docker/formula_template.txt
@@ -2,6 +2,7 @@ class AzureCli < Formula
   desc "Microsoft Azure CLI 2.0"
   homepage "https://docs.microsoft.com/cli/azure/overview"
   url "{{ upstream_url }}"
+  version "{{ cli_version }}"
   sha256 "{{ upstream_sha }}"
   head "https://github.com/Azure/azure-cli.git"
 


### PR DESCRIPTION
Before we enable this build to execute on PRs from forks, we need to prevent arbitrary access to upload files into our Azure Storage account. This PR removes those steps, and tweaks the Homebrew build phase to not require any assets that we host. Instead, for Homebrew it relies on archives created by GitHub for an arbitrary ref (not just tags as some previous iterations had.)