### PR TITLE
Fixes #8021, binary data is encoded in Base 64 when returned

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
@@ -64,31 +64,17 @@ def transform_entity_query_output(result):
 
 
 def transform_entities_result(result):
-    new_items = []
     for entity in result.items:
-        new_items.append(transform_entity_result(entity))
-    return {
-        'items': new_items,
-        'nextMarker': result.next_marker
-    }
+        transform_entity_result(entity)
+    return result
 
 
 def transform_entity_result(entity):
-    new_entity = {}
     for key in entity.keys():
-        old_property = entity[key]
-        if hasattr(old_property, 'encrypt') \
-                and hasattr(old_property, 'type') \
-                and hasattr(old_property, 'value') \
-                and isinstance(old_property.value, bytes):
-            new_entity[key] = {
-                'encrypt': old_property.encrypt,
-                'type': old_property.type,
-                'value': base64.b64encode(old_property.value).decode()
-            }
-        else:
-            new_entity[key] = old_property
-    return new_entity
+        property = entity[key]
+        if hasattr(property, 'value') and isinstance(property.value, bytes):
+            property.value = base64.b64encode(property.value).decode()
+    return entity
 
 
 def transform_logging_list_output(result):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import base64
 from knack.log import get_logger
 from .url_quote_util import encode_url_path
 
@@ -60,6 +61,31 @@ def transform_entity_query_output(result):
             new_entry[key] = row[key]
         new_results.append(new_entry)
     return new_results
+
+
+def transform_entities_result(result):
+    new_items = []
+    for entity in result.items:
+        new_items.append(transform_entity_result(entity))
+    return {
+        'items': new_items,
+        'nextMarker': result.next_marker
+    }
+
+
+def transform_entity_result(entity):
+    new_entity = {}
+    for key in entity.keys():
+        old_property = entity[key]
+        if hasattr(old_property, 'encrypt') and hasattr(old_property, 'type') and hasattr(old_property, 'value') and isinstance(old_property.value, bytes):
+            new_entity[key] = {
+                'encrypt': old_property.encrypt,
+                'type': old_property.type,
+                'value': base64.b64encode(old_property.value).decode()
+            }
+        else:
+            new_entity[key] = old_property
+    return new_entity
 
 
 def transform_logging_list_output(result):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
@@ -77,8 +77,10 @@ def transform_entity_result(entity):
     new_entity = {}
     for key in entity.keys():
         old_property = entity[key]
-        if (hasattr(old_property, 'encrypt') and hasattr(old_property, 'type') and hasattr(old_property, 'value')
-            and isinstance(old_property.value, bytes)):
+        if hasattr(old_property, 'encrypt') \
+                and hasattr(old_property, 'type') \
+                and hasattr(old_property, 'value') \
+                and isinstance(old_property.value, bytes):
             new_entity[key] = {
                 'encrypt': old_property.encrypt,
                 'type': old_property.type,

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
@@ -71,9 +71,9 @@ def transform_entities_result(result):
 
 def transform_entity_result(entity):
     for key in entity.keys():
-        property = entity[key]
-        if hasattr(property, 'value') and isinstance(property.value, bytes):
-            property.value = base64.b64encode(property.value).decode()
+        entity_property = entity[key]
+        if hasattr(entity_property, 'value') and isinstance(entity_property.value, bytes):
+            entity_property.value = base64.b64encode(entity_property.value).decode()
     return entity
 
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_transformers.py
@@ -77,7 +77,8 @@ def transform_entity_result(entity):
     new_entity = {}
     for key in entity.keys():
         old_property = entity[key]
-        if hasattr(old_property, 'encrypt') and hasattr(old_property, 'type') and hasattr(old_property, 'value') and isinstance(old_property.value, bytes):
+        if (hasattr(old_property, 'encrypt') and hasattr(old_property, 'type') and hasattr(old_property, 'value')
+            and isinstance(old_property.value, bytes)):
             new_entity[key] = {
                 'encrypt': old_property.encrypt,
                 'type': old_property.type,

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -388,9 +388,15 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
     with self.command_group('storage entity', table_sdk,
                             custom_command_type=get_custom_sdk('table', table_data_service_factory)) as g:
         from ._format import transform_boolean_for_table, transform_entity_show
-        from ._transformers import create_boolean_result_output_transformer, transform_entity_query_output, transform_entities_result, transform_entity_result
+        from ._transformers import (create_boolean_result_output_transformer,
+                                    transform_entity_query_output,
+                                    transform_entities_result,
+                                    transform_entity_result)
 
-        g.storage_command('query', 'query_entities', table_transformer=transform_entity_query_output, transform=transform_entities_result)
+        g.storage_command('query',
+                          'query_entities',
+                          table_transformer=transform_entity_query_output,
+                          transform=transform_entities_result)
         g.storage_command('replace', 'update_entity')
         g.storage_command('merge', 'merge_entity')
         g.storage_command('delete', 'delete_entity', transform=create_boolean_result_output_transformer('deleted'),

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -388,13 +388,14 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
     with self.command_group('storage entity', table_sdk,
                             custom_command_type=get_custom_sdk('table', table_data_service_factory)) as g:
         from ._format import transform_boolean_for_table, transform_entity_show
-        from ._transformers import create_boolean_result_output_transformer, transform_entity_query_output
+        from ._transformers import create_boolean_result_output_transformer, transform_entity_query_output, transform_entities_result, transform_entity_result
 
-        g.storage_command('query', 'query_entities', table_transformer=transform_entity_query_output)
+        g.storage_command('query', 'query_entities', table_transformer=transform_entity_query_output, transform=transform_entities_result)
         g.storage_command('replace', 'update_entity')
         g.storage_command('merge', 'merge_entity')
         g.storage_command('delete', 'delete_entity', transform=create_boolean_result_output_transformer('deleted'),
                           table_transformer=transform_boolean_for_table)
         g.storage_command('show', 'get_entity', table_transformer=transform_entity_show,
-                          exception_handler=show_exception_handler)
+                          exception_handler=show_exception_handler,
+                          transform=transform_entity_result)
         g.storage_custom_command('insert', 'insert_table_entity')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_table_main_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_table_main_scenario.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2018-11-16T21:45:27Z"}}'
+      "date": "2019-01-17T12:50:42Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -10,19 +10,18 @@ interactions:
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--location --name --tag]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.4
-          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.51]
+      User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.55]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2018-11-16T21:45:27Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-01-17T12:50:42Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:29 GMT']
+      date: ['Thu, 17 Jan 2019 12:50:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -39,8 +38,8 @@ interactions:
       Content-Length: ['76']
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-n -g -l --sku]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.4
-          msrest_azure/0.4.34 azure-mgmt-storage/3.1.0 Azure-SDK-For-Python AZURECLI/2.0.51]
+      User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002?api-version=2018-07-01
@@ -50,15 +49,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['0']
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:31 GMT']
+      date: ['Thu, 17 Jan 2019 12:50:47 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/fd938f60-d2c4-4cb0-b067-951a8d046b2b?monitor=true&api-version=2018-07-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/438fa7c4-5aa8-4995-82a9-1c93047f648b?monitor=true&api-version=2018-07-01']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
           Microsoft-HTTPAPI/2.0']
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -68,17 +67,17 @@ interactions:
       CommandName: [storage account create]
       Connection: [keep-alive]
       ParameterSetName: [-n -g -l --sku]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.4
-          msrest_azure/0.4.34 azure-mgmt-storage/3.1.0 Azure-SDK-For-Python AZURECLI/2.0.51]
+      User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/fd938f60-d2c4-4cb0-b067-951a8d046b2b?monitor=true&api-version=2018-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/438fa7c4-5aa8-4995-82a9-1c93047f648b?monitor=true&api-version=2018-07-01
   response:
-    body: {string: '{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-11-16T21:45:31.3825397Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-11-16T21:45:31.3825397Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-11-16T21:45:31.2731674Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available","secondaryLocation":"eastus","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://clitest000002-secondary.blob.core.windows.net/","queue":"https://clitest000002-secondary.queue.core.windows.net/","table":"https://clitest000002-secondary.table.core.windows.net/"}}}'}
+    body: {string: '{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2019-01-17T12:50:47.3240622Z"},"blob":{"enabled":true,"lastEnabledTime":"2019-01-17T12:50:47.3240622Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-01-17T12:50:47.1990662Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available","secondaryLocation":"eastus","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://clitest000002-secondary.blob.core.windows.net/","queue":"https://clitest000002-secondary.queue.core.windows.net/","table":"https://clitest000002-secondary.table.core.windows.net/"}}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['1484']
       content-type: [application/json]
-      date: ['Fri, 16 Nov 2018 21:45:48 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -97,20 +96,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       ParameterSetName: [-n -g --query -o]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.4
-          msrest_azure/0.4.34 azure-mgmt-storage/3.1.0 Azure-SDK-For-Python AZURECLI/2.0.51]
+      User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2018-07-01
   response:
-    body: {string: '{"keys": [{"keyName": "key1", "value": "veryFakedStorageAccountKey==",
-        "permissions": "FULL"}, {"keyName": "key2", "value": "veryFakedStorageAccountKey==",
-        "permissions": "FULL"}]}'}
+    body: {string: '{"keys":[{"keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'}
     headers:
       cache-control: [no-cache]
       content-length: ['288']
       content-type: [application/json]
-      date: ['Fri, 16 Nov 2018 21:45:50 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -119,7 +116,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -130,20 +127,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       ParameterSetName: [-n -g --query -o]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.4
-          msrest_azure/0.4.34 azure-mgmt-storage/3.1.0 Azure-SDK-For-Python AZURECLI/2.0.51]
+      User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2018-07-01
   response:
-    body: {string: '{"keys": [{"keyName": "key1", "value": "veryFakedStorageAccountKey==",
-        "permissions": "FULL"}, {"keyName": "key2", "value": "veryFakedStorageAccountKey==",
-        "permissions": "FULL"}]}'}
+    body: {string: '{"keys":[{"keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'}
     headers:
       cache-control: [no-cache]
       content-length: ['288']
       content-type: [application/json]
-      date: ['Fri, 16 Nov 2018 21:45:50 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -152,7 +147,7 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: 'b''{"TableName": "table000003"}'''
@@ -164,8 +159,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:51 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:09 GMT']
       x-ms-version: ['2017-04-17']
     method: POST
     uri: https://clitest000002.table.core.windows.net/Tables
@@ -174,8 +169,8 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://clitestfj4ehk6qeqvwvkhra.table.core.windows.net/Tables(''tablep7okifcguufnzq53mkj'')']
-      date: ['Fri, 16 Nov 2018 21:45:51 GMT']
+      dataserviceid: ['https://clitestlka3s4sregulnz3gq.table.core.windows.net/Tables(''tablenjxsq4ik42ssbul7dqu'')']
+      date: ['Thu, 17 Jan 2019 12:51:07 GMT']
       location: ['https://clitest000002.table.core.windows.net/Tables(''table000003'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
@@ -189,8 +184,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:51 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:10 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/Tables('table000003')
@@ -199,7 +194,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:51 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:08 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -212,8 +207,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:52 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:11 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/Tables
@@ -222,25 +217,25 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:52 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:09 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
     status: {code: 200, message: OK}
 - request:
-    body: '{"name": "test", "value": "something", "PartitionKey": "001", "RowKey":
-      "001"}'
+    body: '{"name": "test", "value": "something", "binaryProperty": "AAECAwQF", "binaryProperty@odata.type":
+      "Edm.Binary", "PartitionKey": "001", "RowKey": "001"}'
     headers:
       Accept: [application/json;odata=minimalmetadata]
       Connection: [keep-alive]
-      Content-Length: ['78']
+      Content-Length: ['151']
       Content-Type: [application/json]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:53 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:12 GMT']
       x-ms-version: ['2017-04-17']
     method: POST
     uri: https://clitest000002.table.core.windows.net/table000003
@@ -249,9 +244,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://clitestfj4ehk6qeqvwvkhra.table.core.windows.net/tablep7okifcguufnzq53mkj(PartitionKey=''001'',RowKey=''001'')']
-      date: ['Fri, 16 Nov 2018 21:45:52 GMT']
-      etag: [W/"datetime'2018-11-16T21%3A45%3A53.2406878Z'"]
+      dataserviceid: ['https://clitestlka3s4sregulnz3gq.table.core.windows.net/tablenjxsq4ik42ssbul7dqu(PartitionKey=''001'',RowKey=''001'')']
+      date: ['Thu, 17 Jan 2019 12:51:10 GMT']
+      etag: [W/"datetime'2019-01-17T12%3A51%3A11.295677Z'"]
       location: ['https://clitest000002.table.core.windows.net/table000003(PartitionKey=''001'',RowKey=''001'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
@@ -265,18 +260,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:53 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:13 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2018-11-16T21%3A45%3A53.2406878Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2018-11-16T21:45:53.2406878Z","name":"test","value":"something"}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A11.295677Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-17T12:51:11.295677Z","name":"test","value":"something","binaryProperty@odata.type":"Edm.Binary","binaryProperty":"AAECAwQF"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:53 GMT']
-      etag: [W/"datetime'2018-11-16T21%3A45%3A53.2406878Z'"]
+      date: ['Thu, 17 Jan 2019 12:51:12 GMT']
+      etag: [W/"datetime'2019-01-17T12%3A51%3A11.295677Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -289,18 +284,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:53 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:14 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')?%24select=name
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element&$select=name","odata.etag":"W/\"datetime''2018-11-16T21%3A45%3A53.2406878Z''\"","name":"test"}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element&$select=name","odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A11.295677Z''\"","name":"test"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:53 GMT']
-      etag: [W/"datetime'2018-11-16T21%3A45%3A53.2406878Z'"]
+      date: ['Thu, 17 Jan 2019 12:51:12 GMT']
+      etag: [W/"datetime'2019-01-17T12%3A51%3A11.295677Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -316,8 +311,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:54 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:15 GMT']
       x-ms-version: ['2017-04-17']
     method: MERGE
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
@@ -326,8 +321,8 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:45:54 GMT']
-      etag: [W/"datetime'2018-11-16T21%3A45%3A54.4963362Z'"]
+      date: ['Thu, 17 Jan 2019 12:51:13 GMT']
+      etag: [W/"datetime'2019-01-17T12%3A51%3A14.2856966Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
@@ -339,18 +334,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:54 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:16 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2018-11-16T21%3A45%3A54.4963362Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2018-11-16T21:45:54.4963362Z","name":"test","value":"newval"}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A14.2856966Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-17T12:51:14.2856966Z","binaryProperty@odata.type":"Edm.Binary","binaryProperty":"AAECAwQF","name":"test","value":"newval"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:54 GMT']
-      etag: [W/"datetime'2018-11-16T21%3A45%3A54.4963362Z'"]
+      date: ['Thu, 17 Jan 2019 12:51:15 GMT']
+      etag: [W/"datetime'2019-01-17T12%3A51%3A14.2856966Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -366,8 +361,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:55 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:17 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
@@ -376,8 +371,8 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:45:55 GMT']
-      etag: [W/"datetime'2018-11-16T21%3A45%3A55.443231Z'"]
+      date: ['Thu, 17 Jan 2019 12:51:16 GMT']
+      etag: [W/"datetime'2019-01-17T12%3A51%3A16.3196248Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
@@ -389,18 +384,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:55 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:18 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2018-11-16T21%3A45%3A55.443231Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2018-11-16T21:45:55.443231Z","cat":"hat"}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A16.3196248Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-17T12:51:16.3196248Z","cat":"hat"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:55 GMT']
-      etag: [W/"datetime'2018-11-16T21%3A45%3A55.443231Z'"]
+      date: ['Thu, 17 Jan 2019 12:51:16 GMT']
+      etag: [W/"datetime'2019-01-17T12%3A51%3A16.3196248Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -415,8 +410,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:56 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:19 GMT']
       x-ms-version: ['2017-04-17']
     method: DELETE
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
@@ -425,7 +420,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:45:56 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:17 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
@@ -437,36 +432,36 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:56 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:20 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
   response:
     body: {string: '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
-        specified resource does not exist.\nRequestId:7ef154cb-4002-00ea-2cf5-7d1203000000\nTime:2018-11-16T21:45:56.8280208Z"}}}'}
+        specified resource does not exist.\nRequestId:b9981ec3-6002-0100-4c63-ae7623000000\nTime:2019-01-17T12:51:19.3477913Z"}}}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:56 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:18 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "test", "value": "something", "PartitionKey": "001", "RowKey":
-      "001"}'
+    body: '{"name": "test", "value": "something", "binaryProperty": "AAECAwQF", "binaryProperty@odata.type":
+      "Edm.Binary", "PartitionKey": "001", "RowKey": "001"}'
     headers:
       Accept: [application/json;odata=minimalmetadata]
       Connection: [keep-alive]
-      Content-Length: ['78']
+      Content-Length: ['151']
       Content-Type: [application/json]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:57 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:21 GMT']
       x-ms-version: ['2017-04-17']
     method: POST
     uri: https://clitest000002.table.core.windows.net/table000003
@@ -475,9 +470,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://clitestfj4ehk6qeqvwvkhra.table.core.windows.net/tablep7okifcguufnzq53mkj(PartitionKey=''001'',RowKey=''001'')']
-      date: ['Fri, 16 Nov 2018 21:45:57 GMT']
-      etag: [W/"datetime'2018-11-16T21%3A45%3A57.336724Z'"]
+      dataserviceid: ['https://clitestlka3s4sregulnz3gq.table.core.windows.net/tablenjxsq4ik42ssbul7dqu(PartitionKey=''001'',RowKey=''001'')']
+      date: ['Thu, 17 Jan 2019 12:51:20 GMT']
+      etag: [W/"datetime'2019-01-17T12%3A51%3A20.3908525Z'"]
       location: ['https://clitest000002.table.core.windows.net/table000003(PartitionKey=''001'',RowKey=''001'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
@@ -495,8 +490,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:57 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:22 GMT']
       x-ms-version: ['2017-04-17']
     method: POST
     uri: https://clitest000002.table.core.windows.net/table000003
@@ -505,9 +500,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://clitestfj4ehk6qeqvwvkhra.table.core.windows.net/tablep7okifcguufnzq53mkj(PartitionKey=''002'',RowKey=''002'')']
-      date: ['Fri, 16 Nov 2018 21:45:56 GMT']
-      etag: [W/"datetime'2018-11-16T21%3A45%3A57.795792Z'"]
+      dataserviceid: ['https://clitestlka3s4sregulnz3gq.table.core.windows.net/tablenjxsq4ik42ssbul7dqu(PartitionKey=''002'',RowKey=''002'')']
+      date: ['Thu, 17 Jan 2019 12:51:21 GMT']
+      etag: [W/"datetime'2019-01-17T12%3A51%3A21.3697496Z'"]
       location: ['https://clitest000002.table.core.windows.net/table000003(PartitionKey=''002'',RowKey=''002'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
@@ -521,17 +516,17 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:58 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:23 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003()?%24top=1
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003","value":[{"odata.etag":"W/\"datetime''2018-11-16T21%3A45%3A57.336724Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2018-11-16T21:45:57.336724Z","name":"test","value":"something"}]}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003","value":[{"odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A20.3908525Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-17T12:51:20.3908525Z","name":"test","value":"something","binaryProperty@odata.type":"Edm.Binary","binaryProperty":"AAECAwQF"}]}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:57 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:22 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -546,17 +541,17 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:58 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:24 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003()?NextPartitionKey=1%214%21MDAy&NextRowKey=1%214%21MDAy
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003","value":[{"odata.etag":"W/\"datetime''2018-11-16T21%3A45%3A57.795792Z''\"","PartitionKey":"002","RowKey":"002","Timestamp":"2018-11-16T21:45:57.795792Z","name":"test2","value":"something2"}]}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003","value":[{"odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A21.3697496Z''\"","PartitionKey":"002","RowKey":"002","Timestamp":"2019-01-17T12:51:21.3697496Z","name":"test2","value":"something2"}]}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:45:58 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:22 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -568,17 +563,17 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:59 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:25 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers
-        />"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
+        \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:45:59 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:24 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -589,17 +584,17 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:45:59 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:26 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers
-        />"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
+        \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:45:59 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:25 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -613,8 +608,8 @@ interactions:
       Content-Length: ['184']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:00 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:27 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -622,7 +617,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:45:59 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:31 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -632,8 +627,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:00 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:33 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -641,7 +636,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:00 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:32 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -655,8 +650,8 @@ interactions:
       Content-Length: ['296']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:01 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:34 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -664,7 +659,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:46:01 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:32 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -674,8 +669,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:02 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:35 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -683,7 +678,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:02 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:34 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -697,8 +692,8 @@ interactions:
       Content-Length: ['413']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:03 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:36 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -706,7 +701,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:46:03 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:34 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -716,8 +711,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:03 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:36 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -725,7 +720,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:03 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:37 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -739,8 +734,8 @@ interactions:
       Content-Length: ['591']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:04 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:39 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -748,7 +743,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:46:03 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:37 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -758,8 +753,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:04 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:39 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -767,7 +762,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:04 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:39 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -778,8 +773,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:05 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:42 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -787,7 +782,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:04 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:41 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -798,8 +793,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:05 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:44 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -807,7 +802,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:05 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:42 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -818,8 +813,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:06 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:45 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -827,7 +822,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:06 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:44 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -838,8 +833,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:07 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:46 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -847,7 +842,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:06 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:45 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -858,8 +853,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:07 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:48 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -867,7 +862,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:07 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:46 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -881,8 +876,8 @@ interactions:
       Content-Length: ['598']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:07 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:49 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -890,7 +885,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:46:08 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:48 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -900,8 +895,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:09 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:50 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -909,7 +904,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>au</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:08 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:50 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -920,8 +915,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:09 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:52 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -929,7 +924,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>au</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:09 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:50 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -943,8 +938,8 @@ interactions:
       Content-Length: ['491']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:10 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:53 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -952,7 +947,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:46:09 GMT']
+      date: ['Thu, 17 Jan 2019 12:51:55 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -962,8 +957,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:10 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:51:57 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -971,7 +966,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:10 GMT']
+      date: ['Thu, 17 Jan 2019 12:52:00 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -984,8 +979,8 @@ interactions:
       Content-Length: ['0']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:11 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:52:02 GMT']
       x-ms-version: ['2017-04-17']
     method: DELETE
     uri: https://clitest000002.table.core.windows.net/Tables('table000003')
@@ -994,7 +989,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:46:10 GMT']
+      date: ['Thu, 17 Jan 2019 12:52:00 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
@@ -1006,18 +1001,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:11 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:52:03 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/Tables('table000003')
   response:
     body: {string: '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
-        specified resource does not exist.\nRequestId:57c5b7ac-b002-007c-36f5-7d7037000000\nTime:2018-11-16T21:46:12.1890680Z"}}}'}
+        specified resource does not exist.\nRequestId:4f31ce23-0002-00f1-1663-aee1e5000000\nTime:2019-01-17T12:52:02.5560624Z"}}}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      date: ['Fri, 16 Nov 2018 21:46:12 GMT']
+      date: ['Thu, 17 Jan 2019 12:52:02 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -1029,17 +1024,17 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.5; Windows 10) AZURECLI/2.0.51]
-      x-ms-date: ['Fri, 16 Nov 2018 21:46:12 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
+      x-ms-date: ['Thu, 17 Jan 2019 12:52:04 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002-secondary.table.core.windows.net/?restype=service&comp=stats
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceStats><GeoReplication><Status>live</Status><LastSyncTime>Fri,
-        16 Nov 2018 21:44:03 GMT</LastSyncTime></GeoReplication></StorageServiceStats>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceStats><GeoReplication><Status>live</Status><LastSyncTime>Thu,\
+        \ 17 Jan 2019 12:49:58 GMT</LastSyncTime></GeoReplication></StorageServiceStats>"}
     headers:
       content-type: [application/xml]
-      date: ['Fri, 16 Nov 2018 21:46:13 GMT']
+      date: ['Thu, 17 Jan 2019 12:52:02 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -1054,9 +1049,8 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--name --yes --no-wait]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.17763-SP0) requests/2.19.1 msrest/0.5.4
-          msrest_azure/0.4.34 resourcemanagementclient/2.0.0 Azure-SDK-For-Python
-          AZURECLI/2.0.51]
+      User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.55]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
@@ -1065,12 +1059,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 16 Nov 2018 21:46:13 GMT']
+      date: ['Thu, 17 Jan 2019 12:52:06 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdRMkdMWFVOQlZNWExCNzZUWkxMNEdTV1BPMlg0R1dPSVU0M3xFREE2QjJFMzM0RTVEMzg2LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdTTjczMlg2N0RDS1RSRVlXWUNGQjRHSTM1SlpWRk5OUUdaUnw5OTBDRDFEMEFGRDg2RkI2LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-deletes: ['14998']
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_table_main_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_table_main_scenario.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2019-01-17T12:50:42Z"}}'
+      "date": "2019-01-18T09:51:24Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -11,17 +11,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--location --name --tag]
       User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.55]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-01-17T12:50:42Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-01-18T09:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:50:43 GMT']
+      date: ['Fri, 18 Jan 2019 09:51:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -39,7 +39,7 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-n -g -l --sku]
       User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55]
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002?api-version=2018-07-01
@@ -49,9 +49,9 @@ interactions:
       cache-control: [no-cache]
       content-length: ['0']
       content-type: [text/plain; charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:50:47 GMT']
+      date: ['Fri, 18 Jan 2019 09:51:32 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/438fa7c4-5aa8-4995-82a9-1c93047f648b?monitor=true&api-version=2018-07-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/5f759086-2fda-4aa0-9bb7-fd6d3691e177?monitor=true&api-version=2018-07-01']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
           Microsoft-HTTPAPI/2.0']
@@ -68,16 +68,16 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-n -g -l --sku]
       User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55]
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/438fa7c4-5aa8-4995-82a9-1c93047f648b?monitor=true&api-version=2018-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/5f759086-2fda-4aa0-9bb7-fd6d3691e177?monitor=true&api-version=2018-07-01
   response:
-    body: {string: '{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2019-01-17T12:50:47.3240622Z"},"blob":{"enabled":true,"lastEnabledTime":"2019-01-17T12:50:47.3240622Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-01-17T12:50:47.1990662Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available","secondaryLocation":"eastus","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://clitest000002-secondary.blob.core.windows.net/","queue":"https://clitest000002-secondary.queue.core.windows.net/","table":"https://clitest000002-secondary.table.core.windows.net/"}}}'}
+    body: {string: '{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2019-01-18T09:51:33.0757826Z"},"blob":{"enabled":true,"lastEnabledTime":"2019-01-18T09:51:33.0757826Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-01-18T09:51:32.9663825Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available","secondaryLocation":"eastus","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://clitest000002-secondary.blob.core.windows.net/","queue":"https://clitest000002-secondary.queue.core.windows.net/","table":"https://clitest000002-secondary.table.core.windows.net/"}}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['1484']
       content-type: [application/json]
-      date: ['Thu, 17 Jan 2019 12:51:05 GMT']
+      date: ['Fri, 18 Jan 2019 09:51:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -97,7 +97,7 @@ interactions:
       Content-Length: ['0']
       ParameterSetName: [-n -g --query -o]
       User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55]
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2018-07-01
@@ -107,7 +107,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['288']
       content-type: [application/json]
-      date: ['Thu, 17 Jan 2019 12:51:06 GMT']
+      date: ['Fri, 18 Jan 2019 09:51:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -128,7 +128,7 @@ interactions:
       Content-Length: ['0']
       ParameterSetName: [-n -g --query -o]
       User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55]
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2018-07-01
@@ -138,7 +138,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['288']
       content-type: [application/json]
-      date: ['Thu, 17 Jan 2019 12:51:06 GMT']
+      date: ['Fri, 18 Jan 2019 09:51:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -159,8 +159,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:09 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:51:56 GMT']
       x-ms-version: ['2017-04-17']
     method: POST
     uri: https://clitest000002.table.core.windows.net/Tables
@@ -169,8 +169,8 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://clitestlka3s4sregulnz3gq.table.core.windows.net/Tables(''tablenjxsq4ik42ssbul7dqu'')']
-      date: ['Thu, 17 Jan 2019 12:51:07 GMT']
+      dataserviceid: ['https://clitest3m7kad7jxqd5g5epn.table.core.windows.net/Tables(''tablemk4g7saeq33yqx2ozvl'')']
+      date: ['Fri, 18 Jan 2019 09:51:55 GMT']
       location: ['https://clitest000002.table.core.windows.net/Tables(''table000003'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
@@ -184,8 +184,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:10 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:51:57 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/Tables('table000003')
@@ -194,7 +194,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:51:08 GMT']
+      date: ['Fri, 18 Jan 2019 09:51:56 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -207,8 +207,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:11 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:51:58 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/Tables
@@ -217,7 +217,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:51:09 GMT']
+      date: ['Fri, 18 Jan 2019 09:51:57 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -234,8 +234,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:12 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:00 GMT']
       x-ms-version: ['2017-04-17']
     method: POST
     uri: https://clitest000002.table.core.windows.net/table000003
@@ -244,9 +244,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://clitestlka3s4sregulnz3gq.table.core.windows.net/tablenjxsq4ik42ssbul7dqu(PartitionKey=''001'',RowKey=''001'')']
-      date: ['Thu, 17 Jan 2019 12:51:10 GMT']
-      etag: [W/"datetime'2019-01-17T12%3A51%3A11.295677Z'"]
+      dataserviceid: ['https://clitest3m7kad7jxqd5g5epn.table.core.windows.net/tablemk4g7saeq33yqx2ozvl(PartitionKey=''001'',RowKey=''001'')']
+      date: ['Fri, 18 Jan 2019 09:51:58 GMT']
+      etag: [W/"datetime'2019-01-18T09%3A51%3A59.2020806Z'"]
       location: ['https://clitest000002.table.core.windows.net/table000003(PartitionKey=''001'',RowKey=''001'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
@@ -260,18 +260,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:13 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:01 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A11.295677Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-17T12:51:11.295677Z","name":"test","value":"something","binaryProperty@odata.type":"Edm.Binary","binaryProperty":"AAECAwQF"}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2019-01-18T09%3A51%3A59.2020806Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-18T09:51:59.2020806Z","name":"test","value":"something","binaryProperty@odata.type":"Edm.Binary","binaryProperty":"AAECAwQF"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:51:12 GMT']
-      etag: [W/"datetime'2019-01-17T12%3A51%3A11.295677Z'"]
+      date: ['Fri, 18 Jan 2019 09:51:59 GMT']
+      etag: [W/"datetime'2019-01-18T09%3A51%3A59.2020806Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -284,18 +284,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:14 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:02 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')?%24select=name
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element&$select=name","odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A11.295677Z''\"","name":"test"}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element&$select=name","odata.etag":"W/\"datetime''2019-01-18T09%3A51%3A59.2020806Z''\"","name":"test"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:51:12 GMT']
-      etag: [W/"datetime'2019-01-17T12%3A51%3A11.295677Z'"]
+      date: ['Fri, 18 Jan 2019 09:52:00 GMT']
+      etag: [W/"datetime'2019-01-18T09%3A51%3A59.2020806Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -311,8 +311,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:15 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:03 GMT']
       x-ms-version: ['2017-04-17']
     method: MERGE
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
@@ -321,8 +321,8 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:51:13 GMT']
-      etag: [W/"datetime'2019-01-17T12%3A51%3A14.2856966Z'"]
+      date: ['Fri, 18 Jan 2019 09:52:02 GMT']
+      etag: [W/"datetime'2019-01-18T09%3A52%3A02.2547079Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
@@ -334,18 +334,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:16 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:04 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A14.2856966Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-17T12:51:14.2856966Z","binaryProperty@odata.type":"Edm.Binary","binaryProperty":"AAECAwQF","name":"test","value":"newval"}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2019-01-18T09%3A52%3A02.2547079Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-18T09:52:02.2547079Z","binaryProperty@odata.type":"Edm.Binary","binaryProperty":"AAECAwQF","name":"test","value":"newval"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:51:15 GMT']
-      etag: [W/"datetime'2019-01-17T12%3A51%3A14.2856966Z'"]
+      date: ['Fri, 18 Jan 2019 09:52:03 GMT']
+      etag: [W/"datetime'2019-01-18T09%3A52%3A02.2547079Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -361,8 +361,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:17 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:05 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
@@ -371,8 +371,8 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:51:16 GMT']
-      etag: [W/"datetime'2019-01-17T12%3A51%3A16.3196248Z'"]
+      date: ['Fri, 18 Jan 2019 09:52:03 GMT']
+      etag: [W/"datetime'2019-01-18T09%3A52%3A04.3592076Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
@@ -384,18 +384,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:18 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:06 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A16.3196248Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-17T12:51:16.3196248Z","cat":"hat"}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003/@Element","odata.etag":"W/\"datetime''2019-01-18T09%3A52%3A04.3592076Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-18T09:52:04.3592076Z","cat":"hat"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:51:16 GMT']
-      etag: [W/"datetime'2019-01-17T12%3A51%3A16.3196248Z'"]
+      date: ['Fri, 18 Jan 2019 09:52:05 GMT']
+      etag: [W/"datetime'2019-01-18T09%3A52%3A04.3592076Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -410,8 +410,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:19 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:07 GMT']
       x-ms-version: ['2017-04-17']
     method: DELETE
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
@@ -420,7 +420,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:51:17 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:05 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
@@ -432,18 +432,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:20 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:08 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003(PartitionKey='001',RowKey='001')
   response:
     body: {string: '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
-        specified resource does not exist.\nRequestId:b9981ec3-6002-0100-4c63-ae7623000000\nTime:2019-01-17T12:51:19.3477913Z"}}}'}
+        specified resource does not exist.\nRequestId:a248247b-7002-001a-2b13-af7bbb000000\nTime:2019-01-18T09:52:07.4267670Z"}}}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:51:18 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:07 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -460,8 +460,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:21 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:09 GMT']
       x-ms-version: ['2017-04-17']
     method: POST
     uri: https://clitest000002.table.core.windows.net/table000003
@@ -470,9 +470,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://clitestlka3s4sregulnz3gq.table.core.windows.net/tablenjxsq4ik42ssbul7dqu(PartitionKey=''001'',RowKey=''001'')']
-      date: ['Thu, 17 Jan 2019 12:51:20 GMT']
-      etag: [W/"datetime'2019-01-17T12%3A51%3A20.3908525Z'"]
+      dataserviceid: ['https://clitest3m7kad7jxqd5g5epn.table.core.windows.net/tablemk4g7saeq33yqx2ozvl(PartitionKey=''001'',RowKey=''001'')']
+      date: ['Fri, 18 Jan 2019 09:52:08 GMT']
+      etag: [W/"datetime'2019-01-18T09%3A52%3A08.5136151Z'"]
       location: ['https://clitest000002.table.core.windows.net/table000003(PartitionKey=''001'',RowKey=''001'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
@@ -490,8 +490,8 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:22 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:10 GMT']
       x-ms-version: ['2017-04-17']
     method: POST
     uri: https://clitest000002.table.core.windows.net/table000003
@@ -500,9 +500,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://clitestlka3s4sregulnz3gq.table.core.windows.net/tablenjxsq4ik42ssbul7dqu(PartitionKey=''002'',RowKey=''002'')']
-      date: ['Thu, 17 Jan 2019 12:51:21 GMT']
-      etag: [W/"datetime'2019-01-17T12%3A51%3A21.3697496Z'"]
+      dataserviceid: ['https://clitest3m7kad7jxqd5g5epn.table.core.windows.net/tablemk4g7saeq33yqx2ozvl(PartitionKey=''002'',RowKey=''002'')']
+      date: ['Fri, 18 Jan 2019 09:52:08 GMT']
+      etag: [W/"datetime'2019-01-18T09%3A52%3A09.4961905Z'"]
       location: ['https://clitest000002.table.core.windows.net/table000003(PartitionKey=''002'',RowKey=''002'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
@@ -516,17 +516,17 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:23 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:11 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003()?%24top=1
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003","value":[{"odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A20.3908525Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-17T12:51:20.3908525Z","name":"test","value":"something","binaryProperty@odata.type":"Edm.Binary","binaryProperty":"AAECAwQF"}]}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003","value":[{"odata.etag":"W/\"datetime''2019-01-18T09%3A52%3A08.5136151Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2019-01-18T09:52:08.5136151Z","name":"test","value":"something","binaryProperty@odata.type":"Edm.Binary","binaryProperty":"AAECAwQF"}]}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:51:22 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:10 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -541,17 +541,17 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:24 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:12 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003()?NextPartitionKey=1%214%21MDAy&NextRowKey=1%214%21MDAy
   response:
-    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003","value":[{"odata.etag":"W/\"datetime''2019-01-17T12%3A51%3A21.3697496Z''\"","PartitionKey":"002","RowKey":"002","Timestamp":"2019-01-17T12:51:21.3697496Z","name":"test2","value":"something2"}]}'}
+    body: {string: '{"odata.metadata":"https://clitest000002.table.core.windows.net/$metadata#table000003","value":[{"odata.etag":"W/\"datetime''2019-01-18T09%3A52%3A09.4961905Z''\"","PartitionKey":"002","RowKey":"002","Timestamp":"2019-01-18T09:52:09.4961905Z","name":"test2","value":"something2"}]}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:51:22 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:10 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -563,8 +563,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:25 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:13 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -573,7 +573,7 @@ interactions:
         \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:24 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:13 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -584,8 +584,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:26 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:16 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -594,7 +594,7 @@ interactions:
         \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:25 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:15 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -608,8 +608,8 @@ interactions:
       Content-Length: ['184']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:27 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:17 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -617,7 +617,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:51:31 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:15 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -627,8 +627,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:33 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:17 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -636,7 +636,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:32 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:16 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -650,8 +650,8 @@ interactions:
       Content-Length: ['296']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:34 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:18 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -659,7 +659,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:51:32 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:16 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -669,8 +669,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:35 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:19 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -678,7 +678,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:34 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:17 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -692,8 +692,8 @@ interactions:
       Content-Length: ['413']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:36 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:19 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -701,7 +701,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:51:34 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:17 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -711,8 +711,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:36 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:20 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -720,7 +720,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:37 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:19 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -734,8 +734,8 @@ interactions:
       Content-Length: ['591']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:39 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:21 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -743,7 +743,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:51:37 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:19 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -753,8 +753,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:39 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:22 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -762,7 +762,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:39 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:21 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -773,8 +773,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:42 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:23 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -782,7 +782,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:41 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:22 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -793,8 +793,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:44 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:24 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -802,7 +802,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:42 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:23 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -813,8 +813,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:45 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:26 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -822,7 +822,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:44 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:24 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -833,8 +833,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:46 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:27 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -842,7 +842,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:45 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:25 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -853,8 +853,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:48 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:28 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -862,7 +862,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:46 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:26 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -876,8 +876,8 @@ interactions:
       Content-Length: ['598']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:49 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:29 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -885,7 +885,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:51:48 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:29 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -895,8 +895,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:50 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:32 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -904,7 +904,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>au</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:50 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:31 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -915,8 +915,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:52 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:34 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -924,7 +924,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>au</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:51:50 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:32 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -938,8 +938,8 @@ interactions:
       Content-Length: ['491']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:53 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:35 GMT']
       x-ms-version: ['2017-04-17']
     method: PUT
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -947,7 +947,7 @@ interactions:
     body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:51:55 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:33 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2017-04-17']
     status: {code: 204, message: No Content}
@@ -957,8 +957,8 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:51:57 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:36 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/table000003?comp=acl
@@ -966,7 +966,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:52:00 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:35 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -979,8 +979,8 @@ interactions:
       Content-Length: ['0']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:52:02 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:37 GMT']
       x-ms-version: ['2017-04-17']
     method: DELETE
     uri: https://clitest000002.table.core.windows.net/Tables('table000003')
@@ -989,7 +989,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:52:00 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:36 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2017-04-17']
@@ -1001,18 +1001,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:52:03 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:38 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002.table.core.windows.net/Tables('table000003')
   response:
     body: {string: '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
-        specified resource does not exist.\nRequestId:4f31ce23-0002-00f1-1663-aee1e5000000\nTime:2019-01-17T12:52:02.5560624Z"}}}'}
+        specified resource does not exist.\nRequestId:693a1174-3002-009e-1613-af2d93000000\nTime:2019-01-18T09:52:37.7896470Z"}}}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      date: ['Thu, 17 Jan 2019 12:52:02 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:37 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -1024,17 +1024,16 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55]
-      x-ms-date: ['Thu, 17 Jan 2019 12:52:04 GMT']
+      User-Agent: [Azure-CosmosDB/0.37.1 (Python CPython 3.6.6; Windows 10) AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
+      x-ms-date: ['Fri, 18 Jan 2019 09:52:39 GMT']
       x-ms-version: ['2017-04-17']
     method: GET
     uri: https://clitest000002-secondary.table.core.windows.net/?restype=service&comp=stats
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceStats><GeoReplication><Status>live</Status><LastSyncTime>Thu,\
-        \ 17 Jan 2019 12:49:58 GMT</LastSyncTime></GeoReplication></StorageServiceStats>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceStats><GeoReplication><Status>unavailable</Status><LastSyncTime></LastSyncTime></GeoReplication></StorageServiceStats>"}
     headers:
       content-type: [application/xml]
-      date: ['Thu, 17 Jan 2019 12:52:02 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:38 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2017-04-17']
@@ -1050,7 +1049,7 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--name --yes --no-wait]
       User-Agent: [python/3.6.6 (Windows-10-10.0.17134-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.55]
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.55.dev20190118093501.dev20190118094348]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
@@ -1059,9 +1058,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 17 Jan 2019 12:52:06 GMT']
+      date: ['Fri, 18 Jan 2019 09:52:42 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdTTjczMlg2N0RDS1RSRVlXWUNGQjRHSTM1SlpWRk5OUUdaUnw5OTBDRDFEMEFGRDg2RkI2LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdEVElZVlJQTk5YRkpIWVJYWDdXTldSVlZSTlhCMkVSWVdUUHw5QzRGNjc2NTQxNjRDMkEzLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_table_scenarios.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_table_scenarios.py
@@ -47,33 +47,34 @@ class StorageTableScenarioTests(StorageScenarioMixin, ScenarioTest):
 
     def verify_entity_operations(self, account_info, table_name):
         self.storage_cmd(
-            'storage entity insert -t {} -e rowkey=001 partitionkey=001 name=test value=something',
+            'storage entity insert -t {} -e rowkey=001 partitionkey=001 name=test value=something binaryProperty=AAECAwQF binaryProperty@odata.type=Edm.Binary',
             account_info, table_name)
         self.storage_cmd('storage entity show -t {} --row-key 001 --partition-key 001',
                          account_info, table_name) \
-            .assert_with_checks(JMESPathCheck('name', 'test'), JMESPathCheck('value', 'something'))
+            .assert_with_checks(JMESPathCheck('name', 'test'), JMESPathCheck('value', 'something'), JMESPathCheck('binaryProperty.value', 'AAECAwQF'))
         self.storage_cmd(
             'storage entity show -t {} --row-key 001 --partition-key 001 --select name',
             account_info, table_name).assert_with_checks(JMESPathCheck('name', 'test'),
-                                                         JMESPathCheck('value', None))
+                                                         JMESPathCheck('value', None),
+                                                         JMESPathCheck('binaryProperty.value', None))
         self.storage_cmd('storage entity merge -t {} -e rowkey=001 partitionkey=001 name=test value=newval',
                          account_info, table_name)
         self.storage_cmd('storage entity show -t {} --row-key 001 --partition-key 001',
                          account_info, table_name) \
-            .assert_with_checks(JMESPathCheck('name', 'test'), JMESPathCheck('value', 'newval'))
+            .assert_with_checks(JMESPathCheck('name', 'test'), JMESPathCheck('value', 'newval'), JMESPathCheck('binaryProperty.value', 'AAECAwQF'))
 
         self.storage_cmd('storage entity replace -t {} -e rowkey=001 partitionkey=001 cat=hat',
                          account_info, table_name)
         self.storage_cmd('storage entity show -t {} --row-key 001 --partition-key 001',
                          account_info, table_name) \
             .assert_with_checks(JMESPathCheck('cat', 'hat'), JMESPathCheck('name', None),
-                                JMESPathCheck('value', None))
+                                JMESPathCheck('value', None), JMESPathCheck('binaryProperty.value', None))
 
         self.storage_cmd('storage entity delete -t {} --row-key 001 --partition-key 001',
                          account_info, table_name)
         self.storage_cmd_negative('storage entity show -t {} --row-key 001 --partition-key 001',
                                   account_info, table_name)
-        self.storage_cmd('storage entity insert -t {} -e rowkey=001 partitionkey=001 name=test value=something',
+        self.storage_cmd('storage entity insert -t {} -e rowkey=001 partitionkey=001 name=test value=something binaryProperty=AAECAwQF binaryProperty@odata.type=Edm.Binary',
                          account_info, table_name)
         self.storage_cmd('storage entity insert -t {} -e rowkey=002 partitionkey=002 name=test2 value=something2',
                          account_info, table_name)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_table_scenarios.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_table_scenarios.py
@@ -47,11 +47,14 @@ class StorageTableScenarioTests(StorageScenarioMixin, ScenarioTest):
 
     def verify_entity_operations(self, account_info, table_name):
         self.storage_cmd(
-            'storage entity insert -t {} -e rowkey=001 partitionkey=001 name=test value=something binaryProperty=AAECAwQF binaryProperty@odata.type=Edm.Binary',
+            'storage entity insert -t {} -e rowkey=001 partitionkey=001 name=test value=something '
+            'binaryProperty=AAECAwQF binaryProperty@odata.type=Edm.Binary',
             account_info, table_name)
         self.storage_cmd('storage entity show -t {} --row-key 001 --partition-key 001',
                          account_info, table_name) \
-            .assert_with_checks(JMESPathCheck('name', 'test'), JMESPathCheck('value', 'something'), JMESPathCheck('binaryProperty.value', 'AAECAwQF'))
+            .assert_with_checks(JMESPathCheck('name', 'test'),
+                                JMESPathCheck('value', 'something'),
+                                JMESPathCheck('binaryProperty.value', 'AAECAwQF'))
         self.storage_cmd(
             'storage entity show -t {} --row-key 001 --partition-key 001 --select name',
             account_info, table_name).assert_with_checks(JMESPathCheck('name', 'test'),
@@ -61,7 +64,9 @@ class StorageTableScenarioTests(StorageScenarioMixin, ScenarioTest):
                          account_info, table_name)
         self.storage_cmd('storage entity show -t {} --row-key 001 --partition-key 001',
                          account_info, table_name) \
-            .assert_with_checks(JMESPathCheck('name', 'test'), JMESPathCheck('value', 'newval'), JMESPathCheck('binaryProperty.value', 'AAECAwQF'))
+            .assert_with_checks(JMESPathCheck('name', 'test'),
+                                JMESPathCheck('value', 'newval'),
+                                JMESPathCheck('binaryProperty.value', 'AAECAwQF'))
 
         self.storage_cmd('storage entity replace -t {} -e rowkey=001 partitionkey=001 cat=hat',
                          account_info, table_name)
@@ -74,7 +79,8 @@ class StorageTableScenarioTests(StorageScenarioMixin, ScenarioTest):
                          account_info, table_name)
         self.storage_cmd_negative('storage entity show -t {} --row-key 001 --partition-key 001',
                                   account_info, table_name)
-        self.storage_cmd('storage entity insert -t {} -e rowkey=001 partitionkey=001 name=test value=something binaryProperty=AAECAwQF binaryProperty@odata.type=Edm.Binary',
+        self.storage_cmd('storage entity insert -t {} -e rowkey=001 partitionkey=001 name=test value=something '
+                         'binaryProperty=AAECAwQF binaryProperty@odata.type=Edm.Binary',
                          account_info, table_name)
         self.storage_cmd('storage entity insert -t {} -e rowkey=002 partitionkey=002 name=test2 value=something2',
                          account_info, table_name)


### PR DESCRIPTION
As described in #8021, the CLI crashes for binary data because it is decoded from Base64 and then attempted to be displayed on the screen. The fix goes through the returned entities for `az storage entity query` and `az storage entity show` and transforms binary properties into Base64 strings so they can be displayed on the screen.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
