### PR TITLE
[ACR] Improve error handling for runtime commands when not logged into Azure

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -69,7 +69,7 @@ _SYSTEM_ASSIGNED_IDENTITY = 'systemAssignedIdentity'
 _USER_ASSIGNED_IDENTITY = 'userAssignedIdentity'
 _ASSIGNED_IDENTITY_INFO = 'assignedIdentityInfo'
 
-AZ_LOGIN_MESSAGE = "Please run 'az login' to setup account"
+AZ_LOGIN_MESSAGE = "Please run 'az login' to setup account."
 
 
 def load_subscriptions(cli_ctx, all_clouds=False, refresh=False):

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -69,6 +69,8 @@ _SYSTEM_ASSIGNED_IDENTITY = 'systemAssignedIdentity'
 _USER_ASSIGNED_IDENTITY = 'userAssignedIdentity'
 _ASSIGNED_IDENTITY_INFO = 'assignedIdentityInfo'
 
+AZ_LOGIN_MESSAGE = "Please run 'az login' to setup account"
+
 
 def load_subscriptions(cli_ctx, all_clouds=False, refresh=False):
     profile = Profile(cli_ctx=cli_ctx)
@@ -467,7 +469,7 @@ class Profile(object):
     def get_subscription(self, subscription=None):  # take id or name
         subscriptions = self.load_cached_subscriptions()
         if not subscriptions:
-            raise CLIError("Please run 'az login' to setup account.")
+            raise CLIError(AZ_LOGIN_MESSAGE)
 
         result = [x for x in subscriptions if (
             not subscription and x.get(_IS_DEFAULT_SUBSCRIPTION) or

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -69,7 +69,7 @@ _SYSTEM_ASSIGNED_IDENTITY = 'systemAssignedIdentity'
 _USER_ASSIGNED_IDENTITY = 'userAssignedIdentity'
 _ASSIGNED_IDENTITY_INFO = 'assignedIdentityInfo'
 
-AZ_LOGIN_MESSAGE = "Please run 'az login' to setup account."
+_AZ_LOGIN_MESSAGE = "Please run 'az login' to setup account."
 
 
 def load_subscriptions(cli_ctx, all_clouds=False, refresh=False):
@@ -469,7 +469,7 @@ class Profile(object):
     def get_subscription(self, subscription=None):  # take id or name
         subscriptions = self.load_cached_subscriptions()
         if not subscriptions:
-            raise CLIError(AZ_LOGIN_MESSAGE)
+            raise CLIError(_AZ_LOGIN_MESSAGE)
 
         result = [x for x in subscriptions if (
             not subscription and x.get(_IS_DEFAULT_SUBSCRIPTION) or

--- a/src/command_modules/azure-cli-acr/HISTORY.rst
+++ b/src/command_modules/azure-cli-acr/HISTORY.rst
@@ -6,8 +6,9 @@ Release History
 2.2.0
 +++++
 * BREAKING CHANGE: Remove 'acr build-task' command group.
-* BREAKING CHANGE: Remove --tag/--manifest from 'acr repository delete' command.
+* BREAKING CHANGE: Remove '--tag'/'--manifest' from 'acr repository delete' command.
 * Add '--target' parameter for 'az acr build', 'az acr task create' and 'az acr task update' commands.
+* Improve error handling for runtime commands when not logged into Azure.
 
 2.1.13
 ++++++

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_docker_utils.py
@@ -23,7 +23,7 @@ from knack.log import get_logger
 
 from azure.cli.core.util import should_disable_connection_verify
 from azure.cli.core.cloud import CloudSuffixNotSetException
-from azure.cli.core._profile import AZ_LOGIN_MESSAGE
+from azure.cli.core._profile import _AZ_LOGIN_MESSAGE
 
 from ._client_factory import cf_acr_registries
 from ._constants import get_managed_sku
@@ -164,7 +164,7 @@ def _get_credentials(cmd,
                 "Obtained registry login server '%s' from service. The specified suffix '%s' is ignored.",
                 login_server, tenant_suffix)
     except (ResourceNotFound, CLIError) as e:
-        if not isinstance(e, ResourceNotFound) and AZ_LOGIN_MESSAGE not in str(e):
+        if not isinstance(e, ResourceNotFound) and _AZ_LOGIN_MESSAGE not in str(e):
             raise
         # Try to use the pre-defined login server suffix to construct login server from registry name.
         login_server_suffix = get_login_server_suffix(cli_ctx)

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/commands.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/commands.py
@@ -38,6 +38,10 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         client_factory=cf_acr_registries
     )
 
+    acr_login_util = CliCommandType(
+        operations_tmpl='azure.cli.command_modules.acr.custom#{}'
+    )
+
     acr_import_util = CliCommandType(
         operations_tmpl='azure.cli.command_modules.acr.import#{}',
         client_factory=cf_acr_registries
@@ -104,7 +108,6 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.command('create', 'acr_create')
         g.command('delete', 'acr_delete')
         g.show_command('show', 'acr_show')
-        g.command('login', 'acr_login', table_transformer=None)
         g.command('show-usage', 'acr_show_usage', table_transformer=usage_output_format)
         g.generic_update_command('update',
                                  getter_name='acr_update_get',
@@ -112,6 +115,9 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
                                  custom_func_name='acr_update_custom',
                                  custom_func_type=acr_custom_util,
                                  client_factory=cf_acr_registries)
+
+    with self.command_group('acr', acr_login_util) as g:
+        g.command('login', 'acr_login')
 
     with self.command_group('acr', acr_import_util) as g:
         g.command('import', 'acr_import')


### PR DESCRIPTION
This PR uses a fallback approach to handle different endpoints/routes for Managed vs. Classic registries, rather than proactively ask ARM for the SKU.

When not logged into Azure, runtime commands (i.e., `acr login`, `acr repository`, and `acr helm`) will prompt for username/password to access registry rather than throwing an error for `az login`. This also allows users to provide `--username`/`--password` to access registry without `az login`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
