### PR TITLE
enable kubectl bash-completion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ LABEL maintainer="Microsoft" \
 # jq - we include jq as a useful tool
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool
-RUN apk add --no-cache bash openssh ca-certificates jq curl openssl git \
+RUN apk add --no-cache bash bash-completion openssh ca-certificates jq curl openssl git \
  && apk add --no-cache --virtual .build-deps gcc make openssl-dev libffi-dev musl-dev \
  && update-ca-certificates
 
@@ -58,6 +58,7 @@ RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
     pip install --no-cache-dir $all_modules; \
     pip install --no-cache-dir --force-reinstall --upgrade azure-nspkg azure-mgmt-nspkg;' \
  && cat /azure-cli/az.completion > ~/.bashrc \
+ && echo "source /usr/share/bash-completion/bash_completion" >> ~/.bashrc \
  && runDeps="$( \
     scanelf --needed --nobanner --recursive /usr/local \
         | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
@@ -72,5 +73,9 @@ WORKDIR /
 # Remove CLI source code from the final image and normalize line endings.
 RUN rm -rf ./azure-cli && \
     dos2unix /root/.bashrc /usr/local/bin/az
+
+# Install kubectl with bash-completion
+RUN az aks install-cli && \
+    kubectl completion bash > /usr/share/bash-completion/completions/kubectl
 
 CMD bash

--- a/az.completion
+++ b/az.completion
@@ -19,3 +19,4 @@ _python_argcomplete() {
     fi
 }
 complete -o nospace -F _python_argcomplete "az"
+

--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,8 @@
 Release History
 ===============
 
+* configure kubectl bash-completion during "az aks install-cli"
+
 2.3.19
 ++++++
 * ignore listen-address argument to "az aks browse" if kubectl doesn't support it


### PR DESCRIPTION
Enable `kubectl` bash completion in the azure CLI via the Docker image

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
