### PR TITLE
[AKS] clarify that --output is ignored for "az aks get-credentials" 

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -2,9 +2,11 @@
 
 Release History
 ===============
+
 2.3.17
 ++++++
 * az aks enable-addons /disable-addons: support case insensitive name
+* clarify that "--output" is ignored for "az aks get-credentials"
 
 2.3.16
 ++++++

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -96,6 +96,10 @@ helps['acs kubernetes get-credentials'] = """
     type: command
     short-summary: Download and install credentials to access a cluster.  This command requires
                    the same private-key used to create the cluster.
+    parameters:
+        - name: --output -o
+          type: string
+          long-summary: Credentials are always in YAML format, so this argument is effectively ignored.
 """
 
 helps['acs list-locations'] = """
@@ -331,6 +335,9 @@ helps['aks get-credentials'] = """
         - name: --overwrite-existing
           type: bool
           short-summary: Overwrite any existing cluster entry with the same name.
+        - name: --output -o
+          type: string
+          long-summary: Credentials are always in YAML format, so this argument is effectively ignored.
 """
 
 helps['aks get-upgrades'] = """


### PR DESCRIPTION
Closes #4250.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
