### PR TITLE
WIP: Add homebrew virtualenv

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,7 +196,7 @@ jobs:
   displayName: Build Homebrew Formula
 
   dependsOn: BuildPythonWheel
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
+  condition: and(succeeded())
   pool:
     vmImage: 'ubuntu-16.04'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,7 +196,7 @@ jobs:
   displayName: Build Homebrew Formula
 
   dependsOn: BuildPythonWheel
-  condition: and(succeeded())
+  condition: succeeded()
   pool:
     vmImage: 'ubuntu-16.04'
   steps:

--- a/scripts/release/homebrew/docker/formula_template.txt
+++ b/scripts/release/homebrew/docker/formula_template.txt
@@ -1,4 +1,6 @@
 class AzureCli < Formula
+  include Language::Python::Virtualenv
+
   desc "Microsoft Azure CLI 2.0"
   homepage "https://docs.microsoft.com/cli/azure/overview"
   url "{{ upstream_url }}"
@@ -14,56 +16,60 @@ class AzureCli < Formula
 {{ resources }}
 
   def install
-    xy = Language::Python.major_minor_version "python3"
-    site_packages = libexec/"lib/python#{xy}/site-packages"
-    ENV.prepend_create_path "PYTHONPATH", site_packages
-    ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib}"
-    ENV.prepend "CFLAGS", "-I#{Formula["openssl"].opt_include}"
-    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include}"
+    # xy = Language::Python.major_minor_version "python3"
+    # site_packages = libexec/"lib/python#{xy}/site-packages"
+    # ENV.prepend_create_path "PYTHONPATH", site_packages
+    # ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib}"
+    # ENV.prepend "CFLAGS", "-I#{Formula["openssl"].opt_include}"
+    # ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include}"
 
     # Get the CLI components we'll install
-    components = [
-      buildpath/"src/azure-cli",
-      buildpath/"src/azure-cli-telemetry",
-      buildpath/"src/azure-cli-core",
-      buildpath/"src/azure-cli-nspkg",
-      buildpath/"src/azure-cli-command_modules-nspkg",
-    ]
-    components += Pathname.glob(buildpath/"src/command_modules/azure-cli-*/")
+    # components = [
+    #  buildpath/"src/azure-cli",
+    #  buildpath/"src/azure-cli-telemetry",
+    #  buildpath/"src/azure-cli-core",
+    #  buildpath/"src/azure-cli-nspkg",
+    #  buildpath/"src/azure-cli-command_modules-nspkg",
+    #]
+    # components += Pathname.glob(buildpath/"src/command_modules/azure-cli-*/")
 
     # Install dependencies
     # note: Even if in 'resources', don't include 'futures' as not needed for Python3
     # and causes import errors. See https://github.com/agronholm/pythonfutures/issues/41
-    deps = resources.map(&:name).to_set - ["futures"]
-    deps.each do |r|
-      resource(r).stage do
-        system "python3", *Language::Python.setup_install_args(libexec)
-      end
-    end
+    # deps = resources.map(&:name).to_set - ["futures"]
+    #deps.each do |r|
+    #  resource(r).stage do
+    #    system "python3", *Language::Python.setup_install_args(libexec)
+    #  end
+    #end
 
     # Install CLI
-    components.each do |item|
-      cd item do
-        system "python3", *Language::Python.setup_install_args(libexec)
-      end
-    end
+    # components.each do |item|
+    #  cd item do
+    #    system "python3", *Language::Python.setup_install_args(libexec)
+    #  end
+    # end
 
-    # This replaces the `import pkg_resources` namespace imports from upstream
-    # with empty string as the import is slow and not needed in this environment.
-    File.open(site_packages/"azure/__init__.py", "w") {}
-    File.open(site_packages/"azure/cli/__init__.py", "w") {}
-    File.open(site_packages/"azure/cli/command_modules/__init__.py", "w") {}
-    File.open(site_packages/"azure/mgmt/__init__.py", "w") {}
+    # # This replaces the `import pkg_resources` namespace imports from upstream
+    # # with empty string as the import is slow and not needed in this environment.
+    # File.open(site_packages/"azure/__init__.py", "w") {}
+    # File.open(site_packages/"azure/cli/__init__.py", "w") {}
+    # File.open(site_packages/"azure/cli/command_modules/__init__.py", "w") {}
+    # File.open(site_packages/"azure/mgmt/__init__.py", "w") {}
 
-    (bin/"az").write <<~EOS
-      #!/usr/bin/env bash
-      export PYTHONPATH="#{ENV["PYTHONPATH"]}"
-      if command -v python#{xy} >/dev/null 2>&1; then
-        python#{xy} -m azure.cli \"$@\"
-      else
-        python3 -m azure.cli \"$@\"
-      fi
-    EOS
+    # (bin/"az").write <<~EOS
+    #  #!/usr/bin/env bash
+    #  export PYTHONPATH="#{ENV["PYTHONPATH"]}"
+    #  if command -v python#{xy} >/dev/null 2>&1; then
+    #    python#{xy} -m azure.cli \"$@\"
+    #  else
+    #    python3 -m azure.cli \"$@\"
+    #  fi
+    #EOS
+
+    venv = virtualenv_create(libexec, "python3")
+    venv.pip_install resources
+    venv.pip_install buildpath
 
     bash_completion.install "az.completion" => "az"
   end


### PR DESCRIPTION
Today's Homebrew formula does not install the Azure CLI into a virtual environment. This has caused a good number of issues, especially when people have existing system Python installations in use.
