### PR TITLE
Replace yaml.load with yaml.safe_load

### DIFF
--- a/scripts/temp_help/help_convert.py
+++ b/scripts/temp_help/help_convert.py
@@ -175,7 +175,7 @@ def _get_new_yaml_dict(help_dict):
     content = result['content']
 
     for command_or_group, yaml_text in help_dict.items():
-        help_dict = yaml.load(yaml_text)
+        help_dict = yaml.safe_load(yaml_text)
 
         type = help_dict["type"]
 

--- a/src/azure-cli-core/azure/cli/core/_help_loaders.py
+++ b/src/azure-cli-core/azure/cli/core/_help_loaders.py
@@ -89,7 +89,7 @@ class BaseHelpLoader(ABC):
             pretty_file_path = os.path.join(os.path.basename(dir_name), base_name)
 
             try:
-                data = yaml.load(text)
+                data = yaml.safe_load(text)
                 if not data:
                     raise CLIError("Error: Help file {} is empty".format(pretty_file_path))
                 return data

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -60,7 +60,7 @@ DEPENDENCIES = [
     'colorama>=0.3.9',
     'humanfriendly>=4.7',
     'jmespath',
-    'knack==0.5.1',
+    'knack~=0.5.2',
     'msrest>=0.4.4',
     'msrestazure>=0.4.25',
     'paramiko>=2.0.8',
@@ -68,7 +68,7 @@ DEPENDENCIES = [
     'pygments',
     'PyJWT',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
-    'pyyaml>=4.2b1',
+    'pyyaml',
     'requests>=2.20.0',
     'six',
     'tabulate>=0.7.7,<=0.8.2',

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -236,7 +236,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         merge_kubernetes_configurations(existing.name, addition.name, False)
 
         with open(existing.name, 'r') as stream:
-            merged = yaml.load(stream)
+            merged = yaml.safe_load(stream)
         self.assertEqual(len(merged['clusters']), 2)
         self.assertEqual(merged['clusters'], [obj1['clusters'][0], obj2['clusters'][0]])
         self.assertEqual(len(merged['contexts']), 2)
@@ -328,7 +328,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         merge_kubernetes_configurations(existing.name, addition.name, False)
 
         with open(existing.name, 'r') as stream:
-            merged = yaml.load(stream)
+            merged = yaml.safe_load(stream)
         self.assertEqual(len(merged['clusters']), 1)
         self.assertEqual([c['cluster'] for c in merged['clusters']],
                          [{'certificate-authority-data': 'certificateauthoritydata1',
@@ -410,7 +410,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         merge_kubernetes_configurations(existing.name, addition.name, False)
 
         with open(existing.name, 'r') as stream:
-            merged = yaml.load(stream)
+            merged = yaml.safe_load(stream)
         self.assertEqual(len(merged['clusters']), 1)
         self.assertEqual(merged['clusters'], [obj2['clusters'][0]])
         self.assertEqual(len(merged['contexts']), 2)
@@ -521,7 +521,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         self.addCleanup(os.remove, addition.name)
 
         with open(existing.name, 'r') as stream:
-            merged = yaml.load(stream)
+            merged = yaml.safe_load(stream)
         self.addCleanup(os.remove, existing.name)
 
         self.assertEqual(len(merged['clusters']), 2)

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -36,7 +36,7 @@ DEPENDENCIES = [
     'azure-graphrbac==0.53.0',
     'azure-cli-core',
     'paramiko>=2.0.8',
-    'pyyaml>=4.2b1',
+    'pyyaml',
     'six',
     'scp',
     'sshtunnel'

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/custom.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/custom.py
@@ -377,7 +377,7 @@ def _create_update_from_file(cli_ctx, resource_group_name, name, location, file,
 
     try:
         with open(file, 'r') as f:
-            cg_defintion = yaml.load(f)
+            cg_defintion = yaml.safe_load(f)
     except FileNotFoundError:
         raise CLIError("No such file or directory: " + file)
     except yaml.YAMLError as e:

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/tests/latest/test_container_commands.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/tests/latest/test_container_commands.py
@@ -331,7 +331,7 @@ class AzureContainerInstanceScenarioTest(ScenarioTest):
 
         cg_definition = None
         with open(output_file, 'r') as f:
-            cg_definition = yaml.load(f)
+            cg_definition = yaml.safe_load(f)
 
         self.check(cg_definition["name"], container_group_name)
         self.check(cg_definition['properties']['containers'][0]['properties']['image'], image)

--- a/src/command_modules/azure-cli-container/setup.py
+++ b/src/command_modules/azure-cli-container/setup.py
@@ -36,7 +36,7 @@ DEPENDENCIES = [
     'azure-mgmt-network==2.4.0',
     'azure-mgmt-authorization==0.50.0',
     'azure-cli-core',
-    'pyyaml>=4.2b1',
+    'pyyaml',
     'colorama',
     'websocket-client'
 ]

--- a/src/command_modules/azure-cli-find/azure/cli/command_modules/find/_gather_commands.py
+++ b/src/command_modules/azure-cli-find/azure/cli/command_modules/find/_gather_commands.py
@@ -47,7 +47,7 @@ def build_command_table(cli_ctx):
         data[command] = com_descip
 
     for command in helps:
-        diction_help = yaml.load(helps[command])
+        diction_help = yaml.safe_load(helps[command])
         if command not in data:
             data[command] = {
                 'short-summary': diction_help.get(

--- a/tools/automation/cli_linter/__init__.py
+++ b/tools/automation/cli_linter/__init__.py
@@ -45,7 +45,7 @@ def main(args):
     # load yaml help
     help_file_entries = {}
     for entry_name, help_yaml in helps.items():
-        help_entry = yaml.load(help_yaml)
+        help_entry = yaml.safe_load(help_yaml)
         help_file_entries[entry_name] = help_entry
 
     if not args.rule_types_to_run:
@@ -60,7 +60,7 @@ def main(args):
         for _, path in gen:
             exclusion_path = os.path.join(path, 'linter_exclusions.yml')
             if os.path.isfile(exclusion_path):
-                mod_exclusions = yaml.load(open(exclusion_path))
+                mod_exclusions = yaml.safe_load(open(exclusion_path))
                 exclusions.update(mod_exclusions)
 
     # only run linter on modules and extensions specified

--- a/tools/automation/cli_linter/linter.py
+++ b/tools/automation/cli_linter/linter.py
@@ -181,7 +181,7 @@ class LinterManager(object):
 
         if paths:
             ci_exclusions_path = os.path.join(paths[0], 'ci_exclusions.yml')
-            self._ci_exclusions = yaml.load(open(ci_exclusions_path)) or {}
+            self._ci_exclusions = yaml.safe_load(open(ci_exclusions_path)) or {}
 
         # find all defined rules and check for name conflicts
         found_rules = set()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -30,7 +30,7 @@ DEPENDENCIES = [
     'nose>=1.3.7',
     'readme_renderer>=17.2',
     'requests',
-    'pyyaml>=4.2b1',
+    'pyyaml',
     'knack',
     'six>=1.10.0',
     'tabulate>=0.7.7',


### PR DESCRIPTION
Knack was updated to use `yaml.safe_load` instead of `yaml.load` based on discussions with @derekbekoe. This PR updates the knack dependency in CLI to 0.5.2 and implements the same fix, replacing yaml.load with yaml.safe_load and removing the CLI dependency on the beta version of PyYAML which will be removed from PyPI.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
