### PR TITLE
Minor updates to vmss encryption enable.

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -504,7 +504,8 @@ def encrypt_vmss(cmd, resource_group_name, vmss_name,  # pylint: disable=too-man
     exts = [ext]
 
     # remove any old ade extensions set by this command and add the new one.
-    if vmss.virtual_machine_profile.extension_profile:
+    vmss_ext_profile = vmss.virtual_machine_profile.extension_profile
+    if vmss_ext_profile and vmss_ext_profile.extensions:
         exts.extend(old_ext for old_ext in vmss.virtual_machine_profile.extension_profile.extensions
                     if old_ext.type != ext.type or old_ext.name != ext.name)
     vmss.virtual_machine_profile.extension_profile = VirtualMachineScaleSetExtensionProfile(extensions=exts)


### PR DESCRIPTION
Added logic to make vmss encryption enable safer.
I am not sure if this is necessary, as when I set extensions to None, the service sets vmss.virtual_machine_profile.extension_profile.extensions to an empty list. So it seems this value should always be iterable.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
