### PR TITLE
[core/configure] add '--output none'.

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 2.0.55
 ++++++
-* Minor fixes
+* `--output`: Introduce 'none' as an output format option.
 
 2.0.54
 ++++++

--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -9,12 +9,20 @@ import knack.output
 class AzOutputProducer(knack.output.OutputProducer):
     def __init__(self, cli_ctx=None):
         super(AzOutputProducer, self).__init__(cli_ctx)
-        super(AzOutputProducer, self)._FORMAT_DICT['yaml'] = self.format_yaml
+        additional_formats = {
+            'yaml': self.format_yaml,
+            'none': self.format_none
+        }
+        super(AzOutputProducer, self)._FORMAT_DICT.update(additional_formats)
 
     @staticmethod
     def format_yaml(obj):
         import yaml
         return yaml.safe_dump(obj.result, default_flow_style=False)
+
+    @staticmethod
+    def format_none(_):
+        return ""
 
     def check_valid_format_type(self, format_type):
         return format_type in self._FORMAT_DICT

--- a/src/azure-cli-core/azure/cli/core/tests/test_output.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_output.py
@@ -16,19 +16,6 @@ class TestCoreCLIOutput(unittest.TestCase):
         self.assertIn('yaml', output_producer._FORMAT_DICT)
         self.assertIn('none', output_producer._FORMAT_DICT)
 
-    def test_configure_output_options(self):
-        from azure.cli.core._output import AzOutputProducer
-        from azure.cli.core.mock import DummyCli
-        from azure.cli.command_modules.configure._consts import OUTPUT_LIST
-
-        output_producer = AzOutputProducer(DummyCli())
-        cli_output_options = set(output_producer._FORMAT_DICT.keys())
-        configure_output_options = set(item["name"] for item in OUTPUT_LIST)
-
-        self.assertEqual(cli_output_options, configure_output_options,
-                         "\n{}'s output options: {}\ndon't match az configure's output options ({})."
-                         .format(AzOutputProducer.__name__, cli_output_options, configure_output_options))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_output.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_output.py
@@ -12,8 +12,22 @@ class TestCoreCLIOutput(unittest.TestCase):
         from azure.cli.core.mock import DummyCli
 
         output_producer = AzOutputProducer(DummyCli())
-        self.assertEqual(5, len(output_producer._FORMAT_DICT))  # five types: json, jsonc, table, tsv, yaml
+        self.assertEqual(6, len(output_producer._FORMAT_DICT))  # six types: json, jsonc, table, tsv, yaml, none
         self.assertIn('yaml', output_producer._FORMAT_DICT)
+        self.assertIn('none', output_producer._FORMAT_DICT)
+
+    def test_configure_output_options(self):
+        from azure.cli.core._output import AzOutputProducer
+        from azure.cli.core.mock import DummyCli
+        from azure.cli.command_modules.configure._consts import OUTPUT_LIST
+
+        output_producer = AzOutputProducer(DummyCli())
+        cli_output_options = set(output_producer._FORMAT_DICT.keys())
+        configure_output_options = set(item["name"] for item in OUTPUT_LIST)
+
+        self.assertEqual(cli_output_options, configure_output_options,
+                         "\n{}'s output options: {}\ndon't match az configure's output options ({})."
+                         .format(AzOutputProducer.__name__, cli_output_options, configure_output_options))
 
 
 if __name__ == '__main__':

--- a/src/command_modules/azure-cli-configure/HISTORY.rst
+++ b/src/command_modules/azure-cli-configure/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.20
+++++++
+* Add 'none' as a configurable output format.
 
 2.0.19
 ++++++

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_consts.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_consts.py
@@ -9,7 +9,8 @@ OUTPUT_LIST = [
      'desc': 'Colored JSON formatted output that most closely matches API responses.'},
     {'name': 'table', 'desc': 'Human-readable output format.'},
     {'name': 'tsv', 'desc': 'Tab- and Newline-delimited. Great for GREP, AWK, etc.'},
-    {'name': 'yaml', 'desc': 'YAML formatted output. An alternative to JSON. Great for configuration files.'}
+    {'name': 'yaml', 'desc': 'YAML formatted output. An alternative to JSON. Great for configuration files.'},
+    {'name': 'none', 'desc': 'No output, except for errors and warnings.'}
 ]
 
 LOGIN_METHOD_LIST = [

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
@@ -1,0 +1,24 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+
+
+class TestConfigure(unittest.TestCase):
+    def test_configure_output_options(self):
+        from azure.cli.core._output import AzOutputProducer
+        from azure.cli.core.mock import DummyCli
+        from azure.cli.command_modules.configure._consts import OUTPUT_LIST
+
+        output_producer = AzOutputProducer(DummyCli())
+        cli_output_options = set(output_producer._FORMAT_DICT.keys())
+        configure_output_options = set(item["name"] for item in OUTPUT_LIST)
+
+        self.assertEqual(cli_output_options, configure_output_options,
+                         "\n{}'s output options: {}\ndon't match az configure's output options ({})."
+                         .format(AzOutputProducer.__name__, cli_output_options, configure_output_options))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
@@ -20,5 +20,6 @@ class TestConfigure(unittest.TestCase):
                          "\n{}'s output options: {}\ndon't match az configure's output options ({})."
                          .format(AzOutputProducer.__name__, cli_output_options, configure_output_options))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/command_modules/azure-cli-configure/setup.py
+++ b/src/command_modules/azure-cli-configure/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "2.0.19"
+VERSION = "2.0.20"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Add '--output none'. Add test to make sure configurable options match actual output options.
closes #5667 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
