### PR TITLE
BotService [0.1.7]: Supress 0.4.3 extension

### DIFF
--- a/src/command_modules/azure-cli-botservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-botservice/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.7
++++++
+* Suppress latest `botservice (0.4.3)` extension, this functionality has been rolled into the core CLI
+
 0.1.6
 +++++
 * Improve UX around `az bot publish`

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/__init__.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/__init__.py
@@ -23,7 +23,8 @@ class BotServiceCommandsLoader(AzCommandsLoader):
                                                            __name__,
                                                            'botservice',
                                                            '0.4.3',
-                                                           reason='These commands and functionality are now in the core CLI.',
+                                                           reason='These commands and functionality are now in the '
+                                                                  'core CLI.',
                                                            recommend_remove=True))
 
     def load_command_table(self, args):

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/__init__.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/__init__.py
@@ -22,8 +22,8 @@ class BotServiceCommandsLoader(AzCommandsLoader):
                                                        suppress_extension=ModExtensionSuppress(
                                                            __name__,
                                                            'botservice',
-                                                           '0.4.1',
-                                                           reason='These commands are now in the CLI',
+                                                           '0.4.3',
+                                                           reason='These commands and functionality are now in the core CLI.',
                                                            recommend_remove=True))
 
     def load_command_table(self, args):

--- a/src/command_modules/azure-cli-botservice/setup.py
+++ b/src/command_modules/azure-cli-botservice/setup.py
@@ -17,7 +17,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.1.6"
+VERSION = "0.1.7"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
- Updates version number to 0.1.7
- Supresses the `botservice` extension (0.4.3)
   - This functionality is now in the core CLI and should not be used.
- Fixes: #8464