### PR TITLE
Add Zip Binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ LABEL maintainer="Microsoft" \
 # jq - we include jq as a useful tool
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool
-RUN apk add --no-cache bash openssh ca-certificates jq curl openssl git \
+RUN apk add --no-cache bash openssh ca-certificates jq curl openssl git zip \
  && apk add --no-cache --virtual .build-deps gcc make openssl-dev libffi-dev musl-dev \
  && update-ca-certificates
 


### PR DESCRIPTION
Adds zip binaries for use in `az webapp deployment source config-zip` since tgz is not supported
