### PR TITLE
Using required parameters in help examples.

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -3611,7 +3611,7 @@ helps['network vnet subnet create'] = """
         - name: Create new subnet attached to an NSG with a custom route table.
           text: |
             az network vnet subnet create -g MyResourceGroup --vnet-name MyVnet -n MySubnet \\
-                --address-prefix 10.0.0.0/24 --network-security-group MyNsg --route-table MyRouteTable
+                --address-prefixes 10.0.0.0/24 --network-security-group MyNsg --route-table MyRouteTable
 """
 
 helps['network vnet subnet delete'] = """


### PR DESCRIPTION
Using the required parameter --address-prefixes
 in example makes it clear we can pass in multiple CIDR ranges.   While  --address-prefix  works, it is not documented and is not clear it accepts more than one CIDR range.  The change is for example: "Create new subnet attached to an NSG with a custom route table."
Found here: ### https://docs.microsoft.com/en-us/cli/azure/network/vnet/subnet?view=azure-cli-latest#feedback

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
