### PR TITLE
Adding new constraint to Homebrew requirements.txt

### DIFF
--- a/scripts/release/homebrew/docker/requirements.txt
+++ b/scripts/release/homebrew/docker/requirements.txt
@@ -1,3 +1,4 @@
 homebrew-pypi-poet~=0.10.0
 jinja2~=2.10
 requests>=2.20.0
+cryptography >=2.0.0,<2.5


### PR DESCRIPTION
In https://github.com/Azure/azure-cli/pull/8324, a new contraint was create that put a ceiling on the version of cryptography that we can support. However, that constraint never made its way to our requirements.txt file in our Homebrew build. Because the largest version at the time was 2.4.x, there wasn't a problem up to a few days ago when 2.5 was finally available for download in our CI environment. Because there is another library that requires cryptography, and doesn't have this constraint, and because we do not use `pip freeze` or `pipenv` to lock our dependencies ahead of time, pip greedily installs the largest version available when it first sees the cryptography requirement then fails later when it first sees the trouble.
