### PR TITLE
vm create --secrets parameter validation

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -169,7 +169,9 @@ def load_arguments(self, _):
         c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none.', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
-        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`',  validator=_validate_secrets)
+        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], 
+                   help='One or many Key Vault secrets as JSON strings or files via @{path} containing [{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]',
+                   validator=_validate_secrets)
         c.argument('boot_diagnostics_storage',
                    help='pre-existing storage account name or its blob uri to capture boot diagnostics. Its sku should be one of Standard_GRS, Standard_LRS and Standard_RAGRS')
         c.argument('accelerated_networking', resource_type=ResourceType.MGMT_NETWORK, min_api='2016-09-01', arg_type=get_three_state_flag(), arg_group='Network',

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -169,7 +169,7 @@ def load_arguments(self, _):
         c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none.', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
-        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = '', validator=_validate_secrets)
+        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='', validator=_validate_secrets)
         c.argument('boot_diagnostics_storage',
                    help='pre-existing storage account name or its blob uri to capture boot diagnostics. Its sku should be one of Standard_GRS, Standard_LRS and Standard_RAGRS')
         c.argument('accelerated_networking', resource_type=ResourceType.MGMT_NETWORK, min_api='2016-09-01', arg_type=get_three_state_flag(), arg_group='Network',
@@ -415,7 +415,7 @@ def load_arguments(self, _):
             c.argument('size', help='The VM size to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.')
             c.argument('image', completer=get_urn_aliases_completion_list)
             c.argument('custom_data', help='Custom init script file or text (cloud-init, cloud-config, etc..)', completer=FilesCompleter(), type=file_type)
-            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = '',validator=_validate_secrets)
+            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='', validator=_validate_secrets)
             c.argument('assign_identity', nargs='*', arg_group='Managed Service Identity', help="accept system or user assigned identities separated by spaces. Use '[system]' to refer system assigned identity, or a resource id to refer user assigned identity. Check out help for more examples")
             c.ignore('aux_subscriptions')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -20,7 +20,7 @@ from azure.cli.command_modules.vm._completers import (
     get_urn_aliases_completion_list, get_vm_size_completion_list, get_vm_run_command_completion_list)
 from azure.cli.command_modules.vm._validators import (
     validate_nsg_name, validate_vm_nics, validate_vm_nic, validate_vm_disk, validate_vmss_disk,
-    validate_asg_names_or_ids, validate_keyvault, process_gallery_image_version_namespace)
+    validate_asg_names_or_ids, validate_keyvault, process_gallery_image_version_namespace, _validate_secrets)
 from ._vm_utils import MSI_LOCAL_ID
 
 
@@ -169,6 +169,7 @@ def load_arguments(self, _):
         c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none.', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
+        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`',  validator=_validate_secrets)
         c.argument('boot_diagnostics_storage',
                    help='pre-existing storage account name or its blob uri to capture boot diagnostics. Its sku should be one of Standard_GRS, Standard_LRS and Standard_RAGRS')
         c.argument('accelerated_networking', resource_type=ResourceType.MGMT_NETWORK, min_api='2016-09-01', arg_type=get_three_state_flag(), arg_group='Network',
@@ -219,7 +220,7 @@ def load_arguments(self, _):
         c.argument('vm_name', arg_type=existing_vm_name, options_list=['--vm-name'], id_part=None)
 
     with self.argument_context('vm secret') as c:
-        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='Space-separated list of key vault secret URIs. Perhaps, produced by \'az keyvault secret list-versions --vault-name vaultname -n cert1 --query "[?attributes.enabled].id" -o tsv\'')
+        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`',  validator=_validate_secrets)
         c.argument('keyvault', help='Name or ID of the key vault.', validator=validate_keyvault)
         c.argument('certificate', help='key vault certificate name or its full secret URL')
         c.argument('certificate_store', help='Windows certificate store names. Default: My')
@@ -415,7 +416,7 @@ def load_arguments(self, _):
             c.argument('size', help='The VM size to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.')
             c.argument('image', completer=get_urn_aliases_completion_list)
             c.argument('custom_data', help='Custom init script file or text (cloud-init, cloud-config, etc..)', completer=FilesCompleter(), type=file_type)
-            c.argument('secrets', multi_ids_type, help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`', type=file_type, completer=FilesCompleter())
+            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`',  validator=_validate_secrets)
             c.argument('assign_identity', nargs='*', arg_group='Managed Service Identity', help="accept system or user assigned identities separated by spaces. Use '[system]' to refer system assigned identity, or a resource id to refer user assigned identity. Check out help for more examples")
             c.ignore('aux_subscriptions')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -169,7 +169,7 @@ def load_arguments(self, _):
         c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none.', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
-        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = 'One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{"sourceVault":{"id":"value"},"vaultCertificates":[{"certificateUrl":"value","certificateStore":"cert store name(only on windows)"}]}]',validator=_validate_secrets)
+        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = '', validator=_validate_secrets)
         c.argument('boot_diagnostics_storage',
                    help='pre-existing storage account name or its blob uri to capture boot diagnostics. Its sku should be one of Standard_GRS, Standard_LRS and Standard_RAGRS')
         c.argument('accelerated_networking', resource_type=ResourceType.MGMT_NETWORK, min_api='2016-09-01', arg_type=get_three_state_flag(), arg_group='Network',
@@ -220,7 +220,6 @@ def load_arguments(self, _):
         c.argument('vm_name', arg_type=existing_vm_name, options_list=['--vm-name'], id_part=None)
 
     with self.argument_context('vm secret') as c:
-        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = 'One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{"sourceVault":{"id":"value"},"vaultCertificates":[{"certificateUrl":"value","certificateStore":"cert store name(only on windows)"}]}]',validator=_validate_secrets)
         c.argument('keyvault', help='Name or ID of the key vault.', validator=validate_keyvault)
         c.argument('certificate', help='key vault certificate name or its full secret URL')
         c.argument('certificate_store', help='Windows certificate store names. Default: My')
@@ -416,7 +415,7 @@ def load_arguments(self, _):
             c.argument('size', help='The VM size to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.')
             c.argument('image', completer=get_urn_aliases_completion_list)
             c.argument('custom_data', help='Custom init script file or text (cloud-init, cloud-config, etc..)', completer=FilesCompleter(), type=file_type)
-            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = 'One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{"sourceVault":{"id":"value"},"vaultCertificates":[{"certificateUrl":"value","certificateStore":"cert store name(only on windows)"}]}]',validator=_validate_secrets)
+            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = '',validator=_validate_secrets)
             c.argument('assign_identity', nargs='*', arg_group='Managed Service Identity', help="accept system or user assigned identities separated by spaces. Use '[system]' to refer system assigned identity, or a resource id to refer user assigned identity. Check out help for more examples")
             c.ignore('aux_subscriptions')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -170,7 +170,7 @@ def load_arguments(self, _):
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
         c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], 
-                   help='One or many Key Vault secrets as JSON strings or files via @{path} containing [{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]',
+                   help='One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}]}]',
                    validator=_validate_secrets)
         c.argument('boot_diagnostics_storage',
                    help='pre-existing storage account name or its blob uri to capture boot diagnostics. Its sku should be one of Standard_GRS, Standard_LRS and Standard_RAGRS')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -415,7 +415,7 @@ def load_arguments(self, _):
             c.argument('size', help='The VM size to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.')
             c.argument('image', completer=get_urn_aliases_completion_list)
             c.argument('custom_data', help='Custom init script file or text (cloud-init, cloud-config, etc..)', completer=FilesCompleter(), type=file_type)
-            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='', validator=_validate_secrets)
+            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{"sourceVault":{"id":"value"},"vaultCertificates":[{"certificateUrl":"value","certificateStore":"cert store name(only on windows)"}]}]', validator=_validate_secrets)
             c.argument('assign_identity', nargs='*', arg_group='Managed Service Identity', help="accept system or user assigned identities separated by spaces. Use '[system]' to refer system assigned identity, or a resource id to refer user assigned identity. Check out help for more examples")
             c.ignore('aux_subscriptions')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -220,6 +220,7 @@ def load_arguments(self, _):
         c.argument('vm_name', arg_type=existing_vm_name, options_list=['--vm-name'], id_part=None)
 
     with self.argument_context('vm secret') as c:
+        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='Space-separated list of key vault secret URIs. Perhaps, produced by \'az keyvault secret list-versions --vault-name vaultname -n cert1 --query "[?attributes.enabled].id" -o tsv\'')
         c.argument('keyvault', help='Name or ID of the key vault.', validator=validate_keyvault)
         c.argument('certificate', help='key vault certificate name or its full secret URL')
         c.argument('certificate_store', help='Windows certificate store names. Default: My')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -169,9 +169,7 @@ def load_arguments(self, _):
         c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none.', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
-        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], 
-                   help='One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}]}]',
-                   validator=_validate_secrets)
+        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = 'One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{"sourceVault":{"id":"value"},"vaultCertificates":[{"certificateUrl":"value","certificateStore":"cert store name(only on windows)"}]}]',validator=_validate_secrets)
         c.argument('boot_diagnostics_storage',
                    help='pre-existing storage account name or its blob uri to capture boot diagnostics. Its sku should be one of Standard_GRS, Standard_LRS and Standard_RAGRS')
         c.argument('accelerated_networking', resource_type=ResourceType.MGMT_NETWORK, min_api='2016-09-01', arg_type=get_three_state_flag(), arg_group='Network',
@@ -222,7 +220,7 @@ def load_arguments(self, _):
         c.argument('vm_name', arg_type=existing_vm_name, options_list=['--vm-name'], id_part=None)
 
     with self.argument_context('vm secret') as c:
-        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`',  validator=_validate_secrets)
+        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = 'One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{"sourceVault":{"id":"value"},"vaultCertificates":[{"certificateUrl":"value","certificateStore":"cert store name(only on windows)"}]}]',validator=_validate_secrets)
         c.argument('keyvault', help='Name or ID of the key vault.', validator=validate_keyvault)
         c.argument('certificate', help='key vault certificate name or its full secret URL')
         c.argument('certificate_store', help='Windows certificate store names. Default: My')
@@ -418,7 +416,7 @@ def load_arguments(self, _):
             c.argument('size', help='The VM size to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.')
             c.argument('image', completer=get_urn_aliases_completion_list)
             c.argument('custom_data', help='Custom init script file or text (cloud-init, cloud-config, etc..)', completer=FilesCompleter(), type=file_type)
-            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`',  validator=_validate_secrets)
+            c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'],help = 'One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{"sourceVault":{"id":"value"},"vaultCertificates":[{"certificateUrl":"value","certificateStore":"cert store name(only on windows)"}]}]',validator=_validate_secrets)
             c.argument('assign_identity', nargs='*', arg_group='Managed Service Identity', help="accept system or user assigned identities separated by spaces. Use '[system]' to refer system assigned identity, or a resource id to refer user assigned identity. Check out help for more examples")
             c.ignore('aux_subscriptions')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -169,7 +169,7 @@ def load_arguments(self, _):
         c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none.', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH']))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
-        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='', validator=_validate_secrets)
+        c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{"sourceVault":{"id":"value"},"vaultCertificates":[{"certificateUrl":"value","certificateStore":"cert store name(only on windows)"}]}]', validator=_validate_secrets)
         c.argument('boot_diagnostics_storage',
                    help='pre-existing storage account name or its blob uri to capture boot diagnostics. Its sku should be one of Standard_GRS, Standard_LRS and Standard_RAGRS')
         c.argument('accelerated_networking', resource_type=ResourceType.MGMT_NETWORK, min_api='2016-09-01', arg_type=get_three_state_flag(), arg_group='Network',


### PR DESCRIPTION
Pull #8176 without the comments

I redid the pull without using comments.

1. In line 23 The function "_validate_secrets" despite being part of azure.cli.command_modules.vm._validators  is neither imported nor used in the original file.
The function allows the validation of a secret's format, it is not among the imports and of course is not used in the _params.py file.
2. In line 172 there is a function
with self.argument_context('vm create') as c:
this vm create does NOT have a --secrets argument, I added it whole sale.
3. In line 418
There is a function
 for scope in ['vm create', 'vmss create']:
Original argument:
`c.argument('secrets', multi_ids_type, help='One or many Key Vault secrets as JSON strings or files via `@{path}` containing `[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]`', type=file_type, completer=FilesCompleter())`
New argument
`c.argument('secrets', multi_ids_type, options_list=['--secrets', '-s'], help='One or many Key Vault secrets as JSON strings or files via "@{path}" containing [{"sourceVault":{"id":"value"},"vaultCertificates":[{"certificateUrl":"value","certificateStore":"cert store name(only on windows)"}]}]',  validator=_validate_secrets)`
Differences:
a. I removed the parametes type=file_type AND completer=FilesCompleter()) because I believe they do not apply to the --secrets parameter.
b. I added validator=_validate_secrets (The original didn't have it)
b. I removed ` and replaced them with " in "@path" and removed them altogether in {}[]


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
