### PR TITLE
[Network] Express Route commands and features

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -310,7 +310,6 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
                                                excluded_command_handler_args=EXCLUDED_PARAMS)
         self.min_profile = min_profile
         self.max_profile = max_profile
-        self.suppress_extension = None
         self.suppress_extension = suppress_extension
         self.module_kwargs = kwargs
         self.command_name = None

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -227,9 +227,12 @@ class MainCommandsLoader(CLICommandsLoader):
         def _get_extension_suppressions(mod_loaders):
             res = []
             for m in mod_loaders:
-                sup = getattr(m, 'suppress_extension', None)
-                if sup and isinstance(sup, ModExtensionSuppress):
-                    res.append(sup)
+                suppressions = getattr(m, 'suppress_extension', None)
+                if suppressions:
+                    suppressions = suppressions if isinstance(suppressions, list) else [suppressions]
+                    for sup in suppressions:
+                        if isinstance(sup, ModExtensionSuppress):
+                            res.append(sup)
             return res
 
         _update_command_table_from_modules(args)
@@ -307,6 +310,7 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
                                                excluded_command_handler_args=EXCLUDED_PARAMS)
         self.min_profile = min_profile
         self.max_profile = max_profile
+        self.suppress_extension = None
         self.suppress_extension = suppress_extension
         self.module_kwargs = kwargs
         self.command_name = None

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -234,18 +234,18 @@ def get_enum_type(data, default=None):
 # GLOBAL ARGUMENT DEFINITIONS
 
 resource_group_name_type = CLIArgumentType(
-    options_list=('--resource-group', '-g'),
+    options_list=['--resource-group', '-g'],
     completer=get_resource_group_completion_list,
     id_part='resource_group',
     help="Name of resource group. You can configure the default group using `az configure --defaults group=<name>`",
     configured_default='group')
 
-name_type = CLIArgumentType(options_list=('--name', '-n'), help='the primary resource name')
+name_type = CLIArgumentType(options_list=['--name', '-n'], help='the primary resource name')
 
 
 def get_location_type(cli_ctx):
     location_type = CLIArgumentType(
-        options_list=('--location', '-l'),
+        options_list=['--location', '-l'],
         completer=get_location_completion_list,
         type=get_location_name_type(cli_ctx),
         help="Location. Values from: `az account list-locations`. "
@@ -278,7 +278,7 @@ tag_type = CLIArgumentType(
 )
 
 no_wait_type = CLIArgumentType(
-    options_list=('--no-wait', ),
+    options_list=['--no-wait', ],
     help='do not wait for the long-running operation to finish',
     action='store_true'
 )

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -6,7 +6,8 @@ Release History
 * `vpn-connection create/update`: Add `--express-route-gateway-bypass` argument.
 * `express-route`: Port command groups from `express-route` extensions.
 * `express-route`: Added `express-route gateway` and `express-route port` command groups.
-* `express-route create/update`: Added `--express-route-port` argument.
+* `express-route create/update`: Added arguments: `--express-route-port`, `--allow-classic-operation'.
+* `express-route peering create/update`: Added argument `--legacy-mode`.
 
 2.3.2
 +++++

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -4,6 +4,9 @@ Release History
 ===============
 
 * `vpn-connection create/update`: Add `--express-route-gateway-bypass` argument.
+* `express-route`: Port command groups from `express-route` extensions.
+* `express-route`: Added `express-route gateway` and `express-route port` command groups.
+* `express-route create/update`: Added `--express-route-port` argument.
 
 2.3.2
 +++++

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -6,12 +6,11 @@ Release History
 * `vpn-connection create/update`: Add `--express-route-gateway-bypass` argument.
 * `express-route`: Port command groups from `express-route` extensions.
 * `express-route`: Added `express-route gateway` and `express-route port` command groups.
-* `express-route create/update`: Added arguments: `--express-route-port`, `--allow-classic-operation'.
 * `express-route peering create/update`: Added argument `--legacy-mode`.
+* `express-route create/update`: Added argument `--allow-classic-operations` and `--express-route-port`.
 
 2.3.2
 +++++
-
 * `dns zone export`: Ensure exported CNAMEs are FQDNs.
 * `nic ip-config address-pool add/remove`: Add `--gateway-name` to support application gateway backend address pools.
 * `network watcher flow-log configure`: Add arguments `--traffic-analytics`, `--workspace` to support traffic analytics through a Log Analytics workspace.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/__init__.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/__init__.py
@@ -20,9 +20,14 @@ class NetworkCommandsLoader(AzCommandsLoader):
         super(NetworkCommandsLoader, self).__init__(cli_ctx=cli_ctx,
                                                     resource_type=ResourceType.MGMT_NETWORK,
                                                     custom_command_type=network_custom,
-                                                    suppress_extension=ModExtensionSuppress(__name__, 'dns', '0.0.2',
-                                                                                            reason='These commands are now in the CLI.',
-                                                                                            recommend_remove=True))
+                                                    suppress_extension=[
+                                                        ModExtensionSuppress(__name__, 'dns', '0.0.2',
+                                                                             reason='These commands are now in the CLI.',
+                                                                             recommend_remove=True),
+                                                        ModExtensionSuppress(__name__, 'express-route', '0.1.3',
+                                                                             reason='These commands are now in the CLI.',
+                                                                             recommend_remove=True)
+                                                    ])
 
     def load_command_table(self, args):
         from azure.cli.command_modules.network.commands import load_command_table

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_client_factory.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_client_factory.py
@@ -57,6 +57,26 @@ def cf_express_route_service_providers(cli_ctx, _):
     return network_client_factory(cli_ctx).express_route_service_providers
 
 
+def cf_express_route_connections(cli_ctx, _):
+    return network_client_factory(cli_ctx).express_route_connections
+
+
+def cf_express_route_gateways(cli_ctx, _):
+    return network_client_factory(cli_ctx).express_route_gateways
+
+
+def cf_express_route_ports(cli_ctx, _):
+    return network_client_factory(cli_ctx).express_route_ports
+
+
+def cf_express_route_port_locations(cli_ctx, _):
+    return network_client_factory(cli_ctx).express_route_ports_locations
+
+
+def cf_express_route_links(cli_ctx, _):
+    return network_client_factory(cli_ctx).express_route_links
+
+
 def cf_interface_endpoints(cli_ctx, _):
     return network_client_factory(cli_ctx).interface_endpoints
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1932,6 +1932,87 @@ helps['network express-route auth show'] = """
 """
 # endregion
 
+# region Express Route Gateway
+helps['network express-route gateway'] = """
+    type: group
+    short-summary: Manage ExpressRoute gateways.
+"""
+
+helps['network express-route gateway create'] = """
+    type: command
+    short-summary: Create an ExpressRoute gateway.
+"""
+
+helps['network express-route gateway delete'] = """
+    type: command
+    short-summary: Delete an ExpressRoute gateway.
+"""
+
+helps['network express-route gateway list'] = """
+    type: command
+    short-summary: List ExpressRoute gateways.
+"""
+
+helps['network express-route gateway show'] = """
+    type: command
+    short-summary: Get the details of an ExpressRoute gateway.
+"""
+
+helps['network express-route gateway update'] = """
+    type: command
+    short-summary: Update settings of an ExpressRoute gateway.
+"""
+# endregion
+
+# region Express Route gateway connection
+helps['network express-route gateway connection'] = """
+    type: group
+    short-summary: Manage ExpressRoute gateway connections.
+"""
+
+helps['network express-route gateway connection create'] = """
+    type: command
+    short-summary: Create an ExpressRoute gateway connection.
+"""
+
+helps['network express-route gateway connection delete'] = """
+    type: command
+    short-summary: Delete an ExpressRoute gateway connection.
+"""
+
+helps['network express-route gateway connection list'] = """
+    type: command
+    short-summary: List ExpressRoute gateway connections.
+"""
+
+helps['network express-route gateway connection show'] = """
+    type: command
+    short-summary: Get the details of an ExpressRoute gateway connection.
+"""
+
+helps['network express-route gateway connection update'] = """
+    type: command
+    short-summary: Update an ExpressRoute gateway connection.
+"""
+# endregion
+
+# region Express Route Link
+helps['network express-route port link'] = """
+    type: group
+    short-summary: View ExpressRoute links.
+"""
+
+helps['network express-route port link list'] = """
+    type: command
+    short-summary: List ExpressRoute links.
+"""
+
+helps['network express-route port link show'] = """
+    type: command
+    short-summary: Get the details of an ExpressRoute link.
+"""
+# endregion
+
 # region Express Route peering
 helps['network express-route peering'] = """
     type: group
@@ -2013,6 +2094,55 @@ helps['network express-route peering connection delete'] = """
 helps['network express-route peering connection show'] = """
     type: command
     short-summary: Get the details of an ExpressRoute circuit connection.
+"""
+# endregion
+
+# region Express Route Port
+helps['network express-route port'] = """
+    type: group
+    short-summary: Manage ExpressRoute ports.
+"""
+
+helps['network express-route port create'] = """
+    type: command
+    short-summary: Create an ExpressRoute port.
+"""
+
+helps['network express-route port delete'] = """
+    type: command
+    short-summary: Delete an ExpressRoute port.
+"""
+
+helps['network express-route port list'] = """
+    type: command
+    short-summary: List ExpressRoute ports.
+"""
+
+helps['network express-route port show'] = """
+    type: command
+    short-summary: Get the details of an ExpressRoute port.
+"""
+
+helps['network express-route port update'] = """
+    type: command
+    short-summary: Update settings of an ExpressRoute port.
+"""
+# endregion
+
+# region Express Route Port Locations
+helps['network express-route port location'] = """
+    type: group
+    short-summary: View ExpressRoute port location information.
+"""
+
+helps['network express-route port location list'] = """
+    type: command
+    short-summary: List ExpressRoute port locations.
+"""
+
+helps['network express-route port location show'] = """
+    type: command
+    short-summary: Get the details of an ExpressRoute port location.
 """
 # endregion
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -479,12 +479,15 @@ def load_arguments(self, _):
         c.argument('sku_tier', arg_type=get_enum_type(ExpressRouteCircuitSkuTier))
         c.argument('primary_peer_address_prefix', options_list=['--primary-peer-subnet'], help='/30 subnet used to configure IP addresses for primary interface.')
         c.argument('secondary_peer_address_prefix', options_list=['--secondary-peer-subnet'], help='/30 subnet used to configure IP addresses for secondary interface.')
-        c.argument('advertised_public_prefixes', arg_group='Microsoft Peering', nargs='+', help='Space-separated list of prefixes to be advertised through the BGP peering.')
-        c.argument('customer_asn', arg_group='Microsoft Peering', help='Autonomous system number of the customer.')
-        c.argument('routing_registry_name', arg_group='Microsoft Peering', arg_type=get_enum_type(routing_registry_values), help='Internet Routing Registry / Regional Internet Registry')
-        c.argument('route_filter', min_api='2016-12-01', arg_group='Microsoft Peering', help='Name or ID of a route filter to apply to the peering settings.', validator=validate_route_filter)
-        c.argument('ip_version', min_api='2017-06-01', help='The IP version to update Microsoft Peering settings for.', arg_group='Microsoft Peering', arg_type=get_enum_type(['IPv4', 'IPv6']))
         c.argument('shared_key', help='Key for generating an MD5 for the BGP session.')
+
+    with self.argument_context('network express-route peering', arg_group='Microsoft Peering') as c:
+        c.argument('ip_version', min_api='2017-06-01', help='The IP version to update Microsoft Peering settings for.', arg_type=get_enum_type(['IPv4', 'IPv6']))
+        c.argument('advertised_public_prefixes', nargs='+', help='Space-separated list of prefixes to be advertised through the BGP peering.')
+        c.argument('customer_asn', help='Autonomous system number of the customer.')
+        c.argument('routing_registry_name', arg_type=get_enum_type(routing_registry_values), help='Internet Routing Registry / Regional Internet Registry')
+        c.argument('route_filter', min_api='2016-12-01', help='Name or ID of a route filter to apply to the peering settings.', validator=validate_route_filter)
+        c.argument('legacy_mode', min_api='2017-10-01', type=int, help='Integer representing the legacy mode of the peering.')
 
     with self.argument_context('network express-route peering connection') as c:
         c.argument('authorization_key', help='The authorization key used when the peer circuit is in another subscription.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -52,7 +52,7 @@ def load_arguments(self, _):
          'Access', 'ApplicationGatewayFirewallMode', 'ApplicationGatewayProtocol', 'ApplicationGatewayRedirectType',
          'ApplicationGatewayRequestRoutingRuleType', 'ApplicationGatewaySkuName', 'ApplicationGatewaySslProtocol', 'AuthenticationMethod',
          'Direction',
-         'ExpressRouteCircuitSkuFamily', 'ExpressRouteCircuitSkuTier', 'ExpressRoutePortsEncapsulation'
+         'ExpressRouteCircuitSkuFamily', 'ExpressRouteCircuitSkuTier', 'ExpressRoutePortsEncapsulation',
          'FlowLogFormatType', 'HTTPMethod', 'IPAllocationMethod',
          'IPVersion', 'LoadBalancerSkuName', 'LoadDistribution', 'ProbeProtocol', 'ProcessorArchitecture', 'Protocol', 'PublicIPAddressSkuName',
          'RouteNextHopType', 'SecurityRuleAccess', 'SecurityRuleProtocol', 'SecurityRuleDirection', 'TransportProtocol',
@@ -454,6 +454,7 @@ def load_arguments(self, _):
         c.argument('vlan_id', type=int)
         c.argument('allow_global_reach', arg_type=get_three_state_flag(), min_api='2018-07-01', help='Enable global reach on the circuit.')
         c.argument('express_route_port', help='Name or ID of an ExpressRoute port.', min_api='2018-08-01', validator=validate_express_route_port)
+        c.argument('allow_classic_operations', arg_type=get_three_state_flag(), min_api='2017-10-01', help='Allow classic operations.')
 
     with self.argument_context('network express-route update') as c:
         c.argument('sku_family', sku_family_type, default=None)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -29,7 +29,8 @@ from azure.cli.command_modules.network._validators import (
     validate_service_endpoint_policy, validate_delegations, validate_subresource_list,
     validate_er_peer_circuit, validate_ag_address_pools, validate_custom_error_pages,
     validate_custom_headers, validate_status_code_ranges, validate_subnet_ranges,
-    WafConfigExclusionAction)
+    WafConfigExclusionAction, validate_express_route_peering, validate_virtual_hub,
+    validate_express_route_port, bandwidth_validator_factory)
 from azure.mgmt.trafficmanager.models import MonitorProtocol, ProfileStatus
 from azure.cli.command_modules.network._completers import (
     subnet_completion_list, get_lb_subresource_completion_list, get_ag_subresource_completion_list,
@@ -43,14 +44,16 @@ def load_arguments(self, _):
     (Access, ApplicationGatewayFirewallMode, ApplicationGatewayProtocol, ApplicationGatewayRedirectType,
      ApplicationGatewayRequestRoutingRuleType, ApplicationGatewaySkuName, ApplicationGatewaySslProtocol, AuthenticationMethod,
      Direction,
-     ExpressRouteCircuitSkuFamily, ExpressRouteCircuitSkuTier, FlowLogFormatType, HTTPMethod, IPAllocationMethod,
+     ExpressRouteCircuitSkuFamily, ExpressRouteCircuitSkuTier, ExpressRoutePortsEncapsulation,
+     FlowLogFormatType, HTTPMethod, IPAllocationMethod,
      IPVersion, LoadBalancerSkuName, LoadDistribution, ProbeProtocol, ProcessorArchitecture, Protocol, PublicIPAddressSkuName,
      RouteNextHopType, SecurityRuleAccess, SecurityRuleProtocol, SecurityRuleDirection, TransportProtocol,
      VirtualNetworkGatewaySkuName, VirtualNetworkGatewayType, VpnClientProtocol, VpnType, ZoneType) = self.get_models(
          'Access', 'ApplicationGatewayFirewallMode', 'ApplicationGatewayProtocol', 'ApplicationGatewayRedirectType',
          'ApplicationGatewayRequestRoutingRuleType', 'ApplicationGatewaySkuName', 'ApplicationGatewaySslProtocol', 'AuthenticationMethod',
          'Direction',
-         'ExpressRouteCircuitSkuFamily', 'ExpressRouteCircuitSkuTier', 'FlowLogFormatType', 'HTTPMethod', 'IPAllocationMethod',
+         'ExpressRouteCircuitSkuFamily', 'ExpressRouteCircuitSkuTier', 'ExpressRoutePortsEncapsulation'
+         'FlowLogFormatType', 'HTTPMethod', 'IPAllocationMethod',
          'IPVersion', 'LoadBalancerSkuName', 'LoadDistribution', 'ProbeProtocol', 'ProcessorArchitecture', 'Protocol', 'PublicIPAddressSkuName',
          'RouteNextHopType', 'SecurityRuleAccess', 'SecurityRuleProtocol', 'SecurityRuleDirection', 'TransportProtocol',
          'VirtualNetworkGatewaySkuName', 'VirtualNetworkGatewayType', 'VpnClientProtocol', 'VpnType', 'ZoneType')
@@ -65,15 +68,14 @@ def load_arguments(self, _):
 
     # taken from Xplat. No enums in SDK
     routing_registry_values = ['ARIN', 'APNIC', 'AFRINIC', 'LACNIC', 'RIPENCC', 'RADB', 'ALTDB', 'LEVEL3']
-    device_path_values = ['primary', 'secondary']
 
-    name_arg_type = CLIArgumentType(options_list=('--name', '-n'), metavar='NAME')
-    nic_type = CLIArgumentType(options_list=('--nic-name',), metavar='NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
-    nsg_name_type = CLIArgumentType(options_list=('--nsg-name',), metavar='NAME', help='Name of the network security group.')
-    circuit_name_type = CLIArgumentType(options_list=('--circuit-name',), metavar='NAME', help='ExpressRoute circuit name.', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/expressRouteCircuits'))
-    virtual_network_name_type = CLIArgumentType(options_list=('--vnet-name',), metavar='NAME', help='The virtual network (VNet) name.', completer=get_resource_name_completion_list('Microsoft.Network/virtualNetworks'))
-    subnet_name_type = CLIArgumentType(options_list=('--subnet-name',), metavar='NAME', help='The subnet name.')
-    load_balancer_name_type = CLIArgumentType(options_list=('--lb-name',), metavar='NAME', help='The load balancer name.', completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'), id_part='name')
+    name_arg_type = CLIArgumentType(options_list=['--name', '-n'], metavar='NAME')
+    nic_type = CLIArgumentType(options_list='--nic-name', metavar='NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
+    nsg_name_type = CLIArgumentType(options_list='--nsg-name', metavar='NAME', help='Name of the network security group.')
+    circuit_name_type = CLIArgumentType(options_list='--circuit-name', metavar='NAME', help='ExpressRoute circuit name.', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/expressRouteCircuits'))
+    virtual_network_name_type = CLIArgumentType(options_list='--vnet-name', metavar='NAME', help='The virtual network (VNet) name.', completer=get_resource_name_completion_list('Microsoft.Network/virtualNetworks'))
+    subnet_name_type = CLIArgumentType(options_list='--subnet-name', metavar='NAME', help='The subnet name.')
+    load_balancer_name_type = CLIArgumentType(options_list='--lb-name', metavar='NAME', help='The load balancer name.', completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'), id_part='name')
     private_ip_address_type = CLIArgumentType(help='Static private IP address to use.', validator=validate_private_ip_address)
     cookie_based_affinity_type = CLIArgumentType(arg_type=get_three_state_flag(positive_label='Enabled', negative_label='Disabled', return_label=True))
     http_protocol_type = CLIArgumentType(get_enum_type(ApplicationGatewayProtocol))
@@ -124,7 +126,7 @@ def load_arguments(self, _):
         c.argument('subnet', help=subnet_help, completer=subnet_completion_list, arg_group='Network')
 
     with self.argument_context('network application-gateway create', arg_group='Gateway') as c:
-        c.argument('cert_data', options_list=('--cert-file',), type=file_type, completer=FilesCompleter(), help='The path to the PFX certificate file.')
+        c.argument('cert_data', options_list='--cert-file', type=file_type, completer=FilesCompleter(), help='The path to the PFX certificate file.')
         c.argument('frontend_port', help='The front end port number.')
         c.argument('cert_password', help='The certificate password')
         c.argument('http_settings_port', help='The HTTP settings port.')
@@ -153,14 +155,14 @@ def load_arguments(self, _):
 
     for item in ag_subresources:
         with self.argument_context('network application-gateway {}'.format(item['name'])) as c:
-            c.argument('item_name', options_list=('--name', '-n'), help='The name of the {}.'.format(item['display']), completer=get_ag_subresource_completion_list(item['ref']), id_part='child_name_1')
-            c.argument('resource_name', options_list=('--gateway-name',), help='The name of the application gateway.')
-            c.argument('application_gateway_name', options_list=('--gateway-name',), help='The name of the application gateway.')
+            c.argument('item_name', options_list=['--name', '-n'], help='The name of the {}.'.format(item['display']), completer=get_ag_subresource_completion_list(item['ref']), id_part='child_name_1')
+            c.argument('resource_name', options_list='--gateway-name', help='The name of the application gateway.')
+            c.argument('application_gateway_name', options_list='--gateway-name', help='The name of the application gateway.')
             c.argument('private_ip_address', arg_group=None)
             c.argument('virtual_network_name', arg_group=None)
 
         with self.argument_context('network application-gateway {} create'.format(item['name'])) as c:
-            c.argument('item_name', options_list=('--name', '-n'), help='The name of the {}.'.format(item['display']), completer=None)
+            c.argument('item_name', options_list=['--name', '-n'], help='The name of the {}.'.format(item['display']), completer=None)
 
         with self.argument_context('network application-gateway {} list'.format(item['name'])) as c:
             c.argument('resource_name', options_list=['--gateway-name'])
@@ -236,7 +238,7 @@ def load_arguments(self, _):
         c.argument('url_path_map', help='The name or ID of the URL path map.', completer=get_ag_subresource_completion_list('url_path_maps'))
 
     with self.argument_context('network application-gateway ssl-cert') as c:
-        c.argument('cert_data', options_list=('--cert-file',), type=file_type, completer=FilesCompleter(), help='The path to the PFX certificate file.', validator=validate_ssl_cert)
+        c.argument('cert_data', options_list='--cert-file', type=file_type, completer=FilesCompleter(), help='The path to the PFX certificate file.', validator=validate_ssl_cert)
         c.argument('cert_password', help='Certificate password.')
 
     with self.argument_context('network application-gateway ssl-policy') as c:
@@ -258,15 +260,15 @@ def load_arguments(self, _):
         c.argument('default_http_settings', help='The name or ID of the default HTTP settings.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'))
 
     with self.argument_context('network application-gateway url-path-map rule') as c:
-        c.argument('item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=ag_url_map_rule_completion_list, id_part='child_name_2')
-        c.argument('url_path_map_name', options_list=('--path-map-name',), help='The name of the URL path map.', completer=get_ag_subresource_completion_list('url_path_maps'), id_part='child_name_1')
+        c.argument('item_name', options_list=['--name', '-n'], help='The name of the url-path-map rule.', completer=ag_url_map_rule_completion_list, id_part='child_name_2')
+        c.argument('url_path_map_name', options_list='--path-map-name', help='The name of the URL path map.', completer=get_ag_subresource_completion_list('url_path_maps'), id_part='child_name_1')
         c.argument('address_pool', help='The name or ID of the backend address pool. If not specified, the default for the map will be used.', completer=get_ag_subresource_completion_list('backend_address_pools'))
         c.argument('http_settings', help='The name or ID of the HTTP settings. If not specified, the default for the map will be used.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'))
         for item in ['address_pool', 'http_settings', 'redirect_config', 'paths']:
             c.argument(item, arg_group=None)
 
     with self.argument_context('network application-gateway url-path-map rule create') as c:
-        c.argument('item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=None)
+        c.argument('item_name', options_list=['--name', '-n'], help='The name of the url-path-map rule.', completer=None)
 
     with self.argument_context('network application-gateway waf-config') as c:
         c.argument('disabled_rule_groups', nargs='+')
@@ -342,7 +344,7 @@ def load_arguments(self, _):
     with self.argument_context('network dns') as c:
         c.argument('record_set_name', name_arg_type, help='The name of the record set, relative to the name of the zone.')
         c.argument('relative_record_set_name', name_arg_type, help='The name of the record set, relative to the name of the zone.')
-        c.argument('zone_name', options_list=('--zone-name', '-z'), help='The name of the zone.', type=dns_zone_name_type)
+        c.argument('zone_name', options_list=['--zone-name', '-z'], help='The name of the zone.', type=dns_zone_name_type)
         c.argument('metadata', nargs='+', help='Metadata in space-separated key=value pairs. This overwrites any existing metadata.', validator=validate_metadata)
 
     with self.argument_context('network dns list-references') as c:
@@ -357,10 +359,10 @@ def load_arguments(self, _):
         c.argument('resolution_vnets', arg_group='Private Zone', nargs='+', help='Space-separated names or IDs of virtual networks that resolve records in this DNS zone.', validator=get_vnet_validator('resolution_vnets'))
 
     with self.argument_context('network dns zone import') as c:
-        c.argument('file_name', options_list=('--file-name', '-f'), type=file_type, completer=FilesCompleter(), help='Path to the DNS zone file to import')
+        c.argument('file_name', options_list=['--file-name', '-f'], type=file_type, completer=FilesCompleter(), help='Path to the DNS zone file to import')
 
     with self.argument_context('network dns zone export') as c:
-        c.argument('file_name', options_list=('--file-name', '-f'), type=file_type, completer=FilesCompleter(), help='Path to the DNS zone file to save')
+        c.argument('file_name', options_list=['--file-name', '-f'], type=file_type, completer=FilesCompleter(), help='Path to the DNS zone file to save')
 
     with self.argument_context('network dns zone update') as c:
         c.ignore('if_none_match')
@@ -377,10 +379,10 @@ def load_arguments(self, _):
 
     for item in ['a', 'aaaa', 'caa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
         with self.argument_context('network dns record-set {} add-record'.format(item)) as c:
-            c.argument('record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone. Creates a new record set if one does not exist.')
+            c.argument('record_set_name', options_list=['--record-set-name', '-n'], help='The name of the record set relative to the zone. Creates a new record set if one does not exist.')
 
         with self.argument_context('network dns record-set {} remove-record'.format(item)) as c:
-            c.argument('record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone.')
+            c.argument('record_set_name', options_list=['--record-set-name', '-n'], help='The name of the record set relative to the zone.')
             c.argument('keep_empty_record_set', action='store_true', help='Keep the empty record set if the last record is removed.')
 
     with self.argument_context('network dns record-set cname set-record') as c:
@@ -390,10 +392,10 @@ def load_arguments(self, _):
         c.argument('relative_record_set_name', ignore_type, default='@')
 
     with self.argument_context('network dns record-set a') as c:
-        c.argument('ipv4_address', options_list=('--ipv4-address', '-a'), help='IPV4 address in string notation.')
+        c.argument('ipv4_address', options_list=['--ipv4-address', '-a'], help='IPV4 address in string notation.')
 
     with self.argument_context('network dns record-set aaaa') as c:
-        c.argument('ipv6_address', options_list=('--ipv6-address', '-a'), help='IPV6 address in string notation.')
+        c.argument('ipv6_address', options_list=['--ipv6-address', '-a'], help='IPV6 address in string notation.')
 
     with self.argument_context('network dns record-set caa') as c:
         c.argument('value', help='Value of the CAA record.')
@@ -401,51 +403,57 @@ def load_arguments(self, _):
         c.argument('tag', help='Record tag')
 
     with self.argument_context('network dns record-set cname') as c:
-        c.argument('cname', options_list=('--cname', '-c'), help='Canonical name.')
+        c.argument('cname', options_list=['--cname', '-c'], help='Canonical name.')
 
     with self.argument_context('network dns record-set mx') as c:
-        c.argument('exchange', options_list=('--exchange', '-e'), help='Exchange metric.')
-        c.argument('preference', options_list=('--preference', '-p'), help='Preference metric.')
+        c.argument('exchange', options_list=['--exchange', '-e'], help='Exchange metric.')
+        c.argument('preference', options_list=['--preference', '-p'], help='Preference metric.')
 
     with self.argument_context('network dns record-set ns') as c:
-        c.argument('dname', options_list=('--nsdname', '-d'), help='Name server domain name.')
+        c.argument('dname', options_list=['--nsdname', '-d'], help='Name server domain name.')
 
     with self.argument_context('network dns record-set ptr') as c:
-        c.argument('dname', options_list=('--ptrdname', '-d'), help='PTR target domain name.')
+        c.argument('dname', options_list=['--ptrdname', '-d'], help='PTR target domain name.')
 
     with self.argument_context('network dns record-set soa') as c:
-        c.argument('host', options_list=('--host', '-t'), help='Host name.')
-        c.argument('email', options_list=('--email', '-e'), help='Email address.')
-        c.argument('expire_time', options_list=('--expire-time', '-x'), help='Expire time (seconds).')
-        c.argument('minimum_ttl', options_list=('--minimum-ttl', '-m'), help='Minimum TTL (time-to-live, seconds).')
-        c.argument('refresh_time', options_list=('--refresh-time', '-f'), help='Refresh value (seconds).')
-        c.argument('retry_time', options_list=('--retry-time', '-r'), help='Retry time (seconds).')
-        c.argument('serial_number', options_list=('--serial-number', '-s'), help='Serial number.')
+        c.argument('host', options_list=['--host', '-t'], help='Host name.')
+        c.argument('email', options_list=['--email', '-e'], help='Email address.')
+        c.argument('expire_time', options_list=['--expire-time', '-x'], help='Expire time (seconds).')
+        c.argument('minimum_ttl', options_list=['--minimum-ttl', '-m'], help='Minimum TTL (time-to-live, seconds).')
+        c.argument('refresh_time', options_list=['--refresh-time', '-f'], help='Refresh value (seconds).')
+        c.argument('retry_time', options_list=['--retry-time', '-r'], help='Retry time (seconds).')
+        c.argument('serial_number', options_list=['--serial-number', '-s'], help='Serial number.')
 
     with self.argument_context('network dns record-set srv') as c:
-        c.argument('priority', options_list=('--priority', '-p'), help='Priority metric.')
-        c.argument('weight', options_list=('--weight', '-w'), help='Weight metric.')
-        c.argument('port', options_list=('--port', '-r'), help='Service port.')
-        c.argument('target', options_list=('--target', '-t'), help='Target domain name.')
+        c.argument('priority', options_list=['--priority', '-p'], help='Priority metric.')
+        c.argument('weight', options_list=['--weight', '-w'], help='Weight metric.')
+        c.argument('port', options_list=['--port', '-r'], help='Service port.')
+        c.argument('target', options_list=['--target', '-t'], help='Target domain name.')
 
     with self.argument_context('network dns record-set txt') as c:
-        c.argument('value', options_list=('--value', '-v'), nargs='+', help='Space-separated list of text values which will be concatenated together.')
+        c.argument('value', options_list=['--value', '-v'], nargs='+', help='Space-separated list of text values which will be concatenated together.')
 
     # endregion
 
     # region ExpressRoutes
+    device_path_values = ['primary', 'secondary']
+    er_circuit_name_type = CLIArgumentType(options_list='--circuit-name', metavar='NAME', help='ExpressRoute circuit name.', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/expressRouteCircuits'))
+    er_gateway_name_type = CLIArgumentType(options_list='--gateway-name', metavar='NAME', help='ExpressRoute gateway name.', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/expressRouteGateways'))
+    er_port_name_type = CLIArgumentType(options_list='--port-name', metavar='NAME', help='ExpressRoute port name.', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/expressRoutePorts'))
+    er_bandwidth_type = CLIArgumentType(options_list='--bandwidth', nargs='+')
     sku_family_type = CLIArgumentType(help='Chosen SKU family of ExpressRoute circuit.', arg_type=get_enum_type(ExpressRouteCircuitSkuFamily), default=ExpressRouteCircuitSkuFamily.metered_data.value)
     sku_tier_type = CLIArgumentType(help='SKU Tier of ExpressRoute circuit.', arg_type=get_enum_type(ExpressRouteCircuitSkuTier), default=ExpressRouteCircuitSkuTier.standard.value)
     with self.argument_context('network express-route') as c:
-        c.argument('circuit_name', circuit_name_type, options_list=('--name', '-n'))
+        c.argument('circuit_name', circuit_name_type, options_list=['--name', '-n'])
         c.argument('sku_family', sku_family_type)
         c.argument('sku_tier', sku_tier_type)
-        c.argument('bandwidth_in_mbps', options_list=('--bandwidth',), help="Bandwidth in Mbps of the circuit.")
-        c.argument('service_provider_name', options_list=('--provider',), help="Name of the ExpressRoute Service Provider.")
+        c.argument('bandwidth_in_mbps', er_bandwidth_type, validator=bandwidth_validator_factory(mbps=True), help='Bandwidth of the circuit. Usage: INT {Mbps,Gbps}. Defaults to Mbps')
+        c.argument('service_provider_name', options_list='--provider', help="Name of the ExpressRoute Service Provider.")
         c.argument('peering_location', help="Name of the peering location.")
-        c.argument('device_path', options_list=('--path',), arg_type=get_enum_type(device_path_values))
+        c.argument('device_path', options_list='--path', arg_type=get_enum_type(device_path_values))
         c.argument('vlan_id', type=int)
         c.argument('allow_global_reach', arg_type=get_three_state_flag(), min_api='2018-07-01', help='Enable global reach on the circuit.')
+        c.argument('express_route_port', help='Name or ID of an ExpressRoute port.', min_api='2018-08-01', validator=validate_express_route_port)
 
     with self.argument_context('network express-route update') as c:
         c.argument('sku_family', sku_family_type, default=None)
@@ -485,6 +493,44 @@ def load_arguments(self, _):
         c.argument('peer_circuit', help='Name or ID of the peer ExpressRoute circuit.', validator=validate_er_peer_circuit)
     # endregion
 
+    # region ExpressRoute Gateways
+    with self.argument_context('network express-route gateway', min_api='2018-08-01') as c:
+        c.argument('express_route_gateway_name', er_gateway_name_type, options_list=['--name', '-n'])
+        c.argument('min_val', help='Minimum number of scale units deployed for gateway.', type=int, arg_group='Autoscale')
+        c.argument('max_val', help='Maximum number of scale units deployed for gateway.', type=int, arg_group='Autoscale')
+        c.argument('virtual_hub', help='Name or ID of the virtual hub to associate with the gateway.', validator=validate_virtual_hub)
+
+    with self.argument_context('network express-route gateway connection', min_api='2018-08-01') as c:
+        c.argument('express_route_gateway_name', er_gateway_name_type)
+        c.argument('connection_name', options_list=['--name', '-n'], help='ExpressRoute connection name.', id_part='child_name_1')
+        c.argument('routing_weight', help='Routing weight associated with the connection.', type=int)
+        c.argument('authorization_key', help='Authorization key to establish the connection.')
+
+    with self.argument_context('network express-route gateway connection', arg_group='Peering', min_api='2018-08-01') as c:
+        c.argument('peering', help='Name or ID of an ExpressRoute peering.', validator=validate_express_route_peering)
+        c.argument('circuit_name', er_circuit_name_type, id_part=None)
+
+    with self.argument_context('network express-route gateway connection list', min_api='2018-08-01') as c:
+        c.argument('express_route_gateway_name', er_gateway_name_type, id_part=None)
+
+    with self.argument_context('network express-route port', min_api='2018-08-01') as c:
+        c.argument('express_route_port_name', er_port_name_type, options_list=['--name', '-n'])
+        c.argument('encapsulation', arg_type=get_enum_type(ExpressRoutePortsEncapsulation), help='Encapsulation method on physical ports.')
+        c.argument('bandwidth_in_gbps', er_bandwidth_type, validator=bandwidth_validator_factory(mbps=False),
+                   help='Bandwidth of the circuit. Usage: INT {Mbps,Gbps}. Defaults to Gbps')
+        c.argument('peering_location', help='The name of the peering location that the port is mapped to physically.')
+
+    with self.argument_context('network express-route port link', min_api='2018-08-01') as c:
+        c.argument('express_route_port_name', er_port_name_type)
+        c.argument('link_name', options_list=['--name', '-n'], id_part='child_name_1')
+
+    with self.argument_context('network express-route port link list', min_api='2018-08-01') as c:
+        c.argument('express_route_port_name', er_port_name_type, id_part=None)
+
+    with self.argument_context('network express-route port location', min_api='2018-08-01') as c:
+        c.argument('location_name', options_list=['--location', '-l'])
+    # endregion
+
     # region InterfaceEndpoint
     private_endpoint_name = CLIArgumentType(options_list='--endpoint-name', id_part='name', help='Name of the private endpoint.', completer=get_resource_name_completion_list('Microsoft.Network/interfaceEndpoints'))
 
@@ -506,12 +552,12 @@ def load_arguments(self, _):
     ]
     for item in lb_subresources:
         with self.argument_context('network lb {}'.format(item['name'])) as c:
-            c.argument('item_name', options_list=('--name', '-n'), help='The name of the {}'.format(item['display']), completer=get_lb_subresource_completion_list(item['ref']), id_part='child_name_1')
-            c.argument('resource_name', options_list=('--lb-name',), help='The name of the load balancer.', completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'))
+            c.argument('item_name', options_list=['--name', '-n'], help='The name of the {}'.format(item['display']), completer=get_lb_subresource_completion_list(item['ref']), id_part='child_name_1')
+            c.argument('resource_name', options_list='--lb-name', help='The name of the load balancer.', completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'))
             c.argument('load_balancer_name', load_balancer_name_type)
 
     with self.argument_context('network lb') as c:
-        c.argument('load_balancer_name', load_balancer_name_type, options_list=('--name', '-n'))
+        c.argument('load_balancer_name', load_balancer_name_type, options_list=['--name', '-n'])
         c.argument('frontend_port', help='Port number')
         c.argument('frontend_port_range_start', help='Port number')
         c.argument('frontend_port_range_end', help='Port number')
@@ -521,10 +567,10 @@ def load_arguments(self, _):
         c.argument('idle_timeout', help='Idle timeout in minutes.', type=int)
         c.argument('protocol', help='Network transport protocol.', arg_type=get_enum_type(TransportProtocol))
         for item in ['backend_pool_name', 'backend_address_pool_name']:
-            c.argument(item, options_list=('--backend-pool-name',), help='The name of the backend address pool.', completer=get_lb_subresource_completion_list('backend_address_pools'))
+            c.argument(item, options_list='--backend-pool-name', help='The name of the backend address pool.', completer=get_lb_subresource_completion_list('backend_address_pools'))
 
     with self.argument_context('network lb create') as c:
-        c.argument('frontend_ip_zone', zone_type, min_api='2017-06-01', options_list=('--frontend-ip-zone'), help='used to create internal facing Load balancer')
+        c.argument('frontend_ip_zone', zone_type, min_api='2017-06-01', options_list=['--frontend-ip-zone'], help='used to create internal facing Load balancer')
         c.argument('validate', help='Generate and validate the ARM template without creating any resources.', action='store_true')
         c.argument('sku', min_api='2017-08-01', help='Load balancer SKU', arg_type=get_enum_type(LoadBalancerSkuName, default='basic'))
 
@@ -533,7 +579,7 @@ def load_arguments(self, _):
         c.argument('public_ip_address', help=public_ip_help, completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'))
         c.argument('public_ip_address_allocation', help='IP allocation method.', arg_type=get_enum_type(IPAllocationMethod))
         c.argument('public_ip_dns_name', help='Globally unique DNS name for a new public IP.')
-        c.argument('public_ip_zone', zone_type, min_api='2017-06-01', options_list=('--public-ip-zone'), help='used to created a new public ip for the load balancer, a.k.a public facing Load balancer')
+        c.argument('public_ip_zone', zone_type, min_api='2017-06-01', options_list=['--public-ip-zone'], help='used to created a new public ip for the load balancer, a.k.a public facing Load balancer')
         c.ignore('public_ip_address_type')
 
     with self.argument_context('network lb create', arg_group='Subnet') as c:
@@ -582,7 +628,7 @@ def load_arguments(self, _):
     # region LocalGateway
     with self.argument_context('network local-gateway') as c:
         c.argument('local_network_gateway_name', name_arg_type, help='Name of the local network gateway.', completer=get_resource_name_completion_list('Microsoft.Network/localNetworkGateways'), id_part='name')
-        c.argument('local_address_prefix', nargs='+', options_list=('--local-address-prefixes',), help='List of CIDR block prefixes representing the address space of the OnPremise VPN\'s subnet.')
+        c.argument('local_address_prefix', nargs='+', options_list='--local-address-prefixes', help='List of CIDR block prefixes representing the address space of the OnPremise VPN\'s subnet.')
         c.argument('gateway_ip_address', help='Gateway\'s public IP address. (e.g. 10.1.1.1).')
         c.argument('bgp_peering_address', arg_group='BGP Peering', help='IP address from the OnPremise VPN\'s subnet to use for BGP peering.')
 
@@ -598,14 +644,14 @@ def load_arguments(self, _):
     # region NetworkInterfaces (NIC)
     with self.argument_context('network nic') as c:
         c.argument('enable_accelerated_networking', min_api='2016-09-01', options_list=['--accelerated-networking'], help='Enable accelerated networking.', arg_type=get_three_state_flag())
-        c.argument('network_interface_name', nic_type, options_list=('--name', '-n'))
-        c.argument('internal_dns_name_label', options_list=('--internal-dns-name',), help='The internal DNS name label.', arg_group='DNS')
+        c.argument('network_interface_name', nic_type, options_list=['--name', '-n'])
+        c.argument('internal_dns_name_label', options_list='--internal-dns-name', help='The internal DNS name label.', arg_group='DNS')
         c.argument('dns_servers', help='Space-separated list of DNS server IP addresses.', nargs='+', arg_group='DNS')
-        c.argument('enable_ip_forwarding', options_list=('--ip-forwarding',), help='Enable IP forwarding.', arg_type=get_three_state_flag())
+        c.argument('enable_ip_forwarding', options_list='--ip-forwarding', help='Enable IP forwarding.', arg_type=get_three_state_flag())
 
     with self.argument_context('network nic create') as c:
         c.argument('private_ip_address_version', min_api='2016-09-01', help='The private IP address version to use.', default=IPVersion.ipv4.value if IPVersion else '')
-        c.argument('network_interface_name', nic_type, options_list=('--name', '-n'), id_part=None)
+        c.argument('network_interface_name', nic_type, options_list=['--name', '-n'], id_part=None)
 
         public_ip_help = get_folded_parameter_help_string('public IP address', allow_none=True, default_none=True)
         c.argument('public_ip_address', help=public_ip_help, completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'))
@@ -625,19 +671,19 @@ def load_arguments(self, _):
             c.argument('application_security_groups', min_api='2017-09-01', help='Space-separated list of application security groups.', nargs='+', validator=get_asg_validator(self, 'application_security_groups'))
 
         with self.argument_context('network nic {}'.format(item), arg_group='Load Balancer') as c:
-            c.extra('load_balancer_name', options_list=('--lb-name',), completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'), help='The name of the load balancer to use when adding NAT rules or address pools by name (ignored when IDs are specified).')
-            c.argument('load_balancer_backend_address_pool_ids', options_list=('--lb-address-pools',), nargs='+', validator=validate_address_pool_id_list, help='Space-separated list of names or IDs of load balancer address pools to associate with the NIC. If names are used, --lb-name must be specified.', completer=get_lb_subresource_completion_list('backendAddressPools'))
-            c.argument('load_balancer_inbound_nat_rule_ids', options_list=('--lb-inbound-nat-rules',), nargs='+', validator=validate_inbound_nat_rule_id_list, help='Space-separated list of names or IDs of load balancer inbound NAT rules to associate with the NIC. If names are used, --lb-name must be specified.', completer=get_lb_subresource_completion_list('inboundNatRules'))
+            c.extra('load_balancer_name', options_list='--lb-name', completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'), help='The name of the load balancer to use when adding NAT rules or address pools by name (ignored when IDs are specified).')
+            c.argument('load_balancer_backend_address_pool_ids', options_list='--lb-address-pools', nargs='+', validator=validate_address_pool_id_list, help='Space-separated list of names or IDs of load balancer address pools to associate with the NIC. If names are used, --lb-name must be specified.', completer=get_lb_subresource_completion_list('backendAddressPools'))
+            c.argument('load_balancer_inbound_nat_rule_ids', options_list='--lb-inbound-nat-rules', nargs='+', validator=validate_inbound_nat_rule_id_list, help='Space-separated list of names or IDs of load balancer inbound NAT rules to associate with the NIC. If names are used, --lb-name must be specified.', completer=get_lb_subresource_completion_list('inboundNatRules'))
 
         with self.argument_context('network nic {}'.format(item), arg_group='Application Gateway') as c:
             c.argument('app_gateway_backend_address_pools', options_list='--app-gateway-address-pools', nargs='+', help='Space-separated list of names or IDs of application gateway backend address pools to associate with the NIC. If names are used, --gateway-name must be specified.', validator=validate_ag_address_pools, completer=get_ag_subresource_completion_list('backendAddressPools'))
             c.extra('application_gateway_name', options_list='--gateway-name', completer=get_resource_name_completion_list('Microsoft.Network/applicationGateways'), help='The name of the application gateway to use when adding address pools by name (ignored when IDs are specified).')
 
     with self.argument_context('network nic ip-config') as c:
-        c.argument('network_interface_name', options_list=('--nic-name',), metavar='NIC_NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
-        c.argument('ip_config_name', options_list=('--name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name_1')
-        c.argument('resource_name', options_list=('--nic-name',), metavar='NIC_NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
-        c.argument('item_name', options_list=('--name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name_1')
+        c.argument('network_interface_name', options_list='--nic-name', metavar='NIC_NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
+        c.argument('ip_config_name', options_list=['--name', '-n'], metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name_1')
+        c.argument('resource_name', options_list='--nic-name', metavar='NIC_NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
+        c.argument('item_name', options_list=['--name', '-n'], metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name_1')
         c.argument('subnet', validator=get_subnet_validator(), help='Name or ID of an existing subnet. If name is specified, also specify --vnet-name.')
         c.argument('virtual_network_name', help='The virtual network (VNet) associated with the subnet (Omit if supplying a subnet id).', id_part=None, metavar='')
         c.argument('public_ip_address', help='Name or ID of the public IP to use.', validator=get_public_ip_validator())
@@ -655,7 +701,7 @@ def load_arguments(self, _):
 
     for item in ['address-pool', 'inbound-nat-rule']:
         with self.argument_context('network nic ip-config {}'.format(item)) as c:
-            c.argument('ip_config_name', options_list=('--ip-config-name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name_1')
+            c.argument('ip_config_name', options_list=['--ip-config-name', '-n'], metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name_1')
             c.argument('network_interface_name', nic_type)
 
     for item in ['address-pool', 'inbound-nat-rule']:
@@ -673,11 +719,11 @@ def load_arguments(self, _):
 
     with self.argument_context('network nsg rule') as c:
         c.argument('security_rule_name', name_arg_type, id_part='child_name_1', help='Name of the network security group rule')
-        c.argument('network_security_group_name', options_list=('--nsg-name',), metavar='NSGNAME', help='Name of the network security group', id_part='name')
+        c.argument('network_security_group_name', options_list='--nsg-name', metavar='NSGNAME', help='Name of the network security group', id_part='name')
         c.argument('include_default', help='Include default security rules in the output.')
 
     with self.argument_context('network nsg rule create') as c:
-        c.argument('network_security_group_name', options_list=('--nsg-name',), metavar='NSGNAME', help='Name of the network security group', id_part=None)
+        c.argument('network_security_group_name', options_list='--nsg-name', metavar='NSGNAME', help='Name of the network security group', id_part=None)
 
     for item in ['create', 'update']:
         with self.argument_context('network nsg rule {}'.format(item)) as c:
@@ -888,7 +934,7 @@ def load_arguments(self, _):
 
     with self.argument_context('network route-table route') as c:
         c.argument('route_name', name_arg_type, id_part='child_name_1', help='Route name')
-        c.argument('route_table_name', options_list=('--route-table-name',), help='Route table name')
+        c.argument('route_table_name', options_list='--route-table-name', help='Route table name')
         c.argument('next_hop_type', help='The type of Azure hop the packet should be sent to.', arg_type=get_enum_type(RouteNextHopType))
         c.argument('next_hop_ip_address', help='The IP address packets should be forwarded to when using the VirtualAppliance hop type.')
         c.argument('address_prefix', help='The destination CIDR to which the route applies.')
@@ -966,8 +1012,8 @@ def load_arguments(self, _):
 
     # region VirtualNetworks
     with self.argument_context('network vnet') as c:
-        c.argument('virtual_network_name', virtual_network_name_type, options_list=('--name', '-n'), id_part='name')
-        c.argument('vnet_prefixes', nargs='+', help='Space-separated list of IP address prefixes for the VNet.', options_list=('--address-prefixes',), metavar='PREFIX')
+        c.argument('virtual_network_name', virtual_network_name_type, options_list=['--name', '-n'], id_part='name')
+        c.argument('vnet_prefixes', nargs='+', help='Space-separated list of IP address prefixes for the VNet.', options_list='--address-prefixes', metavar='PREFIX')
         c.argument('dns_servers', nargs='+', help='Space-separated list of DNS server IP addresses.', metavar='IP')
         c.argument('ddos_protection', arg_type=get_three_state_flag(), help='Control whether DDoS protection is enabled.', min_api='2017-09-01')
         c.argument('ddos_protection_plan', help='Name or ID of a DDoS protection plan to associate with the VNet.', min_api='2018-02-01', validator=validate_ddos_name_or_id)
@@ -978,7 +1024,7 @@ def load_arguments(self, _):
 
     with self.argument_context('network vnet create') as c:
         c.argument('location', get_location_type(self.cli_ctx))
-        c.argument('vnet_name', virtual_network_name_type, options_list=('--name', '-n'), completer=None)
+        c.argument('vnet_name', virtual_network_name_type, options_list=['--name', '-n'], completer=None)
 
     with self.argument_context('network vnet create', arg_group='Subnet') as c:
         c.argument('subnet_name', help='Name of a new subnet to create within the VNet.')
@@ -990,17 +1036,17 @@ def load_arguments(self, _):
 
     with self.argument_context('network vnet peering') as c:
         c.argument('virtual_network_name', virtual_network_name_type)
-        c.argument('virtual_network_peering_name', options_list=('--name', '-n'), help='The name of the VNet peering.', id_part='child_name_1')
+        c.argument('virtual_network_peering_name', options_list=['--name', '-n'], help='The name of the VNet peering.', id_part='child_name_1')
         c.argument('remote_virtual_network', options_list=['--remote-vnet', c.deprecate(target='--remote-vnet-id', hide=True, expiration='2.1.0')], help='Resource ID or name of the remote VNet.')
 
     with self.argument_context('network vnet peering create') as c:
-        c.argument('allow_virtual_network_access', options_list=('--allow-vnet-access',), action='store_true', help='Allows VMs in the remote VNet to access all VMs in the local VNet.')
+        c.argument('allow_virtual_network_access', options_list='--allow-vnet-access', action='store_true', help='Allows VMs in the remote VNet to access all VMs in the local VNet.')
         c.argument('allow_gateway_transit', action='store_true', help='Allows gateway link to be used in the remote VNet.')
         c.argument('allow_forwarded_traffic', action='store_true', help='Allows forwarded traffic from the VMs in the remote VNet.')
         c.argument('use_remote_gateways', action='store_true', help='Allows VNet to use the remote VNet\'s gateway. Remote VNet gateway must have --allow-gateway-transit enabled for remote peering. Only 1 peering can have this flag enabled. Cannot be set if the VNet already has a gateway.')
 
     with self.argument_context('network vnet subnet') as c:
-        c.argument('subnet_name', arg_type=subnet_name_type, options_list=('--name', '-n'), id_part='child_name_1')
+        c.argument('subnet_name', arg_type=subnet_name_type, options_list=['--name', '-n'], id_part='child_name_1')
         c.argument('address_prefix', metavar='PREFIX', help='Address prefix in CIDR format.', max_api='2018-07-01')
         c.argument('address_prefix', metavar='PREFIXES', options_list='--address-prefixes', nargs='+', help='Space-separated list of address prefixes in CIDR format.', min_api='2018-08-01')
         c.argument('virtual_network_name', virtual_network_name_type)
@@ -1024,8 +1070,8 @@ def load_arguments(self, _):
     vnet_gateway_sku_type = CLIArgumentType(help='VNet gateway SKU.', arg_type=get_enum_type(VirtualNetworkGatewaySkuName), default=VirtualNetworkGatewaySkuName.basic.value)
     vnet_gateway_routing_type = CLIArgumentType(help='VPN routing type.', arg_type=get_enum_type(VpnType), default=VpnType.route_based.value)
     with self.argument_context('network vnet-gateway') as c:
-        c.argument('virtual_network_gateway_name', options_list=('--name', '-n'), help='Name of the VNet gateway.', completer=get_resource_name_completion_list('Microsoft.Network/virtualNetworkGateways'), id_part='name')
-        c.argument('cert_name', help='Root certificate name', options_list=('--name', '-n'))
+        c.argument('virtual_network_gateway_name', options_list=['--name', '-n'], help='Name of the VNet gateway.', completer=get_resource_name_completion_list('Microsoft.Network/virtualNetworkGateways'), id_part='name')
+        c.argument('cert_name', help='Root certificate name', options_list=['--name', '-n'])
         c.argument('gateway_name', help='Virtual network gateway name')
         c.argument('gateway_type', vnet_gateway_type)
         c.argument('sku', vnet_gateway_sku_type)
@@ -1044,16 +1090,16 @@ def load_arguments(self, _):
 
     with self.argument_context('network vnet-gateway create') as c:
         vnet_help = "Name or ID of an existing virtual network which has a subnet named 'GatewaySubnet'."
-        c.argument('virtual_network', options_list=('--vnet',), help=vnet_help)
+        c.argument('virtual_network', options_list='--vnet', help=vnet_help)
 
     with self.argument_context('network vnet-gateway update') as c:
         c.argument('enable_bgp', help='Enable BGP (Border Gateway Protocol)', arg_group='BGP Peering', arg_type=get_enum_type(['true', 'false']))
-        c.argument('virtual_network', virtual_network_name_type, options_list=('--vnet',), help="Name or ID of a virtual network that contains a subnet named 'GatewaySubnet'.")
-        c.extra('address_prefixes', options_list=('--address-prefixes',), help='List of address prefixes for the VPN gateway.  Prerequisite for uploading certificates.', nargs='+')
+        c.argument('virtual_network', virtual_network_name_type, options_list='--vnet', help="Name or ID of a virtual network that contains a subnet named 'GatewaySubnet'.")
+        c.extra('address_prefixes', options_list='--address-prefixes', help='List of address prefixes for the VPN gateway.  Prerequisite for uploading certificates.', nargs='+')
 
     with self.argument_context('network vnet-gateway root-cert create') as c:
         c.argument('public_cert_data', help='Base64 contents of the root certificate file or file path.', type=file_type, completer=FilesCompleter(), validator=load_cert_file('public_cert_data'))
-        c.argument('cert_name', help='Root certificate name', options_list=('--name', '-n'))
+        c.argument('cert_name', help='Root certificate name', options_list=['--name', '-n'])
         c.argument('gateway_name', help='Virtual network gateway name')
 
     with self.argument_context('network vnet-gateway revoked-cert create') as c:
@@ -1070,7 +1116,7 @@ def load_arguments(self, _):
 
     # region VirtualNetworkGatewayConnections
     with self.argument_context('network vpn-connection') as c:
-        c.argument('virtual_network_gateway_connection_name', options_list=('--name', '-n'), metavar='NAME', id_part='name', help='Connection name.')
+        c.argument('virtual_network_gateway_connection_name', options_list=['--name', '-n'], metavar='NAME', id_part='name', help='Connection name.')
         c.argument('shared_key', help='Shared IPSec key.')
         c.argument('connection_name', help='Connection name.')
         c.argument('routing_weight', type=int, help='Connection routing weight')
@@ -1078,7 +1124,7 @@ def load_arguments(self, _):
         c.argument('express_route_gateway_bypass', min_api='2018-07-01', arg_type=get_three_state_flag(), help='Bypass ExpressRoute gateway for data forwarding.')
 
     with self.argument_context('network vpn-connection create') as c:
-        c.argument('connection_name', options_list=('--name', '-n'), metavar='NAME', help='Connection name.')
+        c.argument('connection_name', options_list=['--name', '-n'], metavar='NAME', help='Connection name.')
         c.ignore('connection_type')
         for item in ['vnet_gateway2', 'local_gateway2', 'express_route_circuit2']:
             c.argument(item, arg_group='Destination')
@@ -1087,8 +1133,8 @@ def load_arguments(self, _):
         c.argument('enable_bgp', help='Enable BGP (Border Gateway Protocol)', arg_type=get_enum_type(['true', 'false']))
 
     with self.argument_context('network vpn-connection shared-key') as c:
-        c.argument('connection_shared_key_name', options_list=('--name', '-n'), id_part='name')
-        c.argument('virtual_network_gateway_connection_name', options_list=('--connection-name',), metavar='NAME', id_part='name')
+        c.argument('connection_shared_key_name', options_list=['--name', '-n'], id_part='name')
+        c.argument('virtual_network_gateway_connection_name', options_list='--connection-name', metavar='NAME', id_part='name')
         c.argument('key_length', type=int)
 
     param_map = {

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -3,12 +3,15 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+# pylint: disable=too-many-lines
+
 import argparse
 import base64
 import socket
 import os
 
 from knack.util import CLIError
+from knack.log import get_logger
 
 from azure.cli.core.commands.validators import \
     (validate_tags, get_default_location_from_resource_group)
@@ -17,8 +20,8 @@ from azure.cli.core.commands.client_factory import get_subscription_id, get_mgmt
 from azure.cli.core.commands.validators import validate_parameter_set
 from azure.cli.core.profiles import ResourceType
 
-# PARAMETER VALIDATORS
-# pylint: disable=too-many-lines
+
+logger = get_logger(__name__)
 
 
 def get_asg_validator(loader, dest):
@@ -247,6 +250,93 @@ def validate_dns_record_type(namespace):
             else:
                 namespace.record_set_type = token
             return
+
+
+def validate_express_route_peering(cmd, namespace):
+    from msrestazure.tools import is_valid_resource_id, resource_id
+    circuit = namespace.circuit_name
+    peering = namespace.peering
+
+    if not circuit and not peering:
+        return
+
+    usage_error = CLIError('usage error: --peering ID | --peering NAME --circuit-name CIRCUIT')
+    if not is_valid_resource_id(peering):
+        namespace.peering = resource_id(
+            subscription=get_subscription_id(cmd.cli_ctx),
+            resource_group=namespace.resource_group_name,
+            namespace='Microsoft.Network',
+            type='expressRouteCircuits',
+            name=circuit,
+            child_type_1='peerings',
+            child_name_1=peering
+        )
+    elif circuit:
+        raise usage_error
+
+
+def validate_express_route_port(cmd, namespace):
+    from msrestazure.tools import is_valid_resource_id, resource_id
+    if namespace.express_route_port and not is_valid_resource_id(namespace.express_route_port):
+        namespace.express_route_port = resource_id(
+            subscription=get_subscription_id(cmd.cli_ctx),
+            resource_group=namespace.resource_group_name,
+            namespace='Microsoft.Network',
+            type='expressRoutePorts',
+            name=namespace.express_route_port
+        )
+
+
+def validate_virtual_hub(cmd, namespace):
+    from msrestazure.tools import is_valid_resource_id, resource_id
+    if namespace.virtual_hub and not is_valid_resource_id(namespace.virtual_hub):
+        namespace.virtual_hub = resource_id(
+            subscription=get_subscription_id(cmd.cli_ctx),
+            resource_group=namespace.resource_group_name,
+            namespace='Microsoft.Network',
+            type='virtualHubs',
+            name=namespace.virtual_hub
+        )
+
+
+def bandwidth_validator_factory(mbps=True):
+    def validator(namespace):
+        return validate_circuit_bandwidth(namespace, mbps=mbps)
+    return validator
+
+
+def validate_circuit_bandwidth(namespace, mbps=True):
+    # use gbps if mbps is False
+    unit = 'mbps' if mbps else 'gbps'
+    bandwidth = None
+    bandwidth = getattr(namespace, 'bandwidth_in_{}'.format(unit), None)
+    if bandwidth is None:
+        return
+
+    if len(bandwidth) == 1:
+        bandwidth_comps = bandwidth[0].split(' ')
+    else:
+        bandwidth_comps = bandwidth
+
+    usage_error = CLIError('usage error: --bandwidth INT {Mbps,Gbps}')
+    if len(bandwidth_comps) == 1:
+        logger.warning('interpretting --bandwidth as %s. Consider being explicit: Mbps, Gbps', unit)
+        setattr(namespace, 'bandwidth_in_{}'.format(unit), float(bandwidth_comps[0]))
+        return
+    if len(bandwidth_comps) > 2:
+        raise usage_error
+
+    if float(bandwidth_comps[0]) and bandwidth_comps[1].lower() in ['mbps', 'gbps']:
+        input_unit = bandwidth_comps[1].lower()
+        if input_unit == unit:
+            converted_bandwidth = float(bandwidth_comps[0])
+        elif input_unit == 'gbps':
+            converted_bandwidth = float(bandwidth_comps[0]) * 1000
+        else:
+            converted_bandwidth = float(bandwidth_comps[0]) / 1000
+        setattr(namespace, 'bandwidth_in_{}'.format(unit), converted_bandwidth)
+    else:
+        raise usage_error
 
 
 def validate_er_peer_circuit(cmd, namespace):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -23,7 +23,8 @@ from azure.cli.command_modules.network._client_factory import (
     cf_public_ip_addresses, cf_endpoint_services, cf_application_security_groups, cf_connection_monitor,
     cf_ddos_protection_plans, cf_public_ip_prefixes, cf_service_endpoint_policies,
     cf_service_endpoint_policy_definitions, cf_dns_references, cf_interface_endpoints, cf_network_profiles,
-    cf_express_route_circuit_connections)
+    cf_express_route_circuit_connections, cf_express_route_gateways, cf_express_route_connections,
+    cf_express_route_ports, cf_express_route_port_locations, cf_express_route_links)
 from azure.cli.command_modules.network._util import (
     list_network_resource_property, get_network_resource_property_entry, delete_network_resource_property_entry)
 from azure.cli.command_modules.network._format import (
@@ -104,6 +105,36 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.{}',
         client_factory=cf_express_route_circuits,
         min_api='2016-09-01'
+    )
+
+    network_er_connection_sdk = CliCommandType(
+        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_connections_operations#ExpressRouteConnectionsOperations.{}',
+        client_factory=cf_express_route_connections,
+        min_api='2018-08-01'
+    )
+
+    network_er_gateway_sdk = CliCommandType(
+        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_gateways_operations#ExpressRouteGatewaysOperations.{}',
+        client_factory=cf_express_route_gateways,
+        min_api='2018-08-01'
+    )
+
+    network_er_ports_sdk = CliCommandType(
+        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_ports_operations#ExpressRoutePortsOperations.{}',
+        client_factory=cf_express_route_ports,
+        min_api='2018-08-01'
+    )
+
+    network_er_port_locations_sdk = CliCommandType(
+        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_ports_locations_operations#ExpressRoutePortsLocationsOperations.{}',
+        client_factory=cf_express_route_port_locations,
+        min_api='2018-08-01'
+    )
+
+    network_er_links_sdk = CliCommandType(
+        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_links_operations#ExpressRouteLinksOperations.{}',
+        client_factory=cf_express_route_links,
+        min_api='2018-08-01'
     )
 
     network_erca_sdk = CliCommandType(
@@ -435,6 +466,20 @@ def load_command_table(self, _):
         g.show_command('show', 'get')
         g.command('list', 'list')
 
+    with self.command_group('network express-route gateway', network_er_gateway_sdk) as g:
+        g.custom_command('create', 'create_express_route_gateway')
+        g.command('delete', 'delete')
+        g.custom_command('list', 'list_express_route_gateways')
+        g.show_command('show', 'get')
+        g.generic_update_command('update', custom_func_name='update_express_route_gateway', setter_arg_name='put_express_route_gateway_parameters')
+
+    with self.command_group('network express-route gateway connection', network_er_connection_sdk) as g:
+        g.custom_command('create', 'create_express_route_connection')
+        g.command('delete', 'delete')
+        g.command('list', 'list')
+        g.show_command('show', 'get')
+        g.generic_update_command('update', custom_func_name='update_express_route_connection', setter_arg_name='put_express_route_connection_parameters')
+
     with self.command_group('network express-route peering', network_er_peering_sdk) as g:
         g.custom_command('create', 'create_express_route_peering', client_factory=cf_express_route_circuit_peerings)
         g.command('delete', 'delete')
@@ -443,8 +488,23 @@ def load_command_table(self, _):
         g.generic_update_command('update', setter_arg_name='peering_parameters', custom_func_name='update_express_route_peering')
 
     with self.command_group('network express-route peering connection', network_erconn_sdk) as g:
-        g.custom_command('create', 'create_express_route_connection')
+        g.custom_command('create', 'create_express_route_peering_connection')
         g.command('delete', 'delete')
+        g.show_command('show')
+
+    with self.command_group('network express-route port', network_er_ports_sdk) as g:
+        g.custom_command('create', 'create_express_route_port')
+        g.command('delete', 'delete')
+        g.custom_command('list', 'list_express_route_ports')
+        g.show_command('show')
+        g.generic_update_command('update', custom_func_name='update_express_route_port')
+
+    with self.command_group('network express-route port link', network_er_links_sdk) as g:
+        g.command('list', 'list')
+        g.show_command('show')
+
+    with self.command_group('network express-route port location', network_er_port_locations_sdk) as g:
+        g.command('list', 'list')
         g.show_command('show')
     # endregion
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -108,31 +108,31 @@ def load_command_table(self, _):
     )
 
     network_er_connection_sdk = CliCommandType(
-        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_connections_operations#ExpressRouteConnectionsOperations.{}',
+        operations_tmpl='azure.mgmt.network.operations.express_route_connections_operations#ExpressRouteConnectionsOperations.{}',
         client_factory=cf_express_route_connections,
         min_api='2018-08-01'
     )
 
     network_er_gateway_sdk = CliCommandType(
-        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_gateways_operations#ExpressRouteGatewaysOperations.{}',
+        operations_tmpl='azure.mgmt.network.operations.express_route_gateways_operations#ExpressRouteGatewaysOperations.{}',
         client_factory=cf_express_route_gateways,
         min_api='2018-08-01'
     )
 
     network_er_ports_sdk = CliCommandType(
-        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_ports_operations#ExpressRoutePortsOperations.{}',
+        operations_tmpl='azure.mgmt.network.operations.express_route_ports_operations#ExpressRoutePortsOperations.{}',
         client_factory=cf_express_route_ports,
         min_api='2018-08-01'
     )
 
     network_er_port_locations_sdk = CliCommandType(
-        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_ports_locations_operations#ExpressRoutePortsLocationsOperations.{}',
+        operations_tmpl='azure.mgmt.network.operations.express_route_ports_locations_operations#ExpressRoutePortsLocationsOperations.{}',
         client_factory=cf_express_route_port_locations,
         min_api='2018-08-01'
     )
 
     network_er_links_sdk = CliCommandType(
-        operations_tmpl='azext_express_route.vendored_sdks.operations.express_route_links_operations#ExpressRouteLinksOperations.{}',
+        operations_tmpl='azure.mgmt.network.operations.express_route_links_operations#ExpressRouteLinksOperations.{}',
         client_factory=cf_express_route_links,
         min_api='2018-08-01'
     )

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1498,7 +1498,7 @@ def create_express_route(cmd, circuit_name, resource_group_name, bandwidth_in_mb
                          allow_classic_operations=None):
     ExpressRouteCircuit, ExpressRouteCircuitSku, ExpressRouteCircuitServiceProviderProperties, SubResource = \
         cmd.get_models(
-            'ExpressRouteCircuit', 'ExpressRouteCircuitSku', 'ExpressRouteCircuitServiceProviderProperties'
+            'ExpressRouteCircuit', 'ExpressRouteCircuitSku', 'ExpressRouteCircuitServiceProviderProperties',
             'SubResource')
     client = network_client_factory(cmd.cli_ctx).express_route_circuits
     sku_name = '{}_{}'.format(sku_tier, sku_family)


### PR DESCRIPTION
Closes #8357.

This PR:
- Moves commands from the ExpressRoute extension into the CLI. (`express-route gateway`, express-route port` command groups)
- Updates azure-cli-core to allow modules to specify multiple extension suppressions, since now Network needs to suppress the DNS and ExpressRoute extensions.
- Converts all outdated tuple syntax for options_list to list or string syntax in the Network module.
- Cleans up repetitive statements with an UpdateContext class pulled from the ExpressRoute extension. This might move into core later.
- Adds missing `--legacy-mode` and `--allow-classic-operations` flags to certain ExpressRoute commands.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
