### PR TITLE
docker: do not remove build dep which might be needed by extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,7 @@ RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
         | xargs -r apk info --installed \
         | sort -u \
     )" \
- && apk add --virtual .rundeps $runDeps \
- && apk del .build-deps
+ && apk add --virtual .rundeps $runDeps
 
 WORKDIR /
 


### PR DESCRIPTION
Fix #8284 
Note: the image size increases from 497MB to 666MB, but extension installation must work so build dep has to stay

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
