### PR TITLE
Update Dev-Ops Syntax

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,8 +6,8 @@ jobs:
   displayName: Extract Metadata
 
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: Bash@3
     displayName: 'Extract Version'
@@ -26,8 +26,8 @@ jobs:
 
   dependsOn: ExtractMetadata
   condition: succeeded()
-  queue:
-    name: Hosted VS2017
+  pool:
+    vmImage: 'vs2017-win2016'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
@@ -56,8 +56,8 @@ jobs:
 
   dependsOn: ExtractMetadata
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: Bash@3
     displayName: 'Bash Script'
@@ -78,8 +78,8 @@ jobs:
 
   dependsOn: BuildDockerImage
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Metadata'
@@ -112,8 +112,8 @@ jobs:
 
   dependsOn: ExtractMetadata
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.7'
@@ -140,8 +140,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Metadata'
@@ -189,8 +189,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Metadata'
@@ -245,8 +245,8 @@ jobs:
 
   dependsOn: BuildHomebrewFormula
   condition: succeeded()
-  queue:
-    name: Hosted macOS
+  pool:
+    vmImage: 'macOS-10.13'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Metadata'
@@ -284,8 +284,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: Bash@3
     displayName: 'Build Rpm Package'
@@ -306,8 +306,8 @@ jobs:
 
   dependsOn: BuildYumPackage
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Metadata'
@@ -341,8 +341,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
@@ -371,8 +371,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
@@ -401,8 +401,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
@@ -432,8 +432,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
@@ -463,8 +463,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
@@ -494,8 +494,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
@@ -524,8 +524,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
@@ -562,8 +562,8 @@ jobs:
    - BuildDebianStretch
    - BuildUbuntuCosmic
   condition: succeededOrFailed()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Metadata'
@@ -616,8 +616,8 @@ jobs:
 
   dependsOn: BuildPythonWheel
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,8 @@
 resources:
 - repo: self
 
-phases:
-- phase: ExtractMetadata
+jobs:
+- job: ExtractMetadata
   displayName: Extract Metadata
 
   condition: succeeded()
@@ -21,7 +21,7 @@ phases:
     inputs:
       ArtifactName: metadata
 
-- phase: BuildWindowsMSI
+- job: BuildWindowsMSI
   displayName: Build Windows MSI
 
   dependsOn: ExtractMetadata
@@ -51,7 +51,7 @@ phases:
 
 
 
-- phase: BuildDockerImage
+- job: BuildDockerImage
   displayName: Build Docker Image
 
   dependsOn: ExtractMetadata
@@ -73,7 +73,7 @@ phases:
 
 
 
-- phase: TestDockerImage
+- job: TestDockerImage
   displayName: Test Docker Image
 
   dependsOn: BuildDockerImage
@@ -107,7 +107,7 @@ phases:
     displayName: 'Bash Script'
 
 
-- phase: BuildPythonWheel
+- job: BuildPythonWheel
   displayName: Build Python Wheels
 
   dependsOn: ExtractMetadata
@@ -135,7 +135,7 @@ phases:
 
 
 
-- phase: TestPythonWheel
+- job: TestPythonWheel
   displayName: Test Python Wheels
 
   dependsOn: BuildPythonWheel
@@ -184,7 +184,7 @@ phases:
     displayName: 'Test pip Install'
 
 
-- phase: BuildHomebrewFormula
+- job: BuildHomebrewFormula
   displayName: Build Homebrew Formula
 
   dependsOn: BuildPythonWheel
@@ -240,7 +240,7 @@ phases:
 
 
 
-- phase: TestHomebrewFormula
+- job: TestHomebrewFormula
   displayName: Test Homebrew Formula
 
   dependsOn: BuildHomebrewFormula
@@ -279,7 +279,7 @@ phases:
     displayName: 'Bash Script'
 
 
-- phase: BuildYumPackage
+- job: BuildYumPackage
   displayName: Build Yum Package
 
   dependsOn: BuildPythonWheel
@@ -301,7 +301,7 @@ phases:
 
 
 
-- phase: TestYumPackage
+- job: TestYumPackage
   displayName: Test Yum Package
 
   dependsOn: BuildYumPackage
@@ -336,7 +336,7 @@ phases:
     displayName: 'Bash Script'
 
 
-- phase: BuildUbuntuXenial
+- job: BuildUbuntuXenial
   displayName: Build Ubuntu Xenial Package
 
   dependsOn: BuildPythonWheel
@@ -366,7 +366,7 @@ phases:
 
 
 
-- phase: BuildUbuntuArtful
+- job: BuildUbuntuArtful
   displayName: Build Ubuntu Artful Package
 
   dependsOn: BuildPythonWheel
@@ -396,7 +396,7 @@ phases:
 
 
 
-- phase: BuildUbuntuTrusty
+- job: BuildUbuntuTrusty
   displayName: Build Ubuntu Trusty Package
 
   dependsOn: BuildPythonWheel
@@ -427,7 +427,7 @@ phases:
 
 
 
-- phase: BuildUbuntuBionic
+- job: BuildUbuntuBionic
   displayName: Build Ubuntu Bionic Package
 
   dependsOn: BuildPythonWheel
@@ -458,7 +458,7 @@ phases:
 
 
 
-- phase: BuildDebianWheezy
+- job: BuildDebianWheezy
   displayName: Build Debian Wheezy Package
 
   dependsOn: BuildPythonWheel
@@ -489,7 +489,7 @@ phases:
 
 
 
-- phase: BuildDebianJessie
+- job: BuildDebianJessie
   displayName: Build Debian Jessie Package
 
   dependsOn: BuildPythonWheel
@@ -519,7 +519,7 @@ phases:
 
 
 
-- phase: BuildDebianStretch
+- job: BuildDebianStretch
   displayName: Build Debian Stretch Package
 
   dependsOn: BuildPythonWheel
@@ -549,7 +549,7 @@ phases:
 
 
 
-- phase: TestLinuxPackages
+- job: TestLinuxPackages
   displayName: Test Linux Packages
 
   dependsOn:
@@ -611,7 +611,7 @@ phases:
        done
     displayName: 'Bash Script'
 
-- phase: BuildUbuntuCosmic
+- job: BuildUbuntuCosmic
   displayName: Build Ubuntu Cosmic
 
   dependsOn: BuildPythonWheel


### PR DESCRIPTION
While trying to setup our private build/release pipelines in devdiv.visualstudio.com, I discovered that it only supports a newer syntax than what this file was originally tooled in. This PR looks to make our build definition portable between both dev.azure.com/azure-public/azcli and devdiv.visualstudio.com

An overview of the difference in syntax can be found here:
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=vsts&tabs=yaml