### PR TITLE
Add update available notification on `az --version`

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,9 +2,10 @@
 
 Release History
 ===============
+
 2.0.58
 ++++++
-
+* `az --version` now displays a notification if you have packages that can be updated.
 * Fixes regression where `--ids` could no longer be used with JSON output.
 
 2.0.57

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -85,7 +85,9 @@ class AzCli(CLI):
         from azure.cli.core.util import get_az_version_string
         ver_string, updates_available = get_az_version_string()
         print(ver_string)
-        if updates_available:
+        if updates_available == -1:
+            logger.warning('Unable to check if your CLI is up-to-date. Check your internet connection.')
+        elif updates_available:
             logger.warning('You have %i updates available. Consider updating your CLI installation.', updates_available)
         else:
             print('Your CLI is up-to-date.')

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -83,7 +83,12 @@ class AzCli(CLI):
 
     def show_version(self):
         from azure.cli.core.util import get_az_version_string
-        print(get_az_version_string())
+        ver_string, updates_available = get_az_version_string()
+        print(ver_string)
+        if updates_available:
+            logger.warning('You have %i updates available. Consider updating your CLI installation.', updates_available)
+        else:
+            print('Your CLI is up-to-date.')
 
     def exception_handler(self, ex):  # pylint: disable=no-self-use
         from azure.cli.core.util import handle_exception

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -141,9 +141,9 @@ def get_az_version_string():
         _print('Extensions:')
         for ext in extensions:
             if ext.ext_type == 'dev':
-                _print('{} ({}) [{}]'.format(ext.name, ext.version, ext.path))
+                _print(ext.name.ljust(20) + ext.version.rjust(20) + ' (dev) ' + ext.path)
             else:
-                _print('{} ({})'.format(ext.name, ext.version))
+                _print(ext.name.ljust(20) + (ext.version or 'Unknown').rjust(20))
         _print()
     _print("Python location '{}'".format(sys.executable))
     _print("Extensions directory '{}'".format(EXTENSIONS_DIR))

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -121,22 +121,21 @@ def get_az_version_string():
         print(val, file=output)
 
     def _get_version_string(name, version_dict):
-        from distutils.version import LooseVersion
+        from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
         local = version_dict['local']
         pypi = version_dict.get('pypi', None)
-        # logger.info('Module'.ljust(40) + 'Local Version'.rjust(20) + 'Public Version'.rjust(20))  # pylint: disable=logging-not-lazy
         if LooseVersion(pypi) > LooseVersion(local):
-            return name.ljust(20) + local.rjust(20) + 'UPDATE AVAILABLE ({})'.format(pypi).rjust(40)
+            return name.ljust(20) + local.rjust(20) + ' *'
         return name.ljust(20) + local.rjust(20)
 
     ver_string = _get_version_string(CLI_PACKAGE_NAME, versions.pop(CLI_PACKAGE_NAME))
-    if 'UPDATE' in ver_string:
+    if '*' in ver_string:
         updates_available += 1
     _print(ver_string)
     _print()
     for name in sorted(versions.keys()):
         ver_string = _get_version_string(name, versions.pop(name))
-        if 'UPDATE' in ver_string:
+        if '*' in ver_string:
             updates_available += 1
         _print(ver_string)
     _print()
@@ -160,12 +159,8 @@ def get_az_version_string():
     _print()
     _print('Legal docs and information: aka.ms/AzureCliLegal')
     _print()
-    if updates_available:
-        _print('You have {} updates available.'.format(updates_available))
-    else:
-        _print('Your CLI is up-to-date.')
     version_string = output.getvalue()
-    return version_string
+    return version_string, updates_available
 
 
 def get_json_object(json_string):

--- a/src/command_modules/azure-cli-cdn/setup.py
+++ b/src/command_modules/azure-cli-cdn/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.1.0"
+VERSION = "0.2.0"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-cdn/setup.py
+++ b/src/command_modules/azure-cli-cdn/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.2.0"
+VERSION = "0.1.0"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
Fixes #7815. Quick proof of concept for what an improve `az --version` could look like where we can communicate to users that updates are available. 

TODO:
- [x] Settle on UX
- [x] Ensure doesn't crash w/ no internet
- [x] Apply to extensions

Example of what output looks like:
```
(env) E:\github>az --version
azure-cli                         2.0.55 *

acr                               2.1.13
acs                               2.3.14 *
advisor                            2.0.0
ams                                0.4.0
appservice                        0.2.11 *
backup                             1.2.1
batch                              3.4.1
batchai                            0.4.6 *
billing                            0.2.0
botservice                         0.1.4 *
cdn                                0.2.0
cloud                              2.1.0
cognitiveservices                  0.2.4
configure                         2.0.20
consumption                        0.4.2
container                         0.3.11 *
core                              2.0.55 *
cosmosdb                           0.2.7
dla                                0.2.3
dls                                0.1.7
dms                                0.1.1 *
eventgrid                          0.2.0 *
eventhubs                          0.3.2 *
extension                          0.2.3
feedback                           2.1.4
find                              0.2.13
hdinsight                          0.2.0 *
interactive                        0.4.1
iot                                0.3.5
iotcentral                         0.1.5
keyvault                           2.2.9 *
lab                                0.1.5
maps                               0.3.3
monitor                            0.2.8 *
network                            2.3.1
nspkg                              3.0.3
policyinsights                     0.1.0
profile                            2.1.2 *
rdbms                              0.3.5 *
redis                              0.3.2
relay                              0.1.2 *
reservations                       0.4.1
resource                           2.1.8 *
role                               2.3.0 *
search                             0.1.1
security                           0.1.0
servicebus                         0.3.2 *
servicefabric                     0.1.11 *
signalr                            1.0.0
sql                                2.1.7 *
sqlvirtualmachine                  0.1.0
storage                            2.3.0 *
telemetry                          1.0.0 *
vm                                2.2.13

Extensions:
aem (None)
alias (0.5.2)
azure-firewall (0.1.1) [E:\github\azure-cli-extensions\src\azure-firewall]
find (0.3.0) [E:\github\azure-cli-extensions\src\find]
front-door (0.1.1) [E:\github\azure-cli-extensions\src\front-door]
virtual-network-tap (0.1.0) [E:\github\azure-cli-extensions\src\virtual-network-tap]

Python location 'E:\github\env\Scripts\python.exe'
Extensions directory 'C:\Users\travi\.azure\cliextensions'
Development extension sources:
    E:\github\azure-cli-extensions

Python (Windows) 3.6.5 (v3.6.5:f59c0932b4, Mar 28 2018, 17:00:18) [MSC v.1900 64 bit (AMD64)]

Legal docs and information: aka.ms/AzureCliLegal


You have 23 updates available. Consider updating your CLI installation.
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
