### PR TITLE
[HDInsight] - Support ADLS Gen2 MSI

### DIFF
--- a/src/command_modules/azure-cli-hdinsight/HISTORY.rst
+++ b/src/command_modules/azure-cli-hdinsight/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.3.1
++++++
+
+* `create`: added the `--storage-account-managed-identity` parameter to support ADLS Gen2 MSI.
+
 0.3.0
 +++++
 

--- a/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/_help.py
+++ b/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/_help.py
@@ -39,6 +39,12 @@ helps['hdinsight create'] = """
              --encryption-key-version 00000000000000000000000000000000 \\
              --encryption-vault-uri https://MyKeyVault.vault.azure.net \\
              --assign-identity MyMSI
+        - name: Create a cluster with Azure Data Lake Storage Gen2
+          text: |-
+              az hdinsight create -t spark -g MyResourceGroup -n MyCluster \\
+              -p "HttpPassword1234!" \\
+              --storage-account MyStorageAccount \\
+              --storage-account-managed-identity MyMSI
 """
 
 helps['hdinsight list'] = """

--- a/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/_params.py
+++ b/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/_params.py
@@ -8,6 +8,7 @@ from azure.cli.core.commands.parameters import get_enum_type, name_type, tags_ty
 from ._validators import (validate_component_version,
                           validate_storage_account,
                           validate_msi,
+                          validate_storage_msi,
                           validate_subnet,
                           validate_domain_service)
 
@@ -98,6 +99,10 @@ def load_arguments(self, _):
                         'Uses the cluster name if none was specified. (WASB only)')
         c.argument('storage_default_filesystem', arg_group='Storage',
                    help='The storage filesystem the cluster will use. (DFS only)')
+        c.argument('storage_account_managed_identity', arg_group='Storage', validator=validate_storage_msi,
+                   completer=get_resource_name_completion_list('Microsoft.ManagedIdentity/userAssignedIdentities'),
+                   help='User-assigned managed identity with access to the storage account filesystem. '
+                        'Only required when storage account type is Azure Data Lake Storage Gen2.')
 
         # Network
         c.argument('vnet_name', arg_group='Network', validator=validate_subnet,

--- a/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/_validators.py
+++ b/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/_validators.py
@@ -69,6 +69,22 @@ def validate_msi(cmd, namespace):
             )
 
 
+# Validate managed identity to access storage account v2.
+def validate_storage_msi(cmd, namespace):
+    from azure.cli.core.commands.client_factory import get_subscription_id
+    from msrestazure.tools import is_valid_resource_id, resource_id
+
+    if namespace.storage_account_managed_identity is not None:
+        if not is_valid_resource_id(namespace.storage_account_managed_identity):
+            namespace.storage_account_managed_identity = resource_id(
+                subscription=get_subscription_id(cmd.cli_ctx),
+                resource_group=namespace.resource_group_name,
+                namespace='Microsoft.ManagedIdentity',
+                type='userAssignedIdentities',
+                name=namespace.storage_account_managed_identity
+            )
+
+
 # Validate domain service.
 def validate_domain_service(cmd, namespace):
     from azure.cli.core.commands.client_factory import get_subscription_id

--- a/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/custom.py
+++ b/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/custom.py
@@ -100,7 +100,7 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
         raise CLIError('Either the default container or the default filesystem can be specified, but not both.')
 
     # Retrieve primary blob service endpoint
-    is_wasb = True if not storage_account_managed_identity else False
+    is_wasb = not storage_account_managed_identity
     storage_account_endpoint = None
     if storage_account:
         storage_account_endpoint = get_storage_account_endpoint(cmd, storage_account, is_wasb)
@@ -207,7 +207,7 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
                 key=storage_account_key,
                 container=storage_default_container,
                 file_system=storage_default_filesystem,
-                resource_id=storage_account if not is_wasb else None,
+                resource_id=None if is_wasb else storage_account,
                 msi_resource_id=storage_account_managed_identity,
                 is_default=True
             )

--- a/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/custom.py
+++ b/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/custom.py
@@ -23,6 +23,7 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
                    ssh_username='sshuser', ssh_password=None, ssh_public_key=None,
                    storage_account=None, storage_account_key=None,
                    storage_default_container=None, storage_default_filesystem=None,
+                   storage_account_managed_identity=None,
                    vnet_name=None, subnet=None,
                    domain=None, ldaps_urls=None,
                    cluster_admin_account=None, cluster_admin_password=None,
@@ -99,13 +100,13 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
         raise CLIError('Either the default container or the default filesystem can be specified, but not both.')
 
     # Retrieve primary blob service endpoint
+    is_wasb = True if not storage_account_managed_identity else False
     storage_account_endpoint = None
     if storage_account:
-        dfs = True if storage_default_filesystem else False
-        storage_account_endpoint = get_storage_account_endpoint(cmd, storage_account, dfs)
+        storage_account_endpoint = get_storage_account_endpoint(cmd, storage_account, is_wasb)
 
     # Attempt to infer the storage account key from the endpoint
-    if not storage_account_key and storage_account:
+    if not storage_account_key and storage_account and is_wasb:
         from .util import get_key_for_storage_account
         logger.info('Storage account key not specified. Attempting to retrieve key...')
         key = get_key_for_storage_account(cmd, storage_account)
@@ -115,16 +116,20 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
             storage_account_key = key
 
     # Attempt to provide a default container for WASB storage accounts
-    if not storage_default_container and storage_account_endpoint \
-       and _is_wasb_endpoint(storage_account_endpoint):
+    if not storage_default_container and is_wasb:
         storage_default_container = cluster_name
         logger.warning('Default WASB container not specified, using "%s".', storage_default_container)
+    elif not storage_default_filesystem and not is_wasb:
+        storage_default_filesystem = cluster_name
+        logger.warning('Default ADLS file system not specified, using "%s".', storage_default_filesystem)
 
     # Validate storage info parameters
-    if not _all_or_none(storage_account, storage_account_key,
-                        (storage_default_container or storage_default_filesystem)):
+    if is_wasb and not _all_or_none(storage_account, storage_account_key, storage_default_container):
         raise CLIError('If storage details are specified, the storage account, storage account key, '
-                       'and either the default container or default filesystem must be specified.')
+                       'and the default container must be specified.')
+    elif not is_wasb and not _all_or_none(storage_account, storage_default_filesystem):
+        raise CLIError('If storage details are specified, the storage account, '
+                       'and the default filesystem must be specified.')
 
     # Validate disk encryption parameters
     if not _all_or_none(encryption_vault_uri, encryption_key_name, encryption_key_version):
@@ -202,6 +207,8 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
                 key=storage_account_key,
                 container=storage_default_container,
                 file_system=storage_default_filesystem,
+                resource_id=storage_account if not is_wasb else None,
+                msi_resource_id=storage_account_managed_identity,
                 is_default=True
             )
         )
@@ -218,7 +225,14 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
             for s in additional_storage_accounts
         ]
 
-    cluster_identity = assign_identity and build_identities_info([assign_identity])
+    assign_identities = []
+    if assign_identity:
+        assign_identities.append(assign_identity)
+
+    if storage_account_managed_identity:
+        assign_identities.append(storage_account_managed_identity)
+
+    cluster_identity = build_identities_info(assign_identities) if assign_identities else None
 
     domain_name = domain and parse_domain_name(domain)
     if not ldaps_urls and domain_name:
@@ -306,10 +320,6 @@ def _get_rg_location(ctx, resource_group_name, subscription_id=None):
     # Just do the get, we don't need the result, it will error out if the group doesn't exist.
     rg = groups.get(resource_group_name)
     return rg.location
-
-
-def _is_wasb_endpoint(storage_endpoint):
-    return '.blob.' in storage_endpoint
 
 
 # pylint: disable=unused-argument

--- a/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/util.py
+++ b/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/util.py
@@ -23,7 +23,7 @@ def get_key_for_storage_account(cmd, storage_account):  # pylint: disable=unused
     return storage_account_key
 
 
-def get_storage_account_endpoint(cmd, storage_account, dfs):
+def get_storage_account_endpoint(cmd, storage_account, is_wasb):
     from ._client_factory import cf_storage
     from msrestazure.tools import parse_resource_id, is_valid_resource_id
     host = None
@@ -37,16 +37,16 @@ def get_storage_account_endpoint(cmd, storage_account, dfs):
             resource_group_name=resource_group_name,
             account_name=storage_account_name)
 
-        def extract_endpoint(storage_account, dfs):
+        def extract_endpoint(storage_account, is_wasb):
             if not storage_account:
                 return None
-            return storage_account.primary_endpoints.dfs if dfs else storage_account.primary_endpoints.blob
+            return storage_account.primary_endpoints.dfs if not is_wasb else storage_account.primary_endpoints.blob
 
         def extract_host(uri):
             import re
             return uri and re.search('//(.*)/', uri).groups()[0]
 
-        host = extract_host(extract_endpoint(storage_account, dfs))
+        host = extract_host(extract_endpoint(storage_account, is_wasb))
     return host
 
 
@@ -90,8 +90,8 @@ def parse_domain_name(domain):
     from msrestazure.tools import parse_resource_id, is_valid_resource_id
     domain_name = None
     if is_valid_resource_id(domain):
-        parsed_subnet_id = parse_resource_id(domain)
-        domain_name = parsed_subnet_id['resource_name']
+        parsed_domain_id = parse_resource_id(domain)
+        domain_name = parsed_domain_id['resource_name']
     return domain_name
 
 

--- a/src/command_modules/azure-cli-hdinsight/setup.py
+++ b/src/command_modules/azure-cli-hdinsight/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
@@ -30,7 +30,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-hdinsight==0.2.0',
+    'azure-mgmt-hdinsight==0.2.1',
     'azure-mgmt-storage==3.1.1',
     'azure-mgmt-network==2.4.0',
     'azure-cli-core',


### PR DESCRIPTION
## Note

- Update `azure-mgmt-hdinsight` SDK version to 0.2.1
- `az hdinsight create`: added the `--storage-account-managed-identity` parameter to support ADLS Gen2 MSI.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
