### PR TITLE
[AKS] handle older kubectl versions in "az aks browse" 

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.3.19
+++++++
+* ignore listen-address argument to "az aks browse" if kubectl doesn't support it
+
 2.3.18
 ++++++
 * add listen-address option to "az aks port-forward"

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1401,11 +1401,13 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False,
     try:
         try:
             subprocess.check_output(["kubectl", "--kubeconfig", browse_path, "--namespace", "kube-system",
-                                    "port-forward", "--address", listen_address, dashboard_pod, "{0}:9090".format(listen_port)],
-                                    stderr=subprocess.STDOUT)
+                                     "port-forward", "--address", listen_address, dashboard_pod,
+                                     "{0}:9090".format(listen_port)], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as err:
             if err.output.find(b'unknown flag: --address'):
-                logger.warning('The "--address" argument is only supported in kubectl v1.13 and later. It will be ignored.')
+                if listen_address != '127.0.0.1':
+                    logger.warning('"--address" is only supported in kubectl v1.13 and later.')
+                    logger.warning('The "--listen-address" argument will be ignored.')
                 subprocess.call(["kubectl", "--kubeconfig", browse_path, "--namespace", "kube-system",
                                  "port-forward", dashboard_pod, "{0}:9090".format(listen_port)])
     except KeyboardInterrupt:

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.3.18"
+VERSION = "2.3.19"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
#8408 relied on a new `--address` argument that only appears in `kubectl` v1.13.x and later, so it effectively broke `az aks browse` for most users. This adds fallback logic to call `kubectl` without that argument if need be.

I've tested this with various versions of `kubectl`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
