### PR TITLE
auth: enable tenant level account for managed service identity

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,6 +2,7 @@
 
 Release History
 ===============
+* auth: enable tenant level account for managed service identity
 
 2.0.55
 ++++++

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,6 +2,8 @@
 
 Release History
 ===============
+* az login: enable tenant level account for managed service identity
+
 2.1.2
 ++++++
 * az login: expose --use-cert-sn-issuer flag for service principal login with cert auto-rolls

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -92,7 +92,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
     import requests
 
     # quick argument usage check
-    if any([password, service_principal, tenant, allow_no_subscriptions]) and identity:
+    if any([password, service_principal, tenant]) and identity:
         raise CLIError("usage error: '--identity' is not applicable with other arguments")
     if any([password, service_principal, username, identity]) and use_device_code:
         raise CLIError("usage error: '--use-device-code' is not applicable with other arguments")
@@ -108,7 +108,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
     if identity:
         if in_cloud_console():
             return profile.find_subscriptions_in_cloud_console()
-        return profile.find_subscriptions_in_vm_with_msi(username)
+        return profile.find_subscriptions_in_vm_with_msi(username, allow_no_subscriptions)
     elif in_cloud_console():  # tell users they might not need login
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)
 


### PR DESCRIPTION
Fix #7225  

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
