### PR TITLE
add "az aks install-cli" support for Azure China

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -292,17 +292,21 @@ def dcos_install_cli(cmd, install_location=None, client_version='1.8'):
 def k8s_install_cli(cmd, client_version='latest', install_location=None):
     """Install kubectl, a command-line interface for Kubernetes clusters."""
 
+    source_url = "https://storage.googleapis.com/kubernetes-release/release"
+    cloud_name = cmd.cli_ctx.cloud.name
+    if cloud_name.lower() == 'azurechinacloud':
+        source_url = 'https://mirror.azure.cn/kubernetes/kubectl'
+
     if client_version == 'latest':
         context = _ssl_context()
-        version = urlopen('https://storage.googleapis.com/kubernetes-release/release/stable.txt',
-                          context=context).read()
+        version = urlopen(source_url + '/stable.txt', context=context).read()
         client_version = version.decode('UTF-8').strip()
     else:
         client_version = "v%s" % client_version
 
     file_url = ''
     system = platform.system()
-    base_url = 'https://storage.googleapis.com/kubernetes-release/release/{}/bin/{}/amd64/{}'
+    base_url = source_url + '/{}/bin/{}/amd64/{}'
 
     # ensure installation directory exists
     install_dir, cli = os.path.dirname(install_location), os.path.basename(install_location)

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -634,7 +634,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         try:
             temp_dir = tempfile.mkdtemp()  # tempfile.TemporaryDirectory() is no available on 2.7
             test_location = os.path.join(temp_dir, 'kubectl.exe')
-            k8s_install_cli(None, client_version='1.2.3', install_location=test_location)
+            k8s_install_cli(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
             self.assertEqual(mock_url_retrieve.call_count, 1)
             # 2 warnings, 1st for download result; 2nd for updating PATH
             self.assertEqual(logger_mock.warning.call_count, 2)  # 2 warnings, one for download result
@@ -642,7 +642,7 @@ class AcsCustomCommandTest(unittest.TestCase):
             if platform.system() == 'Windows':
                 # try again with install location in PATH, we should only get one more warning
                 os.environ['PATH'] += ';' + temp_dir
-                k8s_install_cli(None, client_version='1.2.3', install_location=test_location)
+                k8s_install_cli(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
                 self.assertEqual(logger_mock.warning.call_count, 3)
         finally:
             shutil.rmtree(temp_dir)
@@ -654,7 +654,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         try:
             temp_dir = tempfile.mkdtemp()  # tempfile.TemporaryDirectory() is no available on 2.7
             test_location = os.path.join(temp_dir, 'foo', 'kubectl.exe')
-            k8s_install_cli(None, client_version='1.2.3', install_location=test_location)
+            k8s_install_cli(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
             self.assertTrue(os.path.exists(test_location))
         finally:
             shutil.rmtree(temp_dir)


### PR DESCRIPTION
On global azure, `/usr/local/bin/kubectl` would be downloaded from https://storage.googleapis.com which is ok, while on Azure China, it did not work, this PR would download `/usr/local/bin/kubectl` from https://mirror.azure.cn/kubernetes/kubectl/ if cloud env is set as `AzureChinaCloud`

I have tested this PR by following way:
```
docker build --no-cache -t andyzhangx/azure-cli:mooncake-kubectl -f ./Dockerfile .
docker run -v ${HOME}:/root -it andyzhangx/azure-cli:mooncake-kubectl

# by default, it's still downloading from `storage.googleapis.com`
root@09feb993f352:/# az aks install-cli
Downloading client to "/usr/local/bin/kubectl" from "https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kubectl"
Please ensure that /usr/local/bin is in your search PATH, so the `kubectl` command can be found.

# after set to 'AzureChinaCloud', it's downloading from "mirror.azure.cn"
root@09feb993f352:/# az cloud set --name AzureChinaCloud
Switched active cloud to 'AzureChinaCloud'.
Use 'az login' to log in to this cloud.
Use 'az account set' to set the active subscription.

root@09feb993f352:/# az aks install-cli
Downloading client to "/usr/local/bin/kubectl" from "https://mirror.azure.cn/kubernetes/kubectl/v1.13.4/bin/linux/amd64/kubectl"
Please ensure that /usr/local/bin is in your search PATH, so the `kubectl` command can be found.
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [No] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [Yes ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
