### PR TITLE
Alphabetically order commands in help files and add crafted examples

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
@@ -5,810 +5,793 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.help_files import helps
-
+# pylint: disable=line-too-long, too-many-lines
 
 helps['acr'] = """
-    type: group
-    short-summary: Manage private registries with Azure Container Registries.
-    """
-
-helps['acr credential'] = """
-    type: group
-    short-summary: Manage login credentials for Azure Container Registries.
-    """
-
-helps['acr config'] = """
-    type: group
-    short-summary: Configure policies for Azure Container Registries.
-    """
-
-helps['acr config content-trust'] = """
-    type: group
-    short-summary: Manage content-trust policy for Azure Container Registries.
-    """
-
-helps['acr repository'] = """
-    type: group
-    short-summary: Manage repositories (image names) for Azure Container Registries.
-    """
-
-helps['acr webhook'] = """
-    type: group
-    short-summary: Manage webhooks for Azure Container Registries.
-    """
-
-helps['acr replication'] = """
-    type: group
-    short-summary: Manage geo-replicated regions of Azure Container Registries.
-    """
-
-helps['acr build-task'] = """
-    type: group
-    short-summary: Manage build definitions, which can be triggered by git commits or base image updates for OS & Framework Patching.
-    """
-
-helps['acr task'] = """
-    type: group
-    short-summary: Manage a collection of steps for building, testing and OS & Framework patching container images using Azure Container Registries.
-    """
-
-helps['acr run'] = """
-    type: command
-    short-summary: Queues a quick run providing streamed logs for an Azure Container Registry.
-    examples:
-        - name: Queue a local context, pushed to ACR with streaming logs.
-          text: >
-            az acr run -r MyRegistry -f bash-echo.yaml .
-        - name: Queue a remote git context with streaming logs.
-          text: >
-            az acr run -r MyRegistry https://github.com/Azure-Samples/acr-tasks.git -f hello-world.yaml
-        - name: Queue a remote git context with streaming logs and runs the task on Linux platform.
-          text: >
-            az acr run -r MyRegistry https://github.com/Azure-Samples/acr-tasks.git -f build-hello-world.yaml --platform linux
-    """
-
-helps['acr helm'] = """
-    type: group
-    short-summary: Manage helm charts for Azure Container Registries.
-    """
-
-helps['acr helm repo'] = """
-    type: group
-    short-summary: Manage helm chart repositories for Azure Container Registries.
-    """
-
-helps['acr network-rule'] = """
-    type: group
-    short-summary: Manage network rules for Azure Container Registries.
-    """
-
-helps['acr check-name'] = """
-    type: command
-    short-summary: Checks if an Azure Container Registry name is valid and available for use.
-    examples:
-        - name: Check if a registry name already exists.
-          text: >
-            az acr check-name -n doesthisnameexist
-"""
-
-helps['acr list'] = """
-    type: command
-    short-summary: Lists all the container registries under the current subscription.
-    examples:
-        - name: List container registries and show the results in a table, across multiple resource groups.
-          text: >
-            az acr list -o table
-        - name: List container registries in a resource group and show the results in a table.
-          text: >
-            az acr list -g MyResourceGroup -o table
-"""
-
-helps['acr create'] = """
-    type: command
-    short-summary: Creates an Azure Container Registry.
-    examples:
-        - name: Create a managed container registry with the Standard SKU.
-          text: >
-            az acr create -n MyRegistry -g MyResourceGroup --sku Standard
-        - name: Create an Azure Container Registry with a new storage account with the Classic SKU (Classic registries are being deprecated by March 2019).
-          text: >
-            az acr create -n MyRegistry -g MyResourceGroup --sku Classic
-"""
-
-helps['acr delete'] = """
-    type: command
-    short-summary: Deletes an Azure Container Registry.
-    examples:
-        - name: Delete an Azure Container Registry.
-          text: >
-            az acr delete -n MyRegistry
-"""
-
-helps['acr show'] = """
-    type: command
-    short-summary: Get the details of an Azure Container Registry.
-    examples:
-        - name: Get the login server for an Azure Container Registry.
-          text: >
-            az acr show -n MyRegistry --query loginServer
-"""
-
-helps['acr update'] = """
-    type: command
-    short-summary: Update an Azure Container Registry.
-    examples:
-        - name: Update tags for an Azure Container Registry.
-          text: >
-            az acr update -n MyRegistry --tags key1=value1 key2=value2
-        - name: Update the storage account for an Azure Container Registry (Classic Registries are being deprecated as of March 2019).
-          text: >
-            az acr update -n MyRegistry --storage-account-name MyStorageAccount
-        - name: Enable the administrator user account for an Azure Container Registry.
-          text: >
-            az acr update -n MyRegistry --admin-enabled true
-"""
-
-helps['acr login'] = """
-    type: command
-    short-summary: Log in to an Azure Container Registry through the Docker CLI.
-    long-summary: Docker must be installed on your machine.
-    examples:
-        - name: Log in to an Azure Container Registry
-          text: >
-            az acr login -n MyRegistry
-"""
-
-helps['acr show-usage'] = """
-    type: command
-    short-summary: Get the storage usage for an Azure Container Registry.
-    examples:
-        - name: Get the storage usage for an Azure Container Registry.
-          text: >
-            az acr show-usage -n MyRegistry
-"""
-
-helps['acr config content-trust show'] = """
-    type: command
-    short-summary: Show the configured content-trust policy for an Azure Container Registry.
-    examples:
-        - name: Show the configured content-trust policy for an Azure Container Registry
-          text: >
-            az acr config content-trust show -n MyRegistry
-"""
-
-helps['acr config content-trust update'] = """
-    type: command
-    short-summary: Update content-trust policy for an Azure Container Registry.
-    examples:
-        - name: Update content-trust policy for an Azure Container Registry
-          text: >
-            az acr config content-trust update -n MyRegistry --status Enabled
-"""
-
-helps['acr credential show'] = """
-    type: command
-    short-summary: Get the login credentials for an Azure Container Registry.
-    examples:
-        - name: Get the login credentials for an Azure Container Registry.
-          text: >
-            az acr credential show -n MyRegistry
-        - name: Get the username used to log in to an Azure Container Registry.
-          text: >
-            az acr credential show -n MyRegistry --query username
-        - name: Get a password used to log in to an Azure Container Registry.
-          text: >
-            az acr credential show -n MyRegistry --query passwords[0].value
-"""
-
-helps['acr credential renew'] = """
-    type: command
-    short-summary: Regenerate login credentials for an Azure Container Registry.
-    examples:
-        - name: Renew the second password for an Azure Container Registry.
-          text: >
-            az acr credential renew -n MyRegistry --password-name password2
-"""
-
-helps['acr repository list'] = """
-    type: command
-    short-summary: List repositories in an Azure Container Registry.
-    examples:
-        - name: List repositories in a given Azure Container Registry.
-          text:
-            az acr repository list -n MyRegistry
-"""
-
-helps['acr repository show-tags'] = """
-    type: command
-    short-summary: Show tags for a repository in an Azure Container Registry.
-    examples:
-        - name: Show tags of a repository in an Azure Container Registry.
-          text:
-            az acr repository show-tags -n MyRegistry --repository MyRepository
-        - name: Show the detailed information of tags of a repository in an Azure Container Registry.
-          text:
-            az acr repository show-tags -n MyRegistry --repository MyRepository --detail
-        - name: Show the detailed information of the latest 10 tags ordered by timestamp of a repository in an Azure Container Registry.
-          text:
-            az acr repository show-tags -n MyRegistry --repository MyRepository --top 10 --orderby time_desc --detail
-"""
-
-helps['acr repository show-manifests'] = """
-    type: command
-    short-summary: Show manifests of a repository in an Azure Container Registry.
-    examples:
-        - name: Show manifests of a repository in an Azure Container Registry.
-          text:
-            az acr repository show-manifests -n MyRegistry --repository MyRepository
-        - name: Show the latest 10 manifests ordered by timestamp of a repository in an Azure Container Registry.
-          text:
-            az acr repository show-manifests -n MyRegistry --repository MyRepository --top 10 --orderby time_desc
-        - name: Show the detailed information of the latest 10 manifests ordered by timestamp of a repository in an Azure Container Registry.
-          text:
-            az acr repository show-manifests -n MyRegistry --repository MyRepository --top 10 --orderby time_desc --detail
-"""
-
-helps['acr repository show'] = """
-    type: command
-    short-summary: Get the attributes of a repository or image in an Azure Container Registry.
-    examples:
-        - name: Get the attributes of the repository 'hello-world'.
-          text:
-            az acr repository show -n MyRegistry --repository hello-world
-        - name: Get the attributes of the image referenced by tag 'hello-world:latest'.
-          text:
-            az acr repository show -n MyRegistry --image hello-world:latest
-        - name: Get the attributes of the image referenced by digest 'hello-world@sha256:abc123'.
-          text:
-            az acr repository show -n MyRegistry --image hello-world@sha256:abc123
-"""
-
-helps['acr repository update'] = """
-    type: command
-    short-summary: Update the attributes of a repository or image in an Azure Container Registry.
-    examples:
-        - name: Update the attributes of the repository 'hello-world' to disable write operation.
-          text:
-            az acr repository update -n MyRegistry --repository hello-world --write-enabled false
-        - name: Update the attributes of the image referenced by tag 'hello-world:latest' to disable write operation.
-          text:
-            az acr repository update -n MyRegistry --image hello-world:latest --write-enabled false
-        - name: Update the attributes of the image referenced by digest 'hello-world@sha256:abc123' to disable write operation.
-          text:
-            az acr repository update -n MyRegistry --image hello-world@sha256:abc123 --write-enabled false
-"""
-
-helps['acr repository delete'] = """
-    type: command
-    short-summary: Delete a repository or image in an Azure Container Registry.
-    long-summary: This command deletes all associated layer data that are not referenced by any other manifest in the container registry.
-    examples:
-        - name: Delete a repository from an Azure Container Registry. This deletes all manifests and tags under 'hello-world'.
-          text:
-            az acr repository delete -n MyRegistry --repository hello-world
-        - name: Delete an image by tag. This deletes the manifest referenced by 'hello-world:latest' and all other tags referencing the manifest.
-          text:
-            az acr repository delete -n MyRegistry --image hello-world:latest
-        - name: Delete an image by sha256-based manifest digest. This deletes the manifest identified by 'hello-world@sha256:abc123' and all tags referencing the manifest.
-          text:
-            az acr repository delete -n MyRegistry --image hello-world@sha256:abc123
-"""
-
-helps['acr repository untag'] = """
-    type: command
-    short-summary: Untag an image in an Azure Container Registry.
-    long-summary: This command does not delete the manifest referenced by the tag or any associated layer data.
-    examples:
-        - name: Untag an image from a repository.
-          text:
-            az acr repository untag -n MyRegistry --image hello-world:latest
-"""
-
-helps['acr webhook list'] = """
-    type: command
-    short-summary: List all of the webhooks for an Azure Container Registry.
-    examples:
-        - name: List webhooks and show the results in a table.
-          text: >
-            az acr webhook list -r MyRegistry -o table
-"""
-
-helps['acr webhook create'] = """
-    type: command
-    short-summary: Create a webhook for an Azure Container Registry.
-    examples:
-        - name: Create a webhook for an Azure Container Registry that will deliver docker push and delete events to a service URI.
-          text: >
-            az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push delete
-        - name: Create a webhook for an Azure Container Registry that will deliver docker push events to a service URI with a basic authentication header.
-          text: >
-            az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push --headers "Authorization=Basic 000000"
-        - name: Create a webhook for an Azure Container Registry that will deliver helm chart push and delete events to a service URI.
-          text: >
-            az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions chart_push chart_delete
-"""
-
-helps['acr webhook delete'] = """
-    type: command
-    short-summary: Delete a webhook from an Azure Container Registry.
-    examples:
-        - name: Delete a webhook from an Azure Container Registry.
-          text: >
-            az acr webhook delete -n MyWebhook -r MyRegistry
-"""
-
-helps['acr webhook show'] = """
-    type: command
-    short-summary: Get the details of a webhook.
-    examples:
-        - name: Get the details of a webhook.
-          text: >
-            az acr webhook show -n MyWebhook -r MyRegistry
-"""
-
-helps['acr webhook update'] = """
-    type: command
-    short-summary: Update a webhook.
-    examples:
-        - name: Update headers for a webhook.
-          text: >
-            az acr webhook update -n MyWebhook -r MyRegistry --headers "Authorization=Basic 000000"
-        - name: Update the service URI and actions for a webhook.
-          text: >
-            az acr webhook update -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push delete
-        - name: Disable a webhook.
-          text: >
-            az acr webhook update -n MyWebhook -r MyRegistry --status disabled
-"""
-
-helps['acr webhook get-config'] = """
-    type: command
-    short-summary: Get the service URI and custom headers for the webhook.
-    examples:
-        - name: Get the configuration information for a webhook.
-          text: >
-            az acr webhook get-config -n MyWebhook -r MyRegistry
-"""
-
-helps['acr webhook ping'] = """
-    type: command
-    short-summary: Trigger a ping event for a webhook.
-    examples:
-        - name: Trigger a ping event for a webhook.
-          text: >
-            az acr webhook ping -n MyWebhook -r MyRegistry
-"""
-
-helps['acr webhook list-events'] = """
-    type: command
-    short-summary: List recent events for a webhook.
-    examples:
-        - name: List recent events for a webhook.
-          text: >
-            az acr webhook list-events -n MyWebhook -r MyRegistry
-"""
-
-helps['acr replication list'] = """
-    type: command
-    short-summary: List all of the regions for a geo-replicated Azure Container Registry.
-    examples:
-        - name: List replications and show the results in a table.
-          text: >
-            az acr replication list -r MyRegistry -o table
-"""
-
-helps['acr replication create'] = """
-    type: command
-    short-summary: Create a replicated region for an Azure Container Registry.
-    examples:
-        - name: Create a replicated region for an Azure Container Registry.
-          text: >
-            az acr replication create -r MyRegistry -l westus
-"""
-
-helps['acr replication delete'] = """
-    type: command
-    short-summary: Delete a replicated region from an Azure Container Registry.
-    examples:
-        - name: Delete a replicated region from an Azure Container Registry.
-          text: >
-            az acr replication delete -n MyReplication -r MyRegistry
-"""
-
-helps['acr replication show'] = """
-    type: command
-    short-summary: Get the details of a replicated region.
-    examples:
-        - name: Get the details of a replicated region
-          text: >
-            az acr replication show -n MyReplication -r MyRegistry
-"""
-
-helps['acr replication update'] = """
-    type: command
-    short-summary: Updates a replication.
-    examples:
-        - name: Update tags for a replication
-          text: >
-            az acr replication update -n MyReplication -r MyRegistry --tags key1=value1 key2=value2
-"""
-
-helps['acr task create'] = """
-    type: command
-    short-summary: Creates a series of steps for building, testing and OS & Framework patching containers. Tasks support triggers from git commits and base image updates.
-    examples:
-        - name: Create a Linux task from a public GitHub repository which builds the hello-world image without triggers
-          text: >
-            az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git -f Dockerfile --commit-trigger-enabled false --pull-request-trigger-enabled false
-        - name: Create a Linux task using a private GitHub repository which builds the hello-world image without triggers on Arm architecture (V7 variant)
-          text: >
-            az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git -f Dockerfile --commit-trigger-enabled false --pull-request-trigger-enabled false --git-access-token 0000000000000000000000000000000000000000 --platform linux/arm/v7
-        - name: Create a Linux task from a public GitHub repository which builds the hello-world image with a git commit trigger
-          text: >
-            az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git -f Dockerfile --git-access-token 0000000000000000000000000000000000000000
-        - name: Create a Windows task from a public GitHub repository which builds the Azure Container Builder image on Amd64 architecture.
-          text: >
-            az acr task create -t acb:{{.Run.ID}} -n acb-win -r MyRegistry -c https://github.com/Azure/acr-builder.git -f Windows.Dockerfile --commit-trigger-enabled false --pull-request-trigger-enabled false --platform Windows/amd64
-"""
-
-helps['acr task show'] = """
-    type: command
-    short-summary: Get the properties of a named task for an Azure Container Registry.
-    examples:
-        - name: Get the properties of a task, displaying the results in a table.
-          text: >
-            az acr task show -n MyTask -r MyRegistry -o table
-
-        - name: Get the properties of a task, including secure properties.
-          text: >
-            az acr task show -n MyTask -r MyRegistry --with-secure-properties
-"""
-
-helps['acr task list'] = """
-    type: command
-    short-summary: List the tasks for an Azure Container Registry.
-    examples:
-        - name: List tasks and show the results in a table.
-          text: >
-            az acr task list -r MyRegistry -o table
-"""
-
-helps['acr task delete'] = """
-    type: command
-    short-summary: Delete a task from an Azure Container Registry.
-    examples:
-        - name: Delete a task from an Azure Container Registry.
-          text: >
-            az acr task delete -n MyTask -r MyRegistry
-"""
-
-helps['acr task update'] = """
-    type: command
-    short-summary: Update a task for an Azure Container Registry.
-    examples:
-        - name: Update base image updates to trigger on all dependent images of a multi-stage dockerfile, and status of a task in an Azure Container Registry.
-          text: >
-            az acr task update -n MyTask -r MyRegistry --base-image-trigger-type All --status Disabled
-        - name: Update platform for the Build step of your Task to Windows (prev Linux).
-          text: >
-            az acr task update -n MyTask -r MyRegistry --platform Windows
-"""
-
-helps['acr task list-runs'] = """
-    type: command
-    short-summary: List all of the executed runs for an Azure Container Registry, with the ability to filter by a specific Task.
-    examples:
-        - name: List all of the runs for a registry and show the results in a table.
-          text: >
-            az acr task list-runs -r MyRegistry -o table
-        - name: List runs for a task and show the results in a table.
-          text: >
-            az acr task list-runs -r MyRegistry -n MyTask -o table
-        - name: List the last 10 successful runs for a registry and show the results in a table.
-          text: >
-            az acr task list-runs -r MyRegistry --run-status Succeeded --top 10 -o table
-        - name: List all of the runs that built the image 'hello-world' for a registry and show the results in a table.
-          text: >
-            az acr task list-runs -r MyRegistry --image hello-world -o table
-"""
-
-helps['acr task show-run'] = """
-    type: command
-    short-summary: Get the properties of a specified run of an Azure Container Registry Task.
-    examples:
-        - name:  Get the details of a run, displaying the results in a table.
-          text: >
-            az acr task show-run -r MyRegistry --run-id runId -o table
-"""
-
-helps['acr task cancel-run'] = """
-    type: command
-    short-summary: Cancel a specified run of an Azure Container Registry.
-    examples:
-        - name:  Cancel a run
-          text: >
-            az acr task cancel-run -r MyRegistry --run-id runId
-"""
-
-helps['acr task run'] = """
-    type: command
-    short-summary: Manually trigger a task that might otherwise be waiting for git commits or base image update triggers.
-    examples:
-        - name: Trigger a task.
-          text: >
-            az acr task run -n MyTask -r MyRegistry
-"""
-
-helps['acr task update-run'] = """
-    type: command
-    short-summary: Patch the run properties of an Azure Container Registry Task.
-    examples:
-        - name: Update an existing run to be archived.
-          text: >
-            az acr task update-run -r MyRegistry --run-id runId --no-archive false
-"""
-
-helps['acr task logs'] = """
-    type: command
-    short-summary: Show logs for a particular run. If no run-id is supplied, show logs for the last created run.
-    examples:
-        - name: Show logs for the last created run in the registry.
-          text: >
-            az acr task logs -r MyRegistry
-        - name: Show logs for the last created run in the registry, filtered by task.
-          text: >
-            az acr task logs -r MyRegistry -n MyTask
-        - name: Show logs for a particular run.
-          text: >
-            az acr task logs -r MyRegistry --run-id runId
-        - name: Show logs for the last created run in the registry that built the image 'hello-world'.
-          text: >
-            az acr task logs -r MyRegistry --image hello-world
+type: group
+short-summary: Manage private registries with Azure Container Registries.
 """
 
 helps['acr build'] = """
-    type: command
-    short-summary: Queues a quick build, providing streaming logs for an Azure Container Registry.
-    examples:
-        - name: Queue a local context as a Linux build, tag it, and push it to the registry.
-          text: >
-            az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry .
-        - name: Queue a local context as a Linux build, tag it, and push it to the registry without streaming logs.
-          text: >
-            az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry --no-logs .
-        - name: Queue a local context as a Linux build without pushing it to the registry.
-          text: >
-            az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry --no-push .
-        - name: Queue a local context as a Linux build without pushing it to the registry.
-          text: >
-            az acr build -r MyRegistry .
-        - name: Queue a remote GitHub context as a Windows build and x86 architecture, tag it, and push it to the registry.
-          text: >
-            az acr build -r MyRegistry https://github.com/Azure/acr-builder.git -f Windows.Dockerfile --platform Windows/x86
-        - name: Queue a local context as a Linux build on arm/v7 architecture, tag it, and push it to the registry.
-          text: >
-            az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry . --platform linux/arm/v7
+type: command
+short-summary: Queues a quick build, providing streaming logs for an Azure Container Registry.
+examples:
+  - name: Queue a local context as a Linux build, tag it, and push it to the registry.
+    text: >
+        az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry .
+  - name: Queue a local context as a Linux build, tag it, and push it to the registry without streaming logs.
+    text: >
+        az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry --no-logs .
+  - name: Queue a local context as a Linux build without pushing it to the registry.
+    text: >
+        az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry --no-push .
+  - name: Queue a local context as a Linux build without pushing it to the registry.
+    text: >
+        az acr build -r MyRegistry .
+  - name: Queue a remote GitHub context as a Windows build and x86 architecture, tag it, and push it to the registry.
+    text: >
+        az acr build -r MyRegistry https://github.com/Azure/acr-builder.git -f Windows.Dockerfile --platform Windows/x86
+  - name: Queue a local context as a Linux build on arm/v7 architecture, tag it, and push it to the registry.
+    text: >
+        az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry . --platform linux/arm/v7
+"""
+
+helps['acr build-task'] = """
+type: group
+short-summary: Manage build definitions, which can be triggered by git commits or base image updates for OS & Framework Patching.
 """
 
 helps['acr build-task create'] = """
-    type: command
-    short-summary: Creates a new build definition which can be triggered by git commits or base image updates for an Azure Container Registry.
-    examples:
-        - name: Create a build definition without git commits and base image updates.
-          text: >
-            az acr build-task create -t hello-world:{{.Build.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git --commit-trigger-enabled false --git-access-token 0000000000000000000000000000000000000000
-        - name: Create a build definition which updates on git commits and base image updates (--git-access-token must have permissions to create github webhooks).
-          text: >
-            az acr build-task create -t hello-world:{{.Build.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git --git-access-token 0000000000000000000000000000000000000000
-"""
-
-helps['acr build-task show'] = """
-    type: command
-    short-summary: Get the properties of a specified build task for an Azure Container Registry.
-    examples:
-        - name: Get the details of a build task, displaying the results in a table.
-          text: >
-            az acr build-task show -n MyBuildTask -r MyRegistry -o table
-        - name: Get the details of a build task including secure properties.
-          text: >
-            az acr build-task show -n MyBuildTask -r MyRegistry --with-secure-properties
-"""
-
-helps['acr build-task list'] = """
-    type: command
-    short-summary: List the build tasks for an Azure Container Registry.
-    examples:
-        - name: List build tasks and show the results in a table.
-          text: >
-            az acr build-task list -r MyRegistry -o table
+type: command
+short-summary: Creates a new build definition which can be triggered by git commits or base image updates for an Azure Container Registry.
+examples:
+  - name: Create a build definition without git commits and base image updates.
+    text: >
+        az acr build-task create -t hello-world:{{.Build.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git --commit-trigger-enabled false --git-access-token 0000000000000000000000000000000000000000
+  - name: Create a build definition which updates on git commits and base image updates (--git-access-token must have permissions to create github webhooks).
+    text: >
+        az acr build-task create -t hello-world:{{.Build.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git --git-access-token 0000000000000000000000000000000000000000
 """
 
 helps['acr build-task delete'] = """
-    type: command
-    short-summary: Delete a build task from an Azure Container Registry.
-    examples:
-        - name: Delete a build task from an Azure Container Registry
-          text: >
-            az acr build-task delete -n MyBuildTask -r MyRegistry
+type: command
+short-summary: Delete a build task from an Azure Container Registry.
+examples:
+  - name: Delete a build task from an Azure Container Registry
+    text: >
+        az acr build-task delete -n MyBuildTask -r MyRegistry
 """
 
-helps['acr build-task update'] = """
-    type: command
-    short-summary: Update a build task for an Azure Container Registry.
-    examples:
-        - name: Update the git access token for a build definition in an Azure Container Registry.
-          text: >
-            az acr build-task update -n MyBuildTask -r MyRegistry --git-access-token 0000000000000000000000000000000000000000
+helps['acr build-task list'] = """
+type: command
+short-summary: List the build tasks for an Azure Container Registry.
+examples:
+  - name: List build tasks and show the results in a table.
+    text: >
+        az acr build-task list -r MyRegistry -o table
 """
 
 helps['acr build-task list-builds'] = """
-    type: command
-    short-summary: List all of the executed builds for an Azure Container Registry.
-    examples:
-        - name: List builds for a build task and show the results in a table.
-          text: >
-            az acr build-task list-builds -n MyBuildTask -r MyRegistry -o table
-        - name: List all of the builds for a registry displaying the results in a table.
-          text: >
-            az acr build-task list-builds -r MyRegistry -o table
-        - name: List the last 10 successful builds for a registry displaying the results in a table.
-          text: >
-            az acr build-task list-builds -r MyRegistry --build-status Succeeded --top 10 -o table
-        - name: List all of the builds that built the image 'hello-world' for an Azure Container Registry, displaying the results in a table.
-          text: >
-            az acr build-task list-builds -r MyRegistry --image hello-world -o table
-"""
-
-helps['acr build-task show-build'] = """
-    type: command
-    short-summary: Get the properties of a specified build for an Azure Container Registry.
-    examples:
-        - name:  Get the details of a build, displaying the results in a table.
-          text: >
-            az acr build-task show-build -r MyRegistry --build-id aab1 -o table
-"""
-
-helps['acr build-task run'] = """
-    type: command
-    short-summary: Trigger a build task that might otherwise be waiting for git commits or base image update triggers for an Azure Container Registry.
-    examples:
-        - name: Trigger a build task.
-          text: >
-            az acr build-task run -n MyBuildTask -r MyRegistry
-"""
-
-helps['acr build-task update-build'] = """
-    type: command
-    short-summary: Patch the build properties of an Azure Container Registry.
-    examples:
-        - name: Update an existing build to be archived.
-          text: >
-            az acr build-task update-build -r MyRegistry --build-id MyBuild --no-archive false
+type: command
+short-summary: List all of the executed builds for an Azure Container Registry.
+examples:
+  - name: List builds for a build task and show the results in a table.
+    text: >
+        az acr build-task list-builds -n MyBuildTask -r MyRegistry -o table
+  - name: List all of the builds for a registry displaying the results in a table.
+    text: >
+        az acr build-task list-builds -r MyRegistry -o table
+  - name: List the last 10 successful builds for a registry displaying the results in a table.
+    text: >
+        az acr build-task list-builds -r MyRegistry --build-status Succeeded --top 10 -o table
+  - name: List all of the builds that built the image 'hello-world' for an Azure Container Registry, displaying the results in a table.
+    text: >
+        az acr build-task list-builds -r MyRegistry --image hello-world -o table
 """
 
 helps['acr build-task logs'] = """
-    type: command
-    short-summary: Show logs for a particular build. If no build-id is supplied, display the logs for the last created build.
-    examples:
-        - name: Show logs for the last created build in the registry.
-          text: >
-            az acr build-task logs -r MyRegistry
-        - name: Show logs for the last created build in the registry, filtered by build task.
-          text: >
-            az acr build-task logs -r MyRegistry -n MyBuildTask
-        - name: Show logs for a particular build.
-          text: >
-            az acr build-task logs -r MyRegistry --build-id aa1b
-        - name: Show logs for the last created build in the registry that built the image 'hello-world'.
-          text: >
-            az acr build-task logs -r MyRegistry --image hello-world
+type: command
+short-summary: Show logs for a particular build. If no build-id is supplied, display the logs for the last created build.
+examples:
+  - name: Show logs for the last created build in the registry.
+    text: >
+        az acr build-task logs -r MyRegistry
+  - name: Show logs for the last created build in the registry, filtered by build task.
+    text: >
+        az acr build-task logs -r MyRegistry -n MyBuildTask
+  - name: Show logs for a particular build.
+    text: >
+        az acr build-task logs -r MyRegistry --build-id aa1b
+  - name: Show logs for the last created build in the registry that built the image 'hello-world'.
+    text: >
+        az acr build-task logs -r MyRegistry --image hello-world
 """
 
-helps['acr import'] = """
-    type: command
-    short-summary: Imports an image to an Azure Container Registry from another Container Registry. Import removes the need to docker pull, docker tag, docker push.
-    examples:
-        - name: Import an image to the target registry and inherits sourcerepository:sourcetag from the source registry.
-          text: >
-            az acr import -n MyRegistry --source sourceregistry.azurecr.io/sourcerepository:sourcetag
-        - name: Import an image from a registry in a different subscription.
-          text: >
-            az acr import -n MyRegistry --source sourcerepository:sourcetag -t targetrepository:targettag -r /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceResourceGroup/providers/Microsoft.ContainerRegistry/registries/sourceRegistry
-        - name: Import an image from a public repository in Docker Hub
-          text: >
-            az acr import -n MyRegistry --source docker.io/sourcerepository:sourcetag -t targetrepository:targettag
+helps['acr build-task run'] = """
+type: command
+short-summary: Trigger a build task that might otherwise be waiting for git commits or base image update triggers for an Azure Container Registry.
+examples:
+  - name: Trigger a build task.
+    text: >
+        az acr build-task run -n MyBuildTask -r MyRegistry
 """
 
-helps['acr helm list'] = """
-    type: command
-    short-summary: List all helm charts in an Azure Container Registry.
-    examples:
-        - name: List all helm charts in an Azure Container Registry
-          text: >
-            az acr helm list -n MyRegistry
+helps['acr build-task show'] = """
+type: command
+short-summary: Get the properties of a specified build task for an Azure Container Registry.
+examples:
+  - name: Get the details of a build task, displaying the results in a table.
+    text: >
+        az acr build-task show -n MyBuildTask -r MyRegistry -o table
+  - name: Get the details of a build task including secure properties.
+    text: >
+        az acr build-task show -n MyBuildTask -r MyRegistry --with-secure-properties
 """
 
-helps['acr helm show'] = """
-    type: command
-    short-summary: Describe a helm chart in an Azure Container Registry.
-    examples:
-        - name: Show all versions of a helm chart in an Azure Container Registry
-          text: >
-            az acr helm show -n MyRegistry mychart
-        - name: Show a helm chart version in an Azure Container Registry
-          text: >
-            az acr helm show -n MyRegistry mychart --version 0.3.2
+helps['acr build-task show-build'] = """
+type: command
+short-summary: Get the properties of a specified build for an Azure Container Registry.
+examples:
+  - name: Get the details of a build, displaying the results in a table.
+    text: >
+        az acr build-task show-build -r MyRegistry --build-id aab1 -o table
+"""
+
+helps['acr build-task update'] = """
+type: command
+short-summary: Update a build task for an Azure Container Registry.
+examples:
+  - name: Update the git access token for a build definition in an Azure Container Registry.
+    text: >
+        az acr build-task update -n MyBuildTask -r MyRegistry --git-access-token 0000000000000000000000000000000000000000
+"""
+
+helps['acr build-task update-build'] = """
+type: command
+short-summary: Patch the build properties of an Azure Container Registry.
+examples:
+  - name: Update an existing build to be archived.
+    text: >
+        az acr build-task update-build -r MyRegistry --build-id MyBuild --no-archive false
+"""
+
+helps['acr check-name'] = """
+type: command
+short-summary: Checks if an Azure Container Registry name is valid and available for use.
+examples:
+  - name: Check if a registry name already exists.
+    text: >
+        az acr check-name -n doesthisnameexist
+"""
+
+helps['acr config'] = """
+type: group
+short-summary: Configure policies for Azure Container Registries.
+"""
+
+helps['acr config content-trust'] = """
+type: group
+short-summary: Manage content-trust policy for Azure Container Registries.
+"""
+
+helps['acr config content-trust show'] = """
+type: command
+short-summary: Show the configured content-trust policy for an Azure Container Registry.
+examples:
+  - name: Show the configured content-trust policy for an Azure Container Registry
+    text: >
+        az acr config content-trust show -n MyRegistry
+"""
+
+helps['acr config content-trust update'] = """
+type: command
+short-summary: Update content-trust policy for an Azure Container Registry.
+examples:
+  - name: Update content-trust policy for an Azure Container Registry
+    text: >
+        az acr config content-trust update -n MyRegistry --status Enabled
+"""
+
+helps['acr create'] = """
+type: command
+short-summary: Creates an Azure Container Registry.
+examples:
+  - name: Create a managed container registry with the Standard SKU.
+    text: >
+        az acr create -n MyRegistry -g MyResourceGroup --sku Standard
+  - name: Create an Azure Container Registry with a new storage account with the Classic SKU (Classic registries are being deprecated by March 2019).
+    text: >
+        az acr create -n MyRegistry -g MyResourceGroup --sku Classic
+"""
+
+helps['acr credential'] = """
+type: group
+short-summary: Manage login credentials for Azure Container Registries.
+"""
+
+helps['acr credential renew'] = """
+type: command
+short-summary: Regenerate login credentials for an Azure Container Registry.
+examples:
+  - name: Renew the second password for an Azure Container Registry.
+    text: >
+        az acr credential renew -n MyRegistry --password-name password2
+"""
+
+helps['acr credential show'] = """
+type: command
+short-summary: Get the login credentials for an Azure Container Registry.
+examples:
+  - name: Get the login credentials for an Azure Container Registry.
+    text: >
+        az acr credential show -n MyRegistry
+  - name: Get the username used to log in to an Azure Container Registry.
+    text: >
+        az acr credential show -n MyRegistry --query username
+  - name: Get a password used to log in to an Azure Container Registry.
+    text: >
+        az acr credential show -n MyRegistry --query passwords[0].value
+"""
+
+helps['acr delete'] = """
+type: command
+short-summary: Deletes an Azure Container Registry.
+examples:
+  - name: Delete an Azure Container Registry.
+    text: >
+        az acr delete -n MyRegistry
+"""
+
+helps['acr helm'] = """
+type: group
+short-summary: Manage helm charts for Azure Container Registries.
 """
 
 helps['acr helm delete'] = """
-    type: command
-    short-summary: Delete a helm chart version in an Azure Container Registry.
-    examples:
-        - name: Delete all versions of a helm chart in an Azure Container Registry
-          text: >
-            az acr helm delete -n MyRegistry mychart
-        - name: Delete a helm chart version in an Azure Container Registry
-          text: >
-            az acr helm delete -n MyRegistry mychart --version 0.3.2
+type: command
+short-summary: Delete a helm chart version in an Azure Container Registry.
+examples:
+  - name: Delete all versions of a helm chart in an Azure Container Registry
+    text: >
+        az acr helm delete -n MyRegistry mychart
+  - name: Delete a helm chart version in an Azure Container Registry
+    text: >
+        az acr helm delete -n MyRegistry mychart --version 0.3.2
+"""
+
+helps['acr helm list'] = """
+type: command
+short-summary: List all helm charts in an Azure Container Registry.
+examples:
+  - name: List all helm charts in an Azure Container Registry
+    text: >
+        az acr helm list -n MyRegistry
 """
 
 helps['acr helm push'] = """
-    type: command
-    short-summary: Push a helm chart package to an Azure Container Registry.
-    examples:
-        - name: Push a chart package to an Azure Container Registry
-          text: >
-            az acr helm push -n MyRegistry mychart-0.3.2.tgz
-        - name: Push a chart package to an Azure Container Registry, overwriting the existing one.
-          text: >
-            az acr helm push -n MyRegistry mychart-0.3.2.tgz --force
+type: command
+short-summary: Push a helm chart package to an Azure Container Registry.
+examples:
+  - name: Push a chart package to an Azure Container Registry
+    text: >
+        az acr helm push -n MyRegistry mychart-0.3.2.tgz
+  - name: Push a chart package to an Azure Container Registry, overwriting the existing one.
+    text: >
+        az acr helm push -n MyRegistry mychart-0.3.2.tgz --force
+"""
+
+helps['acr helm repo'] = """
+type: group
+short-summary: Manage helm chart repositories for Azure Container Registries.
 """
 
 helps['acr helm repo add'] = """
-    type: command
-    short-summary: Add a helm chart repository from an Azure Container Registry through the Helm CLI.
-    long-summary: Helm must be installed on your machine.
-    examples:
-        - name: Add a helm chart repository from an Azure Container Registry to manage helm charts.
-          text: >
-            az acr helm repo add -n MyRegistry
+type: command
+short-summary: Add a helm chart repository from an Azure Container Registry through the Helm CLI.
+long-summary: Helm must be installed on your machine.
+examples:
+  - name: Add a helm chart repository from an Azure Container Registry to manage helm charts.
+    text: >
+        az acr helm repo add -n MyRegistry
 """
 
-helps['acr network-rule list'] = """
-    type: command
-    short-summary: List network rules.
-    examples:
-        - name: List network rules for a registry.
-          text: >
-            az acr network-rule list -n MyRegistry
+helps['acr helm show'] = """
+type: command
+short-summary: Describe a helm chart in an Azure Container Registry.
+examples:
+  - name: Show all versions of a helm chart in an Azure Container Registry
+    text: >
+        az acr helm show -n MyRegistry mychart
+  - name: Show a helm chart version in an Azure Container Registry
+    text: >
+        az acr helm show -n MyRegistry mychart --version 0.3.2
+"""
+
+helps['acr import'] = """
+type: command
+short-summary: Imports an image to an Azure Container Registry from another Container Registry. Import removes the need to docker pull, docker tag, docker push.
+examples:
+  - name: Import an image to the target registry and inherits sourcerepository:sourcetag from the source registry.
+    text: >
+        az acr import -n MyRegistry --source sourceregistry.azurecr.io/sourcerepository:sourcetag
+  - name: Import an image from a registry in a different subscription.
+    text: >
+        az acr import -n MyRegistry --source sourcerepository:sourcetag -t targetrepository:targettag -r /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceResourceGroup/providers/Microsoft.ContainerRegistry/registries/sourceRegistry
+  - name: Import an image from a public repository in Docker Hub
+    text: >
+        az acr import -n MyRegistry --source docker.io/sourcerepository:sourcetag -t targetrepository:targettag
+"""
+
+helps['acr list'] = """
+type: command
+short-summary: Lists all the container registries under the current subscription.
+examples:
+  - name: List container registries and show the results in a table, across multiple resource groups.
+    text: >
+        az acr list -o table
+  - name: List container registries in a resource group and show the results in a table.
+    text: >
+        az acr list -g MyResourceGroup -o table
+"""
+
+helps['acr login'] = """
+type: command
+short-summary: Log in to an Azure Container Registry through the Docker CLI.
+long-summary: Docker must be installed on your machine.
+examples:
+  - name: Log in to an Azure Container Registry
+    text: >
+        az acr login -n MyRegistry
+"""
+
+helps['acr network-rule'] = """
+type: group
+short-summary: Manage network rules for Azure Container Registries.
 """
 
 helps['acr network-rule add'] = """
-    type: command
-    short-summary: Add a network rule.
-    examples:
-        - name: Add a rule to allow access for a subnet in the same resource group as the registry.
-          text: >
-            az acr network-rule add -n MyRegistry --vnet-name myvnet --subnet mysubnet
-        - name: Add a rule to allow access for a subnet in a different subscription or resource group.
-          text: >
-            az acr network-rule add -n MyRegistry --subnet /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet
-        - name: Add a rule to allow access for a specific IP address-range.
-          text: >
-            az acr network-rule add -n MyRegistry --ip-address 23.45.1.0/24
+type: command
+short-summary: Add a network rule.
+examples:
+  - name: Add a rule to allow access for a subnet in the same resource group as the registry.
+    text: >
+        az acr network-rule add -n MyRegistry --vnet-name myvnet --subnet mysubnet
+  - name: Add a rule to allow access for a subnet in a different subscription or resource group.
+    text: >
+        az acr network-rule add -n MyRegistry --subnet /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet
+  - name: Add a rule to allow access for a specific IP address-range.
+    text: >
+        az acr network-rule add -n MyRegistry --ip-address 23.45.1.0/24
+"""
+
+helps['acr network-rule list'] = """
+type: command
+short-summary: List network rules.
+examples:
+  - name: List network rules for a registry.
+    text: >
+        az acr network-rule list -n MyRegistry
 """
 
 helps['acr network-rule remove'] = """
-    type: command
-    short-summary: Remove a network rule.
-    examples:
-        - name: Remove a rule that allows access for a subnet in the same resource group as the registry.
-          text: >
-            az acr network-rule remove -n MyRegistry --vnet-name myvnet --subnet mysubnet
-        - name: Remove a rule that allows access for a subnet in a different subscription or resource group.
-          text: >
-            az acr network-rule remove -n MyRegistry --subnet /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet
-        - name: Remove a rule that allows access for a specific IP address-range.
-          text: >
-            az acr network-rule remove -n MyRegistry --ip-address 23.45.1.0/24
+type: command
+short-summary: Remove a network rule.
+examples:
+  - name: Remove a rule that allows access for a subnet in the same resource group as the registry.
+    text: >
+        az acr network-rule remove -n MyRegistry --vnet-name myvnet --subnet mysubnet
+  - name: Remove a rule that allows access for a subnet in a different subscription or resource group.
+    text: >
+        az acr network-rule remove -n MyRegistry --subnet /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet
+  - name: Remove a rule that allows access for a specific IP address-range.
+    text: >
+        az acr network-rule remove -n MyRegistry --ip-address 23.45.1.0/24
+"""
+
+helps['acr replication'] = """
+type: group
+short-summary: Manage geo-replicated regions of Azure Container Registries.
+"""
+
+helps['acr replication create'] = """
+type: command
+short-summary: Create a replicated region for an Azure Container Registry.
+examples:
+  - name: Create a replicated region for an Azure Container Registry.
+    text: >
+        az acr replication create -r MyRegistry -l westus
+"""
+
+helps['acr replication delete'] = """
+type: command
+short-summary: Delete a replicated region from an Azure Container Registry.
+examples:
+  - name: Delete a replicated region from an Azure Container Registry.
+    text: >
+        az acr replication delete -n MyReplication -r MyRegistry
+"""
+
+helps['acr replication list'] = """
+type: command
+short-summary: List all of the regions for a geo-replicated Azure Container Registry.
+examples:
+  - name: List replications and show the results in a table.
+    text: >
+        az acr replication list -r MyRegistry -o table
+"""
+
+helps['acr replication show'] = """
+type: command
+short-summary: Get the details of a replicated region.
+examples:
+  - name: Get the details of a replicated region
+    text: >
+        az acr replication show -n MyReplication -r MyRegistry
+"""
+
+helps['acr replication update'] = """
+type: command
+short-summary: Updates a replication.
+examples:
+  - name: Update tags for a replication
+    text: >
+        az acr replication update -n MyReplication -r MyRegistry --tags key1=value1 key2=value2
+"""
+
+helps['acr repository'] = """
+type: group
+short-summary: Manage repositories (image names) for Azure Container Registries.
+"""
+
+helps['acr repository delete'] = """
+type: command
+short-summary: Delete a repository or image in an Azure Container Registry.
+long-summary: This command deletes all associated layer data that are not referenced by any other manifest in the container registry.
+examples:
+  - name: Delete a repository from an Azure Container Registry. This deletes all manifests and tags under 'hello-world'.
+    text: az acr repository delete -n MyRegistry --repository hello-world
+  - name: Delete an image by tag. This deletes the manifest referenced by 'hello-world:latest' and all other tags referencing the manifest.
+    text: az acr repository delete -n MyRegistry --image hello-world:latest
+  - name: Delete an image by sha256-based manifest digest. This deletes the manifest identified by 'hello-world@sha256:abc123' and all tags referencing the manifest.
+    text: az acr repository delete -n MyRegistry --image hello-world@sha256:abc123
+"""
+
+helps['acr repository list'] = """
+type: command
+short-summary: List repositories in an Azure Container Registry.
+examples:
+  - name: List repositories in a given Azure Container Registry.
+    text: az acr repository list -n MyRegistry
+"""
+
+helps['acr repository show'] = """
+type: command
+short-summary: Get the attributes of a repository or image in an Azure Container Registry.
+examples:
+  - name: Get the attributes of the repository 'hello-world'.
+    text: az acr repository show -n MyRegistry --repository hello-world
+  - name: Get the attributes of the image referenced by tag 'hello-world:latest'.
+    text: az acr repository show -n MyRegistry --image hello-world:latest
+  - name: Get the attributes of the image referenced by digest 'hello-world@sha256:abc123'.
+    text: az acr repository show -n MyRegistry --image hello-world@sha256:abc123
+"""
+
+helps['acr repository show-manifests'] = """
+type: command
+short-summary: Show manifests of a repository in an Azure Container Registry.
+examples:
+  - name: Show manifests of a repository in an Azure Container Registry.
+    text: az acr repository show-manifests -n MyRegistry --repository MyRepository
+  - name: Show the latest 10 manifests ordered by timestamp of a repository in an Azure Container Registry.
+    text: az acr repository show-manifests -n MyRegistry --repository MyRepository --top 10 --orderby time_desc
+  - name: Show the detailed information of the latest 10 manifests ordered by timestamp of a repository in an Azure Container Registry.
+    text: az acr repository show-manifests -n MyRegistry --repository MyRepository --top 10 --orderby time_desc --detail
+"""
+
+helps['acr repository show-tags'] = """
+type: command
+short-summary: Show tags for a repository in an Azure Container Registry.
+examples:
+  - name: Show tags of a repository in an Azure Container Registry.
+    text: az acr repository show-tags -n MyRegistry --repository MyRepository
+  - name: Show the detailed information of tags of a repository in an Azure Container Registry.
+    text: az acr repository show-tags -n MyRegistry --repository MyRepository --detail
+  - name: Show the detailed information of the latest 10 tags ordered by timestamp of a repository in an Azure Container Registry.
+    text: az acr repository show-tags -n MyRegistry --repository MyRepository --top 10 --orderby time_desc --detail
+"""
+
+helps['acr repository untag'] = """
+type: command
+short-summary: Untag an image in an Azure Container Registry.
+long-summary: This command does not delete the manifest referenced by the tag or any associated layer data.
+examples:
+  - name: Untag an image from a repository.
+    text: az acr repository untag -n MyRegistry --image hello-world:latest
+"""
+
+helps['acr repository update'] = """
+type: command
+short-summary: Update the attributes of a repository or image in an Azure Container Registry.
+examples:
+  - name: Update the attributes of the repository 'hello-world' to disable write operation.
+    text: az acr repository update -n MyRegistry --repository hello-world --write-enabled false
+  - name: Update the attributes of the image referenced by tag 'hello-world:latest' to disable write operation.
+    text: az acr repository update -n MyRegistry --image hello-world:latest --write-enabled false
+  - name: Update the attributes of the image referenced by digest 'hello-world@sha256:abc123' to disable write operation.
+    text: az acr repository update -n MyRegistry --image hello-world@sha256:abc123 --write-enabled false
+"""
+
+helps['acr run'] = """
+type: command
+short-summary: Queues a quick run providing streamed logs for an Azure Container Registry.
+examples:
+  - name: Queue a local context, pushed to ACR with streaming logs.
+    text: >
+        az acr run -r MyRegistry -f bash-echo.yaml .
+  - name: Queue a remote git context with streaming logs.
+    text: >
+        az acr run -r MyRegistry https://github.com/Azure-Samples/acr-tasks.git -f hello-world.yaml
+  - name: Queue a remote git context with streaming logs and runs the task on Linux platform.
+    text: >
+        az acr run -r MyRegistry https://github.com/Azure-Samples/acr-tasks.git -f build-hello-world.yaml --platform linux
+"""
+
+helps['acr show'] = """
+type: command
+short-summary: Get the details of an Azure Container Registry.
+examples:
+  - name: Get the login server for an Azure Container Registry.
+    text: >
+        az acr show -n MyRegistry --query loginServer
+"""
+
+helps['acr show-usage'] = """
+type: command
+short-summary: Get the storage usage for an Azure Container Registry.
+examples:
+  - name: Get the storage usage for an Azure Container Registry.
+    text: >
+        az acr show-usage -n MyRegistry
+"""
+
+helps['acr task'] = """
+type: group
+short-summary: Manage a collection of steps for building, testing and OS & Framework patching container images using Azure Container Registries.
+"""
+
+helps['acr task cancel-run'] = """
+type: command
+short-summary: Cancel a specified run of an Azure Container Registry.
+examples:
+  - name: Cancel a run
+    text: >
+        az acr task cancel-run -r MyRegistry --run-id runId
+"""
+
+helps['acr task create'] = """
+type: command
+short-summary: Creates a series of steps for building, testing and OS & Framework patching containers. Tasks support triggers from git commits and base image updates.
+examples:
+  - name: Create a Linux task from a public GitHub repository which builds the hello-world image without triggers
+    text: >
+        az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git -f Dockerfile --commit-trigger-enabled false --pull-request-trigger-enabled false
+  - name: Create a Linux task using a private GitHub repository which builds the hello-world image without triggers on Arm architecture (V7 variant)
+    text: >
+        az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git -f Dockerfile --commit-trigger-enabled false --pull-request-trigger-enabled false --git-access-token 0000000000000000000000000000000000000000 --platform linux/arm/v7
+  - name: Create a Linux task from a public GitHub repository which builds the hello-world image with a git commit trigger
+    text: >
+        az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry -c https://github.com/Azure-Samples/acr-build-helloworld-node.git -f Dockerfile --git-access-token 0000000000000000000000000000000000000000
+  - name: Create a Windows task from a public GitHub repository which builds the Azure Container Builder image on Amd64 architecture.
+    text: >
+        az acr task create -t acb:{{.Run.ID}} -n acb-win -r MyRegistry -c https://github.com/Azure/acr-builder.git -f Windows.Dockerfile --commit-trigger-enabled false --pull-request-trigger-enabled false --platform Windows/amd64
+"""
+
+helps['acr task delete'] = """
+type: command
+short-summary: Delete a task from an Azure Container Registry.
+examples:
+  - name: Delete a task from an Azure Container Registry.
+    text: >
+        az acr task delete -n MyTask -r MyRegistry
+"""
+
+helps['acr task list'] = """
+type: command
+short-summary: List the tasks for an Azure Container Registry.
+examples:
+  - name: List tasks and show the results in a table.
+    text: >
+        az acr task list -r MyRegistry -o table
+"""
+
+helps['acr task list-runs'] = """
+type: command
+short-summary: List all of the executed runs for an Azure Container Registry, with the ability to filter by a specific Task.
+examples:
+  - name: List all of the runs for a registry and show the results in a table.
+    text: >
+        az acr task list-runs -r MyRegistry -o table
+  - name: List runs for a task and show the results in a table.
+    text: >
+        az acr task list-runs -r MyRegistry -n MyTask -o table
+  - name: List the last 10 successful runs for a registry and show the results in a table.
+    text: >
+        az acr task list-runs -r MyRegistry --run-status Succeeded --top 10 -o table
+  - name: List all of the runs that built the image 'hello-world' for a registry and show the results in a table.
+    text: >
+        az acr task list-runs -r MyRegistry --image hello-world -o table
+"""
+
+helps['acr task logs'] = """
+type: command
+short-summary: Show logs for a particular run. If no run-id is supplied, show logs for the last created run.
+examples:
+  - name: Show logs for the last created run in the registry.
+    text: >
+        az acr task logs -r MyRegistry
+  - name: Show logs for the last created run in the registry, filtered by task.
+    text: >
+        az acr task logs -r MyRegistry -n MyTask
+  - name: Show logs for a particular run.
+    text: >
+        az acr task logs -r MyRegistry --run-id runId
+  - name: Show logs for the last created run in the registry that built the image 'hello-world'.
+    text: >
+        az acr task logs -r MyRegistry --image hello-world
+"""
+
+helps['acr task run'] = """
+type: command
+short-summary: Manually trigger a task that might otherwise be waiting for git commits or base image update triggers.
+examples:
+  - name: Trigger a task.
+    text: >
+        az acr task run -n MyTask -r MyRegistry
+"""
+
+helps['acr task show'] = """
+type: command
+short-summary: Get the properties of a named task for an Azure Container Registry.
+examples:
+  - name: Get the properties of a task, displaying the results in a table.
+    text: >
+        az acr task show -n MyTask -r MyRegistry -o table
+
+  - name: Get the properties of a task, including secure properties.
+    text: >
+        az acr task show -n MyTask -r MyRegistry --with-secure-properties
+"""
+
+helps['acr task show-run'] = """
+type: command
+short-summary: Get the properties of a specified run of an Azure Container Registry Task.
+examples:
+  - name: Get the details of a run, displaying the results in a table.
+    text: >
+        az acr task show-run -r MyRegistry --run-id runId -o table
+"""
+
+helps['acr task update'] = """
+type: command
+short-summary: Update a task for an Azure Container Registry.
+examples:
+  - name: Update base image updates to trigger on all dependent images of a multi-stage dockerfile, and status of a task in an Azure Container Registry.
+    text: >
+        az acr task update -n MyTask -r MyRegistry --base-image-trigger-type All --status Disabled
+  - name: Update platform for the Build step of your Task to Windows (prev Linux).
+    text: >
+        az acr task update -n MyTask -r MyRegistry --platform Windows
+"""
+
+helps['acr task update-run'] = """
+type: command
+short-summary: Patch the run properties of an Azure Container Registry Task.
+examples:
+  - name: Update an existing run to be archived.
+    text: >
+        az acr task update-run -r MyRegistry --run-id runId --no-archive false
+"""
+
+helps['acr update'] = """
+type: command
+short-summary: Update an Azure Container Registry.
+examples:
+  - name: Update tags for an Azure Container Registry.
+    text: >
+        az acr update -n MyRegistry --tags key1=value1 key2=value2
+  - name: Update the storage account for an Azure Container Registry (Classic Registries are being deprecated as of March 2019).
+    text: >
+        az acr update -n MyRegistry --storage-account-name MyStorageAccount
+  - name: Enable the administrator user account for an Azure Container Registry.
+    text: >
+        az acr update -n MyRegistry --admin-enabled true
+"""
+
+helps['acr webhook'] = """
+type: group
+short-summary: Manage webhooks for Azure Container Registries.
+"""
+
+helps['acr webhook create'] = """
+type: command
+short-summary: Create a webhook for an Azure Container Registry.
+examples:
+  - name: Create a webhook for an Azure Container Registry that will deliver docker push and delete events to a service URI.
+    text: >
+        az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push delete
+  - name: Create a webhook for an Azure Container Registry that will deliver docker push events to a service URI with a basic authentication header.
+    text: >
+        az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push --headers "Authorization=Basic 000000"
+  - name: Create a webhook for an Azure Container Registry that will deliver helm chart push and delete events to a service URI.
+    text: >
+        az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions chart_push chart_delete
+"""
+
+helps['acr webhook delete'] = """
+type: command
+short-summary: Delete a webhook from an Azure Container Registry.
+examples:
+  - name: Delete a webhook from an Azure Container Registry.
+    text: >
+        az acr webhook delete -n MyWebhook -r MyRegistry
+"""
+
+helps['acr webhook get-config'] = """
+type: command
+short-summary: Get the service URI and custom headers for the webhook.
+examples:
+  - name: Get the configuration information for a webhook.
+    text: >
+        az acr webhook get-config -n MyWebhook -r MyRegistry
+"""
+
+helps['acr webhook list'] = """
+type: command
+short-summary: List all of the webhooks for an Azure Container Registry.
+examples:
+  - name: List webhooks and show the results in a table.
+    text: >
+        az acr webhook list -r MyRegistry -o table
+"""
+
+helps['acr webhook list-events'] = """
+type: command
+short-summary: List recent events for a webhook.
+examples:
+  - name: List recent events for a webhook.
+    text: >
+        az acr webhook list-events -n MyWebhook -r MyRegistry
+"""
+
+helps['acr webhook ping'] = """
+type: command
+short-summary: Trigger a ping event for a webhook.
+examples:
+  - name: Trigger a ping event for a webhook.
+    text: >
+        az acr webhook ping -n MyWebhook -r MyRegistry
+"""
+
+helps['acr webhook show'] = """
+type: command
+short-summary: Get the details of a webhook.
+examples:
+  - name: Get the details of a webhook.
+    text: >
+        az acr webhook show -n MyWebhook -r MyRegistry
+"""
+
+helps['acr webhook update'] = """
+type: command
+short-summary: Update a webhook.
+examples:
+  - name: Update headers for a webhook.
+    text: >
+        az acr webhook update -n MyWebhook -r MyRegistry --headers "Authorization=Basic 000000"
+  - name: Update the service URI and actions for a webhook.
+    text: >
+        az acr webhook update -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push delete
+  - name: Disable a webhook.
+    text: >
+        az acr webhook update -n MyWebhook -r MyRegistry --status disabled
 """

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -617,7 +617,7 @@ examples:
 helps['webapp config set'] = """
 type: command
 short-summary: Set a web app's configuration.
-Examples:
+examples:
   - name: turn on "alwaysOn"
     text: >
         az webapp config set -g MyResourceGroup -n MyUniqueApp --always-on true
@@ -625,10 +625,6 @@ Examples:
     text: >
         az webapp config set -g MyResourceGroup -n MyUniqueApp --generic-configurations "{"alwaysOn": true}"
 
-examples:
-  - name: Set a web app's configuration. (crafted)
-    text: az webapp config set --name My --resource-group MyResourceGroup --always-on {always-on}
-    crafted: true
 """
 
 helps['webapp config show'] = """

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -3,13 +3,369 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-# pylint: disable=too-many-lines
-from knack.help_files import helps
 
+from knack.help_files import helps
+# pylint: disable=line-too-long, too-many-lines
 
 helps['appservice'] = """
 type: group
 short-summary: Manage App Service plans.
+"""
+
+helps['appservice list-locations'] = """
+type: command
+short-summary: List regions where a plan sku is available.
+"""
+
+helps['appservice plan'] = """
+type: group
+short-summary: Manage app service plans.
+"""
+
+helps['appservice plan create'] = """
+type: command
+short-summary: Create an app service plan.
+examples:
+  - name: Create a basic app service plan.
+    text: >
+        az appservice plan create -g MyResourceGroup -n MyPlan
+  - name: Create a standard app service plan with with four Linux workers.
+    text: >
+        az appservice plan create -g MyResourceGroup -n MyPlan \
+            --is-linux --number-of-workers 4 --sku S1
+"""
+
+helps['appservice plan delete'] = """
+type: command
+short-summary: Delete an app service plan.
+"""
+
+helps['appservice plan list'] = """
+type: command
+short-summary: List app service plans.
+examples:
+  - name: List all free tier App Service plans.
+    text: >
+        az appservice plan list --query "[?sku.tier=='Free']"
+"""
+
+helps['appservice plan show'] = """
+type: command
+short-summary: Get the app service plans for a resource group or a set of resource groups.
+"""
+
+helps['appservice plan update'] = """
+type: command
+short-summary: Update an app service plan. See https://docs.microsoft.com/en-us/azure/app-service/app-service-plan-manage#move-an-app-to-another-app-service-plan to learn more
+"""
+
+helps['functionapp'] = """
+type: group
+short-summary: Manage function apps.
+"""
+
+helps['functionapp config'] = """
+type: group
+short-summary: Configure a function app.
+"""
+
+helps['functionapp config appsettings'] = """
+type: group
+short-summary: Configure function app settings.
+"""
+
+helps['functionapp config appsettings delete'] = """
+type: command
+short-summary: Delete a function app's settings.
+"""
+
+helps['functionapp config appsettings list'] = """
+type: command
+short-summary: Show settings for a function app.
+"""
+
+helps['functionapp config appsettings set'] = """
+type: command
+short-summary: Update a function app's settings.
+"""
+
+helps['functionapp config hostname'] = """
+type: group
+short-summary: Configure hostnames for a function app.
+"""
+
+helps['functionapp config hostname add'] = """
+type: command
+short-summary: Bind a hostname to a function app.
+"""
+
+helps['functionapp config hostname delete'] = """
+type: command
+short-summary: Unbind a hostname from a function app.
+"""
+
+helps['functionapp config hostname get-external-ip'] = """
+type: command
+short-summary: Get the external-facing IP address for a function app.
+"""
+
+helps['functionapp config hostname list'] = """
+type: command
+short-summary: List all hostname bindings for a function app.
+"""
+
+helps['functionapp config set'] = """
+type: command
+short-summary: Set the web app's configuration.
+"""
+
+helps['functionapp config show'] = """
+type: command
+short-summary: Get the details of a web app's configuration.
+"""
+
+helps['functionapp config ssl'] = """
+type: group
+short-summary: Configure SSL certificates.
+"""
+
+helps['functionapp config ssl bind'] = """
+type: command
+short-summary: Bind an SSL certificate to a function app.
+"""
+
+helps['functionapp config ssl delete'] = """
+type: command
+short-summary: Delete an SSL certificate from a function app.
+"""
+
+helps['functionapp config ssl list'] = """
+type: command
+short-summary: List SSL certificates for a function app.
+"""
+
+helps['functionapp config ssl unbind'] = """
+type: command
+short-summary: Unbind an SSL certificate from a function app.
+"""
+
+helps['functionapp config ssl upload'] = """
+type: command
+short-summary: Upload an SSL certificate to a function app.
+"""
+
+helps['functionapp cors'] = """
+type: group
+short-summary: Manage Cross-Origin Resource Sharing (CORS)
+"""
+
+helps['functionapp cors add'] = """
+type: command
+short-summary: Add allowed origins
+examples:
+  - name: add a new allowed origin
+    text: >
+        az functionapp cors add -g <myRG> -n <myAppName> --allowed-origins https://myapps.com
+"""
+
+helps['functionapp cors remove'] = """
+type: command
+short-summary: Remove allowed origins
+examples:
+  - name: remove an allowed origin
+    text: >
+        az functionapp cors remove -g <myRG> -n <myAppName> --allowed-origins https://myapps.com
+  - name: remove all allowed origins
+    text: >
+        az functionapp cors remove -g <myRG> -n <myAppName> --allowed-origins *
+"""
+
+helps['functionapp cors show'] = """
+type: command
+short-summary: show allowed origins
+"""
+
+helps['functionapp create'] = """
+type: command
+short-summary: Create a function app.
+long-summary: The function app's name must be able to produce a unique FQDN as AppName.azurewebsites.net.
+examples:
+  - name: Create a basic function app.
+    text: >
+        az functionapp create -g MyResourceGroup  -p MyPlan -n MyUniqueAppName -s MyStorageAccount
+"""
+
+helps['functionapp delete'] = """
+type: command
+short-summary: Delete a function app.
+"""
+
+helps['functionapp deployment'] = """
+type: group
+short-summary: Manage function app deployments.
+"""
+
+helps['functionapp deployment list-publishing-profiles'] = """
+type: command
+short-summary: Get the details for available function app deployment profiles.
+"""
+
+helps['functionapp deployment source'] = """
+type: group
+short-summary: Manage function app deployment via source control.
+"""
+
+helps['functionapp deployment source config'] = """
+type: command
+short-summary: Manage deployment from git or Mercurial repositories.
+"""
+
+helps['functionapp deployment source config-local-git'] = """
+type: command
+short-summary: Get a URL for a git repository endpoint to clone and push to for function app deployment.
+examples:
+  - name: Get an endpoint and add it as a git remote.
+    text: >
+        az functionapp deployment source config-local-git \
+            -g MyResourceGroup -n MyUniqueApp
+
+        git remote add azure \
+            https://<deploy_user_name>@MyUniqueApp.scm.azurewebsites.net/MyUniqueApp.git
+"""
+
+helps['functionapp deployment source config-zip'] = """
+type: command
+short-summary: Perform deployment using the kudu zip push deployment for a function app.
+long-summary: >
+    By default Kudu assumes that zip deployments do not require any build-related actions like
+    npm install or dotnet publish. This can be overridden by including an .deployment file in your
+    zip file with the following content '[config] SCM_DO_BUILD_DURING_DEPLOYMENT = true',
+    to enable Kudu detection logic and build script generation process.
+    See https://github.com/projectkudu/kudu/wiki/Configurable-settings#enabledisable-build-actions-preview.
+    Alternately the setting can be enabled using the az functionapp config appsettings set command.
+examples:
+  - name: Perform deployment by using zip file content.
+    text: >
+        az functionapp deployment source config-zip \
+            -g {myRG>} -n {myAppName} \
+            --src {zipFilePathLocation}
+"""
+
+helps['functionapp deployment source delete'] = """
+type: command
+short-summary: Delete a source control deployment configuration.
+"""
+
+helps['functionapp deployment source show'] = """
+type: command
+short-summary: Get the details of a source control deployment configuration.
+"""
+
+helps['functionapp deployment source sync'] = """
+type: command
+short-summary: Synchronize from the repository. Only needed under manual integration mode.
+"""
+
+helps['functionapp deployment user'] = """
+type: group
+short-summary: Manage user credentials for deployment.
+"""
+
+helps['functionapp deployment user set'] = """
+type: command
+short-summary: Update deployment credentials.
+long-summary: All function and web apps in the subscription will be impacted since they share the same deployment credentials.
+examples:
+  - name: Set FTP and git deployment credentials for all apps.
+    text: >
+        az functionapp deployment user set
+        --user-name MyUserName
+"""
+
+helps['functionapp identity'] = """
+type: group
+short-summary: manage web app's managed service identity
+"""
+
+helps['functionapp identity assign'] = """
+type: command
+short-summary: assign or disable managed service identity to the web app
+examples:
+  - name: assign local identity and assign a reader role to the current resource group.
+    text: >
+        az functionapp identity assign -g MyResourceGroup -n MyUniqueApp --role reader --scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/MyResourceGroup
+  - name: enable identity for the web app.
+    text: >
+        az functionapp identity assign -g MyResourceGroup -n MyUniqueApp
+"""
+
+helps['functionapp identity remove'] = """
+type: command
+short-summary: Disable web app's managed service identity
+"""
+
+helps['functionapp identity show'] = """
+type: command
+short-summary: display web app's managed service identity
+"""
+
+helps['functionapp list'] = """
+type: command
+short-summary: List function apps.
+examples:
+  - name: List default host name and state for all function apps.
+    text: >
+        az functionapp list --query "[].{hostName: defaultHostName, state: state}"
+  - name: List all running function apps.
+    text: >
+        az functionapp list --query "[?state=='Running']"
+"""
+
+helps['functionapp list-consumption-locations'] = """
+type: command
+short-summary: List available locations for running function apps.
+"""
+
+helps['functionapp plan'] = """
+type: group
+short-summary: Manage App Service Plans for an Azure Function
+"""
+
+helps['functionapp plan create'] = """
+type: command
+short-summary: Create an App Service Plan for an Azure Function
+examples:
+  - name: Create a basic app service plan.
+    text: >
+        az functionapp plan create -g MyResourceGroup -n MyPlan --sku B1
+  - name: Create a standard app service plan with with four workers.
+    text: >
+        az functionapp plan create -g MyResourceGroup -n MyPlan --number-of-workers 4 --sku S1
+"""
+
+helps['functionapp restart'] = """
+type: command
+short-summary: Restart a function app.
+"""
+
+helps['functionapp show'] = """
+type: command
+short-summary: Get the details of a function app.
+"""
+
+helps['functionapp start'] = """
+type: command
+short-summary: Start a function app.
+"""
+
+helps['functionapp stop'] = """
+type: command
+short-summary: Stop a function app.
+"""
+
+helps['functionapp update'] = """
+type: command
+short-summary: Update a function app.
 """
 
 helps['webapp'] = """
@@ -18,89 +374,41 @@ short-summary: Manage web apps.
 """
 
 helps['webapp auth'] = """
-    type: group
-    short-summary: Manage webapp authentication and authorization
+type: group
+short-summary: Manage webapp authentication and authorization
 """
 
 helps['webapp auth show'] = """
-    type: command
-    short-summary: Show the authentification settings for the webapp.
+type: command
+short-summary: Show the authentification settings for the webapp.
 """
 
 helps['webapp auth update'] = """
-    type: command
-    short-summary: Update the authentication settings for the webapp.
-    examples:
-    - name: Enable AAD by enabling authentication and setting AAD-associated parameters. Default provider is set to AAD. Must have created a AAD service principal beforehand.
-      text: >
-        az webapp auth update  -g myResourceGroup -n myUniqueApp --enabled true \\
-          --action LoginWithAzureActiveDirectory \\
-          --aad-allowed-token-audiences https://webapp_name.azurewebsites.net/.auth/login/aad/callback \\
-          --aad-client-id ecbacb08-df8b-450d-82b3-3fced03f2b27 --aad-client-secret very_secret_password \\
+type: command
+short-summary: Update the authentication settings for the webapp.
+examples:
+  - name: Enable AAD by enabling authentication and setting AAD-associated parameters. Default provider is set to AAD. Must have created a AAD service principal beforehand.
+    text: >
+        az webapp auth update  -g myResourceGroup -n myUniqueApp --enabled true \
+          --action LoginWithAzureActiveDirectory \
+          --aad-allowed-token-audiences https://webapp_name.azurewebsites.net/.auth/login/aad/callback \
+          --aad-client-id ecbacb08-df8b-450d-82b3-3fced03f2b27 --aad-client-secret very_secret_password \
           --aad-token-issuer-url https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7983a3e9c5a/
-    - name: Allow Facebook authentication by setting FB-associated parameters and turning on public-profile and email scopes; allow anonymous users
-      text: >
-        az webapp auth update -g myResourceGroup -n myUniqueApp --action AllowAnonymous \\
-          --facebook-app-id my_fb_id --facebook-app-secret my_fb_secret \\
+  - name: Allow Facebook authentication by setting FB-associated parameters and turning on public-profile and email scopes; allow anonymous users
+    text: >
+        az webapp auth update -g myResourceGroup -n myUniqueApp --action AllowAnonymous \
+          --facebook-app-id my_fb_id --facebook-app-secret my_fb_secret \
           --facebook-oauth-scopes public_profile email
 """
 
-helps['webapp identity assign'] = """
-    type: command
-    short-summary: assign or disable managed service identity to the web app
-    examples:
-        - name: assign local identity and assign a reader role to the current resource group.
-          text: >
-            az webapp identity assign -g MyResourceGroup -n MyUniqueApp --role reader --scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/MyResourceGroup
-        - name: enable identity for the web app.
-          text: >
-            az webapp identity assign -g MyResourceGroup -n MyUniqueApp
+helps['webapp browse'] = """
+type: command
+short-summary: Open a web app in a browser.
 """
-
-helps['webapp identity'] = """
-    type: group
-    short-summary: manage web app's managed service identity
-"""
-
-helps['webapp identity show'] = """
-    type: command
-    short-summary: display web app's managed service identity
-"""
-
-helps['webapp identity remove'] = """
-    type: command
-    short-summary: Disable web app's managed service identity
-"""
-
-helps['functionapp identity'] = helps['webapp identity'].replace('webapp', 'functionapp')
-
-helps['functionapp identity assign'] = helps['webapp identity assign'].replace('webapp', 'functionapp')
-
-helps['functionapp identity show'] = helps['webapp identity show'].replace('webapp', 'functionapp')
-
-helps['functionapp identity remove'] = helps['webapp identity remove'].replace('webapp', 'functionapp')
 
 helps['webapp config'] = """
 type: group
 short-summary: Configure a web app.
-"""
-
-helps['webapp config show'] = """
-type: command
-short-summary: Get the details of a web app's configuration.
-"""
-
-helps['webapp config set'] = """
-type: command
-short-summary: Set a web app's configuration.
-Examples:
-    - name: turn on "alwaysOn"
-      text: >
-        az webapp config set -g MyResourceGroup -n MyUniqueApp --always-on true
-    - name: turn on "alwaysOn" through a json with content '{"alwaysOn", true}'
-      text: >
-        az webapp config set -g MyResourceGroup -n MyUniqueApp --generic-configurations "{\"alwaysOn\": true}"
-
 """
 
 helps['webapp config appsettings'] = """
@@ -122,53 +430,42 @@ helps['webapp config appsettings set'] = """
 type: command
 short-summary: Set a web app's settings.
 examples:
-    - name: Set the default NodeJS version to 6.9.1 for a web app.
-      text: >
+  - name: Set the default NodeJS version to 6.9.1 for a web app.
+    text: >
         az webapp config appsettings set -g MyResourceGroup -n MyUniqueApp --settings WEBSITE_NODE_DEFAULT_VERSION=6.9.1
-    - name: Set using both key-value pair and a json file with more settings.
-      text: >
+  - name: Set using both key-value pair and a json file with more settings.
+    text: >
         az webapp config appsettings set -g MyResourceGroup -n MyUniqueApp --settings mySetting=value @moreSettings.json
 """
 
-helps['webapp config storage-account'] = """
+helps['webapp config backup'] = """
 type: group
-short-summary: Manage a web app's Azure storage account configurations. (Linux Web Apps and Windows Containers Web Apps Only)
+short-summary: Manage backups for web apps.
 """
 
-helps['webapp config storage-account list'] = """
+helps['webapp config backup create'] = """
 type: command
-short-summary: Get a web app's Azure storage account configurations. (Linux Web Apps and Windows Containers Web Apps Only)
+short-summary: Create a backup of a web app.
 """
 
-helps['webapp config storage-account add'] = """
+helps['webapp config backup list'] = """
 type: command
-short-summary: Add an Azure storage account configuration to a web app. (Linux Web Apps and Windows Containers Web Apps Only)
-examples:
-    - name: Add a connection to the Azure Files file share called MyShare in the storage account named MyStorageAccount.
-      text: >
-        az webapp config storage-account add -g MyResourceGroup -n MyUniqueApp \\
-          --custom-id CustomId \\
-          --storage-type AzureFiles \\
-          --account-name MyStorageAccount \\
-          --share-name MyShare \\
-          --access-key MyAccessKey \\
-          --mount-path /path/to/mount
+short-summary: List backups of a web app.
 """
 
-helps['webapp config storage-account update'] = """
+helps['webapp config backup restore'] = """
 type: command
-short-summary: Update an existing Azure storage account configuration on a web app. (Linux Web Apps and Windows Containers Web Apps Only)
-examples:
-    - name: Update the mount path for a connection to the Azure Files file share with the ID MyId.
-      text: >
-        az webapp config storage-account update -g MyResourceGroup -n MyUniqueApp \\
-          --custom-id CustomId \\
-          --mount-path /path/to/new/mount
+short-summary: Restore a web app from a backup.
 """
 
-helps['webapp config storage-account delete'] = """
+helps['webapp config backup show'] = """
 type: command
-short-summary: Delete a web app's Azure storage account configuration. (Linux Web Apps and Windows Containers Web Apps Only)
+short-summary: Show the backup schedule for a web app.
+"""
+
+helps['webapp config backup update'] = """
+type: command
+short-summary: Configure a new backup schedule for a web app.
 """
 
 helps['webapp config connection-string'] = """
@@ -176,23 +473,23 @@ type: group
 short-summary: Manage a web app's connection strings.
 """
 
-helps['webapp config connection-string list'] = """
-type: command
-short-summary: Get a web app's connection strings.
-"""
-
 helps['webapp config connection-string delete'] = """
 type: command
 short-summary: Delete a web app's connection strings.
+"""
+
+helps['webapp config connection-string list'] = """
+type: command
+short-summary: Get a web app's connection strings.
 """
 
 helps['webapp config connection-string set'] = """
 type: command
 short-summary: Update a web app's connection strings.
 examples:
-    - name: Add a mysql connection string.
-      text: >
-        az webapp config connection-string set -g MyResourceGroup -n MyUniqueApp -t mysql \\
+  - name: Add a mysql connection string.
+    text: >
+        az webapp config connection-string set -g MyResourceGroup -n MyUniqueApp -t mysql \
             --settings mysql1='Server=myServer;Database=myDB;Uid=myUser;Pwd=myPwd;'
 """
 
@@ -201,9 +498,9 @@ type: group
 short-summary: Manage web app container settings.
 """
 
-helps['webapp config container show'] = """
+helps['webapp config container delete'] = """
 type: command
-short-summary: Get details of a web app container's settings.
+short-summary: Delete a web app container's settings.
 """
 
 helps['webapp config container set'] = """
@@ -211,39 +508,52 @@ type: command
 short-summary: Set a web app container's settings.
 """
 
-helps['webapp config container delete'] = """
+helps['webapp config container show'] = """
 type: command
-short-summary: Delete a web app container's settings.
+short-summary: Get details of a web app container's settings.
 """
 
-helps['webapp config ssl'] = """
+helps['webapp config hostname'] = """
 type: group
-short-summary: Configure SSL certificates for web apps.
+short-summary: Configure hostnames for a web app.
 """
 
-helps['webapp config ssl list'] = """
+helps['webapp config hostname add'] = """
 type: command
-short-summary: List SSL certificates for a web app.
+short-summary: Bind a hostname to a web app.
 """
 
-helps['webapp config ssl bind'] = """
+helps['webapp config hostname delete'] = """
 type: command
-short-summary: Bind an SSL certificate to a web app.
+short-summary: Unbind a hostname from a web app.
 """
 
-helps['webapp config ssl unbind'] = """
+helps['webapp config hostname get-external-ip'] = """
 type: command
-short-summary: Unbind an SSL certificate from a web app.
+short-summary: Get the external-facing IP address for a web app.
 """
 
-helps['webapp config ssl delete'] = """
+helps['webapp config hostname list'] = """
 type: command
-short-summary: Delete an SSL certificate from a web app.
+short-summary: List all hostname bindings for a web app.
 """
 
-helps['webapp config ssl upload'] = """
+helps['webapp config set'] = """
 type: command
-short-summary: Upload an SSL certificate to a web app.
+short-summary: Set a web app's configuration.
+Examples:
+  - name: turn on "alwaysOn"
+    text: >
+        az webapp config set -g MyResourceGroup -n MyUniqueApp --always-on true
+  - name: turn on "alwaysOn" through a json with content '{"alwaysOn", true}'
+    text: >
+        az webapp config set -g MyResourceGroup -n MyUniqueApp --generic-configurations "{"alwaysOn": true}"
+
+"""
+
+helps['webapp config show'] = """
+type: command
+short-summary: Get the details of a web app's configuration.
 """
 
 helps['webapp config snapshot'] = """
@@ -260,64 +570,160 @@ helps['webapp config snapshot restore'] = """
 type: command
 short-summary: Restore a web app snapshot.
 examples:
-    - name: Restore web app files from a snapshot. Overwrites the web app's current files and settings.
-      text: >
+  - name: Restore web app files from a snapshot. Overwrites the web app's current files and settings.
+    text: >
         az webapp config snapshot restore -g MyResourceGroup -n MySite --time 2018-12-11T23:34:16.8388367
-    - name: Restore a snapshot of web app SourceApp to web app TargetApp. Use --restore-content-only to not restore app settings. Overwrites TargetApp's files.
-      text: >
+  - name: Restore a snapshot of web app SourceApp to web app TargetApp. Use --restore-content-only to not restore app settings. Overwrites TargetApp's files.
+    text: >
         az webapp config snapshot restore -g TargetResourceGroup -n TargetApp --source-name SourceApp --source-resource-group OriginalResourceGroup --time 2018-12-11T23:34:16.8388367 --restore-content-only
 """
 
+helps['webapp config ssl'] = """
+type: group
+short-summary: Configure SSL certificates for web apps.
+"""
+
+helps['webapp config ssl bind'] = """
+type: command
+short-summary: Bind an SSL certificate to a web app.
+"""
+
+helps['webapp config ssl delete'] = """
+type: command
+short-summary: Delete an SSL certificate from a web app.
+"""
+
+helps['webapp config ssl list'] = """
+type: command
+short-summary: List SSL certificates for a web app.
+"""
+
+helps['webapp config ssl unbind'] = """
+type: command
+short-summary: Unbind an SSL certificate from a web app.
+"""
+
+helps['webapp config ssl upload'] = """
+type: command
+short-summary: Upload an SSL certificate to a web app.
+"""
+
+helps['webapp config storage-account'] = """
+type: group
+short-summary: Manage a web app's Azure storage account configurations. (Linux Web Apps and Windows Containers Web Apps Only)
+"""
+
+helps['webapp config storage-account add'] = """
+type: command
+short-summary: Add an Azure storage account configuration to a web app. (Linux Web Apps and Windows Containers Web Apps Only)
+examples:
+  - name: Add a connection to the Azure Files file share called MyShare in the storage account named MyStorageAccount.
+    text: >
+        az webapp config storage-account add -g MyResourceGroup -n MyUniqueApp \
+          --custom-id CustomId \
+          --storage-type AzureFiles \
+          --account-name MyStorageAccount \
+          --share-name MyShare \
+          --access-key MyAccessKey \
+          --mount-path /path/to/mount
+"""
+
+helps['webapp config storage-account delete'] = """
+type: command
+short-summary: Delete a web app's Azure storage account configuration. (Linux Web Apps and Windows Containers Web Apps Only)
+"""
+
+helps['webapp config storage-account list'] = """
+type: command
+short-summary: Get a web app's Azure storage account configurations. (Linux Web Apps and Windows Containers Web Apps Only)
+"""
+
+helps['webapp config storage-account update'] = """
+type: command
+short-summary: Update an existing Azure storage account configuration on a web app. (Linux Web Apps and Windows Containers Web Apps Only)
+examples:
+  - name: Update the mount path for a connection to the Azure Files file share with the ID MyId.
+    text: >
+        az webapp config storage-account update -g MyResourceGroup -n MyUniqueApp \
+          --custom-id CustomId \
+          --mount-path /path/to/new/mount
+"""
+
+helps['webapp cors'] = """
+type: group
+short-summary: Manage Cross-Origin Resource Sharing (CORS)
+"""
+
+helps['webapp cors add'] = """
+type: command
+short-summary: Add allowed origins
+examples:
+  - name: add a new allowed origin
+    text: >
+        az webapp cors add -g <myRG> -n <myAppName> --allowed-origins https://myapps.com
+"""
+
+helps['webapp cors remove'] = """
+type: command
+short-summary: Remove allowed origins
+examples:
+  - name: remove an allowed origin
+    text: >
+        az webapp cors remove -g <myRG> -n <myAppName> --allowed-origins https://myapps.com
+  - name: remove all allowed origins
+    text: >
+        az webapp cors remove -g <myRG> -n <myAppName> --allowed-origins *
+"""
+
+helps['webapp cors show'] = """
+type: command
+short-summary: show allowed origins
+"""
+
+helps['webapp create'] = """
+type: command
+short-summary: Create a web app.
+long-summary: The web app's name must be able to produce a unique FQDN as AppName.azurewebsites.net.
+examples:
+  - name: Create a web app with the default configuration.
+    text: >
+        az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueAppName
+  - name: Create a web app with a NodeJS 6.2 runtime and deployed from a local git repository.
+    text: >
+        az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueAppName --runtime "node|6.2" --deployment-local-git
+"""
+
+helps['webapp delete'] = """
+type: command
+short-summary: Delete a web app.
+"""
+
+helps['webapp deleted'] = """
+type: group
+short-summary: Manage deleted web apps.
+"""
+
+helps['webapp deleted list'] = """
+type: command
+short-summary: List web apps that have been deleted.
+"""
+
+helps['webapp deleted restore'] = """
+type: command
+short-summary: Restore a deleted web app.
+long-summary: Restores the files and settings of a deleted web app to the specified web app.
+examples:
+  - name: Restore a deleted app to the Staging slot of MySite.
+    text: >
+        az webapp deleted restore -g MyResourceGroup -n MySite -s Staging --deleted-id /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/deletedSites/1234
+  - name: Restore a deleted app to the app MySite. Do not restore the deleted app's settings.
+    text: >
+        az webapp deleted restore -g MyResourceGroup -n MySite --deleted-id /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/deletedSites/1234 --restore-content-only
+"""
+
 helps['webapp deployment'] = """
 type: group
 short-summary: Manage web app deployments.
-"""
-
-helps['webapp deployment slot'] = """
-type: group
-short-summary: Manage web app deployment slots.
-"""
-
-helps['webapp deployment slot auto-swap'] = """
-type: group
-short-summary: Enable or disable auto-swap for a web app deployment slot.
-"""
-
-helps['webapp log'] = """
-type: group
-short-summary: Manage web app logs.
-"""
-
-helps['webapp log config'] = """
-type: command
-short-summary: Configure logging for a web app.
-"""
-
-helps['webapp log show'] = """
-type: command
-short-summary: Get the details of a web app's logging configuration.
-"""
-
-helps['webapp log download'] = """
-type: command
-short-summary: Download a web app's log history as a zip file.
-long-summary: This command may not work with web apps running on Linux.
-"""
-
-helps['webapp log tail'] = """
-type: command
-short-summary: Start live log tracing for a web app.
-long-summary: This command may not work with web apps running on Linux.
-"""
-
-helps['webapp deployment'] = """
-type: group
-short-summary: Manage web app deployments.
-"""
-
-helps['webapp deployment list-publishing-profiles'] = """
-type: command
-short-summary: Get the details for available web app deployment profiles.
 """
 
 helps['webapp deployment container'] = """
@@ -335,6 +741,16 @@ type: command
 short-summary: Get the URL which can be used to configure webhooks for continuous deployment.
 """
 
+helps['webapp deployment list-publishing-profiles'] = """
+type: command
+short-summary: Get the details for available web app deployment profiles.
+"""
+
+helps['webapp deployment slot'] = """
+type: group
+short-summary: Manage web app deployment slots.
+"""
+
 helps['webapp deployment slot auto-swap'] = """
 type: command
 short-summary: Configure deployment slot auto swap.
@@ -345,14 +761,9 @@ type: command
 short-summary: Create a deployment slot.
 """
 
-helps['webapp deployment slot swap'] = """
+helps['webapp deployment slot delete'] = """
 type: command
-short-summary: Change deployment slots for a web app.
-examples:
-    - name: Swap a staging slot into production for the MyUniqueApp web app.
-      text: >
-        az webapp deployment slot swap  -g MyResourceGroup -n MyUniqueApp --slot staging \\
-            --target-slot production
+short-summary: Delete a deployment slot.
 """
 
 helps['webapp deployment slot list'] = """
@@ -360,9 +771,70 @@ type: command
 short-summary: List all deployment slots.
 """
 
-helps['webapp deployment slot delete'] = """
+helps['webapp deployment slot swap'] = """
 type: command
-short-summary: Delete a deployment slot.
+short-summary: Change deployment slots for a web app.
+examples:
+  - name: Swap a staging slot into production for the MyUniqueApp web app.
+    text: >
+        az webapp deployment slot swap  -g MyResourceGroup -n MyUniqueApp --slot staging \
+            --target-slot production
+"""
+
+helps['webapp deployment source'] = """
+type: group
+short-summary: Manage web app deployment via source control.
+"""
+
+helps['webapp deployment source config'] = """
+type: command
+short-summary: Manage deployment from git or Mercurial repositories.
+"""
+
+helps['webapp deployment source config-local-git'] = """
+type: command
+short-summary: Get a URL for a git repository endpoint to clone and push to for web app deployment.
+examples:
+  - name: Get an endpoint and add it as a git remote.
+    text: >
+        az webapp deployment source config-local-git \
+            -g MyResourceGroup -n MyUniqueApp
+
+        git remote add azure \
+            https://<deploy_user_name>@MyUniqueApp.scm.azurewebsites.net/MyUniqueApp.git
+"""
+
+helps['webapp deployment source config-zip'] = """
+type: command
+short-summary: Perform deployment using the kudu zip push deployment for a web app.
+long-summary: >
+    By default Kudu assumes that zip deployments do not require any build-related actions like
+    npm install or dotnet publish. This can be overridden by including a .deployment file in your
+    zip file with the following content '[config] SCM_DO_BUILD_DURING_DEPLOYMENT = true',
+    to enable Kudu detection logic and build script generation process.
+    See https://github.com/projectkudu/kudu/wiki/Configurable-settings#enabledisable-build-actions-preview.
+    Alternately the setting can be enabled using the az webapp config appsettings set command.
+examples:
+  - name: Perform deployment by using zip file content.
+    text: >
+        az webapp deployment source config-zip \
+            -g {myRG} -n {myAppName} \
+            --src {zipFilePathLocation}
+"""
+
+helps['webapp deployment source delete'] = """
+type: command
+short-summary: Delete a source control deployment configuration.
+"""
+
+helps['webapp deployment source show'] = """
+type: command
+short-summary: Get the details of a source control deployment configuration.
+"""
+
+helps['webapp deployment source sync'] = """
+type: command
+short-summary: Synchronize from the repository. Only needed under manual integration mode.
 """
 
 helps['webapp deployment user'] = """
@@ -373,684 +845,211 @@ short-summary: Manage user credentials for deployment.
 helps['webapp deployment user set'] = """
 type: command
 short-summary: Update deployment credentials.
-long-summary: All function and web apps in the subscription will be impacted since they share
-              the same deployment credentials.
+long-summary: All function and web apps in the subscription will be impacted since they share the same deployment credentials.
 examples:
-    - name: Set FTP and git deployment credentials for all apps.
-      text: >
+  - name: Set FTP and git deployment credentials for all apps.
+    text: >
         az webapp deployment user set --user-name MyUserName
 """
 
-helps['webapp deployment slot'] = """
+helps['webapp identity'] = """
 type: group
-short-summary: Manage web app deployment slots.
+short-summary: manage web app's managed service identity
 """
 
-helps['webapp deployment source'] = """
-    type: group
-    short-summary: Manage web app deployment via source control.
+helps['webapp identity assign'] = """
+type: command
+short-summary: assign or disable managed service identity to the web app
+examples:
+  - name: assign local identity and assign a reader role to the current resource group.
+    text: >
+        az webapp identity assign -g MyResourceGroup -n MyUniqueApp --role reader --scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/MyResourceGroup
+  - name: enable identity for the web app.
+    text: >
+        az webapp identity assign -g MyResourceGroup -n MyUniqueApp
 """
 
-helps['webapp deployment source config'] = """
-    type: command
-    short-summary: Manage deployment from git or Mercurial repositories.
+helps['webapp identity remove'] = """
+type: command
+short-summary: Disable web app's managed service identity
 """
 
-helps['webapp deployment source config-local-git'] = """
-    type: command
-    short-summary: Get a URL for a git repository endpoint to clone and push to for web app deployment.
-    examples:
-        - name: Get an endpoint and add it as a git remote.
-          text: >
-            az webapp deployment source config-local-git \\
-                -g MyResourceGroup -n MyUniqueApp
-
-            git remote add azure \\
-                https://<deploy_user_name>@MyUniqueApp.scm.azurewebsites.net/MyUniqueApp.git
-"""
-
-helps['webapp deployment source config-zip'] = """
-    type: command
-    short-summary: Perform deployment using the kudu zip push deployment for a web app.
-    long-summary: >
-        By default Kudu assumes that zip deployments do not require any build-related actions like
-        npm install or dotnet publish. This can be overridden by including a .deployment file in your
-        zip file with the following content '[config] SCM_DO_BUILD_DURING_DEPLOYMENT = true',
-        to enable Kudu detection logic and build script generation process.
-        See https://github.com/projectkudu/kudu/wiki/Configurable-settings#enabledisable-build-actions-preview.
-        Alternately the setting can be enabled using the az webapp config appsettings set command.
-    examples:
-         - name: Perform deployment by using zip file content.
-           text: >
-             az webapp deployment source config-zip \\
-                 -g {myRG} -n {myAppName} \\
-                 --src {zipFilePathLocation}
-"""
-
-helps['webapp deployment source delete'] = """
-    type: command
-    short-summary: Delete a source control deployment configuration.
-"""
-
-helps['webapp deployment source show'] = """
-    type: command
-    short-summary: Get the details of a source control deployment configuration.
-"""
-
-helps['webapp deployment source sync'] = """
-    type: command
-    short-summary: Synchronize from the repository. Only needed under manual integration mode.
-"""
-
-helps['webapp traffic-routing'] = """
-    type: group
-    short-summary: Manage traffic routing for web apps.
-"""
-
-helps['webapp traffic-routing set'] = """
-    type: command
-    short-summary: Configure routing traffic to deployment slots.
-"""
-
-helps['webapp traffic-routing show'] = """
-    type: command
-    short-summary: Display the current distribution of traffic across slots.
-"""
-
-helps['webapp traffic-routing clear'] = """
-    type: command
-    short-summary: Clear the routing rules and send all traffic to production.
-"""
-
-helps['webapp cors'] = """
-    type: group
-    short-summary: Manage Cross-Origin Resource Sharing (CORS)
-"""
-
-helps['webapp cors add'] = """
-    type: command
-    short-summary: Add allowed origins
-    examples:
-         - name: add a new allowed origin
-           text: >
-             az webapp cors add -g <myRG> -n <myAppName> --allowed-origins https://myapps.com
-"""
-
-helps['webapp cors remove'] = """
-    type: command
-    short-summary: Remove allowed origins
-    examples:
-         - name: remove an allowed origin
-           text: >
-             az webapp cors remove -g <myRG> -n <myAppName> --allowed-origins https://myapps.com
-         - name: remove all allowed origins
-           text: >
-             az webapp cors remove -g <myRG> -n <myAppName> --allowed-origins *
-"""
-
-helps['webapp cors show'] = """
-    type: command
-    short-summary: show allowed origins
-"""
-
-helps['appservice plan'] = """
-    type: group
-    short-summary: Manage app service plans.
-"""
-
-helps['appservice list-locations'] = """
-    type: command
-    short-summary: List regions where a plan sku is available.
-"""
-
-helps['appservice plan update'] = """
-    type: command
-    short-summary: Update an app service plan. See https://docs.microsoft.com/en-us/azure/app-service/app-service-plan-manage#move-an-app-to-another-app-service-plan to learn more
-"""
-
-helps['appservice plan create'] = """
-    type: command
-    short-summary: Create an app service plan.
-    examples:
-        - name: Create a basic app service plan.
-          text: >
-            az appservice plan create -g MyResourceGroup -n MyPlan
-        - name: Create a standard app service plan with with four Linux workers.
-          text: >
-            az appservice plan create -g MyResourceGroup -n MyPlan \\
-                --is-linux --number-of-workers 4 --sku S1
-"""
-
-helps['appservice plan delete'] = """
-    type: command
-    short-summary: Delete an app service plan.
-"""
-
-helps['appservice plan list'] = """
-    type: command
-    short-summary: List app service plans.
-    examples:
-        - name: List all free tier App Service plans.
-          text: >
-            az appservice plan list --query "[?sku.tier=='Free']"
-"""
-
-helps['appservice plan show'] = """
-    type: command
-    short-summary: Get the app service plans for a resource group or a set of resource groups.
-"""
-
-helps['webapp config hostname'] = """
-type: group
-short-summary: Configure hostnames for a web app.
-"""
-
-helps['webapp config hostname add'] = """
-    type: command
-    short-summary: Bind a hostname to a web app.
-"""
-
-helps['webapp config hostname delete'] = """
-    type: command
-    short-summary: Unbind a hostname from a web app.
-"""
-
-helps['webapp config hostname list'] = """
-    type: command
-    short-summary: List all hostname bindings for a web app.
-"""
-
-helps['webapp config hostname get-external-ip'] = """
-    type: command
-    short-summary: Get the external-facing IP address for a web app.
-"""
-
-helps['webapp config backup'] = """
-    type: group
-    short-summary: Manage backups for web apps.
-"""
-
-helps['webapp config backup list'] = """
-    type: command
-    short-summary: List backups of a web app.
-"""
-
-helps['webapp config backup create'] = """
-    type: command
-    short-summary: Create a backup of a web app.
-"""
-
-helps['webapp config backup show'] = """
-    type: command
-    short-summary: Show the backup schedule for a web app.
-"""
-
-helps['webapp config backup update'] = """
-    type: command
-    short-summary: Configure a new backup schedule for a web app.
-"""
-
-helps['webapp config backup restore'] = """
-    type: command
-    short-summary: Restore a web app from a backup.
-"""
-
-helps['webapp webjob'] = """
-    type: group
-    short-summary: Allows management operations for webjobs on a web app.
-"""
-
-helps['webapp webjob continuous'] = """
-    type: group
-    short-summary: Allows management operations of continuous webjobs on a web app.
-"""
-
-helps['webapp webjob continuous list'] = """
-    type: command
-    short-summary: List all continuous webjobs on a selected web app.
-"""
-
-helps['webapp webjob continuous start'] = """
-    type: command
-    short-summary: Start a specific continuous webjob on a selected web app.
-"""
-
-helps['webapp webjob continuous stop'] = """
-    type: command
-    short-summary: Stop a specific continuous webjob.
-"""
-
-helps['webapp webjob continuous remove'] = """
-    type: command
-    short-summary: Delete a specific continuous webjob.
-"""
-
-helps['webapp webjob triggered'] = """
-    type: group
-    short-summary: Allows management operations of triggered webjobs on a web app.
-"""
-
-helps['webapp webjob triggered list'] = """
-    type: command
-    short-summary: List all triggered webjobs hosted on a web app.
-"""
-
-helps['webapp webjob triggered run'] = """
-    type: command
-    short-summary: Run a specific triggered webjob hosted on a web app.
-"""
-
-helps['webapp webjob triggered remove'] = """
-    type: command
-    short-summary: Delete a specific triggered webjob hosted on a web app.
-"""
-
-helps['webapp webjob triggered log'] = """
-    type: command
-    short-summary: Get history of a specific triggered webjob hosted on a web app.
-"""
-
-helps['webapp browse'] = """
-    type: command
-    short-summary: Open a web app in a browser.
-"""
-
-helps['webapp create'] = """
-    type: command
-    short-summary: Create a web app.
-    long-summary: The web app's name must be able to produce a unique FQDN as AppName.azurewebsites.net.
-    examples:
-        - name: Create a web app with the default configuration.
-          text: >
-            az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueAppName
-        - name: Create a web app with a NodeJS 6.2 runtime and deployed from a local git repository.
-          text: >
-            az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueAppName --runtime "node|6.2" --deployment-local-git
-"""
-
-helps['webapp ssh'] = """
-    type: command
-    short-summary: (Preview) SSH command establishes a ssh session to the web container and developer would get a shell terminal remotely.
-    examples:
-        - name: ssh into a web app
-          text: >
-            az webapp ssh -n MyUniqueAppName -g MyResourceGroup
-"""
-
-helps['webapp up'] = """
-    type: command
-    short-summary: (Preview) Create and deploy existing local code to the web app, by running the command from the folder where the code is present.
-                   Supports running the command in preview mode using --dryrun parameter. Current supports includes Node, Python,.NET Core, ASP.NET,
-                   staticHtml. Node, Python apps are created as Linux apps. .Net Core, ASP.NET and static HTML apps are created as Windows apps.
-                   If command is run from an empty folder, an empty windows web app is created.
-    examples:
-        - name: View the details of the app that will be created, without actually running the operation
-          text: >
-            az webapp up -n MyUniqueAppName --dryrun
-        - name: Create a web app with the default configuration, by running the command from the folder where the code to deployed exists.
-          text: >
-            az webapp up -n MyUniqueAppName
-        - name: Create a web app in a sepcific region, by running the command from the folder where the code to deployed exists.
-          text: >
-            az webapp up -n MyUniqueAppName -l locationName
-        - name: Deploy new code to an app that was originally created using the same command
-          text: >
-            az webapp up -n MyUniqueAppName -l locationName
-"""
-
-helps['webapp update'] = """
-    type: command
-    short-summary: Update a web app.
-    examples:
-        - name: Update the tags of a web app.
-          text: >
-            az webapp update -g MyResourceGroup -n MyAppName --set tags.tagName=tagValue
-"""
-
-helps['webapp list-runtimes'] = """
-    type: command
-    short-summary: List available built-in stacks which can be used for web apps.
-"""
-
-helps['webapp deleted'] = """
-    type: group
-    short-summary: Manage deleted web apps.
-"""
-
-helps['webapp deleted list'] = """
-    type: command
-    short-summary: List web apps that have been deleted.
-"""
-
-helps['webapp deleted restore'] = """
-    type: command
-    short-summary: Restore a deleted web app.
-    long-summary: Restores the files and settings of a deleted web app to the specified web app.
-    examples:
-        - name: Restore a deleted app to the Staging slot of MySite.
-          text: >
-            az webapp deleted restore -g MyResourceGroup -n MySite -s Staging --deleted-id /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/deletedSites/1234
-        - name: Restore a deleted app to the app MySite. Do not restore the deleted app's settings.
-          text: >
-            az webapp deleted restore -g MyResourceGroup -n MySite --deleted-id /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/deletedSites/1234 --restore-content-only
-"""
-
-
-helps['webapp delete'] = """
-    type: command
-    short-summary: Delete a web app.
+helps['webapp identity show'] = """
+type: command
+short-summary: display web app's managed service identity
 """
 
 helps['webapp list'] = """
-    type: command
-    short-summary: List web apps.
-    examples:
-        - name: List default host name and state for all web apps.
-          text: >
-            az webapp list --query "[].{hostName: defaultHostName, state: state}"
-        - name: List all running web apps.
-          text: >
-            az webapp list --query "[?state=='Running']"
+type: command
+short-summary: List web apps.
+examples:
+  - name: List default host name and state for all web apps.
+    text: >
+        az webapp list --query "[].{hostName: defaultHostName, state: state}"
+  - name: List all running web apps.
+    text: >
+        az webapp list --query "[?state=='Running']"
+"""
+
+helps['webapp list-runtimes'] = """
+type: command
+short-summary: List available built-in stacks which can be used for web apps.
+"""
+
+helps['webapp log'] = """
+type: group
+short-summary: Manage web app logs.
+"""
+
+helps['webapp log config'] = """
+type: command
+short-summary: Configure logging for a web app.
+"""
+
+helps['webapp log download'] = """
+type: command
+short-summary: Download a web app's log history as a zip file.
+long-summary: This command may not work with web apps running on Linux.
+"""
+
+helps['webapp log show'] = """
+type: command
+short-summary: Get the details of a web app's logging configuration.
+"""
+
+helps['webapp log tail'] = """
+type: command
+short-summary: Start live log tracing for a web app.
+long-summary: This command may not work with web apps running on Linux.
 """
 
 helps['webapp restart'] = """
-    type: command
-    short-summary: Restart a web app.
-"""
-
-helps['webapp start'] = """
-    type: command
-    short-summary: Start a web app.
+type: command
+short-summary: Restart a web app.
 """
 
 helps['webapp show'] = """
-    type: command
-    short-summary: Get the details of a web app.
+type: command
+short-summary: Get the details of a web app.
+"""
+
+helps['webapp ssh'] = """
+type: command
+short-summary: (Preview) SSH command establishes a ssh session to the web container and developer would get a shell terminal remotely.
+examples:
+  - name: ssh into a web app
+    text: >
+        az webapp ssh -n MyUniqueAppName -g MyResourceGroup
+"""
+
+helps['webapp start'] = """
+type: command
+short-summary: Start a web app.
 """
 
 helps['webapp stop'] = """
-    type: command
-    short-summary: Stop a web app.
+type: command
+short-summary: Stop a web app.
 """
 
-helps['functionapp'] = """
-    type: group
-    short-summary: Manage function apps.
+helps['webapp traffic-routing'] = """
+type: group
+short-summary: Manage traffic routing for web apps.
 """
 
-helps['functionapp create'] = """
-    type: command
-    short-summary: Create a function app.
-    long-summary: The function app's name must be able to produce a unique FQDN as AppName.azurewebsites.net.
-    examples:
-        - name: Create a basic function app.
-          text: >
-            az functionapp create -g MyResourceGroup  -p MyPlan -n MyUniqueAppName -s MyStorageAccount
+helps['webapp traffic-routing clear'] = """
+type: command
+short-summary: Clear the routing rules and send all traffic to production.
 """
 
-helps['functionapp update'] = """
-    type: command
-    short-summary: Update a function app.
+helps['webapp traffic-routing set'] = """
+type: command
+short-summary: Configure routing traffic to deployment slots.
 """
 
-helps['functionapp delete'] = """
-    type: command
-    short-summary: Delete a function app.
+helps['webapp traffic-routing show'] = """
+type: command
+short-summary: Display the current distribution of traffic across slots.
 """
 
-helps['functionapp list'] = """
-    type: command
-    short-summary: List function apps.
-    examples:
-        - name: List default host name and state for all function apps.
-          text: >
-            az functionapp list --query "[].{hostName: defaultHostName, state: state}"
-        - name: List all running function apps.
-          text: >
-            az functionapp list --query "[?state=='Running']"
+helps['webapp up'] = """
+type: command
+short-summary: (Preview) Create and deploy existing local code to the web app, by running the command from the folder where the code is present. Supports running the command in preview mode using --dryrun parameter. Current supports includes Node, Python,.NET Core, ASP.NET, staticHtml. Node, Python apps are created as Linux apps. .Net Core, ASP.NET and static HTML apps are created as Windows apps. If command is run from an empty folder, an empty windows web app is created.
+examples:
+  - name: View the details of the app that will be created, without actually running the operation
+    text: >
+        az webapp up -n MyUniqueAppName --dryrun
+  - name: Create a web app with the default configuration, by running the command from the folder where the code to deployed exists.
+    text: >
+        az webapp up -n MyUniqueAppName
+  - name: Create a web app in a sepcific region, by running the command from the folder where the code to deployed exists.
+    text: >
+        az webapp up -n MyUniqueAppName -l locationName
+  - name: Deploy new code to an app that was originally created using the same command
+    text: >
+        az webapp up -n MyUniqueAppName -l locationName
 """
 
-helps['functionapp restart'] = """
-    type: command
-    short-summary: Restart a function app.
+helps['webapp update'] = """
+type: command
+short-summary: Update a web app.
+examples:
+  - name: Update the tags of a web app.
+    text: >
+        az webapp update -g MyResourceGroup -n MyAppName --set tags.tagName=tagValue
 """
 
-helps['functionapp start'] = """
-    type: command
-    short-summary: Start a function app.
+helps['webapp webjob'] = """
+type: group
+short-summary: Allows management operations for webjobs on a web app.
 """
 
-helps['functionapp show'] = """
-    type: command
-    short-summary: Get the details of a function app.
+helps['webapp webjob continuous'] = """
+type: group
+short-summary: Allows management operations of continuous webjobs on a web app.
 """
 
-helps['functionapp stop'] = """
-    type: command
-    short-summary: Stop a function app.
+helps['webapp webjob continuous list'] = """
+type: command
+short-summary: List all continuous webjobs on a selected web app.
 """
 
-helps['functionapp list-consumption-locations'] = """
-    type: command
-    short-summary: List available locations for running function apps.
+helps['webapp webjob continuous remove'] = """
+type: command
+short-summary: Delete a specific continuous webjob.
 """
 
-helps['functionapp config'] = """
-    type: group
-    short-summary: Configure a function app.
+helps['webapp webjob continuous start'] = """
+type: command
+short-summary: Start a specific continuous webjob on a selected web app.
 """
 
-helps['functionapp config appsettings'] = """
-    type: group
-    short-summary: Configure function app settings.
+helps['webapp webjob continuous stop'] = """
+type: command
+short-summary: Stop a specific continuous webjob.
 """
 
-helps['functionapp config appsettings list'] = """
-    type: command
-    short-summary: Show settings for a function app.
+helps['webapp webjob triggered'] = """
+type: group
+short-summary: Allows management operations of triggered webjobs on a web app.
 """
 
-helps['functionapp config appsettings set'] = """
-    type: command
-    short-summary: Update a function app's settings.
+helps['webapp webjob triggered list'] = """
+type: command
+short-summary: List all triggered webjobs hosted on a web app.
 """
 
-helps['functionapp config appsettings delete'] = """
-    type: command
-    short-summary: Delete a function app's settings.
+helps['webapp webjob triggered log'] = """
+type: command
+short-summary: Get history of a specific triggered webjob hosted on a web app.
 """
 
-helps['functionapp config hostname'] = """
-    type: group
-    short-summary: Configure hostnames for a function app.
-"""
-helps['functionapp config hostname add'] = """
-    type: command
-    short-summary: Bind a hostname to a function app.
+helps['webapp webjob triggered remove'] = """
+type: command
+short-summary: Delete a specific triggered webjob hosted on a web app.
 """
 
-helps['functionapp config hostname delete'] = """
-    type: command
-    short-summary: Unbind a hostname from a function app.
-"""
-
-helps['functionapp config hostname list'] = """
-    type: command
-    short-summary: List all hostname bindings for a function app.
-"""
-
-helps['functionapp config hostname get-external-ip'] = """
-    type: command
-    short-summary: Get the external-facing IP address for a function app.
-"""
-
-helps['functionapp config ssl'] = """
-    type: group
-    short-summary: Configure SSL certificates.
-"""
-
-helps['functionapp config ssl list'] = """
-    type: command
-    short-summary: List SSL certificates for a function app.
-"""
-
-helps['functionapp config ssl bind'] = """
-    type: command
-    short-summary: Bind an SSL certificate to a function app.
-"""
-
-helps['functionapp config ssl unbind'] = """
-    type: command
-    short-summary: Unbind an SSL certificate from a function app.
-"""
-
-helps['functionapp config ssl delete'] = """
-    type: command
-    short-summary: Delete an SSL certificate from a function app.
-"""
-
-helps['functionapp config ssl upload'] = """
-    type: command
-    short-summary: Upload an SSL certificate to a function app.
-"""
-
-helps['functionapp config show'] = """
-    type: command
-    short-summary: Get the details of a web app's configuration.
-"""
-
-helps['functionapp config set'] = """
-    type: command
-    short-summary: Set the web app's configuration.
-"""
-
-helps['functionapp deployment'] = """
-    type: group
-    short-summary: Manage function app deployments.
-"""
-
-helps['functionapp deployment list-publishing-profiles'] = """
-    type: command
-    short-summary: Get the details for available function app deployment profiles.
-"""
-
-helps['functionapp deployment source'] = """
-    type: group
-    short-summary: Manage function app deployment via source control.
-"""
-
-helps['functionapp deployment source config'] = """
-    type: command
-    short-summary: Manage deployment from git or Mercurial repositories.
-"""
-
-helps['functionapp deployment source config-local-git'] = """
-    type: command
-    short-summary: Get a URL for a git repository endpoint to clone and push to for function app deployment.
-    examples:
-        - name: Get an endpoint and add it as a git remote.
-          text: >
-            az functionapp deployment source config-local-git \\
-                -g MyResourceGroup -n MyUniqueApp
-
-            git remote add azure \\
-                https://<deploy_user_name>@MyUniqueApp.scm.azurewebsites.net/MyUniqueApp.git
-"""
-
-helps['functionapp deployment source delete'] = """
-    type: command
-    short-summary: Delete a source control deployment configuration.
-"""
-
-helps['functionapp deployment source show'] = """
-    type: command
-    short-summary: Get the details of a source control deployment configuration.
-"""
-
-helps['functionapp deployment source sync'] = """
-    type: command
-    short-summary: Synchronize from the repository. Only needed under manual integration mode.
-"""
-
-helps['functionapp deployment user'] = """
-    type: group
-    short-summary: Manage user credentials for deployment.
-"""
-
-helps['functionapp deployment user set'] = """
-    type: command
-    short-summary: Update deployment credentials.
-    long-summary: All function and web apps in the subscription will be impacted since they share
-                  the same deployment credentials.
-    examples:
-        - name: Set FTP and git deployment credentials for all apps.
-          text: >
-            az functionapp deployment user set
-            --user-name MyUserName
-"""
-
-helps['functionapp deployment source config-zip'] = """
-    type: command
-    short-summary: Perform deployment using the kudu zip push deployment for a function app.
-    long-summary: >
-        By default Kudu assumes that zip deployments do not require any build-related actions like
-        npm install or dotnet publish. This can be overridden by including an .deployment file in your
-        zip file with the following content '[config] SCM_DO_BUILD_DURING_DEPLOYMENT = true',
-        to enable Kudu detection logic and build script generation process.
-        See https://github.com/projectkudu/kudu/wiki/Configurable-settings#enabledisable-build-actions-preview.
-        Alternately the setting can be enabled using the az functionapp config appsettings set command.
-    examples:
-         - name: Perform deployment by using zip file content.
-           text: >
-             az functionapp deployment source config-zip \\
-                 -g {myRG>} -n {myAppName} \\
-                 --src {zipFilePathLocation}
-"""
-
-helps['functionapp cors'] = """
-    type: group
-    short-summary: Manage Cross-Origin Resource Sharing (CORS)
-"""
-
-helps['functionapp cors add'] = """
-    type: command
-    short-summary: Add allowed origins
-    examples:
-         - name: add a new allowed origin
-           text: >
-             az functionapp cors add -g <myRG> -n <myAppName> --allowed-origins https://myapps.com
-"""
-
-helps['functionapp cors remove'] = """
-    type: command
-    short-summary: Remove allowed origins
-    examples:
-         - name: remove an allowed origin
-           text: >
-             az functionapp cors remove -g <myRG> -n <myAppName> --allowed-origins https://myapps.com
-         - name: remove all allowed origins
-           text: >
-             az functionapp cors remove -g <myRG> -n <myAppName> --allowed-origins *
-"""
-
-helps['functionapp cors show'] = """
-    type: command
-    short-summary: show allowed origins
-"""
-
-helps['functionapp plan'] = """
-    type: group
-    short-summary: Manage App Service Plans for an Azure Function
-"""
-
-helps['functionapp plan create'] = """
-    type: command
-    short-summary: Create an App Service Plan for an Azure Function
-    examples:
-        - name: Create a basic app service plan.
-          text: >
-            az functionapp plan create -g MyResourceGroup -n MyPlan --sku B1
-        - name: Create a standard app service plan with with four workers.
-          text: >
-            az functionapp plan create -g MyResourceGroup -n MyPlan --number-of-workers 4 --sku S1
+helps['webapp webjob triggered run'] = """
+type: command
+short-summary: Run a specific triggered webjob hosted on a web app.
 """

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -52,11 +52,19 @@ examples:
 helps['appservice plan show'] = """
 type: command
 short-summary: Get the app service plans for a resource group or a set of resource groups.
+examples:
+  - name: Get the app service plans for a resource group or a set of resource groups. (commonly used with --output)
+    text: 'az appservice plan show --name MyAppServicePlan --resource-group MyResourceGroup  '
+    crafted: true
 """
 
 helps['appservice plan update'] = """
 type: command
 short-summary: Update an app service plan. See https://docs.microsoft.com/en-us/azure/app-service/app-service-plan-manage#move-an-app-to-another-app-service-plan to learn more
+examples:
+  - name: Update an app service plan. (crafted)
+    text: az appservice plan update --name MyAppServicePlan --resource-group MyResourceGroup --sku S1
+    crafted: true
 """
 
 helps['functionapp'] = """
@@ -82,11 +90,19 @@ short-summary: Delete a function app's settings.
 helps['functionapp config appsettings list'] = """
 type: command
 short-summary: Show settings for a function app.
+examples:
+  - name: Show settings for a function app. (crafted)
+    text: az functionapp config appsettings list --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['functionapp config appsettings set'] = """
 type: command
 short-summary: Update a function app's settings.
+examples:
+  - name: Update a function app's settings. (crafted)
+    text: az functionapp config appsettings set --name My --resource-group MyResourceGroup --settings {settings}
+    crafted: true
 """
 
 helps['functionapp config hostname'] = """
@@ -132,6 +148,10 @@ short-summary: Configure SSL certificates.
 helps['functionapp config ssl bind'] = """
 type: command
 short-summary: Bind an SSL certificate to a function app.
+examples:
+  - name: Bind an SSL certificate to a function app. (crafted)
+    text: az functionapp config ssl bind --name My --ssl-type {ssl-type} --certificate-thumbprint {certificate-thumbprint} --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['functionapp config ssl delete'] = """
@@ -152,6 +172,10 @@ short-summary: Unbind an SSL certificate from a function app.
 helps['functionapp config ssl upload'] = """
 type: command
 short-summary: Upload an SSL certificate to a function app.
+examples:
+  - name: Upload an SSL certificate to a function app. (commonly used with --output and --query)
+    text: 'az functionapp config ssl upload --name My --certificate-file {certificate-file}   --resource-group MyResourceGroup --certificate-password {certificate-password}  '
+    crafted: true
 """
 
 helps['functionapp cors'] = """
@@ -198,6 +222,10 @@ examples:
 helps['functionapp delete'] = """
 type: command
 short-summary: Delete a function app.
+examples:
+  - name: Delete a function app. (crafted)
+    text: az functionapp delete --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['functionapp deployment'] = """
@@ -218,6 +246,10 @@ short-summary: Manage function app deployment via source control.
 helps['functionapp deployment source config'] = """
 type: command
 short-summary: Manage deployment from git or Mercurial repositories.
+examples:
+  - name: Perform deployment using the kudu zip push deployment for a function app. (crafted)
+    text: az functionapp deployment source config-zip --name My --resource-group MyResourceGroup --src {zip file path location}
+    crafted: true
 """
 
 helps['functionapp deployment source config-local-git'] = """
@@ -264,6 +296,10 @@ short-summary: Get the details of a source control deployment configuration.
 helps['functionapp deployment source sync'] = """
 type: command
 short-summary: Synchronize from the repository. Only needed under manual integration mode.
+examples:
+  - name: Synchronize from the repository. Only needed under manual integration mode. (crafted)
+    text: az functionapp deployment source sync --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['functionapp deployment user'] = """
@@ -307,6 +343,10 @@ short-summary: Disable web app's managed service identity
 helps['functionapp identity show'] = """
 type: command
 short-summary: display web app's managed service identity
+examples:
+  - name: Display functionapp's managed service identity. (commonly used with --output and --query)
+    text: 'az functionapp identity show --name My --resource-group MyResourceGroup    '
+    crafted: true
 """
 
 helps['functionapp list'] = """
@@ -346,21 +386,37 @@ examples:
 helps['functionapp restart'] = """
 type: command
 short-summary: Restart a function app.
+examples:
+  - name: Restart a function app. (crafted)
+    text: az functionapp restart --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['functionapp show'] = """
 type: command
 short-summary: Get the details of a function app.
+examples:
+  - name: Get the details of a function app. (crafted)
+    text: az functionapp show --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['functionapp start'] = """
 type: command
 short-summary: Start a function app.
+examples:
+  - name: Start a function app. (crafted)
+    text: az functionapp start --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['functionapp stop'] = """
 type: command
 short-summary: Stop a function app.
+examples:
+  - name: Stop a function app. (crafted)
+    text: az functionapp stop --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['functionapp update'] = """
@@ -419,11 +475,19 @@ short-summary: Configure web app settings.
 helps['webapp config appsettings delete'] = """
 type: command
 short-summary: Delete web app settings.
+examples:
+  - name: Delete web app settings. (crafted)
+    text: az webapp config appsettings delete --name My --resource-group MyResourceGroup --setting-names {setting-names}
+    crafted: true
 """
 
 helps['webapp config appsettings list'] = """
 type: command
 short-summary: Get the details of a web app's settings.
+examples:
+  - name: Get the details of a web app's settings. (crafted)
+    text: az webapp config appsettings list --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp config appsettings set'] = """
@@ -481,6 +545,10 @@ short-summary: Delete a web app's connection strings.
 helps['webapp config connection-string list'] = """
 type: command
 short-summary: Get a web app's connection strings.
+examples:
+  - name: Get a web app's connection strings. (crafted)
+    text: az webapp config connection-string list --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp config connection-string set'] = """
@@ -506,6 +574,10 @@ short-summary: Delete a web app container's settings.
 helps['webapp config container set'] = """
 type: command
 short-summary: Set a web app container's settings.
+examples:
+  - name: Set a web app container's settings. (crafted)
+    text: az webapp config container set --name My --docker-custom-image-name MyDockerCustomImage --resource-group MyResourceGroup --docker-registry-server-user {docker-registry-server-user} --docker-registry-server-password {docker-registry-server-password} --docker-registry-server-url {docker-registry-server-url}
+    crafted: true
 """
 
 helps['webapp config container show'] = """
@@ -536,6 +608,10 @@ short-summary: Get the external-facing IP address for a web app.
 helps['webapp config hostname list'] = """
 type: command
 short-summary: List all hostname bindings for a web app.
+examples:
+  - name: List all hostname bindings for a web app. (crafted)
+    text: az webapp config hostname list --resource-group MyResourceGroup --webapp-name MyWebapp
+    crafted: true
 """
 
 helps['webapp config set'] = """
@@ -549,11 +625,19 @@ Examples:
     text: >
         az webapp config set -g MyResourceGroup -n MyUniqueApp --generic-configurations "{"alwaysOn": true}"
 
+examples:
+  - name: Set a web app's configuration. (crafted)
+    text: az webapp config set --name My --resource-group MyResourceGroup --always-on {always-on}
+    crafted: true
 """
 
 helps['webapp config show'] = """
 type: command
 short-summary: Get the details of a web app's configuration.
+examples:
+  - name: Get the details of a web app's configuration. (commonly used with --output and --query)
+    text: 'az webapp config show --name My --resource-group MyResourceGroup    '
+    crafted: true
 """
 
 helps['webapp config snapshot'] = """
@@ -586,11 +670,19 @@ short-summary: Configure SSL certificates for web apps.
 helps['webapp config ssl bind'] = """
 type: command
 short-summary: Bind an SSL certificate to a web app.
+examples:
+  - name: Bind an SSL certificate to a web app. (crafted)
+    text: az webapp config ssl bind --name My --ssl-type {ssl-type} --certificate-thumbprint {certificate-thumbprint} --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp config ssl delete'] = """
 type: command
 short-summary: Delete an SSL certificate from a web app.
+examples:
+  - name: Delete an SSL certificate from a web app. (crafted)
+    text: az webapp config ssl delete --resource-group MyResourceGroup --certificate-thumbprint {certificate-thumbprint}
+    crafted: true
 """
 
 helps['webapp config ssl list'] = """
@@ -606,6 +698,10 @@ short-summary: Unbind an SSL certificate from a web app.
 helps['webapp config ssl upload'] = """
 type: command
 short-summary: Upload an SSL certificate to a web app.
+examples:
+  - name: Upload an SSL certificate to a web app. (commonly used with --output and --query)
+    text: 'az webapp config ssl upload --name My --certificate-file {certificate-file}   --resource-group MyResourceGroup --certificate-password {certificate-password}  '
+    crafted: true
 """
 
 helps['webapp config storage-account'] = """
@@ -696,6 +792,10 @@ examples:
 helps['webapp delete'] = """
 type: command
 short-summary: Delete a web app.
+examples:
+  - name: Delete a web app. (crafted)
+    text: az webapp delete --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp deleted'] = """
@@ -734,6 +834,10 @@ short-summary: Manage container-based continuous deployment.
 helps['webapp deployment container config'] = """
 type: command
 short-summary: Configure continuous deployment via containers.
+examples:
+  - name: Configure continuous deployment via containers. (crafted)
+    text: az webapp deployment container config --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp deployment container show-cd-url'] = """
@@ -744,6 +848,10 @@ short-summary: Get the URL which can be used to configure webhooks for continuou
 helps['webapp deployment list-publishing-profiles'] = """
 type: command
 short-summary: Get the details for available web app deployment profiles.
+examples:
+  - name: Get the details for available web app deployment profiles. (commonly used with --output and --query)
+    text: 'az webapp deployment list-publishing-profiles --name My --resource-group MyResourceGroup    '
+    crafted: true
 """
 
 helps['webapp deployment slot'] = """
@@ -769,6 +877,10 @@ short-summary: Delete a deployment slot.
 helps['webapp deployment slot list'] = """
 type: command
 short-summary: List all deployment slots.
+examples:
+  - name: List all deployment slots. (crafted)
+    text: az webapp deployment slot list --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp deployment slot swap'] = """
@@ -789,6 +901,13 @@ short-summary: Manage web app deployment via source control.
 helps['webapp deployment source config'] = """
 type: command
 short-summary: Manage deployment from git or Mercurial repositories.
+examples:
+  - name: Get a URL for a git repository endpoint to clone and push to for web app deployment. (crafted)
+    text: az webapp deployment source config-local-git --name MyUniqueApp git remote add azure https://{deploy_user_name}@MyUniqueApp.scm.azurewebsites.net/MyUniqueApp.git --resource-group MyResourceGroup
+    crafted: true
+  - name: Perform deployment using the kudu zip push deployment for a webapp. (crafted)
+    text: az webapp deployment source config-zip --name MyUniqueApp git remote add azure https://{deploy_user_name}@MyUniqueApp.scm.azurewebsites.net/MyUniqueApp.git --resource-group MyResourceGroup --src {zip file path location}
+    crafted: true
 """
 
 helps['webapp deployment source config-local-git'] = """
@@ -877,6 +996,10 @@ short-summary: Disable web app's managed service identity
 helps['webapp identity show'] = """
 type: command
 short-summary: display web app's managed service identity
+examples:
+  - name: Display webapp's managed service identity. (commonly used with --output and --query)
+    text: 'az webapp identity show --name My --resource-group MyResourceGroup    '
+    crafted: true
 """
 
 helps['webapp list'] = """
@@ -904,12 +1027,20 @@ short-summary: Manage web app logs.
 helps['webapp log config'] = """
 type: command
 short-summary: Configure logging for a web app.
+examples:
+  - name: Configure logging for a web app. (crafted)
+    text: az webapp log config --name My --resource-group MyResourceGroup --web-server-logging {web-server-logging}
+    crafted: true
 """
 
 helps['webapp log download'] = """
 type: command
 short-summary: Download a web app's log history as a zip file.
 long-summary: This command may not work with web apps running on Linux.
+examples:
+  - name: Download a web app's log history as a zip file. (crafted)
+    text: az webapp log download --log-file {log-file} --resource-group MyResourceGroup --slot Staging --name My
+    crafted: true
 """
 
 helps['webapp log show'] = """
@@ -926,11 +1057,19 @@ long-summary: This command may not work with web apps running on Linux.
 helps['webapp restart'] = """
 type: command
 short-summary: Restart a web app.
+examples:
+  - name: Restart a web app. (crafted)
+    text: az webapp restart --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp show'] = """
 type: command
 short-summary: Get the details of a web app.
+examples:
+  - name: Get the details of a web app. (crafted)
+    text: az webapp show --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp ssh'] = """
@@ -945,11 +1084,19 @@ examples:
 helps['webapp start'] = """
 type: command
 short-summary: Start a web app.
+examples:
+  - name: Start a web app. (crafted)
+    text: az webapp start --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp stop'] = """
 type: command
 short-summary: Stop a web app.
+examples:
+  - name: Stop a web app. (crafted)
+    text: az webapp stop --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp traffic-routing'] = """
@@ -1012,6 +1159,10 @@ short-summary: Allows management operations of continuous webjobs on a web app.
 helps['webapp webjob continuous list'] = """
 type: command
 short-summary: List all continuous webjobs on a selected web app.
+examples:
+  - name: List all continuous webjobs on a selected webapp. (crafted)
+    text: az webapp webjob continuous list --name My --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['webapp webjob continuous remove'] = """

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
@@ -401,6 +401,10 @@ short-summary: Retrieve a job recurrence in a Data Lake Analytics account.
 helps['dla job show'] = """
 type: command
 short-summary: Get information for a Data Lake Analytics job.
+examples:
+  - name: Get information for a Data Lake Analytics job. (commonly used with --output)
+    text: 'az dla job show --job-identity {job-identity}  '
+    crafted: true
 """
 
 helps['dla job submit'] = """

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
@@ -5,432 +5,432 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.help_files import helps
-
+# pylint: disable=line-too-long, too-many-lines
 
 helps['dla'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics accounts, jobs, and catalogs.
-"""
-
-helps['dla job'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics jobs.
-"""
-
-helps['dla job submit'] = """
-    type: command
-    short-summary: Submit a job to a Data Lake Analytics account.
-    parameters:
-        - name: --job-name
-          type: string
-          short-summary: Name for the submitted job.
-        - name: --script
-          type: string
-          short-summary: Script to submit. This may be '@{file}' to load from a file.
-        - name: --runtime-version
-          short-summary: The runtime version to use.
-          long-summary: This parameter is used for explicitly overwriting the default runtime. It should only be done if you know what you are doing.
-        - name: --degree-of-parallelism
-          short-summary: The degree of parallelism for the job.
-          long-summary: Higher values equate to more parallelism and will usually yield faster running jobs, at the cost of more AUs.
-        - name: --priority
-          short-summary: The priority of the job.
-          long-summary: Lower values increase the priority, with the lowest value being 1. This determines the order jobs are run in.
-
-"""
-
-helps['dla job cancel'] = """
-    type: command
-    short-summary: Cancel a Data Lake Analytics job.
-"""
-
-helps['dla job show'] = """
-    type: command
-    short-summary: Get information for a Data Lake Analytics job.
-"""
-
-helps['dla job wait'] = """
-    type: command
-    short-summary: Wait for a Data Lake Analytics job to finish.
-    long-summary: This command exits when the job completes.
-    parameters:
-        - name: --job-id
-          type: string
-          short-summary: 'Job ID to poll for completion.'
-"""
-
-helps['dla job list'] = """
-    type: command
-    short-summary: List Data Lake Analytics jobs.
-"""
-
-helps['dla catalog'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalogs.
-"""
-
-helps['dla catalog database'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog databases.
-"""
-
-helps['dla catalog assembly'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog assemblies.
-"""
-
-helps['dla catalog external-data-source'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog external data sources.
-"""
-
-helps['dla catalog procedure'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog stored procedures.
-"""
-
-helps['dla catalog schema'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog schemas.
-"""
-
-helps['dla catalog table'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog tables.
-"""
-
-helps['dla catalog table list'] = """
-    type: command
-    short-summary: List tables in a database or schema.
-    parameters:
-        - name: --database-name
-          type: string
-          short-summary: The name of the database.
-        - name: --schema-name
-          type: string
-          short-summary: The schema assocated with the tables to list.
-"""
-
-helps['dla catalog table-partition'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog table partitions.
-"""
-
-helps['dla catalog table-stats'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog table statistics.
-"""
-
-helps['dla catalog table-stats list'] = """
-    type: command
-    short-summary: List table statistics in a database, table, or schema.
-    parameters:
-        - name: --database-name
-          type: string
-          short-summary: The name of the database.
-        - name: --schema-name
-          type: string
-          short-summary: The schema associated with the tables to list.
-        - name: --table-name
-          type: string
-          short-summary: The table to list statistics for. `--schema-name` must also be specified.
-"""
-
-helps['dla catalog table-type'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog table types.
-"""
-
-helps['dla catalog tvf'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog table valued functions.
-"""
-
-helps['dla catalog tvf list'] = """
-    type: command
-    short-summary: List table valued functions in a database or schema.
-    parameters:
-        - name: --database-name
-          type: string
-          short-summary: The name of the database.
-        - name: --schema-name
-          type: string
-          short-summary: The name of the schema assocated with table valued functions to list.
-"""
-
-helps['dla catalog view'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog views.
-"""
-
-helps['dla catalog view list'] = """
-    type: command
-    short-summary: List views in a database or schema.
-    parameters:
-        - name: --database-name
-          type: string
-          short-summary: The name of the database.
-        - name: --schema-name
-          type: string
-          short-summary: The name of the schema associated with the views to list.
-"""
-
-helps['dla catalog credential'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog credentials.
-"""
-
-helps['dla catalog credential create'] = """
-    type: command
-    short-summary: Create a new catalog credential for use with an external data source.
-    parameters:
-        - name: --credential-name
-          type: string
-          short-summary: The name of the credential.
-        - name: --database-name
-          type: string
-          short-summary: The name of the database in which to create the credential.
-        - name: --user-name
-          type: string
-          short-summary: The user name that will be used when authenticating with this credential.
-"""
-
-helps['dla catalog credential update'] = """
-    type: command
-    short-summary: Update a catalog credential for use with an external data source.
-    parameters:
-        - name: --credential-name
-          type: string
-          short-summary: The name of the credential to update.
-        - name: --database-name
-          type: string
-          short-summary: The name of the database in which the credential exists.
-        - name: --user-name
-          type: string
-          short-summary: The user name associated with the credential that will have its password updated.
-"""
-
-helps['dla catalog credential show'] = """
-    type: command
-    short-summary: Retrieve a catalog credential.
-"""
-
-helps['dla catalog credential list'] = """
-    type: command
-    short-summary: List catalog credentials.
-"""
-
-helps['dla catalog credential delete'] = """
-    type: command
-    short-summary: Delete a catalog credential.
-"""
-
-helps['dla catalog package'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics catalog packages.
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics accounts, jobs, and catalogs.
 """
 
 helps['dla account'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics accounts.
-"""
-
-helps['dla account create'] = """
-    type: command
-    short-summary: Create a Data Lake Analytics account.
-    parameters:
-        - name: --default-data-lake-store
-          type: string
-          short-summary: The default Data Lake Store account to associate with the created account.
-        - name: --max-degree-of-parallelism
-          type: int
-          short-summary: The maximum degree of parallelism for this account.
-        - name: --max-job-count
-          type: int
-          short-summary: The maximum number of concurrent jobs for this account.
-        - name: --query-store-retention
-          type: int
-          short-summary: The number of days to retain job metadata.
-"""
-
-helps['dla account update'] = """
-    type: command
-    short-summary: Update a Data Lake Analytics account.
-    parameters:
-        - name: --max-degree-of-parallelism
-          type: int
-          short-summary: The maximum degree of parallelism for this account.
-        - name: --max-job-count
-          type: int
-          short-summary: The maximum number of concurrent jobs for this account.
-        - name: --query-store-retention
-          type: int
-          short-summary: The number of days to retain job metadata.
-        - name: --firewall-state
-          type: string
-          short-summary: Enable or disable existing firewall rules.
-        - name: --allow-azure-ips
-          type: string
-          short-summary: Allow or block IPs originating from Azure through the firewall.
-"""
-
-helps['dla account show'] = """
-    type: command
-    short-summary: Get the details of a Data Lake Analytics account.
-"""
-
-helps['dla account list'] = """
-    type: command
-    short-summary: List available Data Lake Analytics accounts.
-"""
-
-helps['dla account delete'] = """
-    type: command
-    short-summary: Delete a Data Lake Analytics account.
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics accounts.
 """
 
 helps['dla account blob-storage'] = """
-    type: group
-    short-summary: (PREVIEW) Manage links between Data Lake Analytics accounts and Azure Storage.
+type: group
+short-summary: (PREVIEW) Manage links between Data Lake Analytics accounts and Azure Storage.
 """
 
 helps['dla account blob-storage add'] = """
-    type: command
-    short-summary: Links an Azure Storage account to the specified Data Lake Analytics account.
+type: command
+short-summary: Links an Azure Storage account to the specified Data Lake Analytics account.
 """
 
 helps['dla account blob-storage update'] = """
-    type: command
-    short-summary: Updates an Azure Storage account linked to the specified Data Lake Analytics account.
-"""
-
-helps['dla account data-lake-store'] = """
-    type: group
-    short-summary: (PREVIEW) Manage links between Data Lake Analytics and Data Lake Store accounts.
-"""
-
-helps['dla account firewall'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics account firewall rules.
-"""
-
-helps['dla account firewall create'] = """
-    type: command
-    short-summary: Create a firewall rule in a Data Lake Analytics account.
-    parameters:
-        - name: --end-ip-address
-          type: string
-          short-summary: The end of the valid IP range for the firewall rule.
-        - name: --start-ip-address
-          type: string
-          short-summary: The start of the valid IP range for the firewall rule.
-        - name: --firewall-rule-name
-          type: string
-          short-summary: The name of the firewall rule.
-"""
-
-helps['dla account firewall update'] = """
-    type: command
-    short-summary: Update a firewall rule in a Data Lake Analytics account.
-"""
-
-helps['dla account firewall show'] = """
-    type: command
-    short-summary: Retrieve a firewall rule in a Data Lake Analytics account.
-"""
-
-helps['dla account firewall list'] = """
-    type: command
-    short-summary: List firewall rules in a Data Lake Analytics account.
-"""
-
-helps['dla account firewall delete'] = """
-    type: command
-    short-summary: Delete a firewall rule in a Data Lake Analytics account.
+type: command
+short-summary: Updates an Azure Storage account linked to the specified Data Lake Analytics account.
 """
 
 helps['dla account compute-policy'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics account compute policies.
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics account compute policies.
 """
 
 helps['dla account compute-policy create'] = """
-    type: command
-    short-summary: Create a compute policy in the Data Lake Analytics account.
-    parameters:
-        - name: --max-dop-per-job
-          type: int
-          short-summary: The maximum degree of parallelism allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
-        - name: --min-priority-per-job
-          type: int
-          short-summary: The minimum priority allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
-        - name: --compute-policy-name
-          type: string
-          short-summary: The name of the compute policy to create.
-        - name: --object-id
-          type: string
-          short-summary: The Azure Active Directory object ID of the user, group, or service principal to apply the policy to.
-        - name: --object-type
-          type: string
-          short-summary: The Azure Active Directory object type associated with the supplied object ID.
-"""
-
-helps['dla account compute-policy update'] = """
-    type: command
-    short-summary: Update a compute policy in the Data Lake Analytics account.
-    parameters:
-        - name: --max-dop-per-job
-          type: int
-          short-summary: The maximum degree of parallelism allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
-        - name: --min-priority-per-job
-          type: int
-          short-summary: The minimum priority allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
-        - name: --compute-policy-name
-          type: string
-          short-summary: The name of the compute policy to update.
-"""
-
-helps['dla account compute-policy show'] = """
-    type: command
-    short-summary: Retrieve a compute policy in a Data Lake Analytics account.
-"""
-
-helps['dla account compute-policy list'] = """
-    type: command
-    short-summary: List compute policies in the a Lake Analytics account.
+type: command
+short-summary: Create a compute policy in the Data Lake Analytics account.
+parameters:
+  - name: --max-dop-per-job
+    type: int
+    short-summary: The maximum degree of parallelism allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
+  - name: --min-priority-per-job
+    type: int
+    short-summary: The minimum priority allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
+  - name: --compute-policy-name
+    type: string
+    short-summary: The name of the compute policy to create.
+  - name: --object-id
+    type: string
+    short-summary: The Azure Active Directory object ID of the user, group, or service principal to apply the policy to.
+  - name: --object-type
+    type: string
+    short-summary: The Azure Active Directory object type associated with the supplied object ID.
 """
 
 helps['dla account compute-policy delete'] = """
-    type: command
-    short-summary: Delete a compute policy in a Data Lake Analytics account.
+type: command
+short-summary: Delete a compute policy in a Data Lake Analytics account.
+"""
+
+helps['dla account compute-policy list'] = """
+type: command
+short-summary: List compute policies in the a Lake Analytics account.
+"""
+
+helps['dla account compute-policy show'] = """
+type: command
+short-summary: Retrieve a compute policy in a Data Lake Analytics account.
+"""
+
+helps['dla account compute-policy update'] = """
+type: command
+short-summary: Update a compute policy in the Data Lake Analytics account.
+parameters:
+  - name: --max-dop-per-job
+    type: int
+    short-summary: The maximum degree of parallelism allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
+  - name: --min-priority-per-job
+    type: int
+    short-summary: The minimum priority allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
+  - name: --compute-policy-name
+    type: string
+    short-summary: The name of the compute policy to update.
+"""
+
+helps['dla account create'] = """
+type: command
+short-summary: Create a Data Lake Analytics account.
+parameters:
+  - name: --default-data-lake-store
+    type: string
+    short-summary: The default Data Lake Store account to associate with the created account.
+  - name: --max-degree-of-parallelism
+    type: int
+    short-summary: The maximum degree of parallelism for this account.
+  - name: --max-job-count
+    type: int
+    short-summary: The maximum number of concurrent jobs for this account.
+  - name: --query-store-retention
+    type: int
+    short-summary: The number of days to retain job metadata.
+"""
+
+helps['dla account data-lake-store'] = """
+type: group
+short-summary: (PREVIEW) Manage links between Data Lake Analytics and Data Lake Store accounts.
+"""
+
+helps['dla account delete'] = """
+type: command
+short-summary: Delete a Data Lake Analytics account.
+"""
+
+helps['dla account firewall'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics account firewall rules.
+"""
+
+helps['dla account firewall create'] = """
+type: command
+short-summary: Create a firewall rule in a Data Lake Analytics account.
+parameters:
+  - name: --end-ip-address
+    type: string
+    short-summary: The end of the valid IP range for the firewall rule.
+  - name: --start-ip-address
+    type: string
+    short-summary: The start of the valid IP range for the firewall rule.
+  - name: --firewall-rule-name
+    type: string
+    short-summary: The name of the firewall rule.
+"""
+
+helps['dla account firewall delete'] = """
+type: command
+short-summary: Delete a firewall rule in a Data Lake Analytics account.
+"""
+
+helps['dla account firewall list'] = """
+type: command
+short-summary: List firewall rules in a Data Lake Analytics account.
+"""
+
+helps['dla account firewall show'] = """
+type: command
+short-summary: Retrieve a firewall rule in a Data Lake Analytics account.
+"""
+
+helps['dla account firewall update'] = """
+type: command
+short-summary: Update a firewall rule in a Data Lake Analytics account.
+"""
+
+helps['dla account list'] = """
+type: command
+short-summary: List available Data Lake Analytics accounts.
+"""
+
+helps['dla account show'] = """
+type: command
+short-summary: Get the details of a Data Lake Analytics account.
+"""
+
+helps['dla account update'] = """
+type: command
+short-summary: Update a Data Lake Analytics account.
+parameters:
+  - name: --max-degree-of-parallelism
+    type: int
+    short-summary: The maximum degree of parallelism for this account.
+  - name: --max-job-count
+    type: int
+    short-summary: The maximum number of concurrent jobs for this account.
+  - name: --query-store-retention
+    type: int
+    short-summary: The number of days to retain job metadata.
+  - name: --firewall-state
+    type: string
+    short-summary: Enable or disable existing firewall rules.
+  - name: --allow-azure-ips
+    type: string
+    short-summary: Allow or block IPs originating from Azure through the firewall.
+"""
+
+helps['dla catalog'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalogs.
+"""
+
+helps['dla catalog assembly'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog assemblies.
+"""
+
+helps['dla catalog credential'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog credentials.
+"""
+
+helps['dla catalog credential create'] = """
+type: command
+short-summary: Create a new catalog credential for use with an external data source.
+parameters:
+  - name: --credential-name
+    type: string
+    short-summary: The name of the credential.
+  - name: --database-name
+    type: string
+    short-summary: The name of the database in which to create the credential.
+  - name: --user-name
+    type: string
+    short-summary: The user name that will be used when authenticating with this credential.
+"""
+
+helps['dla catalog credential delete'] = """
+type: command
+short-summary: Delete a catalog credential.
+"""
+
+helps['dla catalog credential list'] = """
+type: command
+short-summary: List catalog credentials.
+"""
+
+helps['dla catalog credential show'] = """
+type: command
+short-summary: Retrieve a catalog credential.
+"""
+
+helps['dla catalog credential update'] = """
+type: command
+short-summary: Update a catalog credential for use with an external data source.
+parameters:
+  - name: --credential-name
+    type: string
+    short-summary: The name of the credential to update.
+  - name: --database-name
+    type: string
+    short-summary: The name of the database in which the credential exists.
+  - name: --user-name
+    type: string
+    short-summary: The user name associated with the credential that will have its password updated.
+"""
+
+helps['dla catalog database'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog databases.
+"""
+
+helps['dla catalog external-data-source'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog external data sources.
+"""
+
+helps['dla catalog package'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog packages.
+"""
+
+helps['dla catalog procedure'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog stored procedures.
+"""
+
+helps['dla catalog schema'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog schemas.
+"""
+
+helps['dla catalog table'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog tables.
+"""
+
+helps['dla catalog table list'] = """
+type: command
+short-summary: List tables in a database or schema.
+parameters:
+  - name: --database-name
+    type: string
+    short-summary: The name of the database.
+  - name: --schema-name
+    type: string
+    short-summary: The schema assocated with the tables to list.
+"""
+
+helps['dla catalog table-partition'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog table partitions.
+"""
+
+helps['dla catalog table-stats'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog table statistics.
+"""
+
+helps['dla catalog table-stats list'] = """
+type: command
+short-summary: List table statistics in a database, table, or schema.
+parameters:
+  - name: --database-name
+    type: string
+    short-summary: The name of the database.
+  - name: --schema-name
+    type: string
+    short-summary: The schema associated with the tables to list.
+  - name: --table-name
+    type: string
+    short-summary: The table to list statistics for. `--schema-name` must also be specified.
+"""
+
+helps['dla catalog table-type'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog table types.
+"""
+
+helps['dla catalog tvf'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog table valued functions.
+"""
+
+helps['dla catalog tvf list'] = """
+type: command
+short-summary: List table valued functions in a database or schema.
+parameters:
+  - name: --database-name
+    type: string
+    short-summary: The name of the database.
+  - name: --schema-name
+    type: string
+    short-summary: The name of the schema assocated with table valued functions to list.
+"""
+
+helps['dla catalog view'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics catalog views.
+"""
+
+helps['dla catalog view list'] = """
+type: command
+short-summary: List views in a database or schema.
+parameters:
+  - name: --database-name
+    type: string
+    short-summary: The name of the database.
+  - name: --schema-name
+    type: string
+    short-summary: The name of the schema associated with the views to list.
+"""
+
+helps['dla job'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics jobs.
+"""
+
+helps['dla job cancel'] = """
+type: command
+short-summary: Cancel a Data Lake Analytics job.
+"""
+
+helps['dla job list'] = """
+type: command
+short-summary: List Data Lake Analytics jobs.
 """
 
 helps['dla job pipeline'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics job pipelines.
-"""
-
-helps['dla job pipeline show'] = """
-    type: command
-    short-summary: Retrieve a job pipeline in a Data Lake Analytics account.
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics job pipelines.
 """
 
 helps['dla job pipeline list'] = """
-    type: command
-    short-summary: List job pipelines in a Data Lake Analytics account.
+type: command
+short-summary: List job pipelines in a Data Lake Analytics account.
+"""
+
+helps['dla job pipeline show'] = """
+type: command
+short-summary: Retrieve a job pipeline in a Data Lake Analytics account.
 """
 
 helps['dla job recurrence'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Analytics job recurrences.
-"""
-
-helps['dla job recurrence show'] = """
-    type: command
-    short-summary: Retrieve a job recurrence in a Data Lake Analytics account.
+type: group
+short-summary: (PREVIEW) Manage Data Lake Analytics job recurrences.
 """
 
 helps['dla job recurrence list'] = """
-    type: command
-    short-summary: List job recurrences in a Data Lake Analytics account.
+type: command
+short-summary: List job recurrences in a Data Lake Analytics account.
+"""
+
+helps['dla job recurrence show'] = """
+type: command
+short-summary: Retrieve a job recurrence in a Data Lake Analytics account.
+"""
+
+helps['dla job show'] = """
+type: command
+short-summary: Get information for a Data Lake Analytics job.
+"""
+
+helps['dla job submit'] = """
+type: command
+short-summary: Submit a job to a Data Lake Analytics account.
+parameters:
+  - name: --job-name
+    type: string
+    short-summary: Name for the submitted job.
+  - name: --script
+    type: string
+    short-summary: Script to submit. This may be '@{file}' to load from a file.
+  - name: --runtime-version
+    short-summary: The runtime version to use.
+    long-summary: This parameter is used for explicitly overwriting the default runtime. It should only be done if you know what you are doing.
+  - name: --degree-of-parallelism
+    short-summary: The degree of parallelism for the job.
+    long-summary: Higher values equate to more parallelism and will usually yield faster running jobs, at the cost of more AUs.
+  - name: --priority
+    short-summary: The priority of the job.
+    long-summary: Lower values increase the priority, with the lowest value being 1. This determines the order jobs are run in.
+
+"""
+
+helps['dla job wait'] = """
+type: command
+short-summary: Wait for a Data Lake Analytics job to finish.
+long-summary: This command exits when the job completes.
+parameters:
+  - name: --job-id
+    type: string
+    short-summary: Job ID to poll for completion.
 """

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
@@ -5,338 +5,338 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.help_files import helps
-
+# pylint: disable=line-too-long, too-many-lines
 
 helps['dls'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Store accounts and filesystems.
+type: group
+short-summary: (PREVIEW) Manage Data Lake Store accounts and filesystems.
 """
 
 helps['dls account'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Store accounts.
+type: group
+short-summary: (PREVIEW) Manage Data Lake Store accounts.
 """
 
 helps['dls account create'] = """
-    type: command
-    short-summary: Creates a Data Lake Store account.
-    parameters:
-        - name: --default-group
-          type: string
-          short-summary: 'Name of the default group to give permissions to for freshly created files and folders in the Data Lake Store account.'
-        - name: --key-vault-id
-          type: string
-          short-summary: 'Key vault for the user-assigned encryption type.'
-        - name: --key-name
-          type: string
-          short-summary: 'Key name for the user-assigned encryption type.'
-        - name: --key-version
-          type: string
-          short-summary: 'Key version for the user-assigned encryption type.'
-"""
-
-helps['dls account update'] = """
-    type: command
-    short-summary: Updates a Data Lake Store account.
-"""
-
-helps['dls account show'] = """
-    type: command
-    short-summary: Get the details of a Data Lake Store account.
-"""
-
-helps['dls account list'] = """
-    type: command
-    short-summary: Lists available Data Lake Store accounts.
-"""
-
-helps['dls account enable-key-vault'] = """
-    type: command
-    short-summary: Enable the use of Azure Key Vault for encryption of a Data Lake Store account.
+type: command
+short-summary: Creates a Data Lake Store account.
+parameters:
+  - name: --default-group
+    type: string
+    short-summary: Name of the default group to give permissions to for freshly created files and folders in the Data Lake Store account.
+  - name: --key-vault-id
+    type: string
+    short-summary: Key vault for the user-assigned encryption type.
+  - name: --key-name
+    type: string
+    short-summary: Key name for the user-assigned encryption type.
+  - name: --key-version
+    type: string
+    short-summary: Key version for the user-assigned encryption type.
 """
 
 helps['dls account delete'] = """
-    type: command
-    short-summary: Delete a Data Lake Store account.
+type: command
+short-summary: Delete a Data Lake Store account.
 """
 
-helps['dls account trusted-provider'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Store account trusted identity providers.
+helps['dls account enable-key-vault'] = """
+type: command
+short-summary: Enable the use of Azure Key Vault for encryption of a Data Lake Store account.
 """
 
 helps['dls account firewall'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Store account firewall rules.
+type: group
+short-summary: (PREVIEW) Manage Data Lake Store account firewall rules.
 """
 
 helps['dls account firewall create'] = """
-    type: command
-    short-summary: Creates a firewall rule in a Data Lake Store account.
-    parameters:
-        - name: --end-ip-address
-          type: string
-          short-summary: 'The end of the valid ip range for the firewall rule.'
-        - name: --start-ip-address
-          type: string
-          short-summary: 'The start of the valid ip range for the firewall rule.'
-        - name: --firewall-rule-name
-          type: string
-          short-summary: 'The name of the firewall rule.'
-"""
-
-helps['dls account firewall update'] = """
-    type: command
-    short-summary: Updates a firewall rule in a Data Lake Store account.
-"""
-
-helps['dls account firewall show'] = """
-    type: command
-    short-summary: Get the details of a firewall rule in a Data Lake Store account.
-"""
-
-helps['dls account firewall list'] = """
-    type: command
-    short-summary: Lists firewall rules in a Data Lake Store account.
+type: command
+short-summary: Creates a firewall rule in a Data Lake Store account.
+parameters:
+  - name: --end-ip-address
+    type: string
+    short-summary: The end of the valid ip range for the firewall rule.
+  - name: --start-ip-address
+    type: string
+    short-summary: The start of the valid ip range for the firewall rule.
+  - name: --firewall-rule-name
+    type: string
+    short-summary: The name of the firewall rule.
 """
 
 helps['dls account firewall delete'] = """
-    type: command
-    short-summary: Deletes a firewall rule in a Data Lake Store account.
+type: command
+short-summary: Deletes a firewall rule in a Data Lake Store account.
+"""
+
+helps['dls account firewall list'] = """
+type: command
+short-summary: Lists firewall rules in a Data Lake Store account.
+"""
+
+helps['dls account firewall show'] = """
+type: command
+short-summary: Get the details of a firewall rule in a Data Lake Store account.
+"""
+
+helps['dls account firewall update'] = """
+type: command
+short-summary: Updates a firewall rule in a Data Lake Store account.
+"""
+
+helps['dls account list'] = """
+type: command
+short-summary: Lists available Data Lake Store accounts.
 """
 
 helps['dls account network-rule'] = """
-    type: group
-    short-summary: (PREVIEW) Manage Data Lake Store account virtual network rules.
+type: group
+short-summary: (PREVIEW) Manage Data Lake Store account virtual network rules.
 """
 
 helps['dls account network-rule create'] = """
-    type: command
-    short-summary: Creates a virtual network rule in a Data Lake Store account.
-    parameters:
-        - name: --subnet
-          type: string
-          short-summary: 'The subnet name or id for the virtual network rule.'
-        - name: --vnet-name
-          type: string
-          short-summary: 'The name of the virtual network rule.'
-"""
-
-helps['dls account network-rule update'] = """
-    type: command
-    short-summary: Updates a virtual network rule in a Data Lake Store account.
-"""
-
-helps['dls account network-rule show'] = """
-    type: command
-    short-summary: Get the details of a virtual network rule in a Data Lake Store account.
-"""
-
-helps['dls account network-rule list'] = """
-    type: command
-    short-summary: Lists virtual network rules in a Data Lake Store account.
+type: command
+short-summary: Creates a virtual network rule in a Data Lake Store account.
+parameters:
+  - name: --subnet
+    type: string
+    short-summary: The subnet name or id for the virtual network rule.
+  - name: --vnet-name
+    type: string
+    short-summary: The name of the virtual network rule.
 """
 
 helps['dls account network-rule delete'] = """
-    type: command
-    short-summary: Deletes a virtual network rule in a Data Lake Store account.
+type: command
+short-summary: Deletes a virtual network rule in a Data Lake Store account.
+"""
+
+helps['dls account network-rule list'] = """
+type: command
+short-summary: Lists virtual network rules in a Data Lake Store account.
+"""
+
+helps['dls account network-rule show'] = """
+type: command
+short-summary: Get the details of a virtual network rule in a Data Lake Store account.
+"""
+
+helps['dls account network-rule update'] = """
+type: command
+short-summary: Updates a virtual network rule in a Data Lake Store account.
+"""
+
+helps['dls account show'] = """
+type: command
+short-summary: Get the details of a Data Lake Store account.
+"""
+
+helps['dls account trusted-provider'] = """
+type: group
+short-summary: (PREVIEW) Manage Data Lake Store account trusted identity providers.
+"""
+
+helps['dls account update'] = """
+type: command
+short-summary: Updates a Data Lake Store account.
 """
 
 helps['dls fs'] = """
-    type: group
-    short-summary: (PREVIEW) Manage a Data Lake Store filesystem.
-"""
-
-helps['dls fs create'] = """
-    type: command
-    short-summary: Creates a file or folder in a Data Lake Store account.
-    parameters:
-        - name: --content
-          type: string
-          short-summary: 'Content for the file to contain upon creation.'
-"""
-
-helps['dls fs show'] = """
-    type: command
-    short-summary: Get file or folder information in a Data Lake Store account.
-"""
-
-helps['dls fs list'] = """
-    type: command
-    short-summary: List the files and folders in a Data Lake Store account.
-"""
-
-helps['dls fs append'] = """
-    type: command
-    short-summary: Append content to a file in a Data Lake Store account.
-    parameters:
-        - name: --content
-          type: string
-          short-summary: 'Content to be appended to the file.'
-"""
-
-helps['dls fs delete'] = """
-    type: command
-    short-summary: Delete a file or folder in a Data Lake Store account.
-"""
-
-helps['dls fs upload'] = """
-    type: command
-    short-summary: Upload a file or folder to a Data Lake Store account.
-    parameters:
-        - name: --source-path
-          type: string
-          short-summary: The path to the file or folder to upload.
-        - name: --destination-path
-          type: string
-          short-summary: The full path in the Data Lake Store filesystem to upload the file or folder to.
-        - name: --thread-count
-          type: int
-          short-summary: 'Parallelism of the upload. Default: The number of cores in the local machine.'
-        - name: --chunk-size
-          type: int
-          short-summary: Size of a chunk, in bytes.
-          long-summary: Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.
-        - name: --buffer-size
-          type: int
-          short-summary: Size of the transfer buffer, in bytes.
-          long-summary: A buffer cannot be bigger than a chunk and cannot be smaller than a block.
-        - name: --block-size
-          type: int
-          short-summary: Size of a block, in bytes.
-          long-summary: Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.
-
-"""
-
-helps['dls fs download'] = """
-    type: command
-    short-summary: Download a file or folder from a Data Lake Store account to the local machine.
-    parameters:
-        - name: --source-path
-          type: string
-          short-summary: The full path in the Data Lake Store filesystem to download the file or folder from.
-        - name: --destination-path
-          type: string
-          short-summary: The local path where the file or folder will be downloaded to.
-        - name: --thread-count
-          type: int
-          short-summary: 'Parallelism of the download. Default: The number of cores in the local machine.'
-        - name: --chunk-size
-          type: int
-          short-summary: Size of a chunk, in bytes.
-          long-summary: Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.
-        - name: --buffer-size
-          type: int
-          short-summary: Size of the transfer buffer, in bytes.
-          long-summary: A buffer cannot be bigger than a chunk and cannot be smaller than a block.
-        - name: --block-size
-          type: int
-          short-summary: Size of a block, in bytes.
-          long-summary: Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.
-"""
-
-helps['dls fs test'] = """
-    type: command
-    short-summary: Test for the existence of a file or folder in a Data Lake Store account.
-"""
-
-helps['dls fs preview'] = """
-    type: command
-    short-summary: Preview the content of a file in a Data Lake Store account.
-    parameters:
-        - name: --length
-          type: long
-          short-summary: The amount of data to preview in bytes.
-          long-summary: If not specified, attempts to preview the full file. If the file is > 1MB `--force` must be specified.
-        - name: --offset
-          type: long
-          short-summary: The position in bytes to start the preview from.
-"""
-
-helps['dls fs join'] = """
-    type: command
-    short-summary: Join files in a Data Lake Store account into one file.
-    parameters:
-        - name: --source-paths
-          type: list
-          short-summary: The space-separated list of files in the Data Lake Store account to join.
-        - name: --destination-path
-          type: string
-          short-summary: The destination path in the Data Lake Store account.
-"""
-
-helps['dls fs move'] = """
-    type: command
-    short-summary: Move a file or folder in a Data Lake Store account.
-    parameters:
-        - name: --source-path
-          type: list
-          short-summary: The file or folder to move.
-        - name: --destination-path
-          type: string
-          short-summary: The destination path in the Data Lake Store account.
-"""
-
-helps['dls fs set-expiry'] = """
-    type: command
-    short-summary: Set the expiration time for a file.
-"""
-
-helps['dls fs remove-expiry'] = """
-    type: command
-    short-summary: Remove the expiration time for a file.
+type: group
+short-summary: (PREVIEW) Manage a Data Lake Store filesystem.
 """
 
 helps['dls fs access'] = """
-    type: group
-    short-summary: Manage Data Lake Store filesystem access and permissions.
-"""
-
-helps['dls fs access show'] = """
-    type: command
-    short-summary: Display the access control list (ACL).
-"""
-
-helps['dls fs access set-owner'] = """
-    type: command
-    short-summary: Set the owner information for a file or folder in a Data Lake Store account.
-    parameters:
-        - name: --owner
-          type: string
-          short-summary: The user Azure Active Directory object ID or user principal name to set as the owner.
-        - name: --group
-          type: string
-          short-summary: The group Azure Active Directory object ID or user principal name to set as the owning group.
-"""
-
-helps['dls fs access set-permission'] = """
-    type: command
-    short-summary: Set the permissions for a file or folder in a Data Lake Store account.
-    parameters:
-        - name: --permission
-          type: int
-          short-summary: The octal representation of the permissions for user, group and mask.
-    example:
-        - name: Set full permissions for a user, read-execute permissions for a group, and execute permissions for all.
-          text: az fs access set-permission --path /path/to/file.txt --permission 751
-"""
-
-helps['dls fs access set-entry'] = """
-    type: command
-    short-summary: Update the access control list for a file or folder.
-"""
-
-helps['dls fs access set'] = """
-    type: command
-    short-summary: Replace the existing access control list for a file or folder.
-"""
-
-helps['dls fs access remove-entry'] = """
-    type: command
-    short-summary: Remove entries for the access control list of a file or folder.
+type: group
+short-summary: Manage Data Lake Store filesystem access and permissions.
 """
 
 helps['dls fs access remove-all'] = """
-    type: command
-    short-summary: Remove the access control list for a file or folder.
+type: command
+short-summary: Remove the access control list for a file or folder.
+"""
+
+helps['dls fs access remove-entry'] = """
+type: command
+short-summary: Remove entries for the access control list of a file or folder.
+"""
+
+helps['dls fs access set'] = """
+type: command
+short-summary: Replace the existing access control list for a file or folder.
+"""
+
+helps['dls fs access set-entry'] = """
+type: command
+short-summary: Update the access control list for a file or folder.
+"""
+
+helps['dls fs access set-owner'] = """
+type: command
+short-summary: Set the owner information for a file or folder in a Data Lake Store account.
+parameters:
+  - name: --owner
+    type: string
+    short-summary: The user Azure Active Directory object ID or user principal name to set as the owner.
+  - name: --group
+    type: string
+    short-summary: The group Azure Active Directory object ID or user principal name to set as the owning group.
+"""
+
+helps['dls fs access set-permission'] = """
+type: command
+short-summary: Set the permissions for a file or folder in a Data Lake Store account.
+parameters:
+  - name: --permission
+    type: int
+    short-summary: The octal representation of the permissions for user, group and mask.
+example:
+  - name: Set full permissions for a user, read-execute permissions for a group, and execute permissions for all.
+    text: az fs access set-permission --path /path/to/file.txt --permission 751
+"""
+
+helps['dls fs access show'] = """
+type: command
+short-summary: Display the access control list (ACL).
+"""
+
+helps['dls fs append'] = """
+type: command
+short-summary: Append content to a file in a Data Lake Store account.
+parameters:
+  - name: --content
+    type: string
+    short-summary: Content to be appended to the file.
+"""
+
+helps['dls fs create'] = """
+type: command
+short-summary: Creates a file or folder in a Data Lake Store account.
+parameters:
+  - name: --content
+    type: string
+    short-summary: Content for the file to contain upon creation.
+"""
+
+helps['dls fs delete'] = """
+type: command
+short-summary: Delete a file or folder in a Data Lake Store account.
+"""
+
+helps['dls fs download'] = """
+type: command
+short-summary: Download a file or folder from a Data Lake Store account to the local machine.
+parameters:
+  - name: --source-path
+    type: string
+    short-summary: The full path in the Data Lake Store filesystem to download the file or folder from.
+  - name: --destination-path
+    type: string
+    short-summary: The local path where the file or folder will be downloaded to.
+  - name: --thread-count
+    type: int
+    short-summary: 'Parallelism of the download. Default: The number of cores in the local machine.'
+  - name: --chunk-size
+    type: int
+    short-summary: Size of a chunk, in bytes.
+    long-summary: Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.
+  - name: --buffer-size
+    type: int
+    short-summary: Size of the transfer buffer, in bytes.
+    long-summary: A buffer cannot be bigger than a chunk and cannot be smaller than a block.
+  - name: --block-size
+    type: int
+    short-summary: Size of a block, in bytes.
+    long-summary: Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.
+"""
+
+helps['dls fs join'] = """
+type: command
+short-summary: Join files in a Data Lake Store account into one file.
+parameters:
+  - name: --source-paths
+    type: list
+    short-summary: The space-separated list of files in the Data Lake Store account to join.
+  - name: --destination-path
+    type: string
+    short-summary: The destination path in the Data Lake Store account.
+"""
+
+helps['dls fs list'] = """
+type: command
+short-summary: List the files and folders in a Data Lake Store account.
+"""
+
+helps['dls fs move'] = """
+type: command
+short-summary: Move a file or folder in a Data Lake Store account.
+parameters:
+  - name: --source-path
+    type: list
+    short-summary: The file or folder to move.
+  - name: --destination-path
+    type: string
+    short-summary: The destination path in the Data Lake Store account.
+"""
+
+helps['dls fs preview'] = """
+type: command
+short-summary: Preview the content of a file in a Data Lake Store account.
+parameters:
+  - name: --length
+    type: long
+    short-summary: The amount of data to preview in bytes.
+    long-summary: If not specified, attempts to preview the full file. If the file is > 1MB `--force` must be specified.
+  - name: --offset
+    type: long
+    short-summary: The position in bytes to start the preview from.
+"""
+
+helps['dls fs remove-expiry'] = """
+type: command
+short-summary: Remove the expiration time for a file.
+"""
+
+helps['dls fs set-expiry'] = """
+type: command
+short-summary: Set the expiration time for a file.
+"""
+
+helps['dls fs show'] = """
+type: command
+short-summary: Get file or folder information in a Data Lake Store account.
+"""
+
+helps['dls fs test'] = """
+type: command
+short-summary: Test for the existence of a file or folder in a Data Lake Store account.
+"""
+
+helps['dls fs upload'] = """
+type: command
+short-summary: Upload a file or folder to a Data Lake Store account.
+parameters:
+  - name: --source-path
+    type: string
+    short-summary: The path to the file or folder to upload.
+  - name: --destination-path
+    type: string
+    short-summary: The full path in the Data Lake Store filesystem to upload the file or folder to.
+  - name: --thread-count
+    type: int
+    short-summary: 'Parallelism of the upload. Default: The number of cores in the local machine.'
+  - name: --chunk-size
+    type: int
+    short-summary: Size of a chunk, in bytes.
+    long-summary: Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.
+  - name: --buffer-size
+    type: int
+    short-summary: Size of the transfer buffer, in bytes.
+    long-summary: A buffer cannot be bigger than a chunk and cannot be smaller than a block.
+  - name: --block-size
+    type: int
+    short-summary: Size of a block, in bytes.
+    long-summary: Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.
+
 """

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
@@ -170,6 +170,10 @@ short-summary: Replace the existing access control list for a file or folder.
 helps['dls fs access set-entry'] = """
 type: command
 short-summary: Update the access control list for a file or folder.
+examples:
+  - name: Update the access control list for a file or folder. (crafted)
+    text: az dls fs access set-entry --acl-spec user:6360e05d-c381-4275-a932-5535806bb323:-w- --path {path}
+    crafted: true
 """
 
 helps['dls fs access set-owner'] = """
@@ -194,6 +198,10 @@ parameters:
 example:
   - name: Set full permissions for a user, read-execute permissions for a group, and execute permissions for all.
     text: az fs access set-permission --path /path/to/file.txt --permission 751
+examples:
+  - name: Set the permissions for a file or folder in a Data Lake Store account. (crafted)
+    text: az dls fs access set-permission --permission 777 --path {path}
+    crafted: true
 """
 
 helps['dls fs access show'] = """
@@ -217,11 +225,19 @@ parameters:
   - name: --content
     type: string
     short-summary: Content for the file to contain upon creation.
+examples:
+  - name: Creates a file or folder in a Data Lake Store account. (crafted)
+    text: az dls fs create --folder {folder} --path {path}
+    crafted: true
 """
 
 helps['dls fs delete'] = """
 type: command
 short-summary: Delete a file or folder in a Data Lake Store account.
+examples:
+  - name: Delete a file or folder in a Data Lake Store account. (crafted)
+    text: az dls fs delete --path {path}
+    crafted: true
 """
 
 helps['dls fs download'] = """
@@ -249,6 +265,10 @@ parameters:
     type: int
     short-summary: Size of a block, in bytes.
     long-summary: Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.
+examples:
+  - name: Download a file or folder from a Data Lake Store account to the local machine. (crafted)
+    text: az dls fs download --source-path {source-path} --destination-path {destination-path}
+    crafted: true
 """
 
 helps['dls fs join'] = """
@@ -266,6 +286,10 @@ parameters:
 helps['dls fs list'] = """
 type: command
 short-summary: List the files and folders in a Data Lake Store account.
+examples:
+  - name: List the files and folders in a Data Lake Store account. (crafted)
+    text: az dls fs list --path {path}
+    crafted: true
 """
 
 helps['dls fs move'] = """
@@ -306,11 +330,19 @@ short-summary: Set the expiration time for a file.
 helps['dls fs show'] = """
 type: command
 short-summary: Get file or folder information in a Data Lake Store account.
+examples:
+  - name: Get file or folder information in a Data Lake Store account. (commonly used with --output)
+    text: az dls fs show   --path {path}
+    crafted: true
 """
 
 helps['dls fs test'] = """
 type: command
 short-summary: Test for the existence of a file or folder in a Data Lake Store account.
+examples:
+  - name: Test for the existence of a file or folder in a Data Lake Store account. (crafted)
+    text: az dls fs test --path {path}
+    crafted: true
 """
 
 helps['dls fs upload'] = """
@@ -339,4 +371,8 @@ parameters:
     short-summary: Size of a block, in bytes.
     long-summary: Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.
 
+examples:
+  - name: Upload a file or folder to a Data Lake Store account. (crafted)
+    text: az dls fs upload --source-path {source-path} --destination-path {destination-path} --overwrite {overwrite}
+    crafted: true
 """

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -479,6 +479,10 @@ short-summary: List shared access policies of an IoT hub.
 helps['iot hub policy show'] = """
 type: command
 short-summary: Get the details of a shared access policy of an IoT hub.
+examples:
+  - name: Get the details of a shared access policy of an IoT hub. (commonly used with --query)
+    text: 'az iot hub policy show --hub-name MyHub  '
+    crafted: true
 """
 
 helps['iot hub route'] = """
@@ -634,6 +638,13 @@ examples:
 helps['iot hub show'] = """
 type: command
 short-summary: Get the details of an IoT hub.
+examples:
+  - name: Get the details of an IoT hub. (commonly used with --query)
+    text: 'az iot hub show  '
+    crafted: true
+  - name: Show the connection strings for an IoT hub. (crafted)
+    text: az iot hub show-connection-string --hub-name MyHub --policy-name service
+    crafted: true
 """
 
 helps['iot hub show-connection-string'] = """
@@ -657,6 +668,10 @@ examples:
 helps['iot hub show-quota-metrics'] = """
 type: command
 short-summary: Get the quota metrics for an IoT hub.
+examples:
+  - name: Get the quota metrics for an IoT hub. (commonly used with --query)
+    text: 'az iot hub show-quota-metrics  '
+    crafted: true
 """
 
 helps['iot hub show-stats'] = """

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -5,680 +5,670 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.help_files import helps
-
-from ._constants import certificate_help
-
+# pylint: disable=line-too-long, too-many-lines
 
 helps['iot'] = """
-    type: group
-    short-summary: Manage Internet of Things (IoT) assets.
-    long-summary: Comprehensive IoT data-plane functionality is available
-                  in the Azure IoT CLI Extension. For more info and install guide
-                  go to https://github.com/Azure/azure-iot-cli-extension
+type: group
+short-summary: Manage Internet of Things (IoT) assets.
+long-summary: Comprehensive IoT data-plane functionality is available in the Azure IoT CLI Extension. For more info and install guide go to https://github.com/Azure/azure-iot-cli-extension
 """
 
-helps['iot hub'] = """
-    type: group
-    short-summary: Manage Azure IoT hubs.
-"""
 helps['iot dps'] = """
-    type: group
-    short-summary: Manage Azure IoT Hub Device Provisioning Service.
-"""
-
-helps['iot dps create'] = """
-    type: command
-    short-summary: Create an Azure IoT Hub device provisioning service.
-    long-summary: For an introduction to Azure IoT Hub Device Provisioning Service, see https://docs.microsoft.com/en-us/azure/iot-dps/about-iot-dps
-    examples:
-        - name: Create an Azure IoT Hub device provisioning service with the standard pricing tier S1, in the region of the resource group.
-          text: >
-            az iot dps create --name MyDps --resource-group MyResourceGroup
-        - name: Create an Azure IoT Hub device provisioning service with the standard pricing tier S1, in the 'eastus' region.
-          text: >
-            az iot dps create --name MyDps --resource-group MyResourceGroup --location eastus
-"""
-
-helps['iot dps list'] = """
-    type: command
-    short-summary: List Azure IoT Hub device provisioning services.
-    examples:
-        - name: List all Azure IoT Hub device provisioning services in a subscription.
-          text: >
-            az iot dps list
-        - name: List all Azure IoT Hub device provisioning services in the resource group 'MyResourceGroup'
-          text: >
-            az iot dps list --resource-group MyResourceGroup
-"""
-
-helps['iot dps show'] = """
-    type: command
-    short-summary: Get the details of an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Show details of an Azure IoT Hub device provisioning service 'MyDps'
-          text: >
-            az iot dps show --name MyDps --resource-group MyResourceGroup
-"""
-
-helps['iot dps delete'] = """
-    type: command
-    short-summary: Delete an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Delete an Azure IoT Hub device provisioning service 'MyDps'
-          text: >
-            az iot dps delete --name MyDps --resource-group MyResourceGroup
-"""
-
-helps['iot dps update'] = """
-    type: command
-    short-summary: Update an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Update Allocation Policy to 'GeoLatency' of an Azure IoT Hub device provisioning service 'MyDps'
-          text: >
-            az iot dps update --name MyDps --resource-group MyResourceGroup --set properties.allocationPolicy="GeoLatency"
+type: group
+short-summary: Manage Azure IoT Hub Device Provisioning Service.
 """
 
 helps['iot dps access-policy'] = """
-    type: group
-    short-summary: Manage Azure IoT Hub Device Provisioning Service access policies.
+type: group
+short-summary: Manage Azure IoT Hub Device Provisioning Service access policies.
 """
 
 helps['iot dps access-policy create'] = """
-    type: command
-    short-summary: Create a new shared access policy in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Create a new shared access policy in an Azure IoT Hub device provisioning service with EnrollmentRead right
-          text: >
-            az iot dps access-policy create --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy --rights EnrollmentRead
-"""
-
-helps['iot dps access-policy update'] = """
-    type: command
-    short-summary: Update a shared access policy in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Update access policy 'MyPolicy' in an Azure IoT Hub device provisioning service with EnrollmentWrite right
-          text: >
-            az iot dps access-policy update --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy --rights EnrollmentWrite
-"""
-
-helps['iot dps access-policy list'] = """
-    type: command
-    short-summary: List all shared access policies in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: List all shared access policies in MyDps
-          text: >
-            az iot dps access-policy list --dps-name MyDps --resource-group MyResourceGroup
-"""
-
-helps['iot dps access-policy show'] = """
-    type: command
-    short-summary: Show details of a shared access policies in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Show details of shared access policy 'MyPolicy' in an Azure IoT Hub device provisioning service
-          text: >
-            az iot dps access-policy show --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy
+type: command
+short-summary: Create a new shared access policy in an Azure IoT Hub device provisioning service.
+examples:
+  - name: Create a new shared access policy in an Azure IoT Hub device provisioning service with EnrollmentRead right
+    text: >
+        az iot dps access-policy create --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy --rights EnrollmentRead
 """
 
 helps['iot dps access-policy delete'] = """
-    type: command
-    short-summary: Delete a shared access policies in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Delete shared access policy 'MyPolicy' in an Azure IoT Hub device provisioning service
-          text: >
-            az iot dps access-policy delete --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy
+type: command
+short-summary: Delete a shared access policies in an Azure IoT Hub device provisioning service.
+examples:
+  - name: Delete shared access policy 'MyPolicy' in an Azure IoT Hub device provisioning service
+    text: >
+        az iot dps access-policy delete --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy
 """
 
-helps['iot dps linked-hub'] = """
-    type: group
-    short-summary: Manage Azure IoT Hub Device Provisioning Service linked IoT hubs.
+helps['iot dps access-policy list'] = """
+type: command
+short-summary: List all shared access policies in an Azure IoT Hub device provisioning service.
+examples:
+  - name: List all shared access policies in MyDps
+    text: >
+        az iot dps access-policy list --dps-name MyDps --resource-group MyResourceGroup
 """
 
-helps['iot dps linked-hub create'] = """
-    type: command
-    short-summary: Create a linked IoT hub in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Create a linked IoT hub in an Azure IoT Hub device provisioning service
-          text: >
-            az iot dps linked-hub create --dps-name MyDps --resource-group MyResourceGroup --connection-string
-            HostName=test.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=XNBhoasdfhqRlgGnasdfhivtshcwh4bJwe7c0RIGuWsirW0=
-            --location westus
-        - name: Create a linked IoT hub in an Azure IoT Hub device provisioning service which applies allocation weight and weight being 10
-          text: >
-            az iot dps linked-hub create --dps-name MyDps --resource-group MyResourceGroup --connection-string
-            HostName=test.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=XNBhoasdfhqRlgGnasdfhivtshcwh4bJwe7c0RIGuWsirW0=
-            --location westus --allocation-weight 10 --apply-allocation-policy True
+helps['iot dps access-policy show'] = """
+type: command
+short-summary: Show details of a shared access policies in an Azure IoT Hub device provisioning service.
+examples:
+  - name: Show details of shared access policy 'MyPolicy' in an Azure IoT Hub device provisioning service
+    text: >
+        az iot dps access-policy show --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy
 """
 
-helps['iot dps linked-hub update'] = """
-    type: command
-    short-summary: Update a linked IoT hub in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Update linked IoT hub 'MyLinkedHub.azure-devices.net' in an Azure IoT Hub device provisioning service
-          text: >
-            az iot dps linked-hub update --dps-name MyDps --resource-group MyResourceGroup --linked-hub MyLinkedHub.azure-devices.net
-            --allocation-weight 10 --apply-allocation-policy True
-"""
-
-helps['iot dps linked-hub list'] = """
-    type: command
-    short-summary: List all linked IoT hubs in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: List all linked IoT hubs in MyDps
-          text: >
-            az iot dps linked-hub list --dps-name MyDps --resource-group MyResourceGroup
-"""
-
-helps['iot dps linked-hub show'] = """
-    type: command
-    short-summary: Show details of a linked IoT hub in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Show details of linked IoT hub 'MyLinkedHub' in an Azure IoT Hub device provisioning service
-          text: >
-            az iot dps linked-hub show --dps-name MyDps --resource-group MyResourceGroup --linked-hub MyLinkedHub
-"""
-
-helps['iot dps linked-hub delete'] = """
-    type: command
-    short-summary: Update a linked IoT hub in an Azure IoT Hub device provisioning service.
-    examples:
-        - name: Delete linked IoT hub 'MyLinkedHub' in an Azure IoT Hub device provisioning service
-          text: >
-            az iot dps linked-hub delete --dps-name MyDps --resource-group MyResourceGroup --linked-hub MyLinkedHub
+helps['iot dps access-policy update'] = """
+type: command
+short-summary: Update a shared access policy in an Azure IoT Hub device provisioning service.
+examples:
+  - name: Update access policy 'MyPolicy' in an Azure IoT Hub device provisioning service with EnrollmentWrite right
+    text: >
+        az iot dps access-policy update --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy --rights EnrollmentWrite
 """
 
 helps['iot dps certificate'] = """
-    type: group
-    short-summary: Manage Azure IoT Hub Device Provisioning Service certificates.
+type: group
+short-summary: Manage Azure IoT Hub Device Provisioning Service certificates.
 """
 
 helps['iot dps certificate create'] = """
-    type: command
-    short-summary: Create/upload an Azure IoT Hub Device Provisioning Service certificate.
-    examples:
-        - name: Upload a CA certificate PEM file to an Azure IoT Hub device provisioning service.
-          text: >
-            az iot dps certificate create --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate --path /certificates/Certificate.pem
-        - name: Upload a CA certificate CER file to an Azure IoT Hub device provisioning service.
-          text: >
-            az iot dps certificate create --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate --path /certificates/Certificate.cer
-"""
-
-helps['iot dps certificate update'] = """
-    type: command
-    short-summary: Update an Azure IoT Hub Device Provisioning Service certificate.
-    long-summary: Upload a new certificate to replace the existing certificate with the same name.
-    examples:
-        - name: Update a CA certificate in an Azure IoT Hub device provisioning service by uploading a new PEM file.
-          text: >
-            az iot dps certificate update --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
-            --path /certificates/NewCertificate.pem --etag AAAAAAAAAAA=
-        - name: Update a CA certificate in an Azure IoT Hub device provisioning service by uploading a new CER file.
-          text: >
-            az iot dps certificate update --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
-            --path /certificates/NewCertificate.cer --etag AAAAAAAAAAA=
+type: command
+short-summary: Create/upload an Azure IoT Hub Device Provisioning Service certificate.
+examples:
+  - name: Upload a CA certificate PEM file to an Azure IoT Hub device provisioning service.
+    text: >
+        az iot dps certificate create --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate --path /certificates/Certificate.pem
+  - name: Upload a CA certificate CER file to an Azure IoT Hub device provisioning service.
+    text: >
+        az iot dps certificate create --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate --path /certificates/Certificate.cer
 """
 
 helps['iot dps certificate delete'] = """
-    type: command
-    short-summary: Delete an Azure IoT Hub Device Provisioning Service certificate.
-    examples:
-        - name: Delete MyCertificate in an Azure IoT Hub device provisioning service
-          text: >
-            az iot dps certificate delete --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate --etag AAAAAAAAAAA=
-"""
-
-helps['iot dps certificate show'] = """
-    type: command
-    short-summary: Show information about a particular Azure IoT Hub Device Provisioning Service certificate.
-    examples:
-        - name: Show details about MyCertificate in an Azure IoT Hub device provisioning service
-          text: >
-            az iot dps certificate show --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
-"""
-
-helps['iot dps certificate list'] = """
-    type: command
-    short-summary: List all certificates contained within an Azure IoT Hub device provisioning service
-    examples:
-        - name: List all certificates in MyDps
-          text: >
-            az iot dps certificate list --dps-name MyDps --resource-group MyResourceGroup
+type: command
+short-summary: Delete an Azure IoT Hub Device Provisioning Service certificate.
+examples:
+  - name: Delete MyCertificate in an Azure IoT Hub device provisioning service
+    text: >
+        az iot dps certificate delete --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate --etag AAAAAAAAAAA=
 """
 
 helps['iot dps certificate generate-verification-code'] = """
-    type: command
-    short-summary: Generate a verification code for an Azure IoT Hub Device Provisioning Service certificate.
-    long-summary: This verification code is used to complete the proof of possession step for a certificate. Use this
-                  verification code as the CN of a new certificate signed with the root certificates private key.
-    examples:
-        - name: Generate a verification code for MyCertificate
-          text: >
-            az iot dps certificate generate-verification-code --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
-            --etag AAAAAAAAAAA=
+type: command
+short-summary: Generate a verification code for an Azure IoT Hub Device Provisioning Service certificate.
+long-summary: This verification code is used to complete the proof of possession step for a certificate. Use this verification code as the CN of a new certificate signed with the root certificates private key.
+examples:
+  - name: Generate a verification code for MyCertificate
+    text: >
+        az iot dps certificate generate-verification-code --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
+        --etag AAAAAAAAAAA=
+"""
+
+helps['iot dps certificate list'] = """
+type: command
+short-summary: List all certificates contained within an Azure IoT Hub device provisioning service
+examples:
+  - name: List all certificates in MyDps
+    text: >
+        az iot dps certificate list --dps-name MyDps --resource-group MyResourceGroup
+"""
+
+helps['iot dps certificate show'] = """
+type: command
+short-summary: Show information about a particular Azure IoT Hub Device Provisioning Service certificate.
+examples:
+  - name: Show details about MyCertificate in an Azure IoT Hub device provisioning service
+    text: >
+        az iot dps certificate show --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
+"""
+
+helps['iot dps certificate update'] = """
+type: command
+short-summary: Update an Azure IoT Hub Device Provisioning Service certificate.
+long-summary: Upload a new certificate to replace the existing certificate with the same name.
+examples:
+  - name: Update a CA certificate in an Azure IoT Hub device provisioning service by uploading a new PEM file.
+    text: >
+        az iot dps certificate update --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
+        --path /certificates/NewCertificate.pem --etag AAAAAAAAAAA=
+  - name: Update a CA certificate in an Azure IoT Hub device provisioning service by uploading a new CER file.
+    text: >
+        az iot dps certificate update --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
+        --path /certificates/NewCertificate.cer --etag AAAAAAAAAAA=
 """
 
 helps['iot dps certificate verify'] = """
-    type: command
-    short-summary: Verify an Azure IoT Hub Device Provisioning Service certificate.
-    long-summary: Verify a certificate by uploading a verification certificate containing the verification code obtained
-                  by calling generate-verification-code. This is the last step in the proof of possession process.
-    examples:
-        - name: Verify ownership of the MyCertificate private key.
-          text: >
-            az iot dps certificate verify --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
-            --path /certificates/Verification.pem --etag AAAAAAAAAAA=
+type: command
+short-summary: Verify an Azure IoT Hub Device Provisioning Service certificate.
+long-summary: Verify a certificate by uploading a verification certificate containing the verification code obtained by calling generate-verification-code. This is the last step in the proof of possession process.
+examples:
+  - name: Verify ownership of the MyCertificate private key.
+    text: >
+        az iot dps certificate verify --dps-name MyDps --resource-group MyResourceGroup --name MyCertificate
+        --path /certificates/Verification.pem --etag AAAAAAAAAAA=
+"""
+
+helps['iot dps create'] = """
+type: command
+short-summary: Create an Azure IoT Hub device provisioning service.
+long-summary: For an introduction to Azure IoT Hub Device Provisioning Service, see https://docs.microsoft.com/en-us/azure/iot-dps/about-iot-dps
+examples:
+  - name: Create an Azure IoT Hub device provisioning service with the standard pricing tier S1, in the region of the resource group.
+    text: >
+        az iot dps create --name MyDps --resource-group MyResourceGroup
+  - name: Create an Azure IoT Hub device provisioning service with the standard pricing tier S1, in the 'eastus' region.
+    text: >
+        az iot dps create --name MyDps --resource-group MyResourceGroup --location eastus
+"""
+
+helps['iot dps delete'] = """
+type: command
+short-summary: Delete an Azure IoT Hub device provisioning service.
+examples:
+  - name: Delete an Azure IoT Hub device provisioning service 'MyDps'
+    text: >
+        az iot dps delete --name MyDps --resource-group MyResourceGroup
+"""
+
+helps['iot dps linked-hub'] = """
+type: group
+short-summary: Manage Azure IoT Hub Device Provisioning Service linked IoT hubs.
+"""
+
+helps['iot dps linked-hub create'] = """
+type: command
+short-summary: Create a linked IoT hub in an Azure IoT Hub device provisioning service.
+examples:
+  - name: Create a linked IoT hub in an Azure IoT Hub device provisioning service
+    text: >
+        az iot dps linked-hub create --dps-name MyDps --resource-group MyResourceGroup --connection-string
+        HostName=test.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=XNBhoasdfhqRlgGnasdfhivtshcwh4bJwe7c0RIGuWsirW0=
+        --location westus
+  - name: Create a linked IoT hub in an Azure IoT Hub device provisioning service which applies allocation weight and weight being 10
+    text: >
+        az iot dps linked-hub create --dps-name MyDps --resource-group MyResourceGroup --connection-string
+        HostName=test.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=XNBhoasdfhqRlgGnasdfhivtshcwh4bJwe7c0RIGuWsirW0=
+        --location westus --allocation-weight 10 --apply-allocation-policy True
+"""
+
+helps['iot dps linked-hub delete'] = """
+type: command
+short-summary: Update a linked IoT hub in an Azure IoT Hub device provisioning service.
+examples:
+  - name: Delete linked IoT hub 'MyLinkedHub' in an Azure IoT Hub device provisioning service
+    text: >
+        az iot dps linked-hub delete --dps-name MyDps --resource-group MyResourceGroup --linked-hub MyLinkedHub
+"""
+
+helps['iot dps linked-hub list'] = """
+type: command
+short-summary: List all linked IoT hubs in an Azure IoT Hub device provisioning service.
+examples:
+  - name: List all linked IoT hubs in MyDps
+    text: >
+        az iot dps linked-hub list --dps-name MyDps --resource-group MyResourceGroup
+"""
+
+helps['iot dps linked-hub show'] = """
+type: command
+short-summary: Show details of a linked IoT hub in an Azure IoT Hub device provisioning service.
+examples:
+  - name: Show details of linked IoT hub 'MyLinkedHub' in an Azure IoT Hub device provisioning service
+    text: >
+        az iot dps linked-hub show --dps-name MyDps --resource-group MyResourceGroup --linked-hub MyLinkedHub
+"""
+
+helps['iot dps linked-hub update'] = """
+type: command
+short-summary: Update a linked IoT hub in an Azure IoT Hub device provisioning service.
+examples:
+  - name: Update linked IoT hub 'MyLinkedHub.azure-devices.net' in an Azure IoT Hub device provisioning service
+    text: >
+        az iot dps linked-hub update --dps-name MyDps --resource-group MyResourceGroup --linked-hub MyLinkedHub.azure-devices.net
+        --allocation-weight 10 --apply-allocation-policy True
+"""
+
+helps['iot dps list'] = """
+type: command
+short-summary: List Azure IoT Hub device provisioning services.
+examples:
+  - name: List all Azure IoT Hub device provisioning services in a subscription.
+    text: >
+        az iot dps list
+  - name: List all Azure IoT Hub device provisioning services in the resource group 'MyResourceGroup'
+    text: >
+        az iot dps list --resource-group MyResourceGroup
+"""
+
+helps['iot dps show'] = """
+type: command
+short-summary: Get the details of an Azure IoT Hub device provisioning service.
+examples:
+  - name: Show details of an Azure IoT Hub device provisioning service 'MyDps'
+    text: >
+        az iot dps show --name MyDps --resource-group MyResourceGroup
+"""
+
+helps['iot dps update'] = """
+type: command
+short-summary: Update an Azure IoT Hub device provisioning service.
+examples:
+  - name: Update Allocation Policy to 'GeoLatency' of an Azure IoT Hub device provisioning service 'MyDps'
+    text: >
+        az iot dps update --name MyDps --resource-group MyResourceGroup --set properties.allocationPolicy="GeoLatency"
+"""
+
+helps['iot hub'] = """
+type: group
+short-summary: Manage Azure IoT hubs.
 """
 
 helps['iot hub certificate'] = """
-    type: group
-    short-summary: Manage IoT Hub certificates.
+type: group
+short-summary: Manage IoT Hub certificates.
 """
 
 helps['iot hub certificate create'] = """
-    type: command
-    short-summary: Create/upload an Azure IoT Hub certificate.
-    long-summary: {0}
-    examples:
-        - name: Uploads a CA certificate PEM file to an IoT hub.
-          text: >
-            az iot hub certificate create --hub-name MyIotHub --name MyCertificate --path /certificates/Certificate.pem
-        - name: Uploads a CA certificate CER file to an IoT hub.
-          text: >
-            az iot hub certificate create --hub-name MyIotHub --name MyCertificate --path /certificates/Certificate.cer
-""".format(certificate_help)
-
-helps['iot hub certificate update'] = """
-    type: command
-    short-summary: Update an Azure IoT Hub certificate.
-    long-summary: Uploads a new certificate to replace the existing certificate with the same name. {0}
-    examples:
-        - name: Updates a CA certificate in an IoT hub by uploading a new PEM file.
-          text: >
-            az iot hub certificate update --hub-name MyIotHub --name MyCertificate --path /certificates/NewCertificate.pem --etag
-            AAAAAAAAAAA=
-        - name: Updates a CA certificate in an IoT hub by uploading a new CER file.
-          text: >
-            az iot hub certificate update --hub-name MyIotHub --name MyCertificate --path /certificates/NewCertificate.cer --etag
-            AAAAAAAAAAA=
-""".format(certificate_help)
+type: command
+short-summary: Create/upload an Azure IoT Hub certificate.
+long-summary: For a detailed explanation of CA certificates in Azure IoT Hub, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-x509ca-overview
+examples:
+  - name: Uploads a CA certificate PEM file to an IoT hub.
+    text: >
+        az iot hub certificate create --hub-name MyIotHub --name MyCertificate --path /certificates/Certificate.pem
+  - name: Uploads a CA certificate CER file to an IoT hub.
+    text: >
+        az iot hub certificate create --hub-name MyIotHub --name MyCertificate --path /certificates/Certificate.cer
+"""
 
 helps['iot hub certificate delete'] = """
-    type: command
-    short-summary: Deletes an Azure IoT Hub certificate.
-    long-summary: {0}
-    examples:
-        - name: Deletes MyCertificate
-          text: >
-            az iot hub certificate delete --hub-name MyIotHub --name MyCertificate --etag AAAAAAAAAAA=
-""".format(certificate_help)
-
-helps['iot hub certificate show'] = """
-    type: command
-    short-summary: Shows information about a particular Azure IoT Hub certificate.
-    long-summary: {0}
-    examples:
-        - name: Show details about MyCertificate
-          text: >
-            az iot hub certificate show --hub-name MyIotHub --name MyCertificate
-""".format(certificate_help)
-
-helps['iot hub certificate list'] = """
-    type: command
-    short-summary: Lists all certificates contained within an Azure IoT Hub
-    long-summary: {0}
-    examples:
-        - name: List all certificates in MyIotHub
-          text: >
-            az iot hub certificate list --hub-name MyIotHub
-""".format(certificate_help)
+type: command
+short-summary: Deletes an Azure IoT Hub certificate.
+long-summary: For a detailed explanation of CA certificates in Azure IoT Hub, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-x509ca-overview
+examples:
+  - name: Deletes MyCertificate
+    text: >
+        az iot hub certificate delete --hub-name MyIotHub --name MyCertificate --etag AAAAAAAAAAA=
+"""
 
 helps['iot hub certificate generate-verification-code'] = """
-    type: command
-    short-summary: Generates a verification code for an Azure IoT Hub certificate.
-    long-summary: This verification code is used to complete the proof of possession step for a certificate. Use this
-                  verification code as the CN of a new certificate signed with the root certificates private key. {0}
-    examples:
-        - name: Generates a verification code for MyCertificate
-          text: >
-            az iot hub certificate generate-verification-code --hub-name MyIotHub --name MyCertificate --etag
-            AAAAAAAAAAA=
-""".format(certificate_help)
+type: command
+short-summary: Generates a verification code for an Azure IoT Hub certificate.
+long-summary: This verification code is used to complete the proof of possession step for a certificate. Use this verification code as the CN of a new certificate signed with the root certificates private key. For a detailed explanation of CA certificates in Azure IoT Hub, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-x509ca-overview
+examples:
+  - name: Generates a verification code for MyCertificate
+    text: >
+        az iot hub certificate generate-verification-code --hub-name MyIotHub --name MyCertificate --etag
+        AAAAAAAAAAA=
+"""
+
+helps['iot hub certificate list'] = """
+type: command
+short-summary: Lists all certificates contained within an Azure IoT Hub
+long-summary: For a detailed explanation of CA certificates in Azure IoT Hub, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-x509ca-overview
+examples:
+  - name: List all certificates in MyIotHub
+    text: >
+        az iot hub certificate list --hub-name MyIotHub
+"""
+
+helps['iot hub certificate show'] = """
+type: command
+short-summary: Shows information about a particular Azure IoT Hub certificate.
+long-summary: For a detailed explanation of CA certificates in Azure IoT Hub, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-x509ca-overview
+examples:
+  - name: Show details about MyCertificate
+    text: >
+        az iot hub certificate show --hub-name MyIotHub --name MyCertificate
+"""
+
+helps['iot hub certificate update'] = """
+type: command
+short-summary: Update an Azure IoT Hub certificate.
+long-summary: Uploads a new certificate to replace the existing certificate with the same name. For a detailed explanation of CA certificates in Azure IoT Hub, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-x509ca-overview
+examples:
+  - name: Updates a CA certificate in an IoT hub by uploading a new PEM file.
+    text: >
+        az iot hub certificate update --hub-name MyIotHub --name MyCertificate --path /certificates/NewCertificate.pem --etag
+        AAAAAAAAAAA=
+  - name: Updates a CA certificate in an IoT hub by uploading a new CER file.
+    text: >
+        az iot hub certificate update --hub-name MyIotHub --name MyCertificate --path /certificates/NewCertificate.cer --etag
+        AAAAAAAAAAA=
+"""
 
 helps['iot hub certificate verify'] = """
-    type: command
-    short-summary: Verifies an Azure IoT Hub certificate.
-    long-summary: Verifies a certificate by uploading a verification certificate containing the verification code obtained
-                  by calling generate-verification-code. This is the last step in the proof of possession process. {0}
-    examples:
-        - name: Verifies ownership of the MyCertificate private key.
-          text: >
-            az iot hub certificate verify --hub-name MyIotHub --name MyCertificate --path /certificates/Verification.pem --etag
-            AAAAAAAAAAA=
-""".format(certificate_help)
-
-helps['iot hub create'] = """
-    type: command
-    short-summary: Create an Azure IoT hub.
-    long-summary: For an introduction to Azure IoT Hub, see https://docs.microsoft.com/azure/iot-hub/
-    examples:
-        - name: Create an IoT Hub with the free pricing tier F1, in the region of the resource group.
-          text: >
-            az iot hub create --resource-group MyResourceGroup --name MyIotHub
-        - name: Create an IoT Hub with the standard pricing tier S1 and 4 partitions, in the 'westus' region.
-          text: >
-            az iot hub create --resource-group MyResourceGroup --name MyIotHub --sku S1 --location westus
-            --partition-count 4
-"""
-
-helps['iot hub show'] = """
-    type: command
-    short-summary: Get the details of an IoT hub.
-"""
-
-helps['iot hub update'] = """
-    type: command
-    short-summary: Update metadata for an IoT hub.
-    examples:
-        - name: Add a firewall filter rule to accept traffic from the IP mask 127.0.0.0/31.
-          text: >
-            az iot hub update --name MyIotHub --add properties.ipFilterRules filter_name=test-rule action=Accept ip_mask=127.0.0.0/31
-"""
-
-helps['iot hub list'] = """
-    type: command
-    short-summary: List IoT hubs.
-    examples:
-        - name: List all IoT hubs in a subscription.
-          text: >
-            az iot hub list
-        - name: List all IoT hubs in the resource group 'MyGroup'
-          text: >
-            az iot hub list --resource-group MyGroup
-"""
-
-helps['iot hub show-connection-string'] = """
-    type: command
-    short-summary: Show the connection strings for an IoT hub.
-    examples:
-        - name: Show the connection string of an IoT hub using default policy and primary key.
-          text: >
-            az iot hub show-connection-string --name MyIotHub
-        - name: Show the connection string of an IoT Hub using policy 'service' and secondary key.
-          text: >
-            az iot hub show-connection-string --name MyIotHub --policy-name service --key secondary
-        - name: Show the connection strings for all IoT hubs in a resource group.
-          text: >
-            az iot hub show-connection-string --resource-group MyResourceGroup
-        - name: Show the connection strings for all IoT hubs in a subscription.
-          text: >
-            az iot hub show-connection-string
-"""
-
-helps['iot hub delete'] = """
-    type: command
-    short-summary: Delete an IoT hub.
+type: command
+short-summary: Verifies an Azure IoT Hub certificate.
+long-summary: Verifies a certificate by uploading a verification certificate containing the verification code obtained by calling generate-verification-code. This is the last step in the proof of possession process. For a detailed explanation of CA certificates in Azure IoT Hub, see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-x509ca-overview
+examples:
+  - name: Verifies ownership of the MyCertificate private key.
+    text: >
+        az iot hub certificate verify --hub-name MyIotHub --name MyCertificate --path /certificates/Verification.pem --etag
+        AAAAAAAAAAA=
 """
 
 helps['iot hub consumer-group'] = """
-    type: group
-    short-summary: Manage the event hub consumer groups of an IoT hub.
+type: group
+short-summary: Manage the event hub consumer groups of an IoT hub.
 """
 
 helps['iot hub consumer-group create'] = """
-    type: command
-    short-summary: Create an event hub consumer group.
-    examples:
-        - name: Create a consumer group 'cg1' in the default event hub endpoint.
-          text: >
-            az iot hub consumer-group create --hub-name MyIotHub --name cg1
-        - name: Create a consumer group `cg1` in the operation monitoring event hub endpoint `operationsMonitoringEvents`.
-          text: >
-            az iot hub consumer-group create --hub-name MyIotHub --event-hub-name operationsMonitoringEvents --name cg1
-"""
-
-helps['iot hub consumer-group list'] = """
-    type: command
-    short-summary: List event hub consumer groups.
-"""
-
-helps['iot hub consumer-group show'] = """
-    type: command
-    short-summary: Get the details for an event hub consumer group.
+type: command
+short-summary: Create an event hub consumer group.
+examples:
+  - name: Create a consumer group 'cg1' in the default event hub endpoint.
+    text: >
+        az iot hub consumer-group create --hub-name MyIotHub --name cg1
+  - name: Create a consumer group `cg1` in the operation monitoring event hub endpoint `operationsMonitoringEvents`.
+    text: >
+        az iot hub consumer-group create --hub-name MyIotHub --event-hub-name operationsMonitoringEvents --name cg1
 """
 
 helps['iot hub consumer-group delete'] = """
-    type: command
-    short-summary: Delete an event hub consumer group.
+type: command
+short-summary: Delete an event hub consumer group.
 """
 
-helps['iot hub policy'] = """
-    type: group
-    short-summary: Manage shared access policies of an IoT hub.
+helps['iot hub consumer-group list'] = """
+type: command
+short-summary: List event hub consumer groups.
 """
 
-helps['iot hub policy list'] = """
-    type: command
-    short-summary: List shared access policies of an IoT hub.
+helps['iot hub consumer-group show'] = """
+type: command
+short-summary: Get the details for an event hub consumer group.
 """
 
-helps['iot hub policy show'] = """
-    type: command
-    short-summary: Get the details of a shared access policy of an IoT hub.
+helps['iot hub create'] = """
+type: command
+short-summary: Create an Azure IoT hub.
+long-summary: For an introduction to Azure IoT Hub, see https://docs.microsoft.com/azure/iot-hub/
+examples:
+  - name: Create an IoT Hub with the free pricing tier F1, in the region of the resource group.
+    text: >
+        az iot hub create --resource-group MyResourceGroup --name MyIotHub
+  - name: Create an IoT Hub with the standard pricing tier S1 and 4 partitions, in the 'westus' region.
+    text: >
+        az iot hub create --resource-group MyResourceGroup --name MyIotHub --sku S1 --location westus
+        --partition-count 4
 """
 
-helps['iot hub policy create'] = """
-    type: command
-    short-summary: Create a new shared access policy in an IoT hub.
-    examples:
-        - name: Create a new shared access policy.
-          text: >
-            az iot hub policy create --hub-name MyIotHub --name new-policy --permissions RegistryWrite ServiceConnect DeviceConnect
-"""
-
-helps['iot hub policy delete'] = """
-    type: command
-    short-summary: Delete a shared access policy from an IoT hub.
-"""
-
-helps['iot hub list-skus'] = """
-    type: command
-    short-summary: List available pricing tiers.
-"""
-
-helps['iot hub job'] = """
-    type: group
-    short-summary: Manage jobs in an IoT hub.
-"""
-
-helps['iot hub job list'] = """
-    type: command
-    short-summary: List the jobs in an IoT hub.
-"""
-
-helps['iot hub job show'] = """
-    type: command
-    short-summary: Get the details of a job in an IoT hub.
-"""
-
-helps['iot hub job cancel'] = """
-    type: command
-    short-summary: Cancel a job in an IoT hub.
-"""
-
-helps['iot hub show-quota-metrics'] = """
-    type: command
-    short-summary: Get the quota metrics for an IoT hub.
-"""
-
-helps['iot hub show-stats'] = """
-    type: command
-    short-summary: Get the statistics for an IoT hub.
-"""
-
-helps['iot hub routing-endpoint'] = """
-    type: group
-    short-summary: Manage custom endpoints of an IoT hub.
-"""
-
-helps['iot hub routing-endpoint create'] = """
-    type: command
-    short-summary: Add an endpoint to your IoT Hub.
-    long-summary: Create a new custom endpoint in your IoT Hub.
-    examples:
-        - name: Add a new endpoint "E2" of type EventHub to "MyIotHub" IoT Hub.
-          text: >
-            az iot hub routing-endpoint create --resource-group MyResourceGroup --hub-name MyIotHub
-            --endpoint-name E2 --endpoint-type eventhub --endpoint-resource-group {ResourceGroup}
-            --endpoint-subscription-id {SubscriptionId} --connection-string {ConnectionString}
-        - name: Add a new endpoint "S1" of type AzureStorageContainer to "MyIotHub" IoT Hub.
-          text: |
-            az iot hub routing-endpoint create --resource-group MyResourceGroup --hub-name MyIotHub \\
-            --endpoint-name S1 --endpoint-type azurestoragecontainer --endpoint-resource-group "[Resource Group]" \\
-            --endpoint-subscription-id {SubscriptionId} --connection-string {ConnectionString} \\
-            --container-name {ContainerName}
-"""
-
-helps['iot hub routing-endpoint list'] = """
-    type: command
-    short-summary: Get information on all the endpoints for your IoT Hub.
-    long-summary: Get information on all endpoints in your IoT Hub.
-                  You can also specify which endpoint type you want to get informaiton on.
-    examples:
-        - name: Get all the endpoints from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub routing-endpoint list -g MyResourceGroup --hub-name MyIotHub
-        - name: Get all the endpoints of type "EventHub" from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub routing-endpoint list -g MyResourceGroup --hub-name MyIotHub
-            --endpoint-type eventhub
-"""
-
-helps['iot hub routing-endpoint show'] = """
-    type: command
-    short-summary: Get information on mentioned endpoint for your IoT Hub.
-    long-summary: Get information on a specific endpoint in your IoT Hub
-    examples:
-        - name: Get an endpoint information from "MyIotHub" IoT Hub.
-          text: |
-            az iot hub routing-endpoint show --resource-group MyResourceGroup --hub-name MyIotHub \\
-            --endpoint-name {endpointName}
-"""
-
-helps['iot hub routing-endpoint delete'] = """
-    type: command
-    short-summary: Delete all or mentioned endpoint for your IoT Hub.
-    long-summary: Delete an endpoint for your IoT Hub. We recommend that you delete
-                  any routes to the endpoint, before deleting the endpoint.
-    examples:
-        - name: Delete endpoint "E2" from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub routing-endpoint delete --resource-group MyResourceGroup --hub-name MyIotHub
-            --endpoint-name E2
-        - name: Delete all the endpoints of type "EventHub" from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub routing-endpoint delete --resource-group MyResourceGroup --hub-name MyIotHub
-            --endpoint-type eventhub
-        - name: Delete all the endpoints from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub routing-endpoint delete --resource-group MyResourceGroup --hub-name MyIotHub
-"""
-
-helps['iot hub route'] = """
-    type: group
-    short-summary: Manage routes of an IoT hub.
-"""
-
-helps['iot hub route create'] = """
-    type: command
-    short-summary: Create a route in IoT Hub.
-    long-summary: Create a route to send specific data source and condition to a desired endpoint.
-    examples:
-        - name: Create a new route "R1".
-          text: >
-            az iot hub route create -g MyResourceGroup --hub-name MyIotHub
-            --endpoint-name E2 --source-type DeviceMessages --route-name R1
-        - name: Create a new route "R1" with all parameters.
-          text: >
-            az iot hub route create -g MyResourceGroup --hub-name MyIotHub
-            --endpoint-name E2 --source-type DeviceMessages --route-name R1
-            --condition true --enabled true
-"""
-
-helps['iot hub route list'] = """
-    type: command
-    short-summary: Get all the routes in IoT Hub.
-    long-summary: Get information on all routes from an IoT Hub.
-    examples:
-        - name: Get all route from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub route list -g MyResourceGroup --hub-name MyIotHub
-        - name: Get all the routes of source type "DeviceMessages" from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub route list -g MyResourceGroup --hub-name MyIotHub --source-type DeviceMessages
-"""
-
-helps['iot hub route show'] = """
-    type: command
-    short-summary: Get information about the route in IoT Hub.
-    long-summary: Get information on a specific route in your IoT Hub.
-    examples:
-        - name: Get an route information from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub route show -g MyResourceGroup --hub-name MyIotHub --route-name {routeName}
-"""
-
-helps['iot hub route delete'] = """
-    type: command
-    short-summary: Delete all or mentioned route for your IoT Hub.
-    long-summary: Delete a route or all routes for your IoT Hub.
-    examples:
-        - name: Delete route "R1" from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub route delete -g MyResourceGroup --hub-name MyIotHub --route-name R1
-        - name: Delete all the routes of source type "DeviceMessages" from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub route delete -g MyResourceGroup --hub-name MyIotHub --source-type DeviceMessages
-        - name: Delete all the routes from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub route delete -g MyResourceGroup --hub-name MyIotHub
-"""
-
-helps['iot hub route test'] = """
-    type: command
-    short-summary: Test all routes or mentioned route in IoT Hub.
-    long-summary: Test all existing routes or mentioned route in your IoT Hub.
-                  You can provide a sample message to test your routes.
-    examples:
-        - name: Test the route "R1" from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub route test -g MyResourceGroup --hub-name MyIotHub --route-name R1
-        - name: Test all the route of source type "DeviceMessages" from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub route test -g MyResourceGroup --hub-name MyIotHub --source-type DeviceMessages
-"""
-
-helps['iot hub route update'] = """
-    type: command
-    short-summary: Update a route in IoT Hub.
-    long-summary: Updates a route in IoT Hub. You can change the source, enpoint or query on the route.
-    examples:
-        - name: Update source type of route "R1" from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub route update -g MyResourceGroup --hub-name MyIotHub
-            --source-type DeviceMessages --route-name R1
+helps['iot hub delete'] = """
+type: command
+short-summary: Delete an IoT hub.
 """
 
 helps['iot hub devicestream'] = """
-    type: group
-    short-summary: Manage device streams of an IoT hub.
+type: group
+short-summary: Manage device streams of an IoT hub.
 """
 
 helps['iot hub devicestream show'] = """
-    type: command
-    short-summary: Get IoT Hub's device streams endpoints.
-    long-summary: Get IoT Hub's device streams endpoints.
-    examples:
-        - name: Get all the device streams from "MyIotHub" IoT Hub.
-          text: >
-            az iot hub devicestream show -n MyIotHub
+type: command
+short-summary: Get IoT Hub's device streams endpoints.
+long-summary: Get IoT Hub's device streams endpoints.
+examples:
+  - name: Get all the device streams from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub devicestream show -n MyIotHub
+"""
+
+helps['iot hub job'] = """
+type: group
+short-summary: Manage jobs in an IoT hub.
+"""
+
+helps['iot hub job cancel'] = """
+type: command
+short-summary: Cancel a job in an IoT hub.
+"""
+
+helps['iot hub job list'] = """
+type: command
+short-summary: List the jobs in an IoT hub.
+"""
+
+helps['iot hub job show'] = """
+type: command
+short-summary: Get the details of a job in an IoT hub.
+"""
+
+helps['iot hub list'] = """
+type: command
+short-summary: List IoT hubs.
+examples:
+  - name: List all IoT hubs in a subscription.
+    text: >
+        az iot hub list
+  - name: List all IoT hubs in the resource group 'MyGroup'
+    text: >
+        az iot hub list --resource-group MyGroup
+"""
+
+helps['iot hub list-skus'] = """
+type: command
+short-summary: List available pricing tiers.
+"""
+
+helps['iot hub policy'] = """
+type: group
+short-summary: Manage shared access policies of an IoT hub.
+"""
+
+helps['iot hub policy create'] = """
+type: command
+short-summary: Create a new shared access policy in an IoT hub.
+examples:
+  - name: Create a new shared access policy.
+    text: >
+        az iot hub policy create --hub-name MyIotHub --name new-policy --permissions RegistryWrite ServiceConnect DeviceConnect
+"""
+
+helps['iot hub policy delete'] = """
+type: command
+short-summary: Delete a shared access policy from an IoT hub.
+"""
+
+helps['iot hub policy list'] = """
+type: command
+short-summary: List shared access policies of an IoT hub.
+"""
+
+helps['iot hub policy show'] = """
+type: command
+short-summary: Get the details of a shared access policy of an IoT hub.
+"""
+
+helps['iot hub route'] = """
+type: group
+short-summary: Manage routes of an IoT hub.
+"""
+
+helps['iot hub route create'] = """
+type: command
+short-summary: Create a route in IoT Hub.
+long-summary: Create a route to send specific data source and condition to a desired endpoint.
+examples:
+  - name: Create a new route "R1".
+    text: >
+        az iot hub route create -g MyResourceGroup --hub-name MyIotHub
+        --endpoint-name E2 --source-type DeviceMessages --route-name R1
+  - name: Create a new route "R1" with all parameters.
+    text: >
+        az iot hub route create -g MyResourceGroup --hub-name MyIotHub
+        --endpoint-name E2 --source-type DeviceMessages --route-name R1
+        --condition true --enabled true
+"""
+
+helps['iot hub route delete'] = """
+type: command
+short-summary: Delete all or mentioned route for your IoT Hub.
+long-summary: Delete a route or all routes for your IoT Hub.
+examples:
+  - name: Delete route "R1" from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub route delete -g MyResourceGroup --hub-name MyIotHub --route-name R1
+  - name: Delete all the routes of source type "DeviceMessages" from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub route delete -g MyResourceGroup --hub-name MyIotHub --source-type DeviceMessages
+  - name: Delete all the routes from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub route delete -g MyResourceGroup --hub-name MyIotHub
+"""
+
+helps['iot hub route list'] = """
+type: command
+short-summary: Get all the routes in IoT Hub.
+long-summary: Get information on all routes from an IoT Hub.
+examples:
+  - name: Get all route from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub route list -g MyResourceGroup --hub-name MyIotHub
+  - name: Get all the routes of source type "DeviceMessages" from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub route list -g MyResourceGroup --hub-name MyIotHub --source-type DeviceMessages
+"""
+
+helps['iot hub route show'] = """
+type: command
+short-summary: Get information about the route in IoT Hub.
+long-summary: Get information on a specific route in your IoT Hub.
+examples:
+  - name: Get an route information from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub route show -g MyResourceGroup --hub-name MyIotHub --route-name {routeName}
+"""
+
+helps['iot hub route test'] = """
+type: command
+short-summary: Test all routes or mentioned route in IoT Hub.
+long-summary: Test all existing routes or mentioned route in your IoT Hub. You can provide a sample message to test your routes.
+examples:
+  - name: Test the route "R1" from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub route test -g MyResourceGroup --hub-name MyIotHub --route-name R1
+  - name: Test all the route of source type "DeviceMessages" from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub route test -g MyResourceGroup --hub-name MyIotHub --source-type DeviceMessages
+"""
+
+helps['iot hub route update'] = """
+type: command
+short-summary: Update a route in IoT Hub.
+long-summary: Updates a route in IoT Hub. You can change the source, enpoint or query on the route.
+examples:
+  - name: Update source type of route "R1" from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub route update -g MyResourceGroup --hub-name MyIotHub
+        --source-type DeviceMessages --route-name R1
+"""
+
+helps['iot hub routing-endpoint'] = """
+type: group
+short-summary: Manage custom endpoints of an IoT hub.
+"""
+
+helps['iot hub routing-endpoint create'] = """
+type: command
+short-summary: Add an endpoint to your IoT Hub.
+long-summary: Create a new custom endpoint in your IoT Hub.
+examples:
+  - name: Add a new endpoint "E2" of type EventHub to "MyIotHub" IoT Hub.
+    text: >
+        az iot hub routing-endpoint create --resource-group MyResourceGroup --hub-name MyIotHub
+        --endpoint-name E2 --endpoint-type eventhub --endpoint-resource-group {ResourceGroup}
+        --endpoint-subscription-id {SubscriptionId} --connection-string {ConnectionString}
+  - name: Add a new endpoint "S1" of type AzureStorageContainer to "MyIotHub" IoT Hub.
+    text: |
+        az iot hub routing-endpoint create --resource-group MyResourceGroup --hub-name MyIotHub \
+        --endpoint-name S1 --endpoint-type azurestoragecontainer --endpoint-resource-group "[Resource Group]" \
+        --endpoint-subscription-id {SubscriptionId} --connection-string {ConnectionString} \
+        --container-name {ContainerName}
+"""
+
+helps['iot hub routing-endpoint delete'] = """
+type: command
+short-summary: Delete all or mentioned endpoint for your IoT Hub.
+long-summary: Delete an endpoint for your IoT Hub. We recommend that you delete any routes to the endpoint, before deleting the endpoint.
+examples:
+  - name: Delete endpoint "E2" from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub routing-endpoint delete --resource-group MyResourceGroup --hub-name MyIotHub
+        --endpoint-name E2
+  - name: Delete all the endpoints of type "EventHub" from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub routing-endpoint delete --resource-group MyResourceGroup --hub-name MyIotHub
+        --endpoint-type eventhub
+  - name: Delete all the endpoints from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub routing-endpoint delete --resource-group MyResourceGroup --hub-name MyIotHub
+"""
+
+helps['iot hub routing-endpoint list'] = """
+type: command
+short-summary: Get information on all the endpoints for your IoT Hub.
+long-summary: Get information on all endpoints in your IoT Hub. You can also specify which endpoint type you want to get informaiton on.
+examples:
+  - name: Get all the endpoints from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub routing-endpoint list -g MyResourceGroup --hub-name MyIotHub
+  - name: Get all the endpoints of type "EventHub" from "MyIotHub" IoT Hub.
+    text: >
+        az iot hub routing-endpoint list -g MyResourceGroup --hub-name MyIotHub
+        --endpoint-type eventhub
+"""
+
+helps['iot hub routing-endpoint show'] = """
+type: command
+short-summary: Get information on mentioned endpoint for your IoT Hub.
+long-summary: Get information on a specific endpoint in your IoT Hub
+examples:
+  - name: Get an endpoint information from "MyIotHub" IoT Hub.
+    text: |
+        az iot hub routing-endpoint show --resource-group MyResourceGroup --hub-name MyIotHub \
+        --endpoint-name {endpointName}
+"""
+
+helps['iot hub show'] = """
+type: command
+short-summary: Get the details of an IoT hub.
+"""
+
+helps['iot hub show-connection-string'] = """
+type: command
+short-summary: Show the connection strings for an IoT hub.
+examples:
+  - name: Show the connection string of an IoT hub using default policy and primary key.
+    text: >
+        az iot hub show-connection-string --name MyIotHub
+  - name: Show the connection string of an IoT Hub using policy 'service' and secondary key.
+    text: >
+        az iot hub show-connection-string --name MyIotHub --policy-name service --key secondary
+  - name: Show the connection strings for all IoT hubs in a resource group.
+    text: >
+        az iot hub show-connection-string --resource-group MyResourceGroup
+  - name: Show the connection strings for all IoT hubs in a subscription.
+    text: >
+        az iot hub show-connection-string
+"""
+
+helps['iot hub show-quota-metrics'] = """
+type: command
+short-summary: Get the quota metrics for an IoT hub.
+"""
+
+helps['iot hub show-stats'] = """
+type: command
+short-summary: Get the statistics for an IoT hub.
+"""
+
+helps['iot hub update'] = """
+type: command
+short-summary: Update metadata for an IoT hub.
+examples:
+  - name: Add a firewall filter rule to accept traffic from the IP mask 127.0.0.0/31.
+    text: >
+        az iot hub update --name MyIotHub --add properties.ipFilterRules filter_name=test-rule action=Accept ip_mask=127.0.0.0/31
 """

--- a/src/command_modules/azure-cli-iotcentral/azure/cli/command_modules/iotcentral/_help.py
+++ b/src/command_modules/azure-cli-iotcentral/azure/cli/command_modules/iotcentral/_help.py
@@ -37,6 +37,10 @@ examples:
 helps['iotcentral app delete'] = """
 type: command
 short-summary: Delete an IoT Central application.
+examples:
+  - name: Delete an IoT Central application. (crafted)
+    text: az iotcentral app delete --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['iotcentral app list'] = """

--- a/src/command_modules/azure-cli-iotcentral/azure/cli/command_modules/iotcentral/_help.py
+++ b/src/command_modules/azure-cli-iotcentral/azure/cli/command_modules/iotcentral/_help.py
@@ -1,66 +1,66 @@
+# coding=utf-8
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
 from knack.help_files import helps
-
-# pylint: disable=line-too-long
+# pylint: disable=line-too-long, too-many-lines
 
 helps['iotcentral'] = """
-    type: group
-    short-summary: Manage IoT Central assets.
+type: group
+short-summary: Manage IoT Central assets.
 """
 
 helps['iotcentral app'] = """
-    type: group
-    short-summary: Manage IoT Central applications.
+type: group
+short-summary: Manage IoT Central applications.
 """
 
 helps['iotcentral app create'] = """
-    type: command
-    short-summary: Create an IoT Central application.
-    long-summary: |
-        For an introduction to IoT Central, see https://docs.microsoft.com/en-us/azure/iot-central/.
-        The F1 Sku is no longer supported. Please use the S1 Sku (default) for app creation.
-        For more pricing information, please visit https://azure.microsoft.com/en-us/pricing/details/iot-central/.
-    examples:
-        - name: Create an IoT Central application in the standard pricing tier S1, in the region of the resource group.
-          text: >
-            az iotcentral app create --resource-group MyResourceGroup --name my-app-resource --subdomain my-app-subdomain
-        - name: Create an IoT Central application with the standard pricing tier S1 in the 'westus' region, with a custom display name, based on the iotc-default template.
-          text: >
-            az iotcentral app create --resource-group MyResourceGroup --name my-app-resource-name --sku S1 --location westus
-            --subdomain my-app-subdomain --template iotc-default@1.0.0 --display-name 'My Custom Display Name'
-"""
-
-helps['iotcentral app show'] = """
-    type: command
-    short-summary: Get the details of an IoT Central application.
-    examples:
-        - name: Show an IoT Central application.
-          text: >
-            az iotcentral app show --name MyApp
-"""
-
-helps['iotcentral app update'] = """
-    type: command
-    short-summary: Update metadata for an IoT Central application.
-"""
-
-helps['iotcentral app list'] = """
-    type: command
-    short-summary: List IoT Central applications.
-    examples:
-        - name: List all IoT Central applications in a subscription.
-          text: >
-            az iotcentral app list
-        - name: List all IoT Central applications in the resource group 'MyGroup'
-          text: >
-            az iotcentral app list --resource-group MyGroup
+type: command
+short-summary: Create an IoT Central application.
+long-summary: |
+    For an introduction to IoT Central, see https://docs.microsoft.com/en-us/azure/iot-central/.
+    The F1 Sku is no longer supported. Please use the S1 Sku (default) for app creation.
+    For more pricing information, please visit https://azure.microsoft.com/en-us/pricing/details/iot-central/.
+examples:
+  - name: Create an IoT Central application in the standard pricing tier S1, in the region of the resource group.
+    text: >
+        az iotcentral app create --resource-group MyResourceGroup --name my-app-resource --subdomain my-app-subdomain
+  - name: Create an IoT Central application with the standard pricing tier S1 in the 'westus' region, with a custom display name, based on the iotc-default template.
+    text: >
+        az iotcentral app create --resource-group MyResourceGroup --name my-app-resource-name --sku S1 --location westus
+        --subdomain my-app-subdomain --template iotc-default@1.0.0 --display-name 'My Custom Display Name'
 """
 
 helps['iotcentral app delete'] = """
-    type: command
-    short-summary: Delete an IoT Central application.
+type: command
+short-summary: Delete an IoT Central application.
+"""
+
+helps['iotcentral app list'] = """
+type: command
+short-summary: List IoT Central applications.
+examples:
+  - name: List all IoT Central applications in a subscription.
+    text: >
+        az iotcentral app list
+  - name: List all IoT Central applications in the resource group 'MyGroup'
+    text: >
+        az iotcentral app list --resource-group MyGroup
+"""
+
+helps['iotcentral app show'] = """
+type: command
+short-summary: Get the details of an IoT Central application.
+examples:
+  - name: Show an IoT Central application.
+    text: >
+        az iotcentral app show --name MyApp
+"""
+
+helps['iotcentral app update'] = """
+type: command
+short-summary: Update metadata for an IoT Central application.
 """

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -5,204 +5,204 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.help_files import helps
-
+# pylint: disable=line-too-long, too-many-lines
 
 helps['keyvault'] = """
-    type: group
-    short-summary: Manage KeyVault keys, secrets, and certificates.
-"""
-
-helps['keyvault create'] = """
-    type: command
-    short-summary: Create a key vault.
-    long-summary: Default permissions are created for the current user or service principal unless the `--no-self-perms` flag is specified.
-"""
-
-helps['keyvault delete'] = """
-    type: command
-    short-summary: Delete a key vault.
-"""
-
-helps['keyvault list'] = """
-    type: command
-    short-summary: List key vaults.
-"""
-
-helps['keyvault show'] = """
-    type: command
-    short-summary: Show details of a key vault.
-"""
-
-helps['keyvault update'] = """
-    type: command
-    short-summary: Update the properties of a key vault.
-"""
-
-helps['keyvault recover'] = """
-    type: command
-    short-summary: Recover a key vault.
-    long-summary: Recovers a previously deleted key vault for which soft delete was enabled.
-"""
-
-helps['keyvault key'] = """
-    type: group
-    short-summary: Manage keys.
-"""
-
-helps['keyvault secret'] = """
-    type: group
-    short-summary: Manage secrets.
+type: group
+short-summary: Manage KeyVault keys, secrets, and certificates.
 """
 
 helps['keyvault certificate'] = """
-    type: group
-    short-summary: Manage certificates.
-"""
-
-helps['keyvault storage'] = """
-    type: group
-    short-summary: Manage storage accounts.
-"""
-
-helps['keyvault storage add'] = """
-    type: command
-    examples:
-        - name: Create a storage account and setup a vault to manage its keys
-          text: |
-            $id = az storage account create -g resourcegroup -n storageacct --query id
-
-            # assign the Azure Key Vault service the "Storage Account Key Operator Service Role" role.
-            az role assignment create --role "Storage Account Key Operator Service Role" --scope $id \\
-            --assignee cfa8b339-82a2-471a-a3c9-0fc0be7a4093
-
-            az keyvault storage add --vault-name vault -n storageacct --active-key-name key1    \\
-            --auto-regenerate-key --regeneration-period P90D  --resource-id $id
-"""
-
-helps['keyvault storage sas-definition'] = """
-    type: group
-    short-summary: Manage storage account SAS definitions.
-"""
-
-helps['keyvault storage sas-definition create'] = """
-    type: command
-    examples:
-        - name: Add a sas-definition for an account sas-token
-          text: |
-
-            $sastoken = az storage account generate-sas --expiry 2020-01-01 --permissions rw \\
-            --resource-types sco --services bfqt --https-only --account-name storageacct     \\
-            --account-key 00000000
-
-            az keyvault storage sas-definition create --vault-name vault --account-name storageacct   \\
-            -n rwallserviceaccess --validity-period P2D --sas-type account --template-uri $sastoken
-        - name: Add a sas-definition for a blob sas-token
-          text: >
-
-            $sastoken = az storage blob generate-sas --account-name storageacct --account-key 00000000 \\
-            -c container1 -n blob1 --https-only --permissions rw
-
-            $url = az storage blob url --account-name storageacct -c container1 -n blob1
-
-
-            az keyvault storage sas-definition create --vault-name vault --account-name storageacct   \\
-            -n rwblobaccess --validity-period P2D --sas-type service --template-uri $url?$sastoken
-"""
-
-helps['keyvault network-rule'] = """
-    type: group
-    short-summary: Manage vault network ACLs.
-"""
-
-helps['keyvault certificate download'] = """
-    type: command
-    short-summary: Download the public portion of a Key Vault certificate.
-    long-summary: The certificate formatted as either PEM or DER. PEM is the default.
-    examples:
-        - name: Download a certificate as PEM and check its fingerprint in openssl.
-          text: |
-            az keyvault certificate download --vault-name vault -n cert-name -f cert.pem && \\
-            openssl x509 -in cert.pem -inform PEM  -noout -sha1 -fingerprint
-        - name: Download a certificate as DER and check its fingerprint in openssl.
-          text: |
-            az keyvault certificate download --vault-name vault -n cert-name -f cert.crt -e DER && \\
-            openssl x509 -in cert.crt -inform DER  -noout -sha1 -fingerprint
-"""
-
-helps['keyvault certificate get-default-policy'] = """
-    type: command
-    short-summary: Get the default policy for self-signed certificates.
-    long-summary: |
-        This default policy can be used in conjunction with `az keyvault create` to create a self-signed certificate.
-        The default policy can also be used as a starting point to create derivative policies.
-
-        For more details, see: https://docs.microsoft.com/en-us/rest/api/keyvault/certificates-and-policies
-    examples:
-        - name: Create a self-signed certificate with the default policy
-          text: |
-            az keyvault certificate create --vault-name vaultname -n cert1 \\
-              -p "$(az keyvault certificate get-default-policy)"
-"""
-
-helps['keyvault certificate create'] = """
-    type: command
-    short-summary: Create a Key Vault certificate.
-    long-summary: Certificates can be used as a secrets for provisioned virtual machines.
-    examples:
-        - name: Create a self-signed certificate with the default policy and add it to a virtual machine.
-          text: |
-            az keyvault certificate create --vault-name vaultname -n cert1 \\
-              -p "$(az keyvault certificate get-default-policy)"
-
-            secrets=$(az keyvault secret list-versions --vault-name vaultname \\
-              -n cert1 --query "[?attributes.enabled].id" -o tsv)
-
-            vm_secrets=$(az vm secret format -s "$secrets")
-
-            az vm create -g group-name -n vm-name --admin-username deploy  \\
-              --image debian --secrets "$vm_secrets"
-"""
-
-helps['keyvault certificate import'] = """
-    type: command
-    short-summary: Import a certificate into KeyVault.
-    long-summary: Certificates can also be used as a secrets in provisioned virtual machines.
-    examples:
-        - name: Create a service principal with a certificate, add the certificate to Key Vault and provision a VM with that certificate.
-          text: |
-            service_principal=$(az ad sp create-for-rbac --create-cert)
-
-            cert_file=$(echo $service_principal | jq .fileWithCertAndPrivateKey -r)
-
-            az keyvault create -g my-group -n vaultname
-
-            az keyvault certificate import --vault-name vaultname -n cert_name -f cert_file
-
-            secrets=$(az keyvault secret list-versions --vault-name vaultname \\
-              -n cert1 --query "[?attributes.enabled].id" -o tsv)
-
-            vm_secrets=$(az vm secret format -s "$secrets")
-
-            az vm create -g group-name -n vm-name --admin-username deploy  \\
-              --image debian --secrets "$vm_secrets"
-"""
-
-helps['keyvault certificate pending'] = """
-    type: group
-    short-summary: Manage pending certificate creation operations.
+type: group
+short-summary: Manage certificates.
 """
 
 helps['keyvault certificate contact'] = """
-    type: group
-    short-summary: Manage contacts for certificate management.
+type: group
+short-summary: Manage contacts for certificate management.
+"""
+
+helps['keyvault certificate create'] = """
+type: command
+short-summary: Create a Key Vault certificate.
+long-summary: Certificates can be used as a secrets for provisioned virtual machines.
+examples:
+  - name: Create a self-signed certificate with the default policy and add it to a virtual machine.
+    text: |
+        az keyvault certificate create --vault-name vaultname -n cert1 \
+          -p "$(az keyvault certificate get-default-policy)"
+
+        secrets=$(az keyvault secret list-versions --vault-name vaultname \
+          -n cert1 --query "[?attributes.enabled].id" -o tsv)
+
+        vm_secrets=$(az vm secret format -s "$secrets")
+
+        az vm create -g group-name -n vm-name --admin-username deploy  \
+          --image debian --secrets "$vm_secrets"
+"""
+
+helps['keyvault certificate download'] = """
+type: command
+short-summary: Download the public portion of a Key Vault certificate.
+long-summary: The certificate formatted as either PEM or DER. PEM is the default.
+examples:
+  - name: Download a certificate as PEM and check its fingerprint in openssl.
+    text: |
+        az keyvault certificate download --vault-name vault -n cert-name -f cert.pem && \
+        openssl x509 -in cert.pem -inform PEM  -noout -sha1 -fingerprint
+  - name: Download a certificate as DER and check its fingerprint in openssl.
+    text: |
+        az keyvault certificate download --vault-name vault -n cert-name -f cert.crt -e DER && \
+        openssl x509 -in cert.crt -inform DER  -noout -sha1 -fingerprint
+"""
+
+helps['keyvault certificate get-default-policy'] = """
+type: command
+short-summary: Get the default policy for self-signed certificates.
+long-summary: |
+    This default policy can be used in conjunction with `az keyvault create` to create a self-signed certificate.
+    The default policy can also be used as a starting point to create derivative policies.
+
+    For more details, see: https://docs.microsoft.com/en-us/rest/api/keyvault/certificates-and-policies
+examples:
+  - name: Create a self-signed certificate with the default policy
+    text: |
+        az keyvault certificate create --vault-name vaultname -n cert1 \
+          -p "$(az keyvault certificate get-default-policy)"
+"""
+
+helps['keyvault certificate import'] = """
+type: command
+short-summary: Import a certificate into KeyVault.
+long-summary: Certificates can also be used as a secrets in provisioned virtual machines.
+examples:
+  - name: Create a service principal with a certificate, add the certificate to Key Vault and provision a VM with that certificate.
+    text: |
+        service_principal=$(az ad sp create-for-rbac --create-cert)
+
+        cert_file=$(echo $service_principal | jq .fileWithCertAndPrivateKey -r)
+
+        az keyvault create -g my-group -n vaultname
+
+        az keyvault certificate import --vault-name vaultname -n cert_name -f cert_file
+
+        secrets=$(az keyvault secret list-versions --vault-name vaultname \
+          -n cert1 --query "[?attributes.enabled].id" -o tsv)
+
+        vm_secrets=$(az vm secret format -s "$secrets")
+
+        az vm create -g group-name -n vm-name --admin-username deploy  \
+          --image debian --secrets "$vm_secrets"
 """
 
 helps['keyvault certificate issuer'] = """
-    type: group
-    short-summary: Manage certificate issuer information.
+type: group
+short-summary: Manage certificate issuer information.
 """
 
 helps['keyvault certificate issuer admin'] = """
-    type: group
-    short-summary: Manage admin information for certificate issuers.
+type: group
+short-summary: Manage admin information for certificate issuers.
+"""
+
+helps['keyvault certificate pending'] = """
+type: group
+short-summary: Manage pending certificate creation operations.
+"""
+
+helps['keyvault create'] = """
+type: command
+short-summary: Create a key vault.
+long-summary: Default permissions are created for the current user or service principal unless the `--no-self-perms` flag is specified.
+"""
+
+helps['keyvault delete'] = """
+type: command
+short-summary: Delete a key vault.
+"""
+
+helps['keyvault key'] = """
+type: group
+short-summary: Manage keys.
+"""
+
+helps['keyvault list'] = """
+type: command
+short-summary: List key vaults.
+"""
+
+helps['keyvault network-rule'] = """
+type: group
+short-summary: Manage vault network ACLs.
+"""
+
+helps['keyvault recover'] = """
+type: command
+short-summary: Recover a key vault.
+long-summary: Recovers a previously deleted key vault for which soft delete was enabled.
+"""
+
+helps['keyvault secret'] = """
+type: group
+short-summary: Manage secrets.
+"""
+
+helps['keyvault show'] = """
+type: command
+short-summary: Show details of a key vault.
+"""
+
+helps['keyvault storage'] = """
+type: group
+short-summary: Manage storage accounts.
+"""
+
+helps['keyvault storage add'] = """
+type: command
+examples:
+  - name: Create a storage account and setup a vault to manage its keys
+    text: |
+        $id = az storage account create -g resourcegroup -n storageacct --query id
+
+        # assign the Azure Key Vault service the "Storage Account Key Operator Service Role" role.
+        az role assignment create --role "Storage Account Key Operator Service Role" --scope $id \
+        --assignee cfa8b339-82a2-471a-a3c9-0fc0be7a4093
+
+        az keyvault storage add --vault-name vault -n storageacct --active-key-name key1    \
+        --auto-regenerate-key --regeneration-period P90D  --resource-id $id
+"""
+
+helps['keyvault storage sas-definition'] = """
+type: group
+short-summary: Manage storage account SAS definitions.
+"""
+
+helps['keyvault storage sas-definition create'] = """
+type: command
+examples:
+  - name: Add a sas-definition for an account sas-token
+    text: |4
+
+        $sastoken = az storage account generate-sas --expiry 2020-01-01 --permissions rw \
+        --resource-types sco --services bfqt --https-only --account-name storageacct     \
+        --account-key 00000000
+
+        az keyvault storage sas-definition create --vault-name vault --account-name storageacct   \
+        -n rwallserviceaccess --validity-period P2D --sas-type account --template-uri $sastoken
+  - name: Add a sas-definition for a blob sas-token
+    text: >4
+
+        $sastoken = az storage blob generate-sas --account-name storageacct --account-key 00000000 \
+        -c container1 -n blob1 --https-only --permissions rw
+
+        $url = az storage blob url --account-name storageacct -c container1 -n blob1
+
+
+        az keyvault storage sas-definition create --vault-name vault --account-name storageacct   \
+        -n rwblobaccess --validity-period P2D --sas-type service --template-uri $url?$sastoken
+"""
+
+helps['keyvault update'] = """
+type: command
+short-summary: Update the properties of a key vault.
 """

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -114,6 +114,10 @@ helps['keyvault create'] = """
 type: command
 short-summary: Create a key vault.
 long-summary: Default permissions are created for the current user or service principal unless the `--no-self-perms` flag is specified.
+examples:
+  - name: Create a key vault. (crafted)
+    text: az keyvault create --resource-group MyResourceGroup
+    crafted: true
 """
 
 helps['keyvault delete'] = """

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -351,6 +351,10 @@ parameters:
     long-summary: >
         Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
         It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
+examples:
+  - name: Validate whether a template is syntactically correct. (crafted)
+    text: az group deployment validate --template-file azuredeploy.json --resource-group MyResourceGroup --parameters @myparameters.json
+    crafted: true
 """
 
 helps['group deployment wait'] = """
@@ -429,6 +433,10 @@ examples:
 helps['group update'] = """
 type: command
 short-summary: Update a resource group.
+examples:
+  - name: Update a resource group. (crafted)
+    text: az group update --set {set}
+    crafted: true
 """
 
 helps['group wait'] = """
@@ -1076,6 +1084,10 @@ examples:
 helps['resource update'] = """
 type: command
 short-summary: Update a resource.
+examples:
+  - name: Update a resource. (crafted)
+    text: az resource update --set {set} --api-version {api-version}
+    crafted: true
 """
 
 helps['resource wait'] = """

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -5,1005 +5,1085 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.help_files import helps
-
 # pylint: disable=line-too-long, too-many-lines
-helps['managedapp'] = """
-    type: group
-    short-summary: Manage template solutions provided and maintained by Independent Software Vendors (ISVs).
-"""
-helps['managedapp definition'] = """
-    type: group
-    short-summary: Manage Azure Managed Applications.
-"""
-helps['managedapp create'] = """
-    type: command
-    short-summary: Create a managed application.
-    examples:
-        - name: Create a managed application of kind 'ServiceCatalog'. This requires a valid managed application definition ID.
-          text: |
-            az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind ServiceCatalog \\
-                -m "/subscriptions/{SubID}/resourceGroups/{ManagedResourceGroup}" \\
-                -d "/subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Solutions/applianceDefinitions/{ApplianceDefinition}"
-        - name: Create a managed application of kind 'MarketPlace'. This requires a valid plan, containing details about existing marketplace package like plan name, version, publisher and product.
-          text: |
-            az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind MarketPlace \\
-                -m "/subscriptions/{SubID}/resourceGroups/{ManagedResourceGroup}" \\
-                --plan-name ContosoAppliance --plan-version "1.0" --plan-product "contoso-appliance" --plan-publisher Contoso
-"""
-helps['managedapp definition create'] = """
-    type: command
-    short-summary: Create a managed application definition.
-    examples:
-        - name: Create a managed application defintion.
-          text: >
-            az managedapp definition create -g MyResourceGroup -n MyManagedAppDef -l eastus --display-name "MyManagedAppDef" \\
-                --description "My Managed App Def description" -a "myPrincipalId:myRoleId" --lock-level None \\
-                --package-file-uri "https://path/to/myPackage.zip"
-        - name: Create a managed application defintion with inline values for createUiDefinition and mainTemplate.
-          text: >
-            az managedapp definition create -g MyResourceGroup -n MyManagedAppDef -l eastus --display-name "MyManagedAppDef" \\
-                --description "My Managed App Def description" -a "myPrincipalId:myRoleId" --lock-level None \\
-                --create-ui-definition @myCreateUiDef.json --main-template @myMainTemplate.json
-"""
-helps['managedapp definition delete'] = """
-    type: command
-    short-summary: Delete a managed application definition.
-"""
-helps['managedapp definition list'] = """
-    type: command
-    short-summary: List managed application definitions.
-"""
-helps['managedapp delete'] = """
-    type: command
-    short-summary: Delete a managed application.
-"""
-helps['managedapp list'] = """
-    type: command
-    short-summary: List managed applications.
-"""
-helps['lock'] = """
-    type: group
-    short-summary: Manage Azure locks.
-"""
-helps['lock create'] = """
-    type: command
-    short-summary: Create a lock.
-    long-summary: 'Locks can exist at three different scopes: subscription, resource group and resource.'
-    examples:
-        - name: Create a read-only subscription level lock.
-          text: >
-            az lock create --name lockName --resource-group group --lock-type ReadOnly
-    """
-helps['lock delete'] = """
-    type: command
-    short-summary: Delete a lock.
-    examples:
-        - name: Delete a resource group-level lock
-          text: >
-            az lock delete --name lockName --resource-group group
-    """
-helps['lock list'] = """
-    type: command
-    short-summary: List lock information.
-    examples:
-        - name: List out the locks on a vnet resource. Includes locks in the associated group and subscription.
-          text: >
-            az lock list --resource myvnet --resource-type Microsoft.Network/virtualNetworks -g group
-        - name: List out all locks on the subscription level
-          text: >
-            az lock list
-    """
-helps['lock show'] = """
-    type: command
-    short-summary: Show the properties of a lock
-    examples:
-        - name: Show a subscription level lock
-          text: >
-            az lock show -n lockname
-    """
-helps['lock update'] = """
-    type: command
-    short-summary: Update a lock.
-    examples:
-        - name: Update a resource group level lock with new notes and type
-          text: >
-            az lock update --name lockName --resource-group group --notes newNotesHere --lock-type CanNotDelete
-    """
+
 helps['account lock'] = """
-    type: group
-    short-summary: Manage Azure subscription level locks.
+type: group
+short-summary: Manage Azure subscription level locks.
 """
+
 helps['account lock create'] = """
-    type: command
-    short-summary: Create a subscription lock.
-    examples:
-        - name: Create a read-only subscription level lock.
-          text: >
-            az account lock create --lock-type ReadOnly -n lockName
-    """
+type: command
+short-summary: Create a subscription lock.
+examples:
+  - name: Create a read-only subscription level lock.
+    text: >
+        az account lock create --lock-type ReadOnly -n lockName
+"""
+
 helps['account lock delete'] = """
-    type: command
-    short-summary: Delete a subscription lock.
-    examples:
-        - name: Delete a subscription lock
-          text: >
-            az account lock delete --name lockName
-    """
+type: command
+short-summary: Delete a subscription lock.
+examples:
+  - name: Delete a subscription lock
+    text: >
+        az account lock delete --name lockName
+"""
+
 helps['account lock list'] = """
-    type: command
-    short-summary: List lock information in the subscription.
-    examples:
-        - name: List out all locks on the subscription level
-          text: >
-            az account lock list
-    """
+type: command
+short-summary: List lock information in the subscription.
+examples:
+  - name: List out all locks on the subscription level
+    text: >
+        az account lock list
+"""
+
 helps['account lock show'] = """
-    type: command
-    short-summary: Show the details of a subscription lock
-    examples:
-        - name: Show a subscription level lock
-          text: >
-            az account lock show -n lockname
-    """
+type: command
+short-summary: Show the details of a subscription lock
+examples:
+  - name: Show a subscription level lock
+    text: >
+        az account lock show -n lockname
+"""
+
 helps['account lock update'] = """
-    type: command
-    short-summary: Update a subscription lock.
-    examples:
-        - name: Update a subscription lock with new notes and type
-          text: >
-            az account lock update --name lockName --notes newNotesHere --lock-type CanNotDelete
-    """
+type: command
+short-summary: Update a subscription lock.
+examples:
+  - name: Update a subscription lock with new notes and type
+    text: >
+        az account lock update --name lockName --notes newNotesHere --lock-type CanNotDelete
+"""
+
 helps['account management-group'] = """
-    type: group
-    short-summary: Manage Azure Management Groups.
-"""
-
-helps['account management-group subscription'] = """
-    type: group
-    short-summary: Subscription operations for Management Groups.
-"""
-
-helps['account management-group list'] = """
-    type: command
-    short-summary: List all management groups.
-    long-summary: List of all management groups in the current tenant.
-    examples:
-        - name: List all management groups
-          text: >
-             az account management-group list
-"""
-
-helps['account management-group show'] = """
-    type: command
-    short-summary: Get a specific management group.
-    long-summary: Get the details of the management group.
-    parameters:
-        - name: --name -n
-          type: string
-          short-summary: Name of the management group.
-        - name: --expand -e
-          type: bool
-          short-summary: If given, lists the children in the first level of hierarchy.
-        - name: --recurse -r
-          type: bool
-          short-summary: If given, lists the children in all levels of hierarchy.
-    examples:
-        - name: Get a management group.
-          text: >
-             az account management-group show --name GroupName
-        - name: Get a management group with children in the first level of hierarchy.
-          text: >
-             az account management-group show --name GroupName -e
-        - name: Get a management group with children in all levels of hierarchy.
-          text: >
-             az account management-group show --name GroupName -e -r
+type: group
+short-summary: Manage Azure Management Groups.
 """
 
 helps['account management-group create'] = """
-    type: command
-    short-summary: Create a new management group.
-    long-summary: Create a new management group.
-    parameters:
-        - name: --name -n
-          type: string
-          short-summary: Name of the management group.
-        - name: --display-name -d
-          type: string
-          short-summary: Sets the display name of the management group. If null, the group name is set as the display name.
-        - name: --parent -p
-          type: string
-          short-summary: Sets the parent of the management group. Can be the fully qualified id or the name of the management group. If null, the root tenant group is set as the parent.
-    examples:
-        - name: Create a new management group.
-          text: >
-             az account management-group create --name GroupName
-        - name: Create a new management group with a specific display name.
-          text: >
-             az account management-group create --name GroupName --display-name DisplayName
-        - name: Create a new management group with a specific parent.
-          text: >
-             az account management-group create --name GroupName --parent ParentId/ParentName
-        - name: Create a new management group with a specific display name and parent.
-          text: >
-             az account management-group create --name GroupName --display-name DisplayName --parent ParentId/ParentName
-"""
-
-helps['account management-group update'] = """
-    type: command
-    short-summary: Update an existing management group.
-    long-summary: Update an existing management group.
-    parameters:
-        - name: --name -n
-          type: string
-          short-summary: Name of the management group.
-        - name: --display-name -d
-          type: string
-          short-summary: Updates the display name of the management group. If null, no change is made.
-        - name: --parent -p
-          type: string
-          short-summary: Update the parent of the management group. Can be the fully qualified id or the name of the management group. If null, no change is made.
-    examples:
-        - name: Update an existing management group with a specific display name.
-          text: >
-             az account management-group update --name GroupName --display-name DisplayName
-        - name: Update an existing management group with a specific parent.
-          text: >
-             az account management-group update --name GroupName --parent ParentId/ParentName
-        - name: Update an existing management group with a specific display name and parent.
-          text: >
-             az account management-group update --name GroupName --display-name DisplayName --parent ParentId/ParentName
+type: command
+short-summary: Create a new management group.
+long-summary: Create a new management group.
+parameters:
+  - name: --name -n
+    type: string
+    short-summary: Name of the management group.
+  - name: --display-name -d
+    type: string
+    short-summary: Sets the display name of the management group. If null, the group name is set as the display name.
+  - name: --parent -p
+    type: string
+    short-summary: Sets the parent of the management group. Can be the fully qualified id or the name of the management group. If null, the root tenant group is set as the parent.
+examples:
+  - name: Create a new management group.
+    text: >
+        az account management-group create --name GroupName
+  - name: Create a new management group with a specific display name.
+    text: >
+        az account management-group create --name GroupName --display-name DisplayName
+  - name: Create a new management group with a specific parent.
+    text: >
+        az account management-group create --name GroupName --parent ParentId/ParentName
+  - name: Create a new management group with a specific display name and parent.
+    text: >
+        az account management-group create --name GroupName --display-name DisplayName --parent ParentId/ParentName
 """
 
 helps['account management-group delete'] = """
-    type: command
-    short-summary: Delete an existing management group.
-    long-summary: Delete an existing management group.
-    parameters:
-        - name: --name -n
-          type: string
-          short-summary: Name of the management group.
-    examples:
-        - name: Delete an existing management group
-          text: >
-             az account management-group delete --name GroupName
+type: command
+short-summary: Delete an existing management group.
+long-summary: Delete an existing management group.
+parameters:
+  - name: --name -n
+    type: string
+    short-summary: Name of the management group.
+examples:
+  - name: Delete an existing management group
+    text: >
+        az account management-group delete --name GroupName
+"""
+
+helps['account management-group list'] = """
+type: command
+short-summary: List all management groups.
+long-summary: List of all management groups in the current tenant.
+examples:
+  - name: List all management groups
+    text: >
+        az account management-group list
+"""
+
+helps['account management-group show'] = """
+type: command
+short-summary: Get a specific management group.
+long-summary: Get the details of the management group.
+parameters:
+  - name: --name -n
+    type: string
+    short-summary: Name of the management group.
+  - name: --expand -e
+    type: bool
+    short-summary: If given, lists the children in the first level of hierarchy.
+  - name: --recurse -r
+    type: bool
+    short-summary: If given, lists the children in all levels of hierarchy.
+examples:
+  - name: Get a management group.
+    text: >
+        az account management-group show --name GroupName
+  - name: Get a management group with children in the first level of hierarchy.
+    text: >
+        az account management-group show --name GroupName -e
+  - name: Get a management group with children in all levels of hierarchy.
+    text: >
+        az account management-group show --name GroupName -e -r
+"""
+
+helps['account management-group subscription'] = """
+type: group
+short-summary: Subscription operations for Management Groups.
 """
 
 helps['account management-group subscription add'] = """
-    type: command
-    short-summary: Add a subscription to a management group.
-    long-summary: Add a subscription to a management group.
-    parameters:
-        - name: --name -n
-          type: string
-          short-summary: Name of the management group.
-        - name: --subscription -s
-          type: string
-          short-summary: Subscription Id or Name
-    examples:
-        - name: Add a subscription to a management group.
-          text: >
-             az account management-group subscription add --name GroupName --subscription Subscription
+type: command
+short-summary: Add a subscription to a management group.
+long-summary: Add a subscription to a management group.
+parameters:
+  - name: --name -n
+    type: string
+    short-summary: Name of the management group.
+  - name: --subscription -s
+    type: string
+    short-summary: Subscription Id or Name
+examples:
+  - name: Add a subscription to a management group.
+    text: >
+        az account management-group subscription add --name GroupName --subscription Subscription
 """
 
 helps['account management-group subscription remove'] = """
-    type: command
-    short-summary: Remove an existing subscription from a management group.
-    long-summary: Remove an existing subscription from a management group.
-    parameters:
-        - name: --name -n
-          type: string
-          short-summary: Name of the management group.
-        - name: --subscription -s
-          type: string
-          short-summary: Subscription Id or Name
-    examples:
-        - name: Remove an existing subscription from a management group.
-          text: >
-             az account management-group subscription remove --name GroupName --subscription Subscription
+type: command
+short-summary: Remove an existing subscription from a management group.
+long-summary: Remove an existing subscription from a management group.
+parameters:
+  - name: --name -n
+    type: string
+    short-summary: Name of the management group.
+  - name: --subscription -s
+    type: string
+    short-summary: Subscription Id or Name
+examples:
+  - name: Remove an existing subscription from a management group.
+    text: >
+        az account management-group subscription remove --name GroupName --subscription Subscription
 """
 
-helps['policy'] = """
-    type: group
-    short-summary: Manage resource policies.
-"""
-helps['policy definition'] = """
-    type: group
-    short-summary: Manage resource policy definitions.
-"""
-helps['policy definition create'] = """
-            type: command
-            short-summary: Create a policy definition.
-            parameters:
-                - name: --rules
-                  type: string
-                  short-summary: Policy rules in JSON format, or a path to a file containing JSON rules.
-                - name: --management-group
-                  type: string
-                  short-summary: Name of the management group the new policy definition can be assigned in.
-                - name: --subscription
-                  type: string
-                  short-summary: Name or id of the subscription the new policy definition can be assigned in.
-            examples:
-                - name: Create a read-only policy.
-                  text: |
-                    az policy definition create --name readOnlyStorage --rules '{ \\
-                        "if": \\
-                        { \\
-                            "field": "type", \\
-                            "equals": "Microsoft.Storage/storageAccounts/write" \\
-                        }, \\
-                        "then": \\
-                        { \\
-                            "effect": "deny" \\
-                        } \\
-                    }'
-                - name: Create a policy parameter definition.
-                  text: |
-                    az policy definition create --name allowedLocations --rules '{ \\
-                        "if": { \\
-                            "allOf": [ \\
-                                { \\
-                                    "field": "location", \\
-                                    "notIn": "[parameters('listOfAllowedLocations')]" \\
-                                }, \\
-                                { \\
-                                    "field": "location", \\
-                                    "notEquals": "global" \\
-                                }, \\
-                                { \\
-                                    "field": "type", \\
-                                    "notEquals": "Microsoft.AzureActiveDirectory/b2cDirectories" \\
-                                } \\
-                            ] \\
-                        }, \\
-                        "then": { \\
-                            "effect": "deny" \\
-                        } \\
-                    }' \\
-                    --params '{ \\
-                        "allowedLocations": { \\
-                            "type": "array", \\
-                            "metadata": { \\
-                                "description": "The list of locations that can be specified when deploying resources", \\
-                                "strongType": "location", \\
-                                "displayName": "Allowed locations" \\
-                            } \\
-                        } \\
-                    }'
-                - name: Create a read-only policy that can be applied within a management group.
-                  text: |
-                    az policy definition create -n readOnlyStorage --management-group 'MyManagementGroup' --rules '{ \\
-                        "if": \\
-                        { \\
-                            "field": "type", \\
-                            "equals": "Microsoft.Storage/storageAccounts/write" \\
-                        }, \\
-                        "then": \\
-                        { \\
-                            "effect": "deny" \\
-                        } \\
-                    }'
-"""
-helps['policy definition delete'] = """
-    type: command
-    short-summary: Delete a policy definition.
-"""
-helps['policy definition show'] = """
-    type: command
-    short-summary: Show a policy definition.
-"""
-helps['policy definition update'] = """
-    type: command
-    short-summary: Update a policy definition.
-"""
-helps['policy definition list'] = """
-    type: command
-    short-summary: List policy definitions.
-"""
-helps['policy set-definition'] = """
-    type: group
-    short-summary: Manage resource policy set definitions.
-"""
-helps['policy set-definition create'] = """
-            type: command
-            short-summary: Create a policy set definition.
-            parameters:
-                - name: --definitions
-                  type: string
-                  short-summary: Policy definitions in JSON format, or a path to a file containing JSON rules.
-                - name: --management-group
-                  type: string
-                  short-summary: Name of management group the new policy set definition can be assigned in.
-                - name: --subscription
-                  type: string
-                  short-summary: Name or id of the subscription the new policy set definition can be assigned in.
-            examples:
-                - name: Create a policy set definition.
-                  text: |
-                    az policy set-definition create -n readOnlyStorage --definitions '[ \\
-                            { \\
-                                "policyDefinitionId": "/subscriptions/mySubId/providers/Microsoft.Authorization/policyDefinitions/storagePolicy" \\
-                            } \\
-                        ]'
-                - name: Create a policy set definition to be used by a subscription.
-                  text: |
-                    az policy set-definition create -n readOnlyStorage --subscription '0b1f6471-1bf0-4dda-aec3-111122223333' --definitions '[ \\
-                            { \\
-                                "policyDefinitionId": "/subscriptions/mySubId/providers/Microsoft.Authorization/policyDefinitions/storagePolicy" \\
-                            } \\
-                        ]'
-"""
-helps['policy set-definition delete'] = """
-    type: command
-    short-summary: Delete a policy set definition.
-"""
-helps['policy set-definition show'] = """
-    type: command
-    short-summary: Show a policy set definition.
-"""
-helps['policy set-definition update'] = """
-    type: command
-    short-summary: Update a policy set definition.
-"""
-helps['policy set-definition list'] = """
-    type: command
-    short-summary: List policy set definitions.
-"""
-helps['policy assignment'] = """
-    type: group
-    short-summary: Manage resource policy assignments.
-"""
-helps['policy assignment create'] = """
-    type: command
-    short-summary: Create a resource policy assignment.
-    parameters:
-        - name: --scope
-          type: string
-          short-summary: Scope to which this policy assignment applies.
-    examples:
-        - name: Create a resource policy assignment at scope
-          text: |
-           Valid scopes are management group, subscription, resource group, and resource, for example
-              management group:  /providers/Microsoft.Management/managementGroups/MyManagementGroup
-              subscription:      /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333
-              resource group:    /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup
-              resource:          /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM
-                az policy assignment create --scope '/providers/Microsoft.Management/managementGroups/MyManagementGroup' --policy {PolicyName} -p '{ \\
-                    "allowedLocations": { \\
-                        "value": [ \\
-                            "australiaeast", \\
-                            "eastus", \\
-                            "japaneast" \\
-                        ] \\
-                    } \\
-                }'
-        - name: Create a resource policy assignment and provide rule parameter values.
-          text: |
-                az policy assignment create --policy {PolicyName} -p '{ \\
-                    "allowedLocations": { \\
-                        "value": [ \\
-                            "australiaeast", \\
-                            "eastus", \\
-                            "japaneast" \\
-                        ] \\
-                    } \\
-                }'
-        - name: Create a resource policy assignment with a system assigned identity.
-          text: >
-            az policy assignment create --name myPolicy --policy {PolicyName} --assign-identity
-        - name: Create a resource policy assignment with a system assigned identity. The identity will have 'Contributor' role access to the subscription.
-          text: >
-            az policy assignment create --name myPolicy --policy {PolicyName} --assign-identity --identity-scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --role Contributor
-"""
-helps['policy assignment delete'] = """
-    type: command
-    short-summary: Delete a resource policy assignment.
-"""
-helps['policy assignment show'] = """
-    type: command
-    short-summary: Show a resource policy assignment.
-"""
-helps['policy assignment list'] = """
-    type: command
-    short-summary: List resource policy assignments.
-"""
-helps['policy assignment identity'] = """
-    type: group
-    short-summary: Manage a policy assignment's managed identity.
-"""
-helps['policy assignment identity assign'] = """
-    type: command
-    short-summary: Add a system assigned identity to a policy assignment.
-    examples:
-        - name: Add a system assigned managed identity to a policy assignment.
-          text: >
-            az policy assignment identity assign -g MyResourceGroup -n MyPolicyAssignment
-        - name: Add a system assigned managed identity to a policy assignment and grant it the 'Contributor' role for the current resource group.
-          text: >
-            az policy assignment identity assign -g MyResourceGroup -n MyPolicyAssignment --role Contributor --identity-scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/MyResourceGroup
-"""
-helps['policy assignment identity show'] = """
-    type: command
-    short-summary: Show a policy assignment's managed identity.
-"""
-helps['policy assignment identity remove'] = """
-    type: command
-    short-summary: Remove a managed identity from a policy assignment.
-"""
-helps['resource'] = """
-    type: group
-    short-summary: Manage Azure resources.
-"""
-helps['resource list'] = """
-    type: command
-    short-summary: List resources.
-    examples:
-        - name: List all resources in the West US region.
-          text: >
-            az resource list --location westus
-        - name: List all resources with the name 'resourceName'.
-          text: >
-            az resource list --name 'resourceName'
-        - name: List all resources with the tag 'test'.
-          text: >
-             az resource list --tag test
-        - name: List all resources with a tag that starts with 'test'.
-          text: >
-            az resource list --tag 'test*'
-        - name: List all resources with the tag 'test' that have the value 'example'.
-          text: >
-            az resource list --tag test=example
+helps['account management-group update'] = """
+type: command
+short-summary: Update an existing management group.
+long-summary: Update an existing management group.
+parameters:
+  - name: --name -n
+    type: string
+    short-summary: Name of the management group.
+  - name: --display-name -d
+    type: string
+    short-summary: Updates the display name of the management group. If null, no change is made.
+  - name: --parent -p
+    type: string
+    short-summary: Update the parent of the management group. Can be the fully qualified id or the name of the management group. If null, no change is made.
+examples:
+  - name: Update an existing management group with a specific display name.
+    text: >
+        az account management-group update --name GroupName --display-name DisplayName
+  - name: Update an existing management group with a specific parent.
+    text: >
+        az account management-group update --name GroupName --parent ParentId/ParentName
+  - name: Update an existing management group with a specific display name and parent.
+    text: >
+        az account management-group update --name GroupName --display-name DisplayName --parent ParentId/ParentName
 """
 
-helps['resource show'] = """
-    type: command
-    short-summary: Get the details of a resource.
-    examples:
-        - name: Show a virtual machine resource named 'MyVm'.
-          text: >
-            az resource show -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
-        - name: Show a web app using a resource identifier.
-          text: >
-            az resource show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Web/sites/MyWebapp
-        - name: Show a subnet.
-          text: >
-            az resource show -g MyResourceGroup -n MySubnet --namespace Microsoft.Network --parent virtualnetworks/MyVnet --resource-type subnets
-        - name: Show a subnet using a resource identifier.
-          text: >
-            az resource show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/subnets/MySubnet
-        - name: Show an application gateway path rule.
-          text: >
-            az resource show -g MyResourceGroup --namespace Microsoft.Network --parent applicationGateways/ag1/urlPathMaps/map1 --resource-type pathRules -n rule1
+helps['deployment'] = """
+type: group
+short-summary: Manage Azure Resource Manager deployments at subscription scope.
 """
 
-helps['resource delete'] = """
-    type: command
-    short-summary: Delete a resource.
-    examples:
-        - name: Delete a virtual machine named 'MyVm'.
-          text: >
-            az resource delete -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
-        - name: Delete a web app using a resource identifier.
-          text: >
-            az resource delete --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Web/sites/MyWebapp
-        - name: Delete a subnet using a resource identifier.
-          text: >
-            az resource delete --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/subnets/MySubnet
-"""
-
-helps['resource tag'] = """
-    type: command
-    short-summary: Tag a resource.
-    examples:
-        - name: Tag the virtual machine 'MyVm' with the key 'vmlist' and value 'vm1'.
-          text: >
-            az resource tag --tags vmlist=vm1 -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
-        - name: Tag a web app with the key 'vmlist' and value 'vm1', using a resource identifier.
-          text: >
-            az resource tag --tags vmlist=vm1 --id /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Web/sites/{WebApp}
-"""
-
-helps['resource create'] = """
-    type: command
-    short-summary: create a resource.
-    examples:
-       - name: Create an API app by providing a full JSON configuration.
-         text: |
-            az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties '{ \\
-                        "kind": "api", \\
-                        "location": "West US", \\
-                        "properties": { \\
-                            "serverFarmId": "/subscriptions/{SubID}/resourcegroups/{ResourceGroup}/providers/Microsoft.Web/serverfarms/{ServicePlan}" \\
-                        } \\
-                    }'
-       - name: Create a resource by loading JSON configuration from a file.
-         text: >
-            az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties @jsonConfigFile
-       - name: Create a web app with the minimum required configuration information.
-         text: |
-            az resource create -g myRG -n myWeb --resource-type Microsoft.web/sites --properties '{ \\
-                    "serverFarmId":"/subscriptions/{SubID}/resourcegroups/{ResourceGroup}/providers/Microsoft.Web/serverfarms/{ServicePlan}" \\
-                }'
-"""
-
-helps['resource update'] = """
-    type: command
-    short-summary: Update a resource.
-"""
-
-helps['resource wait'] = """
-    type: command
-    short-summary: Place the CLI in a waiting state until a condition of a resources is met.
-"""
-
-helps['resource invoke-action'] = """
-    type: command
-    short-summary: Invoke an action on the resource.
+helps['deployment create'] = """
+type: command
+short-summary: Start a deployment.
+parameters:
+  - name: --parameters
+    short-summary: Supply deployment parameter values.
     long-summary: >
-        A list of possible actions corresponding to a resource can be found at https://docs.microsoft.com/en-us/rest/api/. All POST requests are actions that can be invoked and are specified at the end of the URI path. For instance, to stop a VM, the
-        request URI is https://management.azure.com/subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroup}/providers/Microsoft.Compute/virtualMachines/{VM}/powerOff?api-version={APIVersion} and the corresponding action is `powerOff`. This can
-        be found at https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/virtualmachines-stop.
-    examples:
-       - name: Power-off a vm, specified by Id.
-         text: >
-            az resource invoke-action --action powerOff \\
-              --ids /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Compute/virtualMachines/{VMName}
-       - name: Capture information for a stopped vm.
-         text: >
-            az resource invoke-action --action capture \\
-              --ids /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Compute/virtualMachines/{VMName} \\
-              --request-body '{ \\
-                "vhdPrefix": "myPrefix", \\
-                "destinationContainerName": "myContainer", \\
-                "overwriteVhds": true \\
+        Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
+        It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
+examples:
+  - name: Create a deployment from a remote template file, using parameters from a local JSON file.
+    text: >
+        az deployment create --location WestUS --template-uri https://myresource/azuredeploy.json --parameters @myparameters.json
+  - name: Create a deployment from a local template file, using parameters from a JSON string.
+    text: |
+        az deployment create --location WestUS --template-file azuredeploy.json --parameters '{ \
+                "policyName": { \
+                    "value": "policy2" \
+                } \
             }'
+  - name: Create a deployment from a local template, using a parameter file, a remote parameter file, and selectively overriding key/value pairs.
+    text: >
+        az deployment create --location WestUS --template-file azuredeploy.json  \
+            --parameters @params.json --parameters https://mysite/params.json --parameters MyValue=This MyArray=@array.json
+"""
+
+helps['deployment export'] = """
+type: command
+short-summary: Export the template used for a deployment.
+"""
+
+helps['deployment operation'] = """
+type: group
+short-summary: Manage deployment operations.
+"""
+
+helps['deployment validate'] = """
+type: command
+short-summary: Validate whether a template is syntactically correct.
+parameters:
+  - name: --parameters
+    short-summary: Supply deployment parameter values.
+    long-summary: >
+        Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
+        It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
+"""
+
+helps['deployment wait'] = """
+type: command
+short-summary: Place the CLI in a waiting state until a deployment condition is met.
 """
 
 helps['feature'] = """
-    type: group
-    short-summary: Manage resource provider features.
+type: group
+short-summary: Manage resource provider features.
 """
 
 helps['feature list'] = """
-    type: command
-    short-summary: List preview features.
+type: command
+short-summary: List preview features.
 """
 
 helps['feature register'] = """
-    type: command
-    short-summary: register a preview feature.
+type: command
+short-summary: register a preview feature.
 """
 
 helps['group'] = """
-    type: group
-    short-summary: Manage resource groups and template deployments.
-"""
-
-helps['group exists'] = """
-    type: command
-    short-summary: Check if a resource group exists.
-    examples:
-        - name: Check if 'MyResourceGroup' exists.
-          text: >
-            az group exists -n MyResourceGroup
+type: group
+short-summary: Manage resource groups and template deployments.
 """
 
 helps['group create'] = """
-    type: command
-    short-summary: Create a new resource group.
-    examples:
-        - name: Create a new resource group in the West US region.
-          text: >
-            az group create -l westus -n MyResourceGroup
+type: command
+short-summary: Create a new resource group.
+examples:
+  - name: Create a new resource group in the West US region.
+    text: >
+        az group create -l westus -n MyResourceGroup
 """
 
 helps['group delete'] = """
-    type: command
-    short-summary: Delete a resource group.
-    examples:
-        - name: Delete a resource group.
-          text: >
-            az group delete -n MyResourceGroup
+type: command
+short-summary: Delete a resource group.
+examples:
+  - name: Delete a resource group.
+    text: >
+        az group delete -n MyResourceGroup
+"""
+
+helps['group deployment'] = """
+type: group
+short-summary: Manage Azure Resource Manager deployments.
+"""
+
+helps['group deployment create'] = """
+type: command
+short-summary: Start a deployment.
+parameters:
+  - name: --parameters
+    short-summary: Supply deployment parameter values.
+    long-summary: >
+        Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
+        It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
+examples:
+  - name: Create a deployment from a remote template file, using parameters from a local JSON file.
+    text: >
+        az group deployment create -g MyResourceGroup --template-uri https://myresource/azuredeploy.json --parameters @myparameters.json
+  - name: Create a deployment from a local template file, using parameters from a JSON string.
+    text: |
+        az group deployment create -g MyResourceGroup --template-file azuredeploy.json --parameters '{ \
+                "location": { \
+                    "value": "westus" \
+                } \
+            }'
+  - name: Create a deployment from a local template, using a local parameter file, a remote parameter file, and selectively overriding key/value pairs.
+    text: >
+        az group deployment create -g MyResourceGroup --template-file azuredeploy.json \
+            --parameters @params.json --parameters https://mysite/params.json --parameters MyValue=This MyArray=@array.json
+"""
+
+helps['group deployment export'] = """
+type: command
+short-summary: Export the template used for a deployment.
+"""
+
+helps['group deployment operation'] = """
+type: group
+short-summary: Manage deployment operations.
+"""
+
+helps['group deployment validate'] = """
+type: command
+short-summary: Validate whether a template is syntactically correct.
+parameters:
+  - name: --parameters
+    short-summary: Supply deployment parameter values.
+    long-summary: >
+        Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
+        It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
+"""
+
+helps['group deployment wait'] = """
+type: command
+short-summary: Place the CLI in a waiting state until a deployment condition is met.
+"""
+
+helps['group exists'] = """
+type: command
+short-summary: Check if a resource group exists.
+examples:
+  - name: Check if 'MyResourceGroup' exists.
+    text: >
+        az group exists -n MyResourceGroup
 """
 
 helps['group list'] = """
-    type: command
-    short-summary: List resource groups.
-    examples:
-        - name: List all resource groups located in the West US region.
-          text: >
-            az group list --query "[?location=='westus']"
+type: command
+short-summary: List resource groups.
+examples:
+  - name: List all resource groups located in the West US region.
+    text: >
+        az group list --query "[?location=='westus']"
+"""
+
+helps['group lock'] = """
+type: group
+short-summary: Manage Azure resource group locks.
+"""
+
+helps['group lock create'] = """
+type: command
+short-summary: Create a resource group lock.
+examples:
+  - name: Create a read-only resource group level lock.
+    text: >
+        az group lock create --lock-type ReadOnly -n lockName -g MyResourceGroup
+"""
+
+helps['group lock delete'] = """
+type: command
+short-summary: Delete a resource group lock.
+examples:
+  - name: Delete a resource group lock
+    text: >
+        az group lock delete --name lockName -g MyResourceGroup
+"""
+
+helps['group lock list'] = """
+type: command
+short-summary: List lock information in the resource-group.
+examples:
+  - name: List out all locks on the resource group level
+    text: >
+        az group lock list -g MyResourceGroup
+"""
+
+helps['group lock show'] = """
+type: command
+short-summary: Show the details of a resource group lock
+examples:
+  - name: Show a resource group level lock
+    text: >
+        az group lock show -n lockname -g MyResourceGroup
+"""
+
+helps['group lock update'] = """
+type: command
+short-summary: Update a resource group lock.
+examples:
+  - name: Update a resource group lock with new notes and type
+    text: >
+        az group lock update --name lockName -g MyResourceGroup --notes newNotesHere --lock-type CanNotDelete
 """
 
 helps['group update'] = """
-    type: command
-    short-summary: Update a resource group.
+type: command
+short-summary: Update a resource group.
 """
+
 helps['group wait'] = """
-    type: command
-    short-summary: Place the CLI in a waiting state until a condition of the resource group is met.
+type: command
+short-summary: Place the CLI in a waiting state until a condition of the resource group is met.
 """
-helps['group deployment'] = """
-    type: group
-    short-summary: Manage Azure Resource Manager deployments.
+
+helps['lock'] = """
+type: group
+short-summary: Manage Azure locks.
 """
-helps['group deployment create'] = """
-    type: command
-    short-summary: Start a deployment.
-    parameters:
-        - name: --parameters
-          short-summary: Supply deployment parameter values.
-          long-summary: >
-            Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
-            It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
-    examples:
-        - name: Create a deployment from a remote template file, using parameters from a local JSON file.
-          text: >
-            az group deployment create -g MyResourceGroup --template-uri https://myresource/azuredeploy.json --parameters @myparameters.json
-        - name: Create a deployment from a local template file, using parameters from a JSON string.
-          text: |
-            az group deployment create -g MyResourceGroup --template-file azuredeploy.json --parameters '{ \\
-                    "location": { \\
-                        "value": "westus" \\
-                    } \\
-                }'
-        - name: Create a deployment from a local template, using a local parameter file, a remote parameter file, and selectively overriding key/value pairs.
-          text: >
-            az group deployment create -g MyResourceGroup --template-file azuredeploy.json \\
-                --parameters @params.json --parameters https://mysite/params.json --parameters MyValue=This MyArray=@array.json
+
+helps['lock create'] = """
+type: command
+short-summary: Create a lock.
+long-summary: 'Locks can exist at three different scopes: subscription, resource group and resource.'
+examples:
+  - name: Create a read-only subscription level lock.
+    text: >
+        az lock create --name lockName --resource-group group --lock-type ReadOnly
 """
-helps['group deployment export'] = """
-    type: command
-    short-summary: Export the template used for a deployment.
+
+helps['lock delete'] = """
+type: command
+short-summary: Delete a lock.
+examples:
+  - name: Delete a resource group-level lock
+    text: >
+        az lock delete --name lockName --resource-group group
 """
-helps['group deployment validate'] = """
-    type: command
-    short-summary: Validate whether a template is syntactically correct.
-    parameters:
-        - name: --parameters
-          short-summary: Supply deployment parameter values.
-          long-summary: >
-            Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
-            It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
+
+helps['lock list'] = """
+type: command
+short-summary: List lock information.
+examples:
+  - name: List out the locks on a vnet resource. Includes locks in the associated group and subscription.
+    text: >
+        az lock list --resource myvnet --resource-type Microsoft.Network/virtualNetworks -g group
+  - name: List out all locks on the subscription level
+    text: >
+        az lock list
 """
-helps['group deployment wait'] = """
-    type: command
-    short-summary: Place the CLI in a waiting state until a deployment condition is met.
+
+helps['lock show'] = """
+type: command
+short-summary: Show the properties of a lock
+examples:
+  - name: Show a subscription level lock
+    text: >
+        az lock show -n lockname
 """
-helps['group deployment operation'] = """
-    type: group
-    short-summary: Manage deployment operations.
+
+helps['lock update'] = """
+type: command
+short-summary: Update a lock.
+examples:
+  - name: Update a resource group level lock with new notes and type
+    text: >
+        az lock update --name lockName --resource-group group --notes newNotesHere --lock-type CanNotDelete
 """
-helps['deployment'] = """
-    type: group
-    short-summary: Manage Azure Resource Manager deployments at subscription scope.
+
+helps['managedapp'] = """
+type: group
+short-summary: Manage template solutions provided and maintained by Independent Software Vendors (ISVs).
 """
-helps['deployment create'] = """
-    type: command
-    short-summary: Start a deployment.
-    parameters:
-        - name: --parameters
-          short-summary: Supply deployment parameter values.
-          long-summary: >
-            Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
-            It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
-    examples:
-        - name: Create a deployment from a remote template file, using parameters from a local JSON file.
-          text: >
-            az deployment create --location WestUS --template-uri https://myresource/azuredeploy.json --parameters @myparameters.json
-        - name: Create a deployment from a local template file, using parameters from a JSON string.
-          text: |
-            az deployment create --location WestUS --template-file azuredeploy.json --parameters '{ \\
-                    "policyName": { \\
-                        "value": "policy2" \\
-                    } \\
-                }'
-        - name: Create a deployment from a local template, using a parameter file, a remote parameter file, and selectively overriding key/value pairs.
-          text: >
-            az deployment create --location WestUS --template-file azuredeploy.json  \\
-                --parameters @params.json --parameters https://mysite/params.json --parameters MyValue=This MyArray=@array.json
+
+helps['managedapp create'] = """
+type: command
+short-summary: Create a managed application.
+examples:
+  - name: Create a managed application of kind 'ServiceCatalog'. This requires a valid managed application definition ID.
+    text: |
+        az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind ServiceCatalog \
+            -m "/subscriptions/{SubID}/resourceGroups/{ManagedResourceGroup}" \
+            -d "/subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Solutions/applianceDefinitions/{ApplianceDefinition}"
+  - name: Create a managed application of kind 'MarketPlace'. This requires a valid plan, containing details about existing marketplace package like plan name, version, publisher and product.
+    text: |
+        az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind MarketPlace \
+            -m "/subscriptions/{SubID}/resourceGroups/{ManagedResourceGroup}" \
+            --plan-name ContosoAppliance --plan-version "1.0" --plan-product "contoso-appliance" --plan-publisher Contoso
 """
-helps['deployment export'] = """
-    type: command
-    short-summary: Export the template used for a deployment.
+
+helps['managedapp definition'] = """
+type: group
+short-summary: Manage Azure Managed Applications.
 """
-helps['deployment validate'] = """
-    type: command
-    short-summary: Validate whether a template is syntactically correct.
-    parameters:
-        - name: --parameters
-          short-summary: Supply deployment parameter values.
-          long-summary: >
-            Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
-            It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
+
+helps['managedapp definition create'] = """
+type: command
+short-summary: Create a managed application definition.
+examples:
+  - name: Create a managed application defintion.
+    text: >
+        az managedapp definition create -g MyResourceGroup -n MyManagedAppDef -l eastus --display-name "MyManagedAppDef" \
+            --description "My Managed App Def description" -a "myPrincipalId:myRoleId" --lock-level None \
+            --package-file-uri "https://path/to/myPackage.zip"
+  - name: Create a managed application defintion with inline values for createUiDefinition and mainTemplate.
+    text: >
+        az managedapp definition create -g MyResourceGroup -n MyManagedAppDef -l eastus --display-name "MyManagedAppDef" \
+            --description "My Managed App Def description" -a "myPrincipalId:myRoleId" --lock-level None \
+            --create-ui-definition @myCreateUiDef.json --main-template @myMainTemplate.json
 """
-helps['deployment wait'] = """
-    type: command
-    short-summary: Place the CLI in a waiting state until a deployment condition is met.
+
+helps['managedapp definition delete'] = """
+type: command
+short-summary: Delete a managed application definition.
 """
-helps['deployment operation'] = """
-    type: group
-    short-summary: Manage deployment operations.
+
+helps['managedapp definition list'] = """
+type: command
+short-summary: List managed application definitions.
 """
-helps['group lock'] = """
-    type: group
-    short-summary: Manage Azure resource group locks.
+
+helps['managedapp delete'] = """
+type: command
+short-summary: Delete a managed application.
 """
-helps['group lock create'] = """
-    type: command
-    short-summary: Create a resource group lock.
-    examples:
-        - name: Create a read-only resource group level lock.
-          text: >
-            az group lock create --lock-type ReadOnly -n lockName -g MyResourceGroup
-    """
-helps['group lock delete'] = """
-    type: command
-    short-summary: Delete a resource group lock.
-    examples:
-        - name: Delete a resource group lock
-          text: >
-            az group lock delete --name lockName -g MyResourceGroup
-    """
-helps['group lock list'] = """
-    type: command
-    short-summary: List lock information in the resource-group.
-    examples:
-        - name: List out all locks on the resource group level
-          text: >
-            az group lock list -g MyResourceGroup
-    """
-helps['group lock show'] = """
-    type: command
-    short-summary: Show the details of a resource group lock
-    examples:
-        - name: Show a resource group level lock
-          text: >
-            az group lock show -n lockname -g MyResourceGroup
-    """
-helps['group lock update'] = """
-    type: command
-    short-summary: Update a resource group lock.
-    examples:
-        - name: Update a resource group lock with new notes and type
-          text: >
-            az group lock update --name lockName -g MyResourceGroup --notes newNotesHere --lock-type CanNotDelete
-    """
+
+helps['managedapp list'] = """
+type: command
+short-summary: List managed applications.
+"""
+
+helps['policy'] = """
+type: group
+short-summary: Manage resource policies.
+"""
+
+helps['policy assignment'] = """
+type: group
+short-summary: Manage resource policy assignments.
+"""
+
+helps['policy assignment create'] = """
+type: command
+short-summary: Create a resource policy assignment.
+parameters:
+  - name: --scope
+    type: string
+    short-summary: Scope to which this policy assignment applies.
+examples:
+  - name: Create a resource policy assignment at scope
+    text: |
+        Valid scopes are management group, subscription, resource group, and resource, for example
+           management group:  /providers/Microsoft.Management/managementGroups/MyManagementGroup
+           subscription:      /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333
+           resource group:    /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup
+           resource:          /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM
+             az policy assignment create --scope '/providers/Microsoft.Management/managementGroups/MyManagementGroup' --policy {PolicyName} -p '{ \
+                 "allowedLocations": { \
+                     "value": [ \
+                         "australiaeast", \
+                         "eastus", \
+                         "japaneast" \
+                     ] \
+                 } \
+             }'
+  - name: Create a resource policy assignment and provide rule parameter values.
+    text: |
+        az policy assignment create --policy {PolicyName} -p '{ \
+            "allowedLocations": { \
+                "value": [ \
+                    "australiaeast", \
+                    "eastus", \
+                    "japaneast" \
+                ] \
+            } \
+        }'
+  - name: Create a resource policy assignment with a system assigned identity.
+    text: >
+        az policy assignment create --name myPolicy --policy {PolicyName} --assign-identity
+  - name: Create a resource policy assignment with a system assigned identity. The identity will have 'Contributor' role access to the subscription.
+    text: >
+        az policy assignment create --name myPolicy --policy {PolicyName} --assign-identity --identity-scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --role Contributor
+"""
+
+helps['policy assignment delete'] = """
+type: command
+short-summary: Delete a resource policy assignment.
+"""
+
+helps['policy assignment identity'] = """
+type: group
+short-summary: Manage a policy assignment's managed identity.
+"""
+
+helps['policy assignment identity assign'] = """
+type: command
+short-summary: Add a system assigned identity to a policy assignment.
+examples:
+  - name: Add a system assigned managed identity to a policy assignment.
+    text: >
+        az policy assignment identity assign -g MyResourceGroup -n MyPolicyAssignment
+  - name: Add a system assigned managed identity to a policy assignment and grant it the 'Contributor' role for the current resource group.
+    text: >
+        az policy assignment identity assign -g MyResourceGroup -n MyPolicyAssignment --role Contributor --identity-scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/MyResourceGroup
+"""
+
+helps['policy assignment identity remove'] = """
+type: command
+short-summary: Remove a managed identity from a policy assignment.
+"""
+
+helps['policy assignment identity show'] = """
+type: command
+short-summary: Show a policy assignment's managed identity.
+"""
+
+helps['policy assignment list'] = """
+type: command
+short-summary: List resource policy assignments.
+"""
+
+helps['policy assignment show'] = """
+type: command
+short-summary: Show a resource policy assignment.
+"""
+
+helps['policy definition'] = """
+type: group
+short-summary: Manage resource policy definitions.
+"""
+
+helps['policy definition create'] = """
+type: command
+short-summary: Create a policy definition.
+parameters:
+  - name: --rules
+    type: string
+    short-summary: Policy rules in JSON format, or a path to a file containing JSON rules.
+  - name: --management-group
+    type: string
+    short-summary: Name of the management group the new policy definition can be assigned in.
+  - name: --subscription
+    type: string
+    short-summary: Name or id of the subscription the new policy definition can be assigned in.
+examples:
+  - name: Create a read-only policy.
+    text: |
+        az policy definition create --name readOnlyStorage --rules '{ \
+            "if": \
+            { \
+                "field": "type", \
+                "equals": "Microsoft.Storage/storageAccounts/write" \
+            }, \
+            "then": \
+            { \
+                "effect": "deny" \
+            } \
+        }'
+  - name: Create a policy parameter definition.
+    text: |
+        az policy definition create --name allowedLocations --rules '{ \
+            "if": { \
+                "allOf": [ \
+                    { \
+                        "field": "location", \
+                        "notIn": "[parameters('listOfAllowedLocations')]" \
+                    }, \
+                    { \
+                        "field": "location", \
+                        "notEquals": "global" \
+                    }, \
+                    { \
+                        "field": "type", \
+                        "notEquals": "Microsoft.AzureActiveDirectory/b2cDirectories" \
+                    } \
+                ] \
+            }, \
+            "then": { \
+                "effect": "deny" \
+            } \
+        }' \
+        --params '{ \
+            "allowedLocations": { \
+                "type": "array", \
+                "metadata": { \
+                    "description": "The list of locations that can be specified when deploying resources", \
+                    "strongType": "location", \
+                    "displayName": "Allowed locations" \
+                } \
+            } \
+        }'
+  - name: Create a read-only policy that can be applied within a management group.
+    text: |
+        az policy definition create -n readOnlyStorage --management-group 'MyManagementGroup' --rules '{ \
+            "if": \
+            { \
+                "field": "type", \
+                "equals": "Microsoft.Storage/storageAccounts/write" \
+            }, \
+            "then": \
+            { \
+                "effect": "deny" \
+            } \
+        }'
+"""
+
+helps['policy definition delete'] = """
+type: command
+short-summary: Delete a policy definition.
+"""
+
+helps['policy definition list'] = """
+type: command
+short-summary: List policy definitions.
+"""
+
+helps['policy definition show'] = """
+type: command
+short-summary: Show a policy definition.
+"""
+
+helps['policy definition update'] = """
+type: command
+short-summary: Update a policy definition.
+"""
+
+helps['policy set-definition'] = """
+type: group
+short-summary: Manage resource policy set definitions.
+"""
+
+helps['policy set-definition create'] = """
+type: command
+short-summary: Create a policy set definition.
+parameters:
+  - name: --definitions
+    type: string
+    short-summary: Policy definitions in JSON format, or a path to a file containing JSON rules.
+  - name: --management-group
+    type: string
+    short-summary: Name of management group the new policy set definition can be assigned in.
+  - name: --subscription
+    type: string
+    short-summary: Name or id of the subscription the new policy set definition can be assigned in.
+examples:
+  - name: Create a policy set definition.
+    text: |
+        az policy set-definition create -n readOnlyStorage --definitions '[ \
+                { \
+                    "policyDefinitionId": "/subscriptions/mySubId/providers/Microsoft.Authorization/policyDefinitions/storagePolicy" \
+                } \
+            ]'
+  - name: Create a policy set definition to be used by a subscription.
+    text: |
+        az policy set-definition create -n readOnlyStorage --subscription '0b1f6471-1bf0-4dda-aec3-111122223333' --definitions '[ \
+                { \
+                    "policyDefinitionId": "/subscriptions/mySubId/providers/Microsoft.Authorization/policyDefinitions/storagePolicy" \
+                } \
+            ]'
+"""
+
+helps['policy set-definition delete'] = """
+type: command
+short-summary: Delete a policy set definition.
+"""
+
+helps['policy set-definition list'] = """
+type: command
+short-summary: List policy set definitions.
+"""
+
+helps['policy set-definition show'] = """
+type: command
+short-summary: Show a policy set definition.
+"""
+
+helps['policy set-definition update'] = """
+type: command
+short-summary: Update a policy set definition.
+"""
+
 helps['provider'] = """
-    type: group
-    short-summary: Manage resource providers.
+type: group
+short-summary: Manage resource providers.
 """
 
 helps['provider list'] = """
-    type: command
-    examples:
-        - name: Display all resource types for the network resource provider.
-          text: >
-            az provider list --query [?namespace=='Microsoft.Network'].resourceTypes[].resourceType
+type: command
+examples:
+  - name: Display all resource types for the network resource provider.
+    text: >
+        az provider list --query [?namespace=='Microsoft.Network'].resourceTypes[].resourceType
+"""
+
+helps['provider operation'] = """
+type: group
+short-summary: Get provider operations metadatas.
+"""
+
+helps['provider operation list'] = """
+type: command
+short-summary: Get operations from all providers.
+"""
+
+helps['provider operation show'] = """
+type: command
+short-summary: Get an individual provider's operations.
 """
 
 helps['provider register'] = """
-    type: command
-    short-summary: Register a provider.
+type: command
+short-summary: Register a provider.
 """
+
 helps['provider unregister'] = """
-    type: command
-    short-summary: Unregister a provider.
+type: command
+short-summary: Unregister a provider.
 """
-helps['provider operation'] = """
-    type: group
-    short-summary: Get provider operations metadatas.
+
+helps['resource'] = """
+type: group
+short-summary: Manage Azure resources.
 """
-helps['provider operation show'] = """
-    type: command
-    short-summary: Get an individual provider's operations.
+
+helps['resource create'] = """
+type: command
+short-summary: create a resource.
+examples:
+  - name: Create an API app by providing a full JSON configuration.
+    text: |
+        az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties '{ \
+                    "kind": "api", \
+                    "location": "West US", \
+                    "properties": { \
+                        "serverFarmId": "/subscriptions/{SubID}/resourcegroups/{ResourceGroup}/providers/Microsoft.Web/serverfarms/{ServicePlan}" \
+                    } \
+                }'
+  - name: Create a resource by loading JSON configuration from a file.
+    text: >
+        az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties @jsonConfigFile
+  - name: Create a web app with the minimum required configuration information.
+    text: |
+        az resource create -g myRG -n myWeb --resource-type Microsoft.web/sites --properties '{ \
+                "serverFarmId":"/subscriptions/{SubID}/resourcegroups/{ResourceGroup}/providers/Microsoft.Web/serverfarms/{ServicePlan}" \
+            }'
 """
-helps['provider operation list'] = """
-    type: command
-    short-summary: Get operations from all providers.
+
+helps['resource delete'] = """
+type: command
+short-summary: Delete a resource.
+examples:
+  - name: Delete a virtual machine named 'MyVm'.
+    text: >
+        az resource delete -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
+  - name: Delete a web app using a resource identifier.
+    text: >
+        az resource delete --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Web/sites/MyWebapp
+  - name: Delete a subnet using a resource identifier.
+    text: >
+        az resource delete --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/subnets/MySubnet
 """
-helps['tag'] = """
-    type: group
-    short-summary: Manage resource tags.
+
+helps['resource invoke-action'] = """
+type: command
+short-summary: Invoke an action on the resource.
+long-summary: >
+    A list of possible actions corresponding to a resource can be found at https://docs.microsoft.com/en-us/rest/api/. All POST requests are actions that can be invoked and are specified at the end of the URI path. For instance, to stop a VM, the
+    request URI is https://management.azure.com/subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroup}/providers/Microsoft.Compute/virtualMachines/{VM}/powerOff?api-version={APIVersion} and the corresponding action is `powerOff`. This can
+    be found at https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/virtualmachines-stop.
+examples:
+  - name: Power-off a vm, specified by Id.
+    text: >
+        az resource invoke-action --action powerOff \
+          --ids /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Compute/virtualMachines/{VMName}
+  - name: Capture information for a stopped vm.
+    text: >
+        az resource invoke-action --action capture \
+          --ids /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Compute/virtualMachines/{VMName} \
+          --request-body '{ \
+            "vhdPrefix": "myPrefix", \
+            "destinationContainerName": "myContainer", \
+            "overwriteVhds": true \
+        }'
 """
+
 helps['resource link'] = """
-    type: group
-    short-summary: Manage links between resources.
-    long-summary: >
-        Linking is a feature of the Resource Manager. It enables declaring relationships between resources even if they do not reside in the same resource group.
-        Linking has no impact on resource usage, no impact on billing, and no impact on role-based access. It allows for managing multiple resources across groups
-        as a single unit.
+type: group
+short-summary: Manage links between resources.
+long-summary: >
+    Linking is a feature of the Resource Manager. It enables declaring relationships between resources even if they do not reside in the same resource group.
+    Linking has no impact on resource usage, no impact on billing, and no impact on role-based access. It allows for managing multiple resources across groups
+    as a single unit.
 """
+
 helps['resource link create'] = """
-    type: command
-    short-summary: Create a new link between resources.
-    long-summary: A link-id is of the form /subscriptions/{SubID}/resourceGroups/{ResourceGroupID}/providers/{ProviderNamespace}/{ResourceType}/{ResourceName}/providers/Microsoft.Resources/links/{LinkName}
-    examples:
-        - name: Create a link from {SourceID} to {ResourceID} with notes
-          text: >
-            az resource link create --link-id {SourceID} --target-id {ResourceID} --notes "SourceID depends on ResourceID"
+type: command
+short-summary: Create a new link between resources.
+long-summary: A link-id is of the form /subscriptions/{SubID}/resourceGroups/{ResourceGroupID}/providers/{ProviderNamespace}/{ResourceType}/{ResourceName}/providers/Microsoft.Resources/links/{LinkName}
+examples:
+  - name: Create a link from {SourceID} to {ResourceID} with notes
+    text: >
+        az resource link create --link-id {SourceID} --target-id {ResourceID} --notes "SourceID depends on ResourceID"
 """
-helps['resource link update'] = """
-    type: command
-    short-summary: Update link between resources.
-    long-summary: A link-id is of the form /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/{ProviderNamespace}/{ResourceType}/{ResourceName}/providers/Microsoft.Resources/links/{LinkName}
-    examples:
-        - name: Update the notes for {LinkID} notes "some notes to explain this link"
-          text: >
-            az resource link update --link-id {LinkID} --notes "some notes to explain this link"
-"""
+
 helps['resource link delete'] = """
-    type: command
-    short-summary: Delete a link between resources.
-    long-summary: A link-id is of the form /subscriptions/{SubID}/resourceGroups/{ResourceGroupID}/providers/{ProviderNamespace}/{ResourceType}/{ResourceName}/providers/Microsoft.Resources/links/{LinkName}
-    examples:
-        - name: Delete link {LinkID}
-          text: >
-            az resource link delete --link-id {LinkID}
+type: command
+short-summary: Delete a link between resources.
+long-summary: A link-id is of the form /subscriptions/{SubID}/resourceGroups/{ResourceGroupID}/providers/{ProviderNamespace}/{ResourceType}/{ResourceName}/providers/Microsoft.Resources/links/{LinkName}
+examples:
+  - name: Delete link {LinkID}
+    text: >
+        az resource link delete --link-id {LinkID}
 """
+
 helps['resource link list'] = """
-    type: command
-    short-summary: List resource links.
-    examples:
-        - name: List links, filtering with <filter-string>
-          text: >
-            az resource link list --filter <filter-string>
-        - name: List all links for resource group {ResourceGroup} in subscription {SubID}
-          text: >
-            az resource link list --scope /subscriptions/{SubID}/resourceGroups/{ResourceGroup}
+type: command
+short-summary: List resource links.
+examples:
+  - name: List links, filtering with <filter-string>
+    text: >
+        az resource link list --filter <filter-string>
+  - name: List all links for resource group {ResourceGroup} in subscription {SubID}
+    text: >
+        az resource link list --scope /subscriptions/{SubID}/resourceGroups/{ResourceGroup}
 """
+
 helps['resource link show'] = """
-    type: command
-    short-summary: Get details for a resource link.
-    long-summary: A link-id is of the form /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/{ProviderNamespace}/{ResourceType}/{ResourceName}/providers/Microsoft.Resources/links/{LinkName}
+type: command
+short-summary: Get details for a resource link.
+long-summary: A link-id is of the form /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/{ProviderNamespace}/{ResourceType}/{ResourceName}/providers/Microsoft.Resources/links/{LinkName}
 """
+
+helps['resource link update'] = """
+type: command
+short-summary: Update link between resources.
+long-summary: A link-id is of the form /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/{ProviderNamespace}/{ResourceType}/{ResourceName}/providers/Microsoft.Resources/links/{LinkName}
+examples:
+  - name: Update the notes for {LinkID} notes "some notes to explain this link"
+    text: >
+        az resource link update --link-id {LinkID} --notes "some notes to explain this link"
+"""
+
+helps['resource list'] = """
+type: command
+short-summary: List resources.
+examples:
+  - name: List all resources in the West US region.
+    text: >
+        az resource list --location westus
+  - name: List all resources with the name 'resourceName'.
+    text: >
+        az resource list --name 'resourceName'
+  - name: List all resources with the tag 'test'.
+    text: >
+        az resource list --tag test
+  - name: List all resources with a tag that starts with 'test'.
+    text: >
+        az resource list --tag 'test*'
+  - name: List all resources with the tag 'test' that have the value 'example'.
+    text: >
+        az resource list --tag test=example
+"""
+
 helps['resource lock'] = """
-    type: group
-    short-summary: Manage Azure resource level locks.
+type: group
+short-summary: Manage Azure resource level locks.
 """
+
 helps['resource lock create'] = """
-    type: command
-    short-summary: Create a resource-level lock.
-    examples:
-        - name: Create a read-only resource level lock on a vnet.
-          text: >
-            az resource lock create --lock-type ReadOnly -n lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
-        - name: Create a read-only resource level lock on a vnet using a vnet id.
-          text: >
-            az resource lock create --lock-type ReadOnly -n lockName --resource /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{VNETName}
-    """
+type: command
+short-summary: Create a resource-level lock.
+examples:
+  - name: Create a read-only resource level lock on a vnet.
+    text: >
+        az resource lock create --lock-type ReadOnly -n lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
+  - name: Create a read-only resource level lock on a vnet using a vnet id.
+    text: >
+        az resource lock create --lock-type ReadOnly -n lockName --resource /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{VNETName}
+"""
+
 helps['resource lock delete'] = """
-    type: command
-    short-summary: Delete a resource-level lock.
-    examples:
-        - name: Delete a resource level lock
-          text: >
-            az resource lock delete --name lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
-        - name: Delete a resource level lock on a vnet using a vnet id.
-          text: >
-            az resource lock delete -n lockName --resource /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{VMName}
-    """
+type: command
+short-summary: Delete a resource-level lock.
+examples:
+  - name: Delete a resource level lock
+    text: >
+        az resource lock delete --name lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
+  - name: Delete a resource level lock on a vnet using a vnet id.
+    text: >
+        az resource lock delete -n lockName --resource /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Network/virtualNetworks/{VMName}
+"""
+
 helps['resource lock list'] = """
-    type: command
-    short-summary: List lock information in the resource-level.
-    examples:
-        - name: List out all locks on a vnet
-          text: >
-            az resource lock list -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
-    """
+type: command
+short-summary: List lock information in the resource-level.
+examples:
+  - name: List out all locks on a vnet
+    text: >
+        az resource lock list -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
+"""
+
 helps['resource lock show'] = """
-    type: command
-    short-summary: Show the details of a resource-level lock
-    examples:
-        - name: Show a resource level lock
-          text: >
-            az resource lock show -n lockname -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
-    """
+type: command
+short-summary: Show the details of a resource-level lock
+examples:
+  - name: Show a resource level lock
+    text: >
+        az resource lock show -n lockname -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks
+"""
+
 helps['resource lock update'] = """
-    type: command
-    short-summary: Update a resource-level lock.
-    examples:
-        - name: Update a resource level lock with new notes and type
-          text: >
-            az resource lock update --name lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks --notes newNotesHere --lock-type CanNotDelete
-    """
+type: command
+short-summary: Update a resource-level lock.
+examples:
+  - name: Update a resource level lock with new notes and type
+    text: >
+        az resource lock update --name lockName -g MyResourceGroup --resource myvnet --resource-type Microsoft.Network/virtualNetworks --notes newNotesHere --lock-type CanNotDelete
+"""
+
+helps['resource show'] = """
+type: command
+short-summary: Get the details of a resource.
+examples:
+  - name: Show a virtual machine resource named 'MyVm'.
+    text: >
+        az resource show -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
+  - name: Show a web app using a resource identifier.
+    text: >
+        az resource show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Web/sites/MyWebapp
+  - name: Show a subnet.
+    text: >
+        az resource show -g MyResourceGroup -n MySubnet --namespace Microsoft.Network --parent virtualnetworks/MyVnet --resource-type subnets
+  - name: Show a subnet using a resource identifier.
+    text: >
+        az resource show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/subnets/MySubnet
+  - name: Show an application gateway path rule.
+    text: >
+        az resource show -g MyResourceGroup --namespace Microsoft.Network --parent applicationGateways/ag1/urlPathMaps/map1 --resource-type pathRules -n rule1
+"""
+
+helps['resource tag'] = """
+type: command
+short-summary: Tag a resource.
+examples:
+  - name: Tag the virtual machine 'MyVm' with the key 'vmlist' and value 'vm1'.
+    text: >
+        az resource tag --tags vmlist=vm1 -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
+  - name: Tag a web app with the key 'vmlist' and value 'vm1', using a resource identifier.
+    text: >
+        az resource tag --tags vmlist=vm1 --id /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Web/sites/{WebApp}
+"""
+
+helps['resource update'] = """
+type: command
+short-summary: Update a resource.
+"""
+
+helps['resource wait'] = """
+type: command
+short-summary: Place the CLI in a waiting state until a condition of a resources is met.
+"""
+
+helps['tag'] = """
+type: group
+short-summary: Manage resource tags.
+"""


### PR DESCRIPTION
- Reorder commands in help files to make future diffing easier.
- Add new crafted examples to commands and groups without existing examples.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
