### PR TITLE
Fix JSON input to `--ids` in bash

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+
+* Fixes regression where `--ids` could no longer be used with JSON output.
+
 2.0.56
 ++++++
 * auth: enable tenant level account for managed service identity

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -258,6 +258,30 @@ def register_ids_argument(cli_ctx):
         for arg in combined_args:
             setattr(namespace, arg.name, IterateValue())
 
+        def assemble_json(ids):
+            json_indices = []
+            assembled_ids = []
+            lcount = 0
+            lind = None
+            for i, line in enumerate(ids):
+                if line == '[':
+                    if lcount == 0:
+                        lind = i
+                    lcount += 1
+                elif line == ']':
+                    lcount -= 1
+                    if lcount == 0:
+                        json_matches.append((lind, i))
+                        lind = None
+            if not json_indices:
+                return
+            for index_tuple in json_indices:
+                pass
+
+
+        # reassemble JSON strings from bash
+        assemble_json(ids)
+
         # expand the IDs into the relevant fields
         full_id_list = []
         for val in ids:

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -259,8 +259,6 @@ def register_ids_argument(cli_ctx):
             setattr(namespace, arg.name, IterateValue())
 
         def assemble_json(ids):
-            json_indices = []
-            assembled_ids = []
             lcount = 0
             lind = None
             for i, line in enumerate(ids):
@@ -270,17 +268,20 @@ def register_ids_argument(cli_ctx):
                     lcount += 1
                 elif line == ']':
                     lcount -= 1
+                    # final closed set of matching brackets
                     if lcount == 0:
-                        json_matches.append((lind, i))
-                        lind = None
-            if not json_indices:
-                return
-            for index_tuple in json_indices:
-                pass
-
+                        left = lind
+                        right = i + 1
+                        l_comp = ids[:left]
+                        m_comp = [''.join(ids[left:right])]
+                        r_comp = ids[right:]
+                        ids = l_comp + m_comp + r_comp
+                        return assemble_json(ids)
+            # base case--no more merging required
+            return ids
 
         # reassemble JSON strings from bash
-        assemble_json(ids)
+        ids = assemble_json(ids)
 
         # expand the IDs into the relevant fields
         full_id_list = []

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -1690,9 +1690,17 @@ class NetworkVNetScenarioTest(ScenarioTest):
         self.cmd('network vnet show --ids {ids}',
                  checks=self.check('length(@)', 2))
 
-        # This test ensures you can pipe JSON output to --ids
+        # This test ensures you can pipe JSON output to --ids Windows-style
+        # ensures a single JSON string has its ids parsed out
         self.kwargs['json'] = json.dumps(self.cmd('network vnet list -g {rg}').get_output_in_json())
         self.cmd('network vnet show --ids \'{json}\'',
+                 checks=self.check('length(@)', 2))
+
+        # This test ensures you can pipe JSON output to --ids bash-style
+        # ensures that a JSON string where each line is interpretted individually
+        # is reassembled and treated as a single json string
+        split_json = json.dumps(self.cmd('network vnet list -g {rg}').get_output_in_json()).split()
+        self.cmd('network vnet show --ids {}'.format(' '.join(split_json)),
                  checks=self.check('length(@)', 2))
 
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -1699,8 +1699,12 @@ class NetworkVNetScenarioTest(ScenarioTest):
         # This test ensures you can pipe JSON output to --ids bash-style
         # ensures that a JSON string where each line is interpretted individually
         # is reassembled and treated as a single json string
-        split_json = json.dumps(self.cmd('network vnet list -g {rg}').get_output_in_json()).split()
-        self.cmd('network vnet show --ids {}'.format(' '.join(split_json)),
+        json_obj = self.cmd('network vnet list -g {rg}').get_output_in_json()
+        for item in json_obj:
+            del item['etag']
+        split_json = json.dumps(json_obj, indent=4).split()
+        split_string = ' '.join(split_json).replace('{', '{{').replace('}', '}}').replace('"', '\\"')
+        self.cmd('network vnet show --ids {}'.format(split_string),
                  checks=self.check('length(@)', 2))
 
 


### PR DESCRIPTION
Fix #8197. Updates the test to account for both behaviors. `test_network_vnet_ids_query` now passes all scenarios.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
