### PR TITLE
Add code to handle supported_profiles in examples.

### DIFF
--- a/doc/authoring_help.md
+++ b/doc/authoring_help.md
@@ -194,10 +194,10 @@ In your YAML files, the same `short-summary` and `long-summary` is used for all 
 
 For the command parameters section, any parameters not used by a profile will be ignored and not displayed.
 
-For command examples, you optionally specify the profile the example is for with the `min_profile` and `max_profile` options.
+For command examples, you optionally specify the profile the example is for with the `supported_profiles` option.
 
-Here's a samply for `storage account create`:  
-The first example is only supported on the profile `latest` and above whilst the second example if only supported on `2017-03-09-profile` and below.
+Here's a demonstration for `storage account create`:
+The first example is only supported on the `latest` and `2018-03-01-hybrid` profiles whilst the second example is only supported on `2017-03-09-profile`.
 
 ### _help.py
 
@@ -205,10 +205,10 @@ The first example is only supported on the profile `latest` and above whilst the
     examples:
         - name: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
-          min_profile: latest
+          supported_profiles: latest, 2018-03-01-hybrid
         - name: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --account-type Standard_LRS
-          max_profile: 2017-03-09-profile
+          supported_profiles: 2017-03-09-profile
 ```
 
 ### help.yaml
@@ -217,15 +217,15 @@ The first example is only supported on the profile `latest` and above whilst the
     examples:
         - summary: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
           command: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
-          min_profile: latest
+          supported_profiles: latest, 2018-03-01-hybrid
         - summary: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
           command: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --account-type Standard_LRS
-          max_profile: 2017-03-09-profile
+          supported_profiles: 2017-03-09-profile
 ```
 
 Here is how this looks in CLI `--help`:
 
-On profile `latest`.
+On profiles `latest` and `2018-03-01-hybrid`.
 ```
 Examples
     Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US

--- a/doc/authoring_help.md
+++ b/doc/authoring_help.md
@@ -194,7 +194,7 @@ In your YAML files, the same `short-summary` and `long-summary` is used for all 
 
 For the command parameters section, any parameters not used by a profile will be ignored and not displayed.
 
-For command examples, you optionally specify the profile the example is for with the `supported_profiles` option.
+For command examples, you can optionally specify the profile the example is for with the `supported-profiles` and `unsupported-profiles` fields.
 
 Here's a demonstration for `storage account create`:
 The first example is only supported on the `latest` and `2018-03-01-hybrid` profiles whilst the second example is only supported on `2017-03-09-profile`.
@@ -205,10 +205,12 @@ The first example is only supported on the `latest` and `2018-03-01-hybrid` prof
     examples:
         - name: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
-          supported_profiles: latest, 2018-03-01-hybrid
+          unsupported-profiles: 2017-03-09-profile
+          # alternatively 
+          # supported-profiles: latest, 2018-03-01-hybrid
         - name: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --account-type Standard_LRS
-          supported_profiles: 2017-03-09-profile
+          supported-profiles: 2017-03-09-profile
 ```
 
 ### help.yaml
@@ -217,10 +219,12 @@ The first example is only supported on the `latest` and `2018-03-01-hybrid` prof
     examples:
         - summary: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
           command: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
-          supported_profiles: latest, 2018-03-01-hybrid
+          supported-profiles: latest, 2018-03-01-hybrid
+          # alternatively 
+          # supported-profiles: latest, 2018-03-01-hybrid
         - summary: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
           command: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --account-type Standard_LRS
-          supported_profiles: 2017-03-09-profile
+          supported-profiles: 2017-03-09-profile
 ```
 
 Here is how this looks in CLI `--help`:

--- a/scripts/temp_help/help_convert.py
+++ b/scripts/temp_help/help_convert.py
@@ -208,8 +208,11 @@ def _get_new_yaml_dict(help_dict):
                     new_ex["summary"] = ex["name"]
                 if "text" in ex:
                     new_ex["command"] = ex["text"]
-                if "supported_profiles" in ex:
-                    new_ex["supported_profiles"] = ex["supported_profiles"]
+                supported_profiles, unsupported_profiles = "supported-profiles", "unsupported-profiles"
+                if supported_profiles in ex:
+                    new_ex[supported_profiles] = ex[supported_profiles]
+                if unsupported_profiles in ex:
+                    new_ex[unsupported_profiles] = ex[unsupported_profiles]
                 elem_examples.append(new_ex)
             elem_content["examples"] = elem_examples
 

--- a/scripts/temp_help/help_convert.py
+++ b/scripts/temp_help/help_convert.py
@@ -208,6 +208,8 @@ def _get_new_yaml_dict(help_dict):
                     new_ex["summary"] = ex["name"]
                 if "text" in ex:
                     new_ex["command"] = ex["text"]
+                if "supported_profiles" in ex:
+                    new_ex["supported_profiles"] = ex["supported_profiles"]
                 if "min_profile" in ex:
                     new_ex["min_profile"] = ex["min_profile"]
                 if "max_profile" in ex:

--- a/scripts/temp_help/help_convert.py
+++ b/scripts/temp_help/help_convert.py
@@ -210,12 +210,6 @@ def _get_new_yaml_dict(help_dict):
                     new_ex["command"] = ex["text"]
                 if "supported_profiles" in ex:
                     new_ex["supported_profiles"] = ex["supported_profiles"]
-                # TODO: after CI passes without refdoc warnings remove this.
-                # TODO: assert that objects the same before and after help convert. # assert help text sphinx equal
-                if "min_profile" in ex:
-                    new_ex["min_profile"] = ex["min_profile"]
-                if "max_profile" in ex:
-                    new_ex["max_profile"] = ex["max_profile"]
                 elem_examples.append(new_ex)
             elem_content["examples"] = elem_examples
 

--- a/scripts/temp_help/help_convert.py
+++ b/scripts/temp_help/help_convert.py
@@ -210,6 +210,8 @@ def _get_new_yaml_dict(help_dict):
                     new_ex["command"] = ex["text"]
                 if "supported_profiles" in ex:
                     new_ex["supported_profiles"] = ex["supported_profiles"]
+                # TODO: after CI passes without refdoc warnings remove this.
+                # TODO: assert that objects the same before and after help convert. # assert help text sphinx equal
                 if "min_profile" in ex:
                     new_ex["min_profile"] = ex["min_profile"]
                 if "max_profile" in ex:

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -8,7 +8,7 @@ import argparse
 from knack.help import (HelpFile as KnackHelpFile, CommandHelpFile as KnackCommandHelpFile,
                         GroupHelpFile as KnackGroupHelpFile, ArgumentGroupRegistry as KnackArgumentGroupRegistry,
                         HelpExample as KnackHelpExample, HelpParameter as KnackHelpParameter,
-                        _print_indent, CLIHelp)
+                        _print_indent, CLIHelp, HelpAuthoringException)
 
 from knack.log import get_logger
 from knack.util import CLIError
@@ -166,10 +166,24 @@ class CliHelpFile(KnackHelpFile):
         self.links = []
 
     def _should_include_example(self, ex):
-        supported_profiles = ex.get('supported_profiles')
+        supported_profiles = ex.get('supported-profiles')
+        unsupported_profiles = ex.get('unsupported-profiles')
+
+        if all((supported_profiles, unsupported_profiles)):
+            raise HelpAuthoringException("An example cannot have both supported-profiles and unsupported-profiles.")
+
+        if 'min_profile' in ex or 'max_profile' in ex:
+            raise HelpAuthoringException("Help entry fields 'min_profile' and 'max_profile' are no longer supported. "
+                                         "Please use 'supported-profiles' or 'unsupported-profiles'.")
+
         if supported_profiles:
             supported_profiles = [profile.strip() for profile in supported_profiles.split(',')]
             return self.help_ctx.cli_ctx.cloud.profile in supported_profiles
+
+        if unsupported_profiles:
+            unsupported_profiles = [profile.strip() for profile in unsupported_profiles.split(',')]
+            return self.help_ctx.cli_ctx.cloud.profile not in unsupported_profiles
+
         return True
 
     # Needs to override base implementation to exclude unsupported examples.
@@ -292,7 +306,8 @@ class HelpExample(KnackHelpExample):  # pylint: disable=too-few-public-methods
         self.text = _data.get('command', '') if _data.get('command', '') else self.text
 
         self.long_summary = _data.get('description', '')
-        self.supported_profiles = _data.get('supported_profiles', '')
+        self.supported_profiles = _data.get('supported-profiles', None)
+        self.unsupported_profiles = _data.get('unsupported-profiles', None)
 
     # alias old params with new
     @property

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -166,8 +166,19 @@ class CliHelpFile(KnackHelpFile):
         self.links = []
 
     def _should_include_example(self, ex):
+        supported_profiles = ex.get('supported_profiles')
         min_profile = ex.get('min_profile')
         max_profile = ex.get('max_profile')
+
+        if min_profile or max_profile:
+            raise CLIError("An example has a min_profile or max_profile.\n{}, {}".
+                           format(ex.get('name'), ex.get('text')))
+
+        if supported_profiles:
+            supported_profiles = supported_profiles.split(',')
+            return self.help_ctx.cli_ctx.cloud.profile in supported_profiles
+
+
         if min_profile or max_profile:
             from azure.cli.core.profiles import supported_api_version, PROFILE_TYPE
             # yaml will load this as a datetime if it's a date, we need a string.
@@ -297,6 +308,8 @@ class HelpExample(KnackHelpExample):  # pylint: disable=too-few-public-methods
         self.text = _data.get('command', '') if _data.get('command', '') else self.text
 
         self.long_summary = _data.get('description', '')
+
+        self.supported_profiles = _data.get('supported_profiles', '')
         self.min_profile = _data.get('min_profile', '')
         self.max_profile = _data.get('max_profile', '')
 

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -170,6 +170,7 @@ class CliHelpFile(KnackHelpFile):
         min_profile = ex.get('min_profile')
         max_profile = ex.get('max_profile')
 
+        # TODO: after CI passes without refdoc warnings remove this.
         if min_profile or max_profile:
             raise CLIError("An example has a min_profile or max_profile.\n{}, {}".
                            format(ex.get('name'), ex.get('text')))
@@ -178,6 +179,7 @@ class CliHelpFile(KnackHelpFile):
             supported_profiles = [profile.strip() for profile in supported_profiles.split(',')]
             return self.help_ctx.cli_ctx.cloud.profile in supported_profiles
 
+        # TODO: after CI passes without refdoc warnings remove this.
         if min_profile or max_profile:
             from azure.cli.core.profiles import supported_api_version, PROFILE_TYPE
             # yaml will load this as a datetime if it's a date, we need a string.
@@ -309,6 +311,8 @@ class HelpExample(KnackHelpExample):  # pylint: disable=too-few-public-methods
         self.long_summary = _data.get('description', '')
 
         self.supported_profiles = _data.get('supported_profiles', '')
+
+        # TODO: after CI passes without refdoc warnings remove this.
         self.min_profile = _data.get('min_profile', '')
         self.max_profile = _data.get('max_profile', '')
 

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -167,26 +167,9 @@ class CliHelpFile(KnackHelpFile):
 
     def _should_include_example(self, ex):
         supported_profiles = ex.get('supported_profiles')
-        min_profile = ex.get('min_profile')
-        max_profile = ex.get('max_profile')
-
-        # TODO: after CI passes without refdoc warnings remove this.
-        if min_profile or max_profile:
-            raise CLIError("An example has a min_profile or max_profile.\n{}, {}".
-                           format(ex.get('name'), ex.get('text')))
-
         if supported_profiles:
             supported_profiles = [profile.strip() for profile in supported_profiles.split(',')]
             return self.help_ctx.cli_ctx.cloud.profile in supported_profiles
-
-        # TODO: after CI passes without refdoc warnings remove this.
-        if min_profile or max_profile:
-            from azure.cli.core.profiles import supported_api_version, PROFILE_TYPE
-            # yaml will load this as a datetime if it's a date, we need a string.
-            min_profile = str(min_profile) if min_profile else None
-            max_profile = str(max_profile) if max_profile else None
-            return supported_api_version(self.help_ctx.cli_ctx, resource_type=PROFILE_TYPE,
-                                         min_api=min_profile, max_api=max_profile)
         return True
 
     # Needs to override base implementation to exclude unsupported examples.
@@ -309,12 +292,7 @@ class HelpExample(KnackHelpExample):  # pylint: disable=too-few-public-methods
         self.text = _data.get('command', '') if _data.get('command', '') else self.text
 
         self.long_summary = _data.get('description', '')
-
         self.supported_profiles = _data.get('supported_profiles', '')
-
-        # TODO: after CI passes without refdoc warnings remove this.
-        self.min_profile = _data.get('min_profile', '')
-        self.max_profile = _data.get('max_profile', '')
 
     # alias old params with new
     @property

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -175,9 +175,8 @@ class CliHelpFile(KnackHelpFile):
                            format(ex.get('name'), ex.get('text')))
 
         if supported_profiles:
-            supported_profiles = supported_profiles.split(',')
+            supported_profiles = [profile.strip() for profile in supported_profiles.split(',')]
             return self.help_ctx.cli_ctx.cloud.profile in supported_profiles
-
 
         if min_profile or max_profile:
             from azure.cli.core.profiles import supported_api_version, PROFILE_TYPE

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -1048,7 +1048,7 @@ class ClientRedirectHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             self.wfile.write(html_file.read())
 
     def log_message(self, format, *args):  # pylint: disable=redefined-builtin,unused-argument,no-self-use
-        return  # this prevent http server from dumping messages to stdout
+        pass  # this prevent http server from dumping messages to stdout
 
 
 def _get_authorization_code_worker(authority_url, resource, results):

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -510,7 +510,13 @@ class TestHelpLoads(unittest.TestCase):
             'supported_profiles': " 2017-03-09-profile, 2018-03-01-hybrid, latest "
         }
 
-        # example should be included in all profiles
+        # example should be included in all profiles (explicit)
+        for profile in AZURE_API_PROFILES.keys():
+            mock_help_file.help_ctx.cli_ctx.cloud.profile = profile
+            self.assertTrue(mock_help_file._should_include_example(ex_dict))
+
+        # example should be included in all profiles (implicit)
+        ex_dict.pop('supported_profiles')
         for profile in AZURE_API_PROFILES.keys():
             mock_help_file.help_ctx.cli_ctx.cloud.profile = profile
             self.assertTrue(mock_help_file._should_include_example(ex_dict))

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -501,6 +501,9 @@ class TestHelpLoads(unittest.TestCase):
             f.write(data)
             return f.name
 
+    def _test_supported_profiles(self):
+        self.assertTrue(False)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
@@ -46,7 +46,7 @@ helps['container create'] = """
           text: az container create -g MyResourceGroup --name myapp --image myimage:latest --assign-identity  /subscriptions/mySubscrpitionId/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
         - name: Create a container group with both system and user assigned identity.
           text: az container create -g MyResourceGroup --name myapp --image myimage:latest --assign-identity [system] /subscriptions/mySubscrpitionId/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
-          supported_profiles: latest
+          supported-profiles: latest
 """
 
 helps['container delete'] = """

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
@@ -46,7 +46,7 @@ helps['container create'] = """
           text: az container create -g MyResourceGroup --name myapp --image myimage:latest --assign-identity  /subscriptions/mySubscrpitionId/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
         - name: Create a container group with both system and user assigned identity.
           text: az container create -g MyResourceGroup --name myapp --image myimage:latest --assign-identity [system] /subscriptions/mySubscrpitionId/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
-          min_profile: latest
+          supported_profiles: latest
 """
 
 helps['container delete'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1986,7 +1986,7 @@ helps['network express-route peering update'] = """
             az network express-route peering update -g MyResourceGroup --circuit-name MyCircuit \\
                 --ip-version ipv6 --primary-peer-subnet 2002:db00::/126 \\
                 --secondary-peer-subnet 2003:db00::/126 --advertised-public-prefixes 2002:db00::/126
-          min_profile: latest
+          supported_profiles: latest
 """
 
 helps['network express-route peering connection'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1986,7 +1986,7 @@ helps['network express-route peering update'] = """
             az network express-route peering update -g MyResourceGroup --circuit-name MyCircuit \\
                 --ip-version ipv6 --primary-peer-subnet 2002:db00::/126 \\
                 --secondary-peer-subnet 2003:db00::/126 --advertised-public-prefixes 2002:db00::/126
-          supported_profiles: latest
+          supported-profiles: latest
 """
 
 helps['network express-route peering connection'] = """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -84,10 +84,10 @@ helps['storage account create'] = """
     examples:
         - name: Create a storage account 'MyStorageAccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
-          min_profile: latest
+          supported_profiles: latest
         - name: Create a storage account 'MyStorageAccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --account-type Standard_LRS
-          max_profile: 2017-03-09-profile
+          supported_profiles: 2017-03-09-profile
 """
 
 helps['storage container create'] = """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -84,10 +84,10 @@ helps['storage account create'] = """
     examples:
         - name: Create a storage account 'MyStorageAccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
-          supported_profiles: latest, 2018-03-01-hybrid
+          unsupported-profiles: 2017-03-09-profile
         - name: Create a storage account 'MyStorageAccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --account-type Standard_LRS
-          supported_profiles: 2017-03-09-profile
+          supported-profiles: 2017-03-09-profile
 """
 
 helps['storage container create'] = """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -84,7 +84,7 @@ helps['storage account create'] = """
     examples:
         - name: Create a storage account 'MyStorageAccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
-          supported_profiles: latest
+          supported_profiles: latest, 2018-03-01-hybrid
         - name: Create a storage account 'MyStorageAccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --account-type Standard_LRS
           supported_profiles: 2017-03-09-profile

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -122,7 +122,7 @@ helps['vm create'] = """
           text: >
              az vm create -n MyVm -g rg1 --image debian --assign-identity  [system] /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
         - name: Create a VM in an availability zone in the current resource group's region
-          min_profile: latest
+          supported_profiles: latest
           text: >
              az vm create -n MyVm -g MyResourceGroup --image Centos --zone 1
 """
@@ -181,7 +181,7 @@ helps['vmss create'] = """
           text: >
              az vmss create -n MyVmss -g rg1 --image debian --assign-identity  [system] /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
         - name: Create a single zone VM scaleset in the current resource group's region
-          min_profile: latest
+          supported_profiles: latest
           text: >
              az vmss create -n MyVmss -g MyResourceGroup --image Centos --zones 1
 """

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -122,7 +122,7 @@ helps['vm create'] = """
           text: >
              az vm create -n MyVm -g rg1 --image debian --assign-identity  [system] /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
         - name: Create a VM in an availability zone in the current resource group's region
-          supported_profiles: latest
+          supported-profiles: latest
           text: >
              az vm create -n MyVm -g MyResourceGroup --image Centos --zone 1
 """
@@ -181,7 +181,7 @@ helps['vmss create'] = """
           text: >
              az vmss create -n MyVmss -g rg1 --image debian --assign-identity  [system] /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
         - name: Create a single zone VM scaleset in the current resource group's region
-          supported_profiles: latest
+          supported-profiles: latest
           text: >
              az vmss create -n MyVmss -g MyResourceGroup --image Centos --zones 1
 """

--- a/tools/automation/cli_linter/rules/help_rules.py
+++ b/tools/automation/cli_linter/rules/help_rules.py
@@ -55,10 +55,16 @@ def faulty_help_example_parameters_rule(linter, help_entry):
     violations = []
 
     for example in linter.get_help_entry_examples(help_entry):
-        supported_profiles = example.get('supported_profiles')
+        supported_profiles = example.get('supported-profiles')
         if supported_profiles and 'latest' not in supported_profiles:
-            logger.warning("\n\tSKIPPING example: {}\n\tas 'latest' is not its supported profiles."
-                           "\n\t\tsupported_profiles: {}.".format(example['text'], example['supported_profiles']))
+            logger.warning("\n\tSKIPPING example: {}\n\tas 'latest' is not in its supported profiles."
+                           "\n\t\tsupported-profiles: {}.".format(example['text'], example['supported-profiles']))
+            continue
+
+        unsupported_profiles = example.get('unsupported-profiles')
+        if unsupported_profiles and 'latest' in unsupported_profiles:
+            logger.warning("\n\tSKIPPING example: {}\n\tas 'latest' is in its unsupported profiles."
+                           "\n\t\tunsupported-profiles: {}.".format(example['text'], example['unsupported-profiles']))
             continue
 
         example_text = example.get('text','')

--- a/tools/automation/cli_linter/rules/help_rules.py
+++ b/tools/automation/cli_linter/rules/help_rules.py
@@ -55,8 +55,8 @@ def faulty_help_example_parameters_rule(linter, help_entry):
     violations = []
 
     for example in linter.get_help_entry_examples(help_entry):
-        max_profile = example.get('max_profile')
-        if max_profile and max_profile != 'latest':
+        supported_profiles = example.get('supported_profiles')
+        if supported_profiles and 'latest' not in supported_profiles:
             logger.warning("\n\tSKIPPING example: {}\n\tas its max profile is {}, instead of latest.".format(example['text'], example['max_profile']))
             continue
 

--- a/tools/automation/cli_linter/rules/help_rules.py
+++ b/tools/automation/cli_linter/rules/help_rules.py
@@ -57,7 +57,8 @@ def faulty_help_example_parameters_rule(linter, help_entry):
     for example in linter.get_help_entry_examples(help_entry):
         supported_profiles = example.get('supported_profiles')
         if supported_profiles and 'latest' not in supported_profiles:
-            logger.warning("\n\tSKIPPING example: {}\n\tas its max profile is {}, instead of latest.".format(example['text'], example['max_profile']))
+            logger.warning("\n\tSKIPPING example: {}\n\tas 'latest' is not its supported profiles."
+                           "\n\t\tsupported_profiles: {}.".format(example['text'], example['supported_profiles']))
             continue
 
         example_text = example.get('text','')


### PR DESCRIPTION
Cli examples should have a supported_profiles field instead of min_profile / max_profile fields.
closes #8354 

Todo:
- [x] Update logic, help_convert script and other references to use supported_profile. Test that it works.
- [x] Update examples to use new field. Ensure no old examples use old fields.
- [x] Update Help Authoring documentation.
- [x] Manually verify that generate docs are the same for latest and for help.yaml.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
