### PR TITLE
Fix issue with TestHelpLoader and pytest

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_help_loaders.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help_loaders.py
@@ -53,7 +53,7 @@ COMMAND_LOADER_CLS = TestCommandLoader
 
 
 # test Help Loader, loads from help.json
-class TestHelpLoader(HelpLoaderV1):
+class DummyHelpLoader(HelpLoaderV1):
     # This loader has different keys in the data object. Except for "arguments" and "examples".
     core_attrs_to_keys = [("short_summary", "short"), ("long_summary", "long")]
     body_attrs_to_keys = core_attrs_to_keys + [("links", "hyper-links")]


### PR DESCRIPTION
Names that begin with Test are picked up by pytest as tests. However, because this class is not a test, and contains an __init__ method, it pollutes the output of `azdev test` with warnings. Renaming the class fixes this.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
