### PR TITLE
Simplify operations_tmpl for graphrbac

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
@@ -97,17 +97,17 @@ def get_graph_client_groups(cli_ctx, _):
 def load_command_table(self, _):
 
     role_users_sdk = CliCommandType(
-        operations_tmpl='azure.graphrbac.operations.users_operations#UsersOperations.{}',
+        operations_tmpl='azure.graphrbac.operations#UsersOperations.{}',
         client_factory=get_graph_client_users
     )
 
     role_group_sdk = CliCommandType(
-        operations_tmpl='azure.graphrbac.operations.groups_operations#GroupsOperations.{}',
+        operations_tmpl='azure.graphrbac.operations#GroupsOperations.{}',
         client_factory=get_graph_client_groups
     )
 
     signed_in_users_sdk = CliCommandType(
-        operations_tmpl='azure.graphrbac.operations.signed_in_user_operations#SignedInUserOperations.{}',
+        operations_tmpl='azure.graphrbac.operations#SignedInUserOperations.{}',
         client_factory=get_graph_client_signed_in_users
     )
 


### PR DESCRIPTION
@yugangw-msft this allows GraphRbac to work with both Autorest V3 (as this PR shows) and Autorest V4 (as this PR https://github.com/Azure/azure-cli/pull/8498 shows).

I'd recommend to merge it.