### PR TITLE
`ad app credential reset`: drop the assumption that app's service principal always exists

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,6 +2,8 @@
 
 Release History
 ===============
+* `ad app credential reset`: drop the assumption that app's service principal always exists
+
 2.4.1
 +++++
 * `az ad app create/update`: support app roles

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -81,13 +81,19 @@ def load_arguments(self, _):
         with self.argument_context('ad sp {}'.format(item)) as c:
             c.argument('name', name_arg_type)
             c.argument('cert', arg_group='Credential', validator=validate_cert)
-            c.argument('password', options_list=['--password', '-p'], arg_group='Credential',
-                       deprecate_info=c.deprecate(expiration='2.1.0', hide=False), help="If missing, CLI will generate a strong password")
             c.argument('years', type=int, default=None, arg_group='Credential')
             c.argument('create_cert', action='store_true', arg_group='Credential')
             c.argument('keyvault', arg_group='Credential')
             c.argument('append', action='store_true', help='Append the new credential instead of overwriting.')
             c.argument('credential_description', help="the description of the password", arg_group='Credential')
+
+    with self.argument_context('ad sp create-for-rbac') as c:
+        c.argument('password', options_list=['--password', '-p'], arg_group='Credential',
+                   deprecate_info=c.deprecate(expiration='2.1.0', hide=False), help="If missing, CLI will generate a strong password")
+
+    with self.argument_context('ad sp credential reset') as c:
+        c.argument('password', options_list=['--password', '-p'], arg_group='Credential',
+                   help="If missing, CLI will generate a strong password")
 
     with self.argument_context('ad app credential reset') as c:
         c.argument('name', options_list=['--id'], help='identifier uri, application id, or object id')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -1398,14 +1398,16 @@ def reset_service_principal_credential(cmd, name, password=None, create_cert=Fal
     # look for the existing application
     query_exp = "servicePrincipalNames/any(x:x eq \'{0}\') or displayName eq '{0}'".format(name)
     aad_sps = list(client.service_principals.list(filter=query_exp))
-    if not aad_sps:
-        raise CLIError("can't find a service principal matching '{}'".format(name))
+
     if len(aad_sps) > 1:
         raise CLIError(
             'more than one entry matches the name, please provide unique names like '
             'app id guid, or app id uri')
-    app = show_application(client.applications, aad_sps[0].app_id)
+    app = (show_application(client.applications, aad_sps[0].app_id) if aad_sps else
+           show_application(client.applications, name))  # possible there is no SP created for the app
 
+    if not app:
+        raise CLIError("can't find an application matching '{}'".format(name))
     app_start_date = datetime.datetime.now(TZ_UTC)
     app_end_date = app_start_date + relativedelta(years=years or 1)
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_application_set_scenario.yaml
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_application_set_scenario.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: 'b''{"homepage": "http://cli-graph000001", "identifierUris": ["http://cli-graph000001"],
-      "availableToOtherTenants": false, "displayName": "cli-graph000001"}'''
+    body: 'b''{"displayName": "cli-graph000001", "homepage": "http://cli-graph000001",
+      "availableToOtherTenants": false, "identifierUris": ["http://cli-graph000001"]}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -11,15 +11,15 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--display-name --homepage --identifier-uris]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logo@odata.mediaContentType":"application/json;odata=minimalmetadata;
-        charset=utf-8","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logo@odata.mediaContentType":"application/json;odata=minimalmetadata;
+        charset=utf-8","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
         cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
@@ -28,15 +28,14 @@ interactions:
       content-length: ['2061']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:37 GMT']
-      duration: ['18096497']
+      date: ['Sat, 02 Mar 2019 04:12:26 GMT']
+      duration: ['18020790']
       expires: ['-1']
-      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application']
-      ocp-aad-diagnostics-server-name: [raR8JNajDTfwSzq60owihwvzZvfOxnwzwr6uWdDMZbM=]
-      ocp-aad-session-key: [DPI9QPcPDomyvhdsYFl9o0YkpGMUwi1KojHL0AJXW0e6IQJtsEaqDa5LzDPYBfKJndU3y2O-OBoNjL-7plDJTp3YOtUNFgeiArLYC-vDBBWlJeMIzIlooYbCQ0vgWW6vpGpHglLF9ayhXropy8YjCg.aDI0m7GLEKw-nQakZgW0NRXtCCSgWRO70sID6uJxDNQ]
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application']
+      ocp-aad-diagnostics-server-name: [fQLJJo2NQKA1MEYhE9K05hCw7w6tp5qp0L6SHCVm0xw=]
+      ocp-aad-session-key: [VvPhvlE3U51uXHbtSDJ5FIV-NDYUUH2zrk0mbQGr9jyI5KYtl9eU0h6aROJHEq3u9KUSwwAYsVfoiXfY4Q7-yePmyUKh2WP5jfsN2umNiFvEjVqhhKByDTwb3x0VTfHdam8jwYIrzSsuMqnzCaSlxg.o4BTq8n_A-igxg9Kyt5hGVk1jLV_RLVkNh9qe3biiG0]
       pragma: [no-cache]
-      request-id: [10a31937-8e6b-4e45-9e34-736088b5b682]
-      server: [Microsoft-IIS/10.0]
+      request-id: [09c1f629-bdc1-4bb3-8fb4-64d19bc1e6d3]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -47,18 +46,51 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      CommandName: [ad app show]
+      CommandName: [ad app credential reset]
       Connection: [keep-alive]
-      ParameterSetName: [--id]
+      ParameterSetName: [--id --append --password --years]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6&$filter=servicePrincipalNames%2Fany%28x%3Ax%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29%20or%20displayName%20eq%20%27http%3A%2F%2Fcli-graph000001%27
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Sat, 02 Mar 2019 04:12:27 GMT']
+      duration: ['527216']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [qZIv9ellq3w2fi4Frv5Uk50GFg2QtOwXyXvP/LyXimo=]
+      ocp-aad-session-key: [Sr-T5bnNFZ55e_2j9BWiIztQYRqXz0WlKCHO2U8gPN1u9oAscLrbHBkY4PxX3X0iSl5v_QA3CKvAjUmq859Y6B3scc5jHIb3psesOYlmd9Juypk4WD5QBIWfqA4OvArMwuJJUhpjpCbE2GVKHO5dHA.jFmHo5ELPP_3LXfG7xSnAhykJue1FH69PdMO7qyiN_c]
+      pragma: [no-cache]
+      request-id: [04c61093-222c-4df6-9fca-12e7f3f01013]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app credential reset]
+      Connection: [keep-alive]
+      ParameterSetName: [--id --append --password --years]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
         cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
@@ -67,14 +99,154 @@ interactions:
       content-length: ['1978']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:38 GMT']
-      duration: ['585242']
+      date: ['Sat, 02 Mar 2019 04:12:28 GMT']
+      duration: ['615560']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [k+a8loBjbxraN1otxCzpa/lm7sS3uSMfCmXQCJ5UeOg=]
-      ocp-aad-session-key: [39HXETz5n4TjWhOmOXt-bS3RYmr0CylChO0D5jnku0yNNea0uiSz1nTk-JmDubnvLaX3b80tUJoAZXk2MAgg5I_YUKazeNkOJru5jh_7sWXhnViY3u2FgkRJMwO8eLnBkHiAiRze4GnsfU0tawygFg.ZAXGDUsulxbSm_3c3n-BPMlkcyzuZPceq09Ti1E6Vrk]
+      ocp-aad-diagnostics-server-name: [qxvg+LgKyuIFTpm0XjmicPMsnZzmR6m/OWBxHpYTkp8=]
+      ocp-aad-session-key: [3QaY5blMIP29lAtH3qDFjezI-TAQyrtWN9vfWlLSXe44LhZjhs5UgJKv7He9NUXwDFdeyCA_3TKv4VdsdDgcWbjhp_QYu8vdRwjHzdhhpnlTHq55oSMSHq0Dc93KSRwI-ioKBlbH4JMca4J76jbLbw.8Ek7-eo-LyNJE62eHiDkTVJWycftyTChu1m2ViUKgfg]
       pragma: [no-cache]
-      request-id: [fb913da4-6879-4b15-bd5a-69f70d91dfbe]
-      server: [Microsoft-IIS/10.0]
+      request-id: [fd9fd298-f7bd-4c6c-b68c-5161e1010f30]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app credential reset]
+      Connection: [keep-alive]
+      ParameterSetName: [--id --append --password --years]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1975']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Sat, 02 Mar 2019 04:12:28 GMT']
+      duration: ['648031']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [hjR4RY9nRvxALTOJY4KnXfIpjm/qwj5JntibyjsUFsE=]
+      ocp-aad-session-key: [_qc7bwYQdtTwYJxyWlF-H9Nb7PNISYuNalTioKCDKGrOoHtZE9h0v7GQr1wbklT3rBjkteML-Hv8shmwzXAG0pxMzuqalLfanqBJRYa1soTwRYlnVki75wyVtoXlP9Wx8PXw3KmwCjWL-S8ozCN6EA.H1l8wXUP7Azsd4_qO1h90fm3WoJ0RsNFg6D2_pIjO0g]
+      pragma: [no-cache]
+      request-id: [74c22af0-bbca-4e7f-93eb-60a7cccf0079]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app credential reset]
+      Connection: [keep-alive]
+      ParameterSetName: [--id --append --password --years]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578/passwordCredentials?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)","value":[]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['163']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Sat, 02 Mar 2019 04:12:28 GMT']
+      duration: ['586935']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [HsKElesTxiLgdPMB0FbOxcZnfgWfQ52qrxu3V/VUL9s=]
+      ocp-aad-session-key: [e-GT-O4HF-tihHF8r2YC023MO4KJW85G7Pq_k9rR_oH-PA4qzKCol6sgDtZdlcxfumgJtkd49HKfOQf837LWiWiaLiIhEEuqFqGXSM4pZyKI6dqCjYhSMlRtS9migD6nAoYcQT0yaki20dhhe0xvIw.BHc0J3K3MvOcDESkACZMg0NCuNDkQkTUqroh0lCI8Jg]
+      pragma: [no-cache]
+      request-id: [a66458c2-b093-42ab-ba78-6e20b295afe9]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"passwordCredentials": [{"startDate": "2019-03-02T04:12:28.90031Z", "keyId":
+      "57f2ddb3-f0c7-42a8-9922-ceb76c33847a", "endDate": "2021-03-02T04:12:28.90031Z",
+      "value": "test"}]}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app credential reset]
+      Connection: [keep-alive]
+      Content-Length: ['177']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--id --append --password --years]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PATCH
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
+  response:
+    body: {string: ''}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      date: ['Sat, 02 Mar 2019 04:12:30 GMT']
+      duration: ['10233674']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [I4v0qcnOlje1nXMrnV4NRb3YM/2Yho5JJMkIV0jxR4s=]
+      ocp-aad-session-key: [hDd7Oj0Urnpg3wiOKijeVE_BJhyfw3TGUbzHAzETXL0QcqRGMGZxQ-n7TiQlyThuRGpyMAgdLaj3-GUP-b7ujKc3ddjHCvyT8TWNyZKtBKMNTxjDksCaLzubrfdsIp4dR7UaXGz0MmueGm39E_7f9w.ABlmO3kLiiGydiTNp91TraUaB5dG4BeOLcQMFisSw8k]
+      pragma: [no-cache]
+      request-id: [ae9bf65b-cdd3-40ae-ae0c-257e30efbc4c]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app show]
+      Connection: [keep-alive]
+      ParameterSetName: [--id]
+      User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['2146']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Sat, 02 Mar 2019 04:12:32 GMT']
+      duration: ['586318']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [3uFtEmQkGsYUBnGiEwpn/QXOmYb7Leu7TgWcHwMJLO8=]
+      ocp-aad-session-key: [BVSOXUfPXWwZqo01L2Szq16rB5H0PN7VNa22zgAwrURslKf4XK7vl2blnq-lIyITS_4_fkiSYxVJ4wgwgpRKKRsLEotgV-AFnvjfCJNr-M23T6LCFHHhv7ZjhEgL18hRppjIBh28CJh5ZRsTJgJVfg.vUkW-w9do2ndOjCmh8IsgOPXDcwsgAHl0vNPa2nYbgU]
+      pragma: [no-cache]
+      request-id: [45c6f357-6d23-4132-aca9-4fcc3efd6331]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -89,30 +261,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1975']
+      content-length: ['2143']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:38 GMT']
-      duration: ['605239']
+      date: ['Sat, 02 Mar 2019 04:12:33 GMT']
+      duration: ['598567']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [QYQhfzFNSSm8b00C1v998memm10SZTVuigsYyWtHlfQ=]
-      ocp-aad-session-key: [C5lhlHEzlKXWCQuqZ9ZHgd--Aseo62wddHWYUjcWugBewY2RREwPdgL2Dyqhe7WR22y_Yr1XA0PN4KAJKtaLZFGwLNcSVTL3f-QbIyc1rjsPYIM8JT8tP9bBOwzxSz9gB8Gg6sOD2nUyM_2HacGJEg.jpGprRwgdABEGzQO6Rn45-sZYcsH--iXsW1ImsMdZ2Q]
+      ocp-aad-diagnostics-server-name: [FbAahKj+CAgBE9nDxnX/a9xy4bKzwpDul27qCyangJw=]
+      ocp-aad-session-key: [GbLGWmRn1e1aP-biKJBiB2uz1IZDM7URdgE8HR-BRJ0I6q-piaHzfW5_-lCa8yAVhHHVcBIY6WKx3dmNodQ4hWh3t6vz5ossxTZxmzLQj96VCigxaWwrRjX5slNoH0AE5kPLchC5DF3Xu2a_uWrlgA.wmRwXPwxJuwdZQAFpjaz7I0VbwxKghq5lCXglw-4uZk]
       pragma: [no-cache]
-      request-id: [8c94a0d9-33e0-425d-b395-4a0c888bb1f4]
-      server: [Microsoft-IIS/10.0]
+      request-id: [f3571b69-65fc-4ab9-b334-6b6534248070]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -127,30 +298,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--display-name]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=startswith%28displayName%2C%27cli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1978']
+      content-length: ['2146']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:40 GMT']
-      duration: ['631609']
+      date: ['Sat, 02 Mar 2019 04:12:33 GMT']
+      duration: ['1077186']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [uHyVfaWnz1wZ+Kit9M+ndgirzc7H4vyg8f/Bx6SxLLI=]
-      ocp-aad-session-key: [Sklv4kWsHUcc8t2Yi3ohZD1sALPhuHXrLosvReHyuirYanJ194daNkZGiBf4N5LGvcihRAZ01-a7Vy0OJwYmN2OT2hI04mtSgJpxtBKf7cD33gjVrEONS8x4oOztVkmgP7BVoeb7VF8rrF0Hj558vg.ofcN1GMAhWMS4rNHv9TY5mK4Qp3hbuNDLg8yIyz0zJQ]
+      ocp-aad-diagnostics-server-name: [PJW6A+9+3YfylcLR1ajT1cnYjGDNUw+aeQtcF3NJNzY=]
+      ocp-aad-session-key: [CHYLubX8BhsVVIgO8veQU6UKwubXP23oCe0efPqHC1y5iO0f8Bbw1nmnLJDKOzOtyRZYxW99xQMUgo-Jg1LMLh_X-EtMQ0z_9fET7j8gqiwWb8FKiJ0FED-BJBf3jBaxGGVr2any98ay7nN823C46g.WkgEk8FJlXDzczda0gv8qE5VOZQJe-pQ8Iyg_9bPyaA]
       pragma: [no-cache]
-      request-id: [29df1290-d5d2-4fa1-9c3f-c705a5521c65]
-      server: [Microsoft-IIS/10.0]
+      request-id: [85c5c5bf-d523-4cc0-8645-96cac5272e59]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -165,30 +335,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id --reply-urls]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1978']
+      content-length: ['2146']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:41 GMT']
-      duration: ['603804']
+      date: ['Sat, 02 Mar 2019 04:12:34 GMT']
+      duration: ['591597']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [VRduinh48wLsWX4gv475GCgG1fPJPOTtSGWFaOBDTQM=]
-      ocp-aad-session-key: [BQqdoNHDtUqRk6b71XmWTVu39-3dygrsutKyoTVS9S4Au6-uMAS18pFlzNxLgKE1JyF_LB_EjDx_oahRov3FDafe140EBPexgeALxMB87UgP1R9haZqmynZ4trU8LQfI1PSnLyrFJzvaYFMN-kQshw.bSKtJvxODo6Rvgy2BIgsM7zAQIsNqxQhoY6ANLALf5I]
+      ocp-aad-diagnostics-server-name: [IPBOae931bn+bJPBnT4uNOWiCrRKetFJ3jeGeHc0YHk=]
+      ocp-aad-session-key: [d3zxyqpXCiWuj2kG9vegO0BgV2yAmTBqir8uOyTPM0NlBoUoj5mCw80ZX42YbRzgKNqCU4Ziwyb9QysHAv_TWf6QBoWFr2ETQezw4_vu1oEOu1ITfsqTYSpv17cmxuC7k2Lcj2KHd_4cQOQ4pKBBhg.dSxOnCNLQ-SEdyWhGTxau8elxgl8a8kcir1aUshLxnM]
       pragma: [no-cache]
-      request-id: [ae13ef95-d12e-4800-81de-caaf9fc19b06]
-      server: [Microsoft-IIS/10.0]
+      request-id: [d8115e79-cff9-4dc8-81b6-6d2c6bafc45a]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -203,30 +372,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id --reply-urls]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1975']
+      content-length: ['2143']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:41 GMT']
-      duration: ['600368']
+      date: ['Sat, 02 Mar 2019 04:12:35 GMT']
+      duration: ['624176']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [NecIdAbtcl2G5DavAD0ay+NyJ0bZ8m4qvkKAOpQmV0w=]
-      ocp-aad-session-key: [YkFyvokXQfjg4N6WMKjHmc4IJiQnfNGxFVwVCZRRq9Q8dXi3ZiRkP1og_v1um_14FLp4hlnHy7pRlLvAeHbvdXV2U0fjnQrhMkQ1vMGeG8IqhDOXFBubivzzoULeCpZZaahk8CYHThqYG2j1VtCo9w.GlnIIG_HF54GyZgRfnkm2a6smUClHsh2ru0DEj3s2bI]
+      ocp-aad-diagnostics-server-name: [K3c4HDsd49YJALs5QZYFWCZXAibSIuNgH0HMT0cyA7s=]
+      ocp-aad-session-key: [75GV-HQf094Us6dMY1JhsXmeR9OErdtFgqHkvZh4QyzSbR4gAyj5oWiZ6z1zUqbZVjI2OvXJ3iDZkF3lMhGbYmq41p7QKBKzHBpCtKLWHf_FvFMc39a4-viTYzMH3JXu5IZdtd79WCm-ePltM5TSaQ.2X22pmb4IPdfdZ_9eaBFgLfBQG3-EDy75ylDNkiCTZk]
       pragma: [no-cache]
-      request-id: [08aa6161-3ed3-4bec-8c25-ba95ec675af1]
-      server: [Microsoft-IIS/10.0]
+      request-id: [3267c137-d50f-4865-b659-2aa7f8b4e128]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -241,40 +409,38 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id --reply-urls]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['1978']
+      content-length: ['2146']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:41 GMT']
-      duration: ['599934']
+      date: ['Sat, 02 Mar 2019 04:12:35 GMT']
+      duration: ['597078']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [uHyVfaWnz1wZ+Kit9M+ndgirzc7H4vyg8f/Bx6SxLLI=]
-      ocp-aad-session-key: [j_w8BqTE_1P-hYM94QU0ztoZe6ELWEJVgf35ivUaQiPaKKaT09wd10FsFgiq-oOK-2pjpJbZ2UIpa4f0u9u-TRKvYabhQBEmGL35aVo8JAOZA3UoWVte_3YWWvlq4swIvunzEDZ1NrKwIEQeh2INEw.OEZyMMGlOe-oY72yESqUtrYt2Byl23jE51mKcfTnBIk]
+      ocp-aad-diagnostics-server-name: [n89Keg3phw3NGk9ObUqYNFrQ8gN7RlXt/txUE8fYons=]
+      ocp-aad-session-key: [6-Ps4fGFxhOAS_hij4H-2zqOilvn3T_3Yo_FSo3kLpKPquNMMsF-zRmUaVRBBh2L8RpuWaxEp9THTGcSv_Zf_BsrbB2nE4-S31YIQ0K-OHwfYoLGlt9IIvU9uomP0G0ngypxR7U9fZeGxEL1rXGHuQ.n-vdrsaSmisPI54x_dnry9lJWKOqFv797EjjSEpCN1I]
       pragma: [no-cache]
-      request-id: [6672fbe9-c2dc-4743-a789-7edc748e2d00]
-      server: [Microsoft-IIS/10.0]
+      request-id: [30547961-e7df-484a-af96-d658a549dae9]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"identifierUris": ["http://cli-graph000001"], "displayName": "cli-graph000001",
-      "requiredResourceAccess": [], "homepage": "http://cli-graph000001", "replyUrls":
-      ["http://azureclitest-replyuri"], "availableToOtherTenants": false, "oauth2AllowImplicitFlow":
-      false}'''
+    body: 'b''{"displayName": "cli-graph000001", "requiredResourceAccess": [], "homepage":
+      "http://cli-graph000001", "availableToOtherTenants": false, "replyUrls": ["http://azureclitest-replyuri"],
+      "identifierUris": ["http://cli-graph000001"], "oauth2AllowImplicitFlow": false}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -284,23 +450,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--id --reply-urls]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      date: ['Sun, 17 Feb 2019 05:43:43 GMT']
-      duration: ['8776544']
+      date: ['Sat, 02 Mar 2019 04:12:37 GMT']
+      duration: ['8796002']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [ugNwVUhy/uil8Pg9hUjbVUCmwvlEB5WBlRSXf9K7vo0=]
-      ocp-aad-session-key: [xp7fOnGSvDq53tqWH96bgEmJkVeckZydvZoRQCJzsVFQ0LDnymwutDcVqFNho2GU2ANN2AQyNDa0L8tlVG9byiI7LNGiYcyTYEnzdhXalUb1z2-NVXaf8lQZv5vIyisoLsCqoiXjok4hd2wqAyO2xA.QoQuxAikIIz7uGvU0QHPI-8_w4WtVsyrOa_6OU2OMv0]
+      ocp-aad-diagnostics-server-name: [3abjruB1Cy3okP0vEppZNocrEoQDzP7wunknChspjP8=]
+      ocp-aad-session-key: [Kc9xXjh8iXPCaqY8uEiQYCnailZ7ETBrz9a3jUXhPJHANN6aiBv_AYAwcC-2DPYpX7u6wwgDb8pH0KOWbKyf2dTH4KMBGtyy6Cd3v_BPwSSBhFEgI6eQzETjoUKtgbRbn570kSwIAZo4lZB8Hk6ILA.IxASCrToXfvBHbvsLu2k4iG1JTIBnq94zG7T55YMMDA]
       pragma: [no-cache]
-      request-id: [4e0ae882-b2e2-4d97-a8c5-822c46247231]
-      server: [Microsoft-IIS/10.0]
+      request-id: [51462e3f-a6a0-499f-9131-8e04049eb36b]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -315,30 +480,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2008']
+      content-length: ['2176']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:43 GMT']
-      duration: ['619763']
+      date: ['Sat, 02 Mar 2019 04:12:38 GMT']
+      duration: ['611603']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [Sv8LAqxM3Xd8KdoykW0mGkYyWG5hzFClI07Ok7DI0I8=]
-      ocp-aad-session-key: [rvUOxrQVretjuN3ZFc4tSMWZDzPh9oZcmheBGDu0ZInDdL0PZcmslaXTggifjyDw3xfcWnvf9oQNATDXQOp9ZOEr5Xl40cfW0w3yQjVj6ZrbjyUh_suYcKFK1osnxDuPSdYQ-Xcp6Y6yFrrkIyHuLA.yCp9_JbkWy6CKvzyJZSIc6b5wvjICK7ZBoLSnchay7Y]
+      ocp-aad-diagnostics-server-name: [YPT0bBpwREL5IJMIvN9GoYV1GS3mAXpIf09yabKcdz0=]
+      ocp-aad-session-key: [Byzvpt7s7uPdWjuDzHotsWVS-sDPp27HyEsGkxJjb6NCRLan1Ua14fJ-6hzr2JDocyEH3GRKlsDMZeL4051WcHwibUzrK-k_gdIB42I9M2IJPYbBJk005JBloVrM75s93hW4FXIFhY078ujixLdKoQ.X87zV915HFSuvNMDo-5Su305afrIBIY_2gTNh0HVnkE]
       pragma: [no-cache]
-      request-id: [07ca7012-fde4-46e9-980e-b95a0c36ff61]
-      server: [Microsoft-IIS/10.0]
+      request-id: [4508cf7b-d5e7-4cfc-a378-23956b8f222d]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -353,30 +517,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2005']
+      content-length: ['2173']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:43 GMT']
-      duration: ['596959']
+      date: ['Sat, 02 Mar 2019 04:12:38 GMT']
+      duration: ['587070']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [rqFHakQzSTiIKdfw0wHGNAyRxVqvFXPolGeTItcd2iI=]
-      ocp-aad-session-key: [sJ3jZu20FZBt1Wa5fibI2qcg1riWZYw4tEJ9zxkgY3WEXvoc8vV1Hr77kvlLUCM2--ZYyIKsUcnjQO-f2yoh0lfWYrFJq4weXzzHiD5up9oia_M6Jn6Q1tVcMOdd3tp_WhPvfkpTpaBtQuCWGPhftw.Pswl-0I1aY1UbCoREGBoyKf2Ge9DReKAKTiEO4tBWLg]
+      ocp-aad-diagnostics-server-name: [cTwo30nQLdbKrpTXiHay43uRQqpX8SWr3xHBnYc4xok=]
+      ocp-aad-session-key: [frl6tL_-vUddxWaiTyTnPpHixvpio7Cpn37hXoZcznMkUCJI6tFvfWEaSwVnPzxsB49afLgtE_GKHWLn6og5I4fqiC9lHwpVNoQXyNbOUb-aw0_lQSS7_cHyfjve2WEnMo_zO6dSLhV-uPbWQrSRBw.Nr-DZoufLz2BTTBbbtbjzGYw7dxKZBwSakW6uaO-orE]
       pragma: [no-cache]
-      request-id: [0d627ed7-f2a3-4d33-9ee2-cc2a4a24aaf8]
-      server: [Microsoft-IIS/10.0]
+      request-id: [61a7710a-a291-46c9-adb9-2edb6a09a84a]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -391,30 +554,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id --set]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2008']
+      content-length: ['2176']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:44 GMT']
-      duration: ['616856']
+      date: ['Sat, 02 Mar 2019 04:12:41 GMT']
+      duration: ['632368']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [27ZEr0h18RCw5oe/AROzipmgItY/LYG5YIwwA5EOEKk=]
-      ocp-aad-session-key: [CqrvH7JaxtY2TJW_-QhlMbWKVGrOCxPq9WwywSpcxI8cFP-D-4wV6_R8-Y3veX9uojb-mrF9lY06V2nzMIw4-6yYO7wri_0irrbSyPoPYUc9hggnGNv7R1OrpwEODBgevGu4GFBcHvhY7dc0EHCuiw.zXgo17c_Cjq5ZFQC7hD4uP4TX09fDOcXcp8OzFl8uo8]
+      ocp-aad-diagnostics-server-name: [vzT+9Yq+aEnlFAqW4ArMt4wc+vCo9D3Xgf5jgx/UnQk=]
+      ocp-aad-session-key: [AmK3bvOC1rYDo1O3xBmfz9uG3oEGl9uZaAna9oE-kr_Hx5WbNkdAGWd-W8DPs0nJlzd7S_6zLMNiEZpjJj3KBWCjnrSNzBSYihojUAzLNlSW2Glr2myPyxxcV9Ms2QXUPICHdkmYFUO0C-QgBPJ1xw.D19nMNvB7mQMkPm--C59CP5iukb_30OPIJK46Rt8_vM]
       pragma: [no-cache]
-      request-id: [3d0a441a-cd11-41c2-806e-e34458be789d]
-      server: [Microsoft-IIS/10.0]
+      request-id: [628af137-b42f-489e-9a39-05140a181aa5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -429,30 +591,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id --set]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2005']
+      content-length: ['2173']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:44 GMT']
-      duration: ['578049']
+      date: ['Sat, 02 Mar 2019 04:12:41 GMT']
+      duration: ['729919']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [+i/Z4hAbtnUv8GUTjtLUQH8z9Wzcl8K6N3Y4i1a4li4=]
-      ocp-aad-session-key: [m_fbYX4mfm9o5y3iSI1aykTyysZYO0DchObo9XjhutZ1p2uNClGVaS1Gwm4Kb3RaQ60Lk2Qp41rFyCLXeU-CLiW6qZOkFt0BSOju0kQAMSni8pmWdLBZUp2Nh6m0lwIqQaqvwBd_IqKmjCP_BiaZog.RKYWS4iCLACbyVIkuQoM1JotcELPhzawwYAWWd-81p4]
+      ocp-aad-diagnostics-server-name: [tw4fYXYGY2N8zzisqCfrGN37d/pH/8bdST30drhOOag=]
+      ocp-aad-session-key: [BfoiD3LhFskomjiQ8YelJlM9ectsK8d5mfjoux-K6EnAdn1tp5lBwNwwJu9R3iblAY6RGpGtKCCYUKXeSfHElDlpJtDk9fwnDYojP0ecdu2xDvPXyBCW7Z-sm5LzZdEKfaHnDLdn9T8Ns0Po_rl5hw.e2cRsRfwcFVRkk_fm43J6ovPJNR9l1lK8_oLcNRknjQ]
       pragma: [no-cache]
-      request-id: [de4c6011-e3c0-422d-ab03-71ea6b3b1379]
-      server: [Microsoft-IIS/10.0]
+      request-id: [f1805cc8-780f-472c-86e6-1a8b348280ee]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -467,40 +628,39 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id --set]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2008']
+      content-length: ['2176']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:44 GMT']
-      duration: ['1312135']
+      date: ['Sat, 02 Mar 2019 04:12:42 GMT']
+      duration: ['603354']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [TXHS25292ScTeNNLyF6Lmk7CTfticyySnjF/t2td1Jk=]
-      ocp-aad-session-key: [_aVcqC-As41aRlVpsW8wgtlA_h62InnBRuHxbXZePDeDVMldUe2IpwyVqHOVIhYC6tHEeG40lgmlJGCzrYnf5Olf0c3eIYeKkCZNk0kbyLMDY_QnP-mGKfOt76GBlHro62Ph0Z5d2Tzq0ar1I2tUPA.ohAVHGtYOcsjNZ4F0yQapRWT_PzwAqoG6_-hpP-7jcs]
+      ocp-aad-diagnostics-server-name: [9RY9kHjIF0sEXCnKZC1J9QU6hhbta/WWZ84XWn9UNrA=]
+      ocp-aad-session-key: [rLjhM47y1aCESGR7By4VOcbxtXMUXXFYO-Hyoi0yjLxZ1gmIiHm51aHX_ERk1PL4VSlrIpesFZpdiv9gO-C3iY9zU8khJSAOVcLouj42NLveihLgAQ3eK6oDpJzg6dEWC3C9Tr0F70zQmCigfnw6Fw.eePaIZ2Udky3AmdxKKJwVrLf64yaiPBeIqDOI4ez2E4]
       pragma: [no-cache]
-      request-id: [86c69897-4d0f-43d0-9782-f7dd27696ef9]
-      server: [Microsoft-IIS/10.0]
+      request-id: [4af23ef3-7175-4a82-b262-a3df2975e20e]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"identifierUris": ["http://cli-graph000001"], "displayName": "cli-graph000001",
-      "oauth2AllowUrlPathMatching": true, "homepage": "http://cli-graph000001", "replyUrls":
-      ["http://azureclitest-replyuri"], "availableToOtherTenants": false, "oauth2AllowImplicitFlow":
-      false, "requiredResourceAccess": []}'''
+    body: 'b''{"displayName": "cli-graph000001", "requiredResourceAccess": [], "homepage":
+      "http://cli-graph000001", "availableToOtherTenants": false, "identifierUris":
+      ["http://cli-graph000001"], "oauth2AllowUrlPathMatching": true, "replyUrls":
+      ["http://azureclitest-replyuri"], "oauth2AllowImplicitFlow": false}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -510,23 +670,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--id --set]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      date: ['Sun, 17 Feb 2019 05:43:46 GMT']
-      duration: ['8786491']
+      date: ['Sat, 02 Mar 2019 04:12:43 GMT']
+      duration: ['8727634']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [1pVa3SlLPlVewEEcHffOLEuXLDc15b2N8ELA+M5a7zw=]
-      ocp-aad-session-key: [fOJKiWiRN4ZbNNx-pgvr4czj3V5GuBuzY9D3XonHyFx6sGi56LWWNEmKpTUtmuAjMzXtC2zsltWjkwPAJ3OcYo4WX_la1J-84AgIUZRfqJF8KvpS1nNg2V4kcczrcqhADumKzqaxsdv_QMnUd8iP7g.1T8fwWvJwmm0P37WzGKuQyq5D4sB15ocOuFNaEelWfc]
+      ocp-aad-diagnostics-server-name: [BXRgh3eu6YIFumaSZy7lFEXIwtoZR+AXCAi0P8igTHU=]
+      ocp-aad-session-key: [1TYHTYg3G6iFnhcFXafTKA6oqf8elEoM2K5U4H1lbHgVQ56qOx6DFwgpmuOsXF_oNx_MQzeVy6vJbdGTs6Z0qsvKFz8RfvJ3ljlv4w-PFtKIiwMFz-BdF-vMhB7QuumohlgT7TiCcU5H2YRBZUuSCw.IStWii_WAcGItrhtP-yFYNMx6D09WIXnq6_yQsMKDDw]
       pragma: [no-cache]
-      request-id: [d63cd351-0e45-466b-a7d1-42823006feb1]
-      server: [Microsoft-IIS/10.0]
+      request-id: [bdc6f5a3-a94b-4b2f-8677-8a526c7b5499]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -541,30 +700,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2007']
+      content-length: ['2175']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:47 GMT']
-      duration: ['574755']
+      date: ['Sat, 02 Mar 2019 04:12:45 GMT']
+      duration: ['641770']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [bLgwXkOhOVEk3vC8NHPdSIeFqRoOWvrUxR2wO1wjuQ4=]
-      ocp-aad-session-key: [gVtG26fzrGi8lnD4HH7zE1cj_aJp_HntgBjLk4rwPIsfz4bAJevl0Xjz22NDhHhyndSkPWYAzkF0_zxCvg_hVLbHk6BmfSOOiWQjp1LbM5hs2JjxhgUhSUkvpZTHxTOo8veyTYk3gj-YOK44gr42MQ.4nyFU0fxLBtLf4eqAGZqOwYZPT72LzAhX8GbnTfSvfU]
+      ocp-aad-diagnostics-server-name: [zZhyt14zl0OhjZk/+0wTMqtIww9oR8AMqmXQ2MnPyJw=]
+      ocp-aad-session-key: [AneRvLdoz0ryWJJfjjGPwJi6Irmyl-tRpSoml0HNySPxyzHpYFR4DAz4pLwW33JubxR5K5C_qsBG1g2N5lvlEqMD2xbH8yHlza9ygHknVqcLDFGQnTu-1TaJq6uWRaTr8AYYY45ZuS5AaWJkmfZBkg.R1JXoKncFc_iTd6I6KGB2UHW05b-862IwqCzHvd7_OA]
       pragma: [no-cache]
-      request-id: [b4499dbb-4c18-4969-9eee-d9f077949a70]
-      server: [Microsoft-IIS/10.0]
+      request-id: [fa7bd942-3619-4e8d-b3b4-1557edcb0018]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -579,30 +737,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2004']
+      content-length: ['2172']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:47 GMT']
-      duration: ['712724']
+      date: ['Sat, 02 Mar 2019 04:12:45 GMT']
+      duration: ['571278']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [ILMkzWumkrWELq2LNz8qYyobu9xzF6HY59qlW8ycA44=]
-      ocp-aad-session-key: [xgWSTBDjHVt1XEeLsuFm1QnPmu52rDa9ymjhvNUYkhUuq2KOgX8Y3ZnTbkp38D7lIudKBHcMZP3POQZcDyfYiR856sBGDvY8ZEv5AWoHVI7gnOYMD7Nn6xAAnD6hX3X8_qYrvXI6YF-KtI_XTv2Jcw.q3aPpShrqJhToaibwUM8FH3Zmro2eoI8tvDeUjKO1ms]
+      ocp-aad-diagnostics-server-name: [9GQqI6S1ECS4j4T2qnjxLorVEkd1sq21GP7tQfmsPNE=]
+      ocp-aad-session-key: [DBt-YEbrrlPXacbOUVziVzTimE9NzdvDccVMU5E-bQ6CVbpFDFEeqPvM_bnaC8iaWTdlIYEH2-jKKfyXePpBWmbE2Qi1FkcdMunfjhU43L5VPHlqCFO2QzL0E1fxeNTDgLnGIKCPNnR1VH76aRqLcQ.CYKTpGLvSBSFhnTNDmSi80C_y4gJvIC2d2p0FuOejWw]
       pragma: [no-cache]
-      request-id: [99608d2d-2e1b-414b-a798-4554b1facd9a]
-      server: [Microsoft-IIS/10.0]
+      request-id: [3dd2994d-5d2f-4340-b137-18d9b4ecb8b3]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -617,30 +774,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id --app-roles]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2007']
+      content-length: ['2175']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:49 GMT']
-      duration: ['1174127']
+      date: ['Sat, 02 Mar 2019 04:12:46 GMT']
+      duration: ['568401']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [vzT+9Yq+aEnlFAqW4ArMt4wc+vCo9D3Xgf5jgx/UnQk=]
-      ocp-aad-session-key: [TBKmTwCL0_zb5jNyxtt160aQd9unprHhWoUCj_5JngAuGayljiQ7a4E1e6EjGwrxRfMkV9j86eOjpgUO2ofJ1RpbylUuzqOmid4taY2OzLkui2qYK1fnqSsl6gU0U8Ds6buWc2MSe-TIcdSOkat10w.s6R0hu3kiMd8bJYa4Xu-Bn5MWDluOl6caEKTzqzIEa4]
+      ocp-aad-diagnostics-server-name: [uuC4ojITP59NTpteQfARMJzW3Ur1U9x1ysBSRndTeew=]
+      ocp-aad-session-key: [s47N0tppphaoCjth6XWBYlY4OtZoUanA4qyZzGERJx4ZVK_JmFkm9Aj5SQG1LhAVp7oxsx6BoKCctShDv0Rn1fCR8EQtBjvK3SoL_1pSr0yjzoMcZ4DnV9IHrb236TRR-uEEUi4dFCxW6lHWtSYh2A.tMJb_f5lqTfgWisoa7yuKPofLlh9xa5AtrYhyQ_VHbk]
       pragma: [no-cache]
-      request-id: [f4a16226-e77e-4b6c-b0d8-5daac16d61a5]
-      server: [Microsoft-IIS/10.0]
+      request-id: [8bab64de-8c38-4d5c-9850-75da6a1f5eea]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -655,30 +811,29 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id --app-roles]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2004']
+      content-length: ['2172']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:48 GMT']
-      duration: ['605653']
+      date: ['Sat, 02 Mar 2019 04:12:46 GMT']
+      duration: ['589893']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [WuWPPeV7dv5/89XBwAEVlawMeyvMAtJ8EugXI+UUkGg=]
-      ocp-aad-session-key: [O5XKpscUAJ90Tn53Rnq9RSsSTVR1BtxZ7qzJEQczIQjHdgs3qr_WMEIMx8mHFERrvGRWrRZtDmmVlRi8DMwr_ni8zz8wZJZwGIgGTNWa1V1XT2n8moFG3J1xi2MiC7wr1X2_cq85t6vw5x4w3sw1-w.PV3-ThtLvfvpPscTjW7ZjFthrP7eu0-EkwuFolE2X-s]
+      ocp-aad-diagnostics-server-name: [JyXqsNiMkuF05SRHy84V1XjyoE0+riVAf3UXk8E8WKU=]
+      ocp-aad-session-key: [wmXGxNgfRPtcPwZ3cT3aubkEb_gYB5c4y5Fbxy990SkTtxWbaG-PWWqD8ixPjNETbKfqU5IG3N-HD6fpeAe1O1JyGcQtpRJ96LCnJgy6Pgy58sYyv9YFDBq3Sl-TCu4lHYtWU_q6jhY-9qG5Fwgc-w.XNBg8DaSTKylVpDgXeHW3Cf62aNlPksMFMiKaMUS394]
       pragma: [no-cache]
-      request-id: [801d9579-ddff-4a06-82e9-82a393096b6f]
-      server: [Microsoft-IIS/10.0]
+      request-id: [298b8dbf-8700-4973-9d65-246c57c871cc]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -693,42 +848,41 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id --app-roles]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2007']
+      content-length: ['2175']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:49 GMT']
-      duration: ['632342']
+      date: ['Sat, 02 Mar 2019 04:12:47 GMT']
+      duration: ['597775']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [2gCJyEullf37VKgfupb1dpGiYlGUN8HjqZHuUwtlts8=]
-      ocp-aad-session-key: [su69iJ3HcclituPMLcYnX5l7emTaiUBNo5znd3GBGpf0YMHsWtMDH9ufYLHO70dyGSFpo4f-gIrD5b9DtzG7i33VTQjfNUUJKRv9B-Ss_w9j0gb8vQKLc1f_ibhW1G_IHWCTVKhWNfhe3QWrVDDEFA.Er2Q1eiKWMLrtwGtV6ya8o0zTpmLPScneH8Vj-RN6Lw]
+      ocp-aad-diagnostics-server-name: [8cABrxGeuUtXZIb4tLTbZKP7GAyp5Rz3TMI9wedexHQ=]
+      ocp-aad-session-key: [CXqem6jObuPL71R2g6UD0dtnPuroONnjnye4162owmbLz_aKwMlavUXvzBlryLDEOPMkvveNyE-DyxWmmoFcrhxltTrW3dOgM1xzcMyz9jFiUUmwcmR9r9D_FM0KTVPrsFW7vMsHK9UHJcm7tKKCnA.mxKmgO_0op_4cL-3UMA65ogirB5zIYrdh-j_wO2zs3w]
       pragma: [no-cache]
-      request-id: [5470e45b-a623-48c5-9a9d-d3db4b8c8f97]
-      server: [Microsoft-IIS/10.0]
+      request-id: [3956f4d9-646d-4679-933a-4bdbb1094323]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"appRoles": [{"isEnabled": true, "displayName": "Approver", "id": "3385de71-05f6-4c54-a3bd-932b71fee68f",
-      "value": "approver", "description": "Approvers can mark documents as approved",
-      "allowedMemberTypes": ["User"]}], "identifierUris": ["http://cli-graph000001"],
-      "displayName": "cli-graph000001", "requiredResourceAccess": [], "homepage":
-      "http://cli-graph000001", "replyUrls": ["http://azureclitest-replyuri"], "availableToOtherTenants":
-      false, "oauth2AllowImplicitFlow": false}'''
+    body: 'b''{"displayName": "cli-graph000001", "requiredResourceAccess": [], "homepage":
+      "http://cli-graph000001", "availableToOtherTenants": false, "replyUrls": ["http://azureclitest-replyuri"],
+      "identifierUris": ["http://cli-graph000001"], "oauth2AllowImplicitFlow": false,
+      "appRoles": [{"displayName": "Approver", "isEnabled": true, "allowedMemberTypes":
+      ["User"], "id": "65b6d534-dc30-451c-bf95-8ba28dd8bb5c", "description": "Approvers
+      can mark documents as approved", "value": "approver"}]}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -738,23 +892,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--id --app-roles]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      date: ['Sun, 17 Feb 2019 05:43:51 GMT']
-      duration: ['9458144']
+      date: ['Sat, 02 Mar 2019 04:12:48 GMT']
+      duration: ['9249098']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [4ccdJd4mkkHNssd76DGmxOgl+8nnZCpcIYgj8ttmA9c=]
-      ocp-aad-session-key: [uKK1DDbSVi0I6z-56LoN3vTWBuDIkqfssZsbFkv1_5-T72yxmnRy6RI4s7uEKMzgUUTDXiqR8Atvm7f_WpANlzeMmvTaw86r87f_5GsOjeD84SHV8G_aU8u0O7oDdvR_-4BjdduqocDkiw_AEJcrhg.kaYzqPM0vVmscFMvlzpUSmZZ4XihMGZsMxUHErGZAOE]
+      ocp-aad-diagnostics-server-name: [+gRo9kBbpO+5VnMcn+RzZWHlpA1jI8D9yT6uheCoEr0=]
+      ocp-aad-session-key: [J0br6If4xlYCwnJ0gbX76yASWZoEoJZXtMUkp8DnyFNn0Ks--dKJavVW8l7tE_uUNEalKJe5mt06WENtbRYspcA8LWcUQz_cDApqlPcA4iPJSbLNk7JzHXaGi_4VZnd__q5mipuiqZbCvHyphFqChg.dfYWGwwgtZytUvT0uvICO9DGhQqBAbISJmP10qIGj2k]
       pragma: [no-cache]
-      request-id: [385e2b89-afe4-4c9e-9512-d049f71931d5]
-      server: [Microsoft-IIS/10.0]
+      request-id: [7d8734dd-806e-4c83-979c-81c48a4480d9]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -769,31 +922,30 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
-        can mark documents as approved","displayName":"Approver","id":"3385de71-05f6-4c54-a3bd-932b71fee68f","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
+        can mark documents as approved","displayName":"Approver","id":"65b6d534-dc30-451c-bf95-8ba28dd8bb5c","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2200']
+      content-length: ['2368']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:52 GMT']
-      duration: ['593870']
+      date: ['Sat, 02 Mar 2019 04:12:49 GMT']
+      duration: ['664477']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [WzhaGtBqxSLZ0hrAkiIQJ9kgl/P+rn9FQMPcJn/2zBI=]
-      ocp-aad-session-key: [yx1D3ELy4gVZHGUsYSpraCGobvbxY5kBuOM_ZS-tP4fcDCCCepqCggsD85R8xkGalB6HERQjEnSp7rduadXeDaamaSkjbAlAaolbA94tzUHNiXQW041RNKsHQubVE6lJVwwI1v-mFK6KjKlUMRRg-A.u8y0hNI22_7FwPWAEpDbB5YKJTd7Xt1lSRE_dNkTJpc]
+      ocp-aad-diagnostics-server-name: [hpfDxhPDvpsezzM4Rl1qV9P5qcNnaUPXm6yGHqCYKyw=]
+      ocp-aad-session-key: [AJAeZicqW593U0FTxJa10Qs5nS_j_IFRba4oo-u7BS2n5sWb5mw5QGEc1isHsIHO7NvadImAUpNQvwhED4k_vZftFH7HdO7m_oi6O0eSePuOAVVah_tsMBdMYJPBFD44JYjkihW5_X4qNkxTeMATpw.0vJylQCtrZsYKxgGa5Ej7So8oEQ3FbFpO2XqzLxPUbE]
       pragma: [no-cache]
-      request-id: [60580093-7ed7-42f4-9bfe-f3f00e02834d]
-      server: [Microsoft-IIS/10.0]
+      request-id: [8e56b2bb-dc04-47a2-8ad3-0bcd66db0ae9]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -808,31 +960,30 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
-        can mark documents as approved","displayName":"Approver","id":"3385de71-05f6-4c54-a3bd-932b71fee68f","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
+        can mark documents as approved","displayName":"Approver","id":"65b6d534-dc30-451c-bf95-8ba28dd8bb5c","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2197']
+      content-length: ['2365']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:52 GMT']
-      duration: ['608162']
+      date: ['Sat, 02 Mar 2019 04:12:50 GMT']
+      duration: ['592771']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [4y+JksyeXuuR5wHMjn66IUe7IMQOGpwF3CpwTP34fgM=]
-      ocp-aad-session-key: [oAN_pAhL9eGPFO24gafixdD4uqBqneyTZMVUVscX2HMu4izv4OJYUHs5Y05k0s_k945NLm8_FukpOcfvgUfJsAAKSfcIqpTHYCD0iuDqFS2Dby5jragiqk_eatadmUyeQugV-4AQqBTY9toZ0GqUoA.gLYmmFnfhjkZqhArd0ZoXgMDMxiOllDyrHFtUcQzPT4]
+      ocp-aad-diagnostics-server-name: [FbAahKj+CAgBE9nDxnX/a9xy4bKzwpDul27qCyangJw=]
+      ocp-aad-session-key: [p7rdPB3bsbakUEKMM7HX6jB2D52zKqU6Vdqq3uwxfi_DvsxjsmHsHdB0HmsbKtuvMwQyOZlf85oGwT8KIXpjHJH-di9ZKEuVs6EpyZ7NdhYDtn9k77FRV9tQJSoddu18XZdqtXwIDR70q3uaKpOsuA.jKtHDOYwzzrLeE_RKl9ctvslPSefF1sLHP48BgRVfz4]
       pragma: [no-cache]
-      request-id: [35e1ff87-6b8b-408c-80c6-b3580fd38432]
-      server: [Microsoft-IIS/10.0]
+      request-id: [6279be60-55bf-4144-af68-45e7df9cd61c]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -847,31 +998,30 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--id]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"1958abd9-6900-4992-b824-67334bcc10c2","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"67492eec-c17b-4211-ad10-e996e2b61183","appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
-        can mark documents as approved","displayName":"Approver","id":"3385de71-05f6-4c54-a3bd-932b71fee68f","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/1958abd9-6900-4992-b824-67334bcc10c2/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"f75894ee-7d17-434a-bac2-dad646f8d578","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"623ec71d-10a7-472e-a1fc-ef889c50892f","appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
+        can mark documents as approved","displayName":"Approver","id":"65b6d534-dc30-451c-bf95-8ba28dd8bb5c","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/f75894ee-7d17-434a-bac2-dad646f8d578/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"ee08b271-586a-4db6-9d92-f04d0cc94fe1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"98912e18-a7ff-4cd7-9d2e-cd6286da9907","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-03-02T04:12:28.90031Z","keyId":"57f2ddb3-f0c7-42a8-9922-ceb76c33847a","startDate":"2019-03-02T04:12:28.90031Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      content-length: ['2200']
+      content-length: ['2368']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:54 GMT']
-      duration: ['1267305']
+      date: ['Sat, 02 Mar 2019 04:12:50 GMT']
+      duration: ['588820']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [aHT5PI9GgMnCtbkQT7/ZEgyUnSyF7IW2bcrqij4e/bI=]
-      ocp-aad-session-key: [iFo0QHpnVabj3TOr56EmDkHzdmET3qH0jklIQERhv5GT3WOFEf5e1VO08r0jxs2a5ZT_vyOo0Mw16j01xD1Ms-lfkYDQAYqfTFHdA1LvgzkxOkyEOBUvKAT3GBi-fg7uVg61WYvZKpgAH470x5oo1w.PCZlICqEKftE5QVBaXS9h1iHhtuubDw5Y5b5tUUAL2o]
+      ocp-aad-diagnostics-server-name: [zoXa5OztcZwC9NCZAVZj5EM6pVPNXpVwNUsgvVT3hYg=]
+      ocp-aad-session-key: [gP8teoAnjDH_W1TY6rpDYyNQzTdBQ71si2vLuL9NajSu7g4-YxqbOtv0aQeHdVb7eAtdPi15jMaEWnkcYDGQKn3erEPYFrrHGWNVl5zOuAAxpcmDpcBHj0lytsmFzzwVu9ftJB8ZAVfPUFUYZmlcxA.LIAM21lRHGkNHz2m7KTVeJB9bFXQvE3KM7eQPxY0gxM]
       pragma: [no-cache]
-      request-id: [4a629e7d-1756-413a-bf12-5eb6918ee5f8]
-      server: [Microsoft-IIS/10.0]
+      request-id: [56e8805e-542e-4308-a251-879149350b86]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -887,23 +1037,22 @@ interactions:
       Content-Length: ['0']
       ParameterSetName: [--id]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/1958abd9-6900-4992-b824-67334bcc10c2?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/f75894ee-7d17-434a-bac2-dad646f8d578?api-version=1.6
   response:
     body: {string: ''}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
-      date: ['Sun, 17 Feb 2019 05:43:55 GMT']
-      duration: ['9161872']
+      date: ['Sat, 02 Mar 2019 04:12:51 GMT']
+      duration: ['8587945']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [ugNwVUhy/uil8Pg9hUjbVUCmwvlEB5WBlRSXf9K7vo0=]
-      ocp-aad-session-key: [G4xK8DM0Uc7r9TIr49Nhlg2OA4uuUQL21jytX9E2y2JkWZ9bU2dLZnDHGbBXQiz6qHPOtyeAhE2T5W5zIqoB1vJuyg01aCa_rcQe3pXuvkko47HclL1RuT1T-EjSwpKyLvcNSFwU1fi_gMxPnvoN2A.JeArK-S8uPtCE65D57d15rsWnrMgOlVqGV8mAlkPFEE]
+      ocp-aad-diagnostics-server-name: [IAJInqPI4lKNkkjmRxlvRCo0yCEDsc0J29jSC990RR4=]
+      ocp-aad-session-key: [P1fmIKtnC87f9B4CLyreU0wdaxvrA6QwrtOVNqzo96i6hH0lCAwWNwIYZXCkTkqJonDGwFDlMFCPSoK7p0JnikMFyzPh-Bf5fIDlBivAPlnMsjEz7KCb4Pw6ael63wUne1dHDNgZGPzzit0geSLkWw.bYfsjN6rYTsBb4Q6v6q6-idMPhKcdzH9--9Dv2A2Ve8]
       pragma: [no-cache]
-      request-id: [0b2fdfa2-971e-4067-a148-2adca373a1b0]
-      server: [Microsoft-IIS/10.0]
+      request-id: [7c968076-3c99-4a80-bdda-aa781b04eb8e]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']
@@ -918,7 +1067,7 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [--identifier-uri]
       User-Agent: [python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          azure-graphrbac/0.53.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6&$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29
@@ -930,14 +1079,13 @@ interactions:
       content-length: ['121']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 17 Feb 2019 05:43:55 GMT']
-      duration: ['532886']
+      date: ['Sat, 02 Mar 2019 04:12:53 GMT']
+      duration: ['554210']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [/ixj3U5tIdjsTF7jhrxO6gaWUFJzDmFQ2+8C7xVSngI=]
-      ocp-aad-session-key: [IPgCPW2EFz6TE_dk8EfHiT2UqT7JfIkCFhy5YF7HLzKQS8xJZYn1h_WcvlwX5qdupx8fhHQDnAitzYd6iQbp1pESTU3awAdEAiMML_6YxHEMM-CDRKZzAq--CefpLznyjN05G0KR9_yMXiuhO57Lng.8AkBpepr19fX-WoprODdplCIocNFBiNQ8_OkYYBEtNA]
+      ocp-aad-diagnostics-server-name: [2IA1QGDvz91haZr/yqk8ls8eQWWKSms5xrjCfc09rfI=]
+      ocp-aad-session-key: [Fcs73NZ50xvMb4GduOAApaEqk9fBIYA7iAWPXQkwlkAAUrH_FpSDCgMpuy0cVBncnQ36am3shLsJ1raoEy3ChJ1MX1ZXvOPjNJuXPMn4Y4hh7opIKrDPYUMrfrYpX2Ag7i2EV_5SY8z4hWBdotb9Lw.Gdnp3O25LX9yaQHT9mo0DMxEQH2W3Toyn9y7z8n6aaU]
       pragma: [no-cache]
-      request-id: [c3b8473e-e260-4b5a-b412-c002c543441a]
-      server: [Microsoft-IIS/10.0]
+      request-id: [809cb472-1c2c-4b52-befa-6f25ebe715dc]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-ms-dirapi-data-contract-version: ['1.6']

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -109,9 +109,13 @@ class ApplicationSetScenarioTest(ScenarioTest):
             ])
         })
 
-        # crerate app through general option
+        # create app through general option
         self.cmd('ad app create --display-name {name} --homepage {app} --identifier-uris {app}',
                  checks=self.check('identifierUris[0]', '{app}'))
+
+        # set app password
+        result = self.cmd('ad app credential reset --id {app} --append --password "test" --years 2').get_output_in_json()
+        self.assertTrue(result['appId'])
 
         # show/list app
         self.cmd('ad app show --id {app}',


### PR DESCRIPTION
Fix #8630 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
