### PR TITLE
doc: better descriptions for 'create-for-rbac --skip-assignment'

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -69,7 +69,7 @@ def load_arguments(self, _):
         c.argument('scopes', nargs='+')
         c.argument('role', completer=get_role_definition_name_completion_list)
         c.argument('skip_assignment', arg_type=get_three_state_flag(),
-                   help='do not create the default assignment which lets the service principal access resources under current subscription')
+                   help='Skip creating the default assignment, which allows the service principal to access resources under the current subscription')
         c.argument('show_auth_for_sdk', options_list='--sdk-auth', help='output result in compatible with Azure SDK auth file', arg_type=get_three_state_flag())
 
     with self.argument_context('ad sp owner list') as c:

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -68,7 +68,8 @@ def load_arguments(self, _):
     with self.argument_context('ad sp create-for-rbac') as c:
         c.argument('scopes', nargs='+')
         c.argument('role', completer=get_role_definition_name_completion_list)
-        c.argument('skip_assignment', arg_type=get_three_state_flag(), help='do not create default assignment')
+        c.argument('skip_assignment', arg_type=get_three_state_flag(),
+                   help='do not create the default assignment which lets the service principal access resources under current subscription')
         c.argument('show_auth_for_sdk', options_list='--sdk-auth', help='output result in compatible with Azure SDK auth file', arg_type=get_three_state_flag())
 
     with self.argument_context('ad sp owner list') as c:


### PR DESCRIPTION
Fix #8264 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
