### PR TITLE
Bug fix for webapp ssh

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -3,6 +3,7 @@
 Release History
 ===============
 * functionapp: add support for app insights on functionapp create
+* webapp: bugfixes for webapp ssh
 
 0.2.11
 ++++++

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -2315,7 +2315,7 @@ def _start_tunnel(tunnel_server):
 
 
 def _start_ssh(host_name, port, user_name):
-    subprocess.call("ssh -o StrictHostKeyChecking=no {}@{} -p {}".format(user_name, host_name, port), shell=True)
+    subprocess.call("ssh -q -o StrictHostKeyChecking=no {}@{} -p {}".format(user_name, host_name, port), shell=True)
 
 
 def ssh_webapp(cmd, resource_group_name, name, slot=None):  # pylint: disable=too-many-statements

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/fabric_license
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/fabric_license
@@ -1,0 +1,22 @@
+Copyright (c) 2018 Jeff Forcier.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tunnel.py
@@ -54,7 +54,7 @@ class TunnelServer(object):
         self.sock.bind((self.local_addr, self.local_port))
         if self.local_port == 0:
             self.local_port = self.sock.getsockname()[1]
-            logger.info('Auto-selecting port: %s', self.local_port)
+            logger.warning('Auto-selecting port: %s', self.local_port)
         logger.info('Finished initialization')
 
     def create_basic_auth(self):
@@ -73,7 +73,7 @@ class TunnelServer(object):
                 is_port_open = True
             return is_port_open
 
-    def is_port_set_to_default(self):
+    def is_webapp_up(self):
         import certifi
         import urllib3
         try:
@@ -97,10 +97,10 @@ class TunnelServer(object):
         msg = r.read().decode('utf-8')
         logger.info('Status response message: %s', msg)
         if 'FAIL' in msg.upper():
-            logger.warning('WARNING - Remote debugging may not be setup properly. Reponse content: %s', msg)
+            logger.info('WARNING - Remote debugging may not be setup properly. Reponse content: %s', msg)
+            return False
         if '2222' in msg:
             return True
-        return False
 
     def _listen(self):
         self.sock.listen(100)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tunnel.py
@@ -54,7 +54,7 @@ class TunnelServer(object):
         self.sock.bind((self.local_addr, self.local_port))
         if self.local_port == 0:
             self.local_port = self.sock.getsockname()[1]
-            logger.warning('Auto-selecting port: %s', self.local_port)
+            logger.info('Auto-selecting port: %s', self.local_port)
         logger.info('Finished initialization')
 
     def create_basic_auth(self):
@@ -69,7 +69,7 @@ class TunnelServer(object):
             if sock.connect_ex(('', self.local_port)) == 0:
                 logger.info('Port %s is NOT open', self.local_port)
             else:
-                logger.warning('Port %s is open', self.local_port)
+                logger.info('Port %s is open', self.local_port)
                 is_port_open = True
             return is_port_open
 
@@ -117,7 +117,7 @@ class TunnelServer(object):
                 logger.info('Websocket tracing enabled')
                 websocket.enableTrace(True)
             else:
-                logger.warning('Websocket tracing disabled, use --verbose flag to enable')
+                logger.info('Websocket tracing disabled, use --verbose flag to enable')
                 websocket.enableTrace(False)
             self.ws = create_connection(host,
                                         sockopt=((socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),),
@@ -133,11 +133,11 @@ class TunnelServer(object):
             debugger_thread.start()
             web_socket_thread.start()
             logger.info('Both debugger and websocket threads started...')
-            logger.warning('Successfully connected to local server..')
+            logger.info('Successfully connected to local server..')
             debugger_thread.join()
             web_socket_thread.join()
             logger.info('Both debugger and websocket threads stopped...')
-            logger.warning('Stopped local server..')
+            logger.info('Stopped local server..')
 
     def _listen_to_web_socket(self, client, ws_socket, index):
         while True:
@@ -173,7 +173,7 @@ class TunnelServer(object):
                     ws_socket.send_binary(responseData)
                     logger.info('Done sending to websocket, index: %s', index)
                 else:
-                    logger.warning('Client disconnected %s', index)
+                    logger.info('Client disconnected %s', index)
                     client.close()
                     ws_socket.close()
                     break

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tunnel.py
@@ -54,7 +54,7 @@ class TunnelServer(object):
         self.sock.bind((self.local_addr, self.local_port))
         if self.local_port == 0:
             self.local_port = self.sock.getsockname()[1]
-            logger.warning('Auto-selecting port: %s', self.local_port)
+            logger.info('Auto-selecting port: %s', self.local_port)
         logger.info('Finished initialization')
 
     def create_basic_auth(self):
@@ -101,6 +101,7 @@ class TunnelServer(object):
             return False
         if '2222' in msg:
             return True
+        return False
 
     def _listen(self):
         self.sock.listen(100)
@@ -108,7 +109,7 @@ class TunnelServer(object):
         basic_auth_string = self.create_basic_auth()
         while True:
             self.client, _address = self.sock.accept()
-            self.client.settimeout(1800)
+            self.client.settimeout(60 * 20)
             host = 'wss://{}{}'.format(self.remote_addr, '.scm.azurewebsites.net/AppServiceTunnel/Tunnel.ashx')
             basic_auth_header = 'Authorization: Basic {}'.format(basic_auth_string)
             cli_logger = get_logger()  # get CLI logger which has the level set through command lines
@@ -124,6 +125,7 @@ class TunnelServer(object):
                                         class_=TunnelWebSocket,
                                         header=[basic_auth_header],
                                         sslopt={'cert_reqs': ssl.CERT_NONE},
+                                        timeout=60 * 20,
                                         enable_multithread=True)
             logger.info('Websocket, connected status: %s', self.ws.connected)
             index = index + 1
@@ -140,8 +142,8 @@ class TunnelServer(object):
             logger.info('Stopped local server..')
 
     def _listen_to_web_socket(self, client, ws_socket, index):
-        while True:
-            try:
+        try:
+            while True:
                 logger.info('Waiting for websocket data, connection status: %s, index: %s', ws_socket.connected, index)
                 data = ws_socket.recv()
                 logger.info('Received websocket data: %s, index: %s', data, index)
@@ -152,17 +154,17 @@ class TunnelServer(object):
                     client.sendall(response)
                     logger.info('Done sending to debugger, index: %s', index)
                 else:
-                    logger.info('Client disconnected!, index: %s', index)
-                    client.close()
-                    ws_socket.close()
                     break
-            except:
-                client.close()
-                ws_socket.close()
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.info(ex)
+        finally:
+            logger.info('Client disconnected!, index: %s', index)
+            client.close()
+            ws_socket.close()
 
     def _listen_to_client(self, client, ws_socket, index):
-        while True:
-            try:
+        try:
+            while True:
                 logger.info('Waiting for debugger data, index: %s', index)
                 buf = bytearray(4096)
                 nbytes = client.recv_into(buf, 4096)
@@ -173,14 +175,14 @@ class TunnelServer(object):
                     ws_socket.send_binary(responseData)
                     logger.info('Done sending to websocket, index: %s', index)
                 else:
-                    logger.info('Client disconnected %s', index)
-                    client.close()
-                    ws_socket.close()
                     break
-            except:
-                traceback.print_exc(file=sys.stdout)
-                client.close()
-                ws_socket.close()
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.info(ex)
+            logger.warning("Connection Timed Out")
+        finally:
+            logger.info('Client disconnected %s', index)
+            client.close()
+            ws_socket.close()
 
     def start_server(self):
         self._listen()

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -38,6 +38,8 @@ DEPENDENCIES = [
     # v1.17 breaks on wildcard cert https://github.com/shazow/urllib3/issues/981
     'urllib3[secure]>=1.18',
     'xmltodict',
+    'fabric>=2.4',
+    'cryptography<2.5',
     'pyOpenSSL',
     'six',
     'vsts-cd-manager<1.1.0',


### PR DESCRIPTION
fixes #8282  #8281, #8280 , #8279

uses fabric ssh library which as a BSD 2-clause license
Added license at  src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/fabric_license
im not sure if that is the correct place top out it.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
