### PR TITLE
Generate random OAuth state instead of using 'code' as state.

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,7 +5,6 @@ Release History
 2.0.59
 ++++++
 * Fix issue where in some instances using `--subscription NAME` would throw an exception.
-* Using a random OAuth state for each login request.
 
 2.0.58
 ++++++

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -4,9 +4,8 @@ Release History
 ===============
 2.0.59
 ++++++
-* Minor fixes
-
 * Fix issue where in some instances using `--subscription NAME` would throw an exception.
+* Using a random OAuth state for each login request.
 
 2.0.58
 ++++++

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -1088,7 +1088,10 @@ def _get_authorization_code_worker(authority_url, resource, results):
         logger.warning("Error: can't reserve a port for authentication reply url")
         return
 
-    request_state = ''.join(random.SystemRandom().choice(string.ascii_lowercase + string.digits) for _ in range(20))
+    try:
+        request_state = ''.join(random.SystemRandom().choice(string.ascii_lowercase + string.digits) for _ in range(20))
+    except NotImplementedError:
+        request_state = 'code'
 
     # launch browser:
     url = ('{0}/oauth2/authorize?response_type=code&client_id={1}'

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -779,7 +779,7 @@ class SubscriptionFinder(object):
             raise CLIError('Login failed')  # error detail is already displayed through previous steps
 
         if not results.get('state'):
-            raise CLIError('Login failed') # error detail is already displayed through previous steps
+            raise CLIError('Login failed')  # error detail is already displayed through previous steps
 
         if results.get('state') != state:
             raise CLIError('Unexpected OAuth state during login')


### PR DESCRIPTION
This is a somewhat academic problem, as this is a developer tool running on localhost and not running across a network. However, according to https://tools.ietf.org/html/rfc6749#section-4.1.1 state should be opaque (e.g. hard to guess.) The easiest way for us to accomodate that is to generate a random value for each login request through the CLI and validate that it is what we get back.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
