### PR TITLE
[Network + Core] Application Gateway Rewrite Rules and ArmCommandGroup

### DIFF
--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -11,9 +11,10 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>MSBuild|env1|$(MSBuildProjectFullPath)</InterpreterId>
+    <InterpreterId>MSBuild|env|$(MSBuildProjectFullPath)</InterpreterId>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <CommandLineArguments>network application-gateway rewrite-rule set create -g tjp-rg --gateway-name gw1 -h</CommandLineArguments>
+    <CommandLineArguments>
+    </CommandLineArguments>
     <IsWindowsApplication>False</IsWindowsApplication>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
@@ -1669,15 +1670,6 @@
     <InterpreterReference Include="Global|PythonCore|3.6" />
   </ItemGroup>
   <ItemGroup>
-    <Interpreter Include="..\..\env\">
-      <Id>env1</Id>
-      <Version>3.7</Version>
-      <Description>env (Python 3.7 (32-bit))</Description>
-      <InterpreterPath>Scripts\python.exe</InterpreterPath>
-      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
-      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
-      <Architecture>X86</Architecture>
-    </Interpreter>
     <Interpreter Include="..\env\">
       <Id>env</Id>
       <Version>3.6</Version>

--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -11,10 +11,9 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>MSBuild|env|$(MSBuildProjectFullPath)</InterpreterId>
+    <InterpreterId>MSBuild|env1|$(MSBuildProjectFullPath)</InterpreterId>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <CommandLineArguments>
-    </CommandLineArguments>
+    <CommandLineArguments>network application-gateway rewrite-rule set create -g tjp-rg --gateway-name gw1 -h</CommandLineArguments>
     <IsWindowsApplication>False</IsWindowsApplication>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
@@ -1670,6 +1669,15 @@
     <InterpreterReference Include="Global|PythonCore|3.6" />
   </ItemGroup>
   <ItemGroup>
+    <Interpreter Include="..\..\env\">
+      <Id>env1</Id>
+      <Version>3.7</Version>
+      <Description>env (Python 3.7 (32-bit))</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+      <Architecture>X86</Architecture>
+    </Interpreter>
     <Interpreter Include="..\env\">
       <Id>env</Id>
       <Version>3.6</Version>

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -405,6 +405,14 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         operation_group = kwargs.get('operation_group', self.module_kwargs.get('operation_group', None))
         return get_sdk(self.cli_ctx, resource_type, *attr_args, mod='models', operation_group=operation_group)
 
+    def _arm_command_group(self, group_name, command_type=None, **kwargs):
+        from azure.cli.core.commands.arm import ArmCommandGroup
+        if command_type:
+            kwargs['command_type'] = command_type
+        if 'deprecate_info' in kwargs:
+            kwargs['deprecate_info'].target = group_name
+        return ArmCommandGroup(self, group_name, **kwargs)
+
     def command_group(self, group_name, command_type=None, **kwargs):
         if command_type:
             kwargs['command_type'] = command_type

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -5,6 +5,9 @@
 
 from __future__ import print_function
 import argparse
+
+from azure.cli.core.commands import ExtensionCommandSource
+
 from knack.help import (HelpFile as KnackHelpFile, CommandHelpFile as KnackCommandHelpFile,
                         GroupHelpFile as KnackGroupHelpFile, ArgumentGroupRegistry as KnackArgumentGroupRegistry,
                         HelpExample as KnackHelpExample, HelpParameter as KnackHelpParameter,
@@ -12,7 +15,7 @@ from knack.help import (HelpFile as KnackHelpFile, CommandHelpFile as KnackComma
 
 from knack.log import get_logger
 from knack.util import CLIError
-from azure.cli.core.commands import ExtensionCommandSource
+
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/_help_loaders.py
+++ b/src/azure-cli-core/azure/cli/core/_help_loaders.py
@@ -6,9 +6,11 @@
 import abc
 import os
 import yaml
+
+from azure.cli.core._help import (HelpExample, CliHelpFile)
+
 from knack.util import CLIError
 from knack.log import get_logger
-from azure.cli.core._help import (HelpExample, CliHelpFile)
 
 
 logger = get_logger(__name__)

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -16,13 +16,14 @@ from copy import deepcopy
 from enum import Enum
 from six.moves import BaseHTTPServer
 
-from knack.log import get_logger
-from knack.util import CLIError
-
 from azure.cli.core._environment import get_config_dir
 from azure.cli.core._session import ACCOUNT
 from azure.cli.core.util import get_file_json, in_cloud_console, open_page_in_browser, can_launch_browser
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
+
+from knack.log import get_logger
+from knack.util import CLIError
+
 
 logger = get_logger(__name__)
 
@@ -479,9 +480,9 @@ class Profile(object):
         if not result and subscription:
             raise CLIError("Subscription '{}' not found. "
                            "Check the spelling and casing and try again.".format(subscription))
-        elif not result and not subscription:
+        if not result and not subscription:
             raise CLIError("No subscription found. Run 'az account set' to select a subscription.")
-        elif len(result) > 1:
+        if len(result) > 1:
             raise CLIError("Multiple subscriptions with the name '{}' found. "
                            "Specify the subscription ID.".format(subscription))
         return result[0]

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -8,8 +8,9 @@ import adal
 
 from msrest.authentication import Authentication
 
-from knack.util import CLIError
 from azure.cli.core.util import in_cloud_console
+
+from knack.util import CLIError
 
 
 class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-methods

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -7,12 +7,13 @@ import os
 from pprint import pformat
 from six.moves import configparser
 
+from azure.cli.core.profiles import API_PROFILES
+from azure.cli.core._config import GLOBAL_CONFIG_DIR
+
 from knack.log import get_logger
 from knack.util import CLIError
 from knack.config import get_config_parser
 
-from azure.cli.core.profiles import API_PROFILES
-from azure.cli.core._config import GLOBAL_CONFIG_DIR
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -15,14 +15,6 @@ import copy
 from importlib import import_module
 import six
 
-from knack.arguments import CLICommandArgument
-from knack.commands import CLICommand, CommandGroup
-from knack.deprecation import ImplicitDeprecated, resolve_deprecate_info
-from knack.invocation import CommandInvoker
-from knack.log import get_logger
-from knack.util import CLIError, CommandResultItem, todict
-from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
-
 # pylint: disable=unused-import
 from azure.cli.core.commands.constants import (
     BLACKLISTED_MODS, DEFAULT_QUERY_TIME_RANGE, CLI_COMMON_KWARGS, CLI_COMMAND_KWARGS, CLI_PARAM_KWARGS,
@@ -32,6 +24,15 @@ from azure.cli.core.commands.parameters import (
 from azure.cli.core.extension import get_extension
 from azure.cli.core.util import get_command_type_kwarg, read_file_content, get_arg_list, poller_classes
 import azure.cli.core.telemetry as telemetry
+
+from knack.arguments import CLICommandArgument
+from knack.commands import CLICommand, CommandGroup
+from knack.deprecation import ImplicitDeprecated, resolve_deprecate_info
+from knack.invocation import CommandInvoker
+from knack.log import get_logger
+from knack.util import CLIError, CommandResultItem, todict
+from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
+
 
 logger = get_logger(__name__)
 
@@ -350,7 +351,7 @@ class AzCliCommandInvoker(CommandInvoker):
         if len(exceptions) == 1 and not results:
             ex, id_arg = exceptions[0]
             raise ex
-        elif exceptions:
+        if exceptions:
             for exception, id_arg in exceptions:
                 logger.warning('%s: "%s"', id_arg, str(exception))
             if not results:

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -201,11 +201,16 @@ class AzCliCommand(CLICommand):
             def __exit__(self, exc_type, exc_val, exc_tb):
                 pass
 
-            def set_param(self, prop, value, allow_clear=True):
-                if value == '' and allow_clear:
-                    setattr(self.instance, prop, None)
+            def set_param(self, prop, value, allow_clear=True, current=None):
+                current = current or self.instance
+                if '.' in prop:
+                    prop, path = prop.split('.', 1)
+                    current = getattr(current, prop)
+                    self.set_param(path, value, allow_clear, current)
+                elif value == '' and allow_clear:
+                    setattr(current, prop, None)
                 elif value is not None:
-                    setattr(self.instance, prop, value)
+                    setattr(current, prop, value)
         return UpdateContext(obj_inst)
 
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -189,6 +189,25 @@ class AzCliCommand(CLICommand):
         return self.loader.get_sdk(*attr_args, resource_type=resource_type, mod='models',
                                    operation_group=operation_group)
 
+    def update_context(self, obj_inst):
+
+        class UpdateContext(object):
+            def __init__(self, instance):
+                self.instance = instance
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            def set_param(self, prop, value, allow_clear=True):
+                if value == '' and allow_clear:
+                    setattr(self.instance, prop, None)
+                elif value is not None:
+                    setattr(self.instance, prop, value)
+        return UpdateContext(obj_inst)
+
 
 # pylint: disable=too-few-public-methods
 class AzCliCommandInvoker(CommandInvoker):

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -1330,6 +1330,7 @@ class ArmCommandGroup(AzCommandGroup):
     def _add_dests(self, scope, required=None, optional=None):
         # from azure.cli.core.commands.parameters import get_resource_name_completion_list
         # TODO: add completers?
+        # TODO: add boilerplate help text?
         required = required or list(self._key_to_dest_map.values())
         optional = optional or []
         command = self.command_loader.command_table.get(scope)
@@ -1453,7 +1454,7 @@ class ArmCommandGroup(AzCommandGroup):
                 model_kwargs[path] = dest_value
         return cmd.get_models(self._model)(**model_kwargs)
 
-    def _parse_model(self, model_cls, ignore_collections=True, parent_path=None):
+    def _parse_model(self, model_cls, parent_path=None):
         attr_map = model_cls.__dict__['_attribute_map']
         validation = model_cls.__dict__.get('_validation', {})
         prefix = self._model_prefix
@@ -1463,14 +1464,10 @@ class ArmCommandGroup(AzCommandGroup):
             # ignore values if Swagger says they are readonly
             if key in validation and validation[key].get('readonly'):
                 continue
-            # skip collections. They will be their own command groups
-            if data_type.startswith('[') and data_type.endswith(']') and ignore_collections:
-                continue
             dest = key if not prefix else '{}_{}'.format(prefix, key)
             if self.command_loader.get_models(data_type):
                 subprop_map = self._parse_model(
                     self.command_loader.get_models(data_type),
-                    ignore_collections=False,
                     parent_path=key
                 )
                 property_map.update(subprop_map)

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -5,14 +5,15 @@
 
 import os
 
-from knack.log import get_logger
-from knack.util import CLIError
-
 from azure.cli.core import __version__ as core_version
 import azure.cli.core._debug as _debug
 from azure.cli.core.extension import EXTENSIONS_MOD_PREFIX
 from azure.cli.core.profiles._shared import get_client_class, SDKProfile
 from azure.cli.core.profiles import ResourceType, CustomResourceType, get_api_version, get_sdk
+
+from knack.log import get_logger
+from knack.util import CLIError
+
 
 logger = get_logger(__name__)
 UA_AGENT = "AZURECLI/{}".format(core_version)
@@ -166,9 +167,7 @@ def get_data_service_client(cli_ctx, service_type, account_name, account_key, co
                                               'common._error#_ERROR_STORAGE_MISSING_INFO')
         if _ERROR_STORAGE_MISSING_INFO in str(exc):
             raise ValueError(exc)
-        else:
-            raise CLIError('Unable to obtain data client. Check your connection parameters.')
-    # TODO: enable Fiddler
+        raise CLIError('Unable to obtain data client. Check your connection parameters.')
     client.request_callback = _get_add_headers_callback(cli_ctx)
     return client
 

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -7,16 +7,17 @@
 import argparse
 import platform
 
-from knack.arguments import (
-    CLIArgumentType, CaseInsensitiveList, ignore_type, ArgumentsContext)
-from knack.log import get_logger
-from knack.util import CLIError
-
 from azure.cli.core import EXCLUDED_PARAMS
 from azure.cli.core.commands.constants import CLI_PARAM_KWARGS, CLI_POSITIONAL_PARAM_KWARGS
 from azure.cli.core.commands.validators import validate_tag, validate_tags, generate_deployment_name
 from azure.cli.core.decorators import Completer
 from azure.cli.core.profiles import ResourceType
+
+from knack.arguments import (
+    CLIArgumentType, CaseInsensitiveList, ignore_type, ArgumentsContext)
+from knack.log import get_logger
+from knack.util import CLIError
+
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/commands/progress.py
+++ b/src/azure-cli-core/azure/cli/core/commands/progress.py
@@ -25,7 +25,7 @@ class ProgressViewBase(object):
 
     def clear(self):
         """ resets the view to neutral """
-        pass
+        pass  # pylint: disable=unnecessary-pass
 
 
 class ProgressReporter(object):

--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -6,10 +6,11 @@
 from __future__ import print_function
 import platform
 
+from azure.cli.core.commands.arm import resource_exists
+
 from knack.log import get_logger
 from knack.util import CLIError
 
-from azure.cli.core.commands.arm import resource_exists
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/commands/transform.py
+++ b/src/azure-cli-core/azure/cli/core/commands/transform.py
@@ -5,9 +5,9 @@
 
 import re
 
-import knack.events as events
-
 from azure.cli.core.util import b64_to_hex
+
+import knack.events as events
 
 
 def register_global_transforms(cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -7,9 +7,10 @@ import argparse
 import time
 import random
 
+from azure.cli.core.profiles import ResourceType
+
 from knack.log import get_logger
 
-from azure.cli.core.profiles import ResourceType
 
 logger = get_logger(__name__)
 
@@ -31,7 +32,7 @@ class IterateValue(list):
 
     Typical use is to allow multiple ID parameter to a show command etc.
     """
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 def validate_tags(ns):

--- a/src/azure-cli-core/azure/cli/core/decorators.py
+++ b/src/azure-cli-core/azure/cli/core/decorators.py
@@ -57,7 +57,7 @@ def hash256_result(func):
         val = func(*args, **kwargs)
         if not val:
             raise ValueError('Return value is None')
-        elif not isinstance(val, str):
+        if not isinstance(val, str):
             raise ValueError('Return value is not string')
         hash_object = hashlib.sha256(val.encode('utf-8'))
         return str(hash_object.hexdigest())

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -8,10 +8,11 @@ import traceback
 import json
 import re
 
+from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
+
 from knack.config import CLIConfig
 from knack.log import get_logger
 
-from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
 
 az_config = CLIConfig(config_dir=GLOBAL_CONFIG_DIR, config_env_var_prefix=ENV_VAR_PREFIX)
 _CUSTOM_EXT_DIR = az_config.get('extension', 'dir', None)

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -5,7 +5,6 @@
 from pkg_resources import parse_version
 
 from azure.cli.core.extension import ext_compat_with_cli, WHEEL_INFO_RE
-from azure.cli.core.extension import ext_compat_with_cli
 from azure.cli.core.extension._index import get_index_extensions
 
 from knack.log import get_logger

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -4,10 +4,11 @@
 # --------------------------------------------------------------------------------------------
 from pkg_resources import parse_version
 
-from knack.log import get_logger
-
 from azure.cli.core.extension import ext_compat_with_cli, WHEEL_INFO_RE
+from azure.cli.core.extension import ext_compat_with_cli
 from azure.cli.core.extension._index import get_index_extensions
+
+from knack.log import get_logger
 
 
 logger = get_logger(__name__)

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -16,13 +16,13 @@ from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
 import requests
 from pkg_resources import parse_version
 
-from knack.log import get_logger
-
 from azure.cli.core.util import CLIError, reload_module
 from azure.cli.core.extension import (extension_exists, get_extension_path, get_extensions, get_extension_modname,
                                       get_extension, ext_compat_with_cli, EXT_METADATA_ISPREVIEW,
                                       WheelExtension, DevExtension, ExtensionNotInstalledException, WHEEL_INFO_RE)
 from azure.cli.core.telemetry import set_extension_management_detail
+
+from knack.log import get_logger
 
 from ._homebrew_patch import HomebrewPipPatch
 from ._index import get_index_extensions

--- a/src/azure-cli-core/azure/cli/core/file_util.py
+++ b/src/azure-cli-core/azure/cli/core/file_util.py
@@ -4,9 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 from __future__ import print_function
-from knack.util import CLIError
 
 from azure.cli.core._help import CliCommandHelpFile, CliGroupHelpFile
+
+from knack.util import CLIError
 
 
 def get_all_help(cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -11,14 +11,14 @@ import difflib
 import argparse
 import argcomplete
 
-from knack.log import get_logger
-from knack.parser import CLICommandParser
-from knack.util import CLIError
-
 import azure.cli.core.telemetry as telemetry
 from azure.cli.core.extension import get_extension
 from azure.cli.core.commands import ExtensionCommandSource
 from azure.cli.core.commands.events import EVENT_INVOKER_ON_TAB_COMPLETION
+
+from knack.log import get_logger
+from knack.parser import CLICommandParser
+from knack.util import CLIError
 
 logger = get_logger(__name__)
 
@@ -27,7 +27,7 @@ class IncorrectUsageError(CLIError):
     '''Raised when a command is incorrectly used and the usage should be
     displayed to the user.
     '''
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 class AzCompletionFinder(argcomplete.CompletionFinder):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -321,7 +321,10 @@ def poller_classes():
 
 def augment_no_wait_handler_args(no_wait_enabled, handler, handler_args):
     """ Populates handler_args with the appropriate args for no wait """
-    h_args = get_arg_list(handler)
+    h_args = list(get_arg_list(handler))
+    if 'kwargs' in h_args and 'no_wait' not in h_args:
+        # support kwarg-based use of no-wait
+        handler_args['no_wait'] = no_wait_enabled
     if 'no_wait' in h_args:
         handler_args['no_wait'] = no_wait_enabled
     if 'raw' in h_args and no_wait_enabled:

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -3,6 +3,8 @@
 Release History
 ===============
 
+* `application-gateway`: Add command group `rewrite-rule` with `set` and `condition` subgroups.
+
 2.3.4
 +++++
 * `vpn-connection update`: Fix issue where updating a VPN connection between gateways in different subscriptions would fail.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -505,7 +505,80 @@ helps['network application-gateway redirect-config update'] = """
             az network application-gateway redirect-config update -g MyResourceGroup --gateway-name MyAppGateway \\
                 -n MyRedirectConfig --type Permanent --target-listener MyNewBackendListener
 """
+# endregion
 
+# region Application Gateway rewrite rules
+helps['network application-gateway rewrite-rule'] = """
+    short-summary: Manage rewrite rules of an application gateway.
+"""
+
+helps['network application-gateway rewrite-rule create'] = """
+    short-summary: Create a rewrite rule.
+"""
+
+helps['network application-gateway rewrite-rule delete'] = """
+    short-summary: Delete a rewrite rule.
+"""
+
+helps['network application-gateway rewrite-rule list'] = """
+    short-summary: List rewrite rules.
+"""
+
+helps['network application-gateway rewrite-rule show'] = """
+    short-summary: Get the details of a rewrite rule.
+"""
+
+helps['network application-gateway rewrite-rule update'] = """
+    short-summary: Update a rewrite rule.
+"""
+
+helps['network application-gateway rewrite-rule set'] = """
+    short-summary: Manage rewrite rulesets of an application gateway.
+"""
+
+helps['network application-gateway rewrite-rule set create'] = """
+    short-summary: Create a rewrite ruleset.
+"""
+
+helps['network application-gateway rewrite-rule set delete'] = """
+    short-summary: Delete a rewrite ruleset.
+"""
+
+helps['network application-gateway rewrite-rule set list'] = """
+    short-summary: List rewrite rulesets.
+"""
+
+helps['network application-gateway rewrite-rule set show'] = """
+    short-summary: Get the details of a rewrite ruleset.
+"""
+
+helps['network application-gateway rewrite-rule set update'] = """
+    short-summary: Update a rewrite ruleset.
+"""
+
+helps['network application-gateway rewrite-rule condition'] = """
+    short-summary: Manage rewrite rule conditions of an application gateway.
+"""
+
+helps['network application-gateway rewrite-rule condition create'] = """
+    short-summary: Create a rewrite rule condition.
+"""
+
+helps['network application-gateway rewrite-rule condition delete'] = """
+    short-summary: Delete a rewrite rule condition.
+"""
+
+helps['network application-gateway rewrite-rule condition list'] = """
+    short-summary: List rewrite rule conditions.
+"""
+
+helps['network application-gateway rewrite-rule condition show'] = """
+    short-summary: Get the details of a rewrite rule condition.
+"""
+
+helps['network application-gateway rewrite-rule condition update'] = """
+    short-summary: Update a rewrite rule condition.
+"""
 # endregion
 
 # region Application Gateway rules

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -510,74 +510,87 @@ helps['network application-gateway redirect-config update'] = """
 # region Application Gateway rewrite rules
 helps['network application-gateway rewrite-rule'] = """
     short-summary: Manage rewrite rules of an application gateway.
+    type: group
 """
 
 helps['network application-gateway rewrite-rule create'] = """
     short-summary: Create a rewrite rule.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule delete'] = """
     short-summary: Delete a rewrite rule.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule list'] = """
     short-summary: List rewrite rules.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule show'] = """
     short-summary: Get the details of a rewrite rule.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule update'] = """
     short-summary: Update a rewrite rule.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule set'] = """
     short-summary: Manage rewrite rulesets of an application gateway.
+    type: group
 """
 
 helps['network application-gateway rewrite-rule set create'] = """
     short-summary: Create a rewrite ruleset.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule set delete'] = """
     short-summary: Delete a rewrite ruleset.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule set list'] = """
     short-summary: List rewrite rulesets.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule set show'] = """
     short-summary: Get the details of a rewrite ruleset.
-"""
-
-helps['network application-gateway rewrite-rule set update'] = """
-    short-summary: Update a rewrite ruleset.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule condition'] = """
     short-summary: Manage rewrite rule conditions of an application gateway.
+    type: group
 """
 
 helps['network application-gateway rewrite-rule condition create'] = """
     short-summary: Create a rewrite rule condition.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule condition delete'] = """
     short-summary: Delete a rewrite rule condition.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule condition list'] = """
     short-summary: List rewrite rule conditions.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule condition show'] = """
     short-summary: Get the details of a rewrite rule condition.
+    type: command
 """
 
 helps['network application-gateway rewrite-rule condition update'] = """
     short-summary: Update a rewrite rule condition.
+    type: command
 """
 # endregion
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -8,8 +8,6 @@ from argcomplete.completers import FilesCompleter
 
 import six
 
-from knack.arguments import CLIArgumentType, ignore_type
-
 from azure.cli.core.commands.parameters import (get_location_type, get_resource_name_completion_list,
                                                 tags_type, zone_type, zones_type,
                                                 file_type, get_resource_group_completion_list,
@@ -37,6 +35,8 @@ from azure.cli.command_modules.network._completers import (
     subnet_completion_list, get_lb_subresource_completion_list, get_ag_subresource_completion_list,
     ag_url_map_rule_completion_list, tm_endpoint_completion_list, service_endpoint_completer)
 from azure.cli.core.util import get_json_object
+
+from knack.arguments import CLIArgumentType, ignore_type
 
 
 # pylint: disable=too-many-locals, too-many-branches, too-many-statements

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -209,18 +209,19 @@ def load_arguments(self, _):
         c.argument('frontend_ip', help='The name or ID of the frontend IP configuration. {}'.format(default_existing))
 
     with self.argument_context('network application-gateway rewrite-rule') as c:
-        c.argument('response_headers', nargs='+', help='Space-separated list of HEADER=VALUE pairs.', validator=get_header_configuration_validator('response_headers'))
-        c.argument('request_headers', nargs='+', help='Space-separated list of HEADER=VALUE pairs.', validator=get_header_configuration_validator('request_headers'))
-        c.argument('sequence', type=int, help='Determines the execution order of the rule in the rule set.')
+        c.argument('rule_response_header_configurations', options_list='--response-headers', nargs='+', help='Space-separated list of HEADER=VALUE pairs.', validator=get_header_configuration_validator('rule_response_header_configurations'))
+        c.argument('rule_request_header_configurations', options_list='--request-headers', nargs='+', help='Space-separated list of HEADER=VALUE pairs.', validator=get_header_configuration_validator('rule_request_header_configurations'))
+        c.argument('rule_rule_sequence', options_list='--rule-sequence', type=int, help='Determines the execution order of the rule in the rule set.')
         c.argument('ruleset_name', help='Name of the rewrite rule set.')
         c.argument('rule_name', help='Name of the rewrite rule.')
         c.argument('gateway_name', help='Name of the application gateway.')
+        c.ignore('ruleset_id')
 
     with self.argument_context('network application-gateway rewrite-rule condition') as c:
-        c.argument('variable', help='The variable whose value is being evaluated.')
-        c.argument('pattern', help='The pattern, either fixed string or regular expression, that evaluates the truthfulness of the condition')
-        c.argument('ignore_case', arg_type=get_three_state_flag(), help='Make comparison case-insensitive.')
-        c.argument('negate', arg_type=get_three_state_flag(), help='Check the negation of the condition.')
+        c.argument('condition_variable', help='The variable whose value is being evaluated.')
+        c.argument('condition_pattern', options_list='--pattern', help='The pattern, either fixed string or regular expression, that evaluates the truthfulness of the condition')
+        c.argument('condition_ignore_case', arg_type=get_three_state_flag(), options_list='--ignore-case', help='Make comparison case-insensitive.')
+        c.argument('condition_negate', arg_type=get_three_state_flag(), options_list='--negate', help='Check the negation of the condition.')
 
     with self.argument_context('network application-gateway rule create') as c:
         c.argument('address_pool', help='The name or ID of the backend address pool. {}'.format(default_existing))

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -216,18 +216,6 @@ def load_arguments(self, _):
         c.argument('rule_name', help='Name of the rewrite rule.')
         c.argument('gateway_name', help='Name of the application gateway.')
 
-    # from ._resources import app_gateway_rewrite_ruleset, app_gateway_rewrite_rule, app_gateway_rewrite_rule_condition
-    # for command in ['list', 'show', 'delete']:
-    #     with self.argument_context('network application-gateway rewrite-rule set {}'.format(command)) as c:
-    #         app_gateway_rewrite_ruleset.register_dests(c)
-
-    #     with self.argument_context('network application-gateway rewrite-rule {}'.format(command)) as c:
-    #         app_gateway_rewrite_rule.register_dests(c)
-
-    #     with self.argument_context('network application-gateway rewrite-rule condition {}'.format(command)) as c:
-    #         app_gateway_rewrite_rule_condition.register_dests(c)
-
-
     with self.argument_context('network application-gateway rewrite-rule condition') as c:
         c.argument('variable', help='The variable whose value is being evaluated.')
         c.argument('pattern', help='The pattern, either fixed string or regular expression, that evaluates the truthfulness of the condition')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_util.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_util.py
@@ -4,8 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 import sys
-from knack.util import CLIError
+
 from azure.cli.core.util import sdk_no_wait
+
+from knack.util import CLIError
 
 from ._client_factory import network_client_factory
 
@@ -14,11 +16,10 @@ def _get_property(items, name):
     result = next((x for x in items if x.name.lower() == name.lower()), None)
     if not result:
         raise CLIError("Property '{}' does not exist".format(name))
-    else:
-        return result
+    return result
 
 
-def list_network_resource_property(resource, prop, path=None):
+def list_network_resource_property(resource, prop):
     """ Factory method for creating list functions. """
 
     def list_func(cmd, resource_group_name, resource_name):
@@ -30,7 +31,7 @@ def list_network_resource_property(resource, prop, path=None):
     return func_name
 
 
-def get_network_resource_property_entry(resource, prop, path=None):
+def get_network_resource_property_entry(resource, prop):
     """ Factory method for creating get functions. """
 
     def get_func(cmd, resource_group_name, resource_name, item_name):
@@ -40,15 +41,14 @@ def get_network_resource_property_entry(resource, prop, path=None):
         if not result:
             raise CLIError("Item '{}' does not exist on {} '{}'".format(
                 item_name, resource, resource_name))
-        else:
-            return result
+        return result
 
     func_name = 'get_network_resource_property_entry_{}_{}'.format(resource, prop)
     setattr(sys.modules[__name__], func_name, get_func)
     return func_name
 
 
-def delete_network_resource_property_entry(resource, prop, path=None):
+def delete_network_resource_property_entry(resource, prop):
     """ Factory method for creating delete functions. """
 
     def delete_func(cmd, resource_group_name, resource_name, item_name, no_wait=False):  # pylint: disable=unused-argument

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -10,15 +10,15 @@ import base64
 import socket
 import os
 
-from knack.util import CLIError
-from knack.log import get_logger
-
 from azure.cli.core.commands.validators import \
     (validate_tags, get_default_location_from_resource_group)
 from azure.cli.core.commands.template_create import get_folded_parameter_validator
 from azure.cli.core.commands.client_factory import get_subscription_id, get_mgmt_service_client
 from azure.cli.core.commands.validators import validate_parameter_set
 from azure.cli.core.profiles import ResourceType
+
+from knack.util import CLIError
+from knack.log import get_logger
 
 
 logger = get_logger(__name__)
@@ -137,9 +137,8 @@ def _generate_lb_id_list_from_names_or_ids(cli_ctx, namespace, prop, child_type)
             if not namespace.load_balancer_name:
                 raise CLIError('Unable to process {}. Please supply a well-formed ID or '
                                '--lb-name.'.format(item))
-            else:
-                result.append({'id': _generate_lb_subproperty_id(
-                    cli_ctx, namespace, child_type, item)})
+            result.append({'id': _generate_lb_subproperty_id(
+                cli_ctx, namespace, child_type, item)})
     setattr(namespace, prop, result)
 
 
@@ -511,7 +510,7 @@ def get_subnet_validator(has_type_field=False, allow_none=False, allow_new=False
         # error if vnet-name is provided along with a subnet ID
         if is_id and namespace.virtual_network_name:
             raise usage_error
-        elif not is_id and not namespace.virtual_network_name:
+        if not is_id and not namespace.virtual_network_name:
             raise usage_error
 
         if not is_id:
@@ -904,8 +903,7 @@ def process_vnet_create_namespace(cmd, namespace):
     if namespace.subnet_prefix and not namespace.subnet_name:
         if cmd.supported_api_version(min_api='2018-08-01'):
             raise ValueError('incorrect usage: --subnet-name NAME [--subnet-prefixes PREFIXES]')
-        else:
-            raise ValueError('incorrect usage: --subnet-name NAME [--subnet-prefix PREFIX]')
+        raise ValueError('incorrect usage: --subnet-name NAME [--subnet-prefix PREFIX]')
 
     if namespace.subnet_name and not namespace.subnet_prefix:
         if isinstance(namespace.vnet_prefixes, str):
@@ -1172,7 +1170,7 @@ def process_nw_topology_namespace(cmd, namespace):
         # targeting subnet - OK
         if subnet_id and (vnet or rg):
             raise subnet_usage
-        elif not subnet_id and (not rg or not vnet or vnet_id):
+        if not subnet_id and (not rg or not vnet or vnet_id):
             raise subnet_usage
         if subnet_id:
             rg = parse_resource_id(subnet_id)['resource_group']
@@ -1195,7 +1193,7 @@ def process_nw_topology_namespace(cmd, namespace):
         vnet_usage = CLIError('usage error: --vnet ID | --vnet NAME --resource-group NAME')
         if vnet_id and (subnet or rg):
             raise vnet_usage
-        elif not vnet_id and not rg or subnet:
+        if not vnet_id and not rg or subnet:
             raise vnet_usage
         if vnet_id:
             rg = parse_resource_id(vnet_id)['resource_group']
@@ -1494,9 +1492,10 @@ class WafConfigExclusionAction(argparse.Action):
             selector=selector
         ))
 
+
 def get_header_configuration_validator(dest):
 
-    def validator(cmd, namespace):
+    def validator(namespace):
 
         values = getattr(namespace, dest, None)
         if not values:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -1493,3 +1493,22 @@ class WafConfigExclusionAction(argparse.Action):
             selector_match_operator=op,
             selector=selector
         ))
+
+def get_header_configuration_validator(dest):
+
+    def validator(cmd, namespace):
+
+        values = getattr(namespace, dest, None)
+        if not values:
+            return
+
+        results = []
+        for item in values:
+            key, value = item.split('=', 1)
+            results.append({
+                'header_name': key,
+                'header_value': value
+            })
+        setattr(namespace, dest, results)
+
+    return validator

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -338,12 +338,11 @@ def load_command_table(self, _):
     for kwargs in subresource_properties:
         alias = kwargs['name']
         subresource = kwargs['prop']
-        path = kwargs.get('path', None)
         create_validator = kwargs.get('validator', None)
         with self.command_group('network application-gateway {}'.format(alias), network_util) as g:
-            g.command('list', list_network_resource_property('application_gateways', subresource, path))
-            g.show_command('show', get_network_resource_property_entry('application_gateways', subresource, path))
-            g.command('delete', delete_network_resource_property_entry('application_gateways', subresource, path), supports_no_wait=True)
+            g.command('list', list_network_resource_property('application_gateways', subresource))
+            g.show_command('show', get_network_resource_property_entry('application_gateways', subresource))
+            g.command('delete', delete_network_resource_property_entry('application_gateways', subresource), supports_no_wait=True)
             g.custom_command('create', 'create_ag_{}'.format(_make_singular(subresource)), supports_no_wait=True, validator=create_validator)
             g.generic_update_command('update', command_type=network_ag_sdk, supports_no_wait=True,
                                      custom_func_name='update_ag_{}'.format(_make_singular(subresource)),

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -370,7 +370,6 @@ def load_command_table(self, _):
         g.show()
         g.delete(confirmation=True)
 
-
     app_gateway_rewrite_rule = CliCommandType(
         path='Microsoft.Network/applicationGateways/{application_gateway_name:gateway_name}/rewriteRuleSets/{name:ruleset_name}/rewriteRules/{name:rule_name}',
         min_api='2018-12-01',
@@ -391,9 +390,9 @@ def load_command_table(self, _):
         model_prefix='condition',
         **ag_kwargs
     )
-
     with self._arm_command_group('network application-gateway rewrite-rule condition', app_gateway_rewrite_rule_condition) as g:
         g.create(supports_no_wait=True)
+        g.update(supports_no_wait=True)
         g.list()
         g.show()
         g.delete()

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -365,7 +365,7 @@ def load_command_table(self, _):
         **ag_kwargs
     )
     with self._arm_command_group('network application-gateway rewrite-rule set', app_gateway_rewrite_ruleset) as g:
-        g.create()
+        g.create(supports_no_wait=True)
         g.list()
         g.show()
         g.delete(confirmation=True)
@@ -379,13 +379,13 @@ def load_command_table(self, _):
         **ag_kwargs
     )
     with self._arm_command_group('network application-gateway rewrite-rule', app_gateway_rewrite_rule) as g:
-        g.create()
+        g.create(supports_no_wait=True)
         g.list()
         g.show()
         g.delete()
 
     app_gateway_rewrite_rule_condition = CliCommandType(
-        path='Microsoft.Network/applicationGateways/{application_gateway_name:gateway_name}/rewriteRuleSets/{name:ruleset_name}/rewriteRules/{name:rule_name}/conditions/{variable}',
+        path='Microsoft.Network/applicationGateways/{application_gateway_name:gateway_name}/rewriteRuleSets/{name:ruleset_name}/rewriteRules/{name:rule_name}/conditions/{variable:condition_variable}',
         min_api='2018-12-01',
         model='ApplicationGatewayRewriteRuleCondition',
         model_prefix='condition',
@@ -393,7 +393,7 @@ def load_command_table(self, _):
     )
 
     with self._arm_command_group('network application-gateway rewrite-rule condition', app_gateway_rewrite_rule_condition) as g:
-        g.create()
+        g.create(supports_no_wait=True)
         g.list()
         g.show()
         g.delete()

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -290,14 +290,12 @@ def load_command_table(self, _):
     )
 
     network_custom = CliCommandType(operations_tmpl='azure.cli.command_modules.network.custom#{}')
-
     # endregion
 
     # region NetworkRoot
     usage_path = 'azure.mgmt.network.operations.usages_operations#UsagesOperations.{}'
     with self.command_group('network') as g:
         g.command('list-usages', 'list', operations_tmpl=usage_path, client_factory=cf_usages, transform=transform_network_usage_list, table_transformer=transform_network_usage_table)
-
     # endregion
 
     # region ApplicationGateways
@@ -351,7 +349,6 @@ def load_command_table(self, _):
                                      custom_func_name='update_ag_{}'.format(_make_singular(subresource)),
                                      child_collection_prop_name=subresource, validator=create_validator)
 
-
     ag_kwargs = {
         'operations_tmpl': 'azure.cli.core.commands.arm#{}',
         'client_factory': cf_application_gateways
@@ -364,7 +361,7 @@ def load_command_table(self, _):
         min_api='2018-12-01',
         **ag_kwargs
     )
-    with self._arm_command_group('network application-gateway rewrite-rule set', app_gateway_rewrite_ruleset) as g:
+    with self._arm_command_group('network application-gateway rewrite-rule set', app_gateway_rewrite_ruleset) as g:  # pylint: disable=protected-access
         g.create(supports_no_wait=True)
         g.list()
         g.show()
@@ -377,7 +374,7 @@ def load_command_table(self, _):
         model_prefix='rule',
         **ag_kwargs
     )
-    with self._arm_command_group('network application-gateway rewrite-rule', app_gateway_rewrite_rule) as g:
+    with self._arm_command_group('network application-gateway rewrite-rule', app_gateway_rewrite_rule) as g:  # pylint: disable=protected-access
         g.create(supports_no_wait=True)
         g.update(supports_no_wait=True)
         g.list()
@@ -391,7 +388,7 @@ def load_command_table(self, _):
         model_prefix='condition',
         **ag_kwargs
     )
-    with self._arm_command_group('network application-gateway rewrite-rule condition', app_gateway_rewrite_rule_condition) as g:
+    with self._arm_command_group('network application-gateway rewrite-rule condition', app_gateway_rewrite_rule_condition) as g:  # pylint: disable=protected-access
         g.create(supports_no_wait=True)
         g.update(supports_no_wait=True)
         g.list()
@@ -428,7 +425,6 @@ def load_command_table(self, _):
         g.custom_command('set', 'set_ag_waf_config_2016_09_01', max_api='2016-09-01', supports_no_wait=True)
         g.custom_show_command('show', 'show_ag_waf_config')
         g.custom_command('list-rule-sets', 'list_ag_waf_rule_sets', min_api='2017-03-01', client_factory=cf_application_gateways, table_transformer=transform_waf_rule_sets_table_output)
-
     # endregion
 
     # region ApplicationSecurityGroups
@@ -438,7 +434,6 @@ def load_command_table(self, _):
         g.command('list', 'list_all')
         g.command('delete', 'delete')
         g.generic_update_command('update', custom_func_name='update_asg')
-
     # endregion
 
     # region DdosProtectionPlans
@@ -494,7 +489,6 @@ def load_command_table(self, _):
         g.custom_command('create', 'create_dns_record_set', transform=transform_dns_record_set_output, doc_string_source=dns_doc_string)
         g.custom_command('set-record', 'add_dns_cname_record', transform=transform_dns_record_set_output)
         g.custom_command('remove-record', 'remove_dns_cname_record', transform=transform_dns_record_set_output)
-
     # endregion
 
     # region ExpressRoutes
@@ -670,7 +664,6 @@ def load_command_table(self, _):
     with self.command_group('network nic ip-config inbound-nat-rule') as g:
         g.custom_command('add', 'add_nic_ip_config_inbound_nat_rule')
         g.custom_command('remove', 'remove_nic_ip_config_inbound_nat_rule')
-
     # endregion
 
     # region NetworkSecurityGroups
@@ -754,7 +747,6 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_public_ip_prefixes')
         g.show_command('show')
         g.generic_update_command('update', custom_func_name='update_public_ip_prefix')
-
     # endregion
 
     # region RouteFilters
@@ -773,7 +765,6 @@ def load_command_table(self, _):
         g.generic_update_command('update', setter_arg_name='route_filter_rule_parameters')
         sc_path = 'azure.mgmt.network.operations#BgpServiceCommunitiesOperations.{}'
         g.command('list-service-communities', 'list', operations_tmpl=sc_path, client_factory=cf_service_community, table_transformer=transform_service_community_table_output)
-
     # endregion
 
     # region RouteTables
@@ -794,7 +785,6 @@ def load_command_table(self, _):
         g.show_command('show', 'get')
         g.command('list', 'list')
         g.generic_update_command('update', setter_arg_name='route_parameters', custom_func_name='update_route')
-
     # endregion
 
     # region ServiceEndpoint
@@ -835,7 +825,6 @@ def load_command_table(self, _):
 
         tm_geographic_path = 'azure.mgmt.trafficmanager.operations.geographic_hierarchies_operations#GeographicHierarchiesOperations.{}'
         g.command('show-geographic-hierarchy', 'get_default', client_factory=cf_tm_geographic, operations_tmpl=tm_geographic_path, table_transformer=transform_geographic_hierachy_table_output)
-
     # endregion
 
     # region VirtualNetworks

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -311,11 +311,8 @@ def load_command_table(self, _):
         g.wait_command('wait')
 
     subresource_properties = [
-        {'prop': 'authentication_certificates', 'name': 'auth-cert'},
-        {'prop': 'ssl_certificates', 'name': 'ssl-cert'},
         {'prop': 'frontend_ip_configurations', 'name': 'frontend-ip'},
         {'prop': 'frontend_ports', 'name': 'frontend-port'},
-        {'prop': 'backend_address_pools', 'name': 'address-pool'},
         {'prop': 'backend_http_settings_collection', 'name': 'http-settings', 'validator': process_ag_http_settings_create_namespace},
         {'prop': 'http_listeners', 'name': 'http-listener', 'validator': process_ag_listener_create_namespace},
         {'prop': 'request_routing_rules', 'name': 'rule', 'validator': process_ag_rule_create_namespace},
@@ -353,6 +350,32 @@ def load_command_table(self, _):
         'client_factory': cf_application_gateways
     }
 
+    app_gateway_backend_pool = CliCommandType(
+        path='Microsoft.Network/applicationGateways/{application_gateway_name:gateway_name}/backendAddressPools/{name:pool_name}',
+        model='ApplicationGatewayBackendAddressPool',
+        model_prefix='pool',
+        **ag_kwargs
+    )
+    with self._arm_command_group('network application-gateway address-pool', app_gateway_backend_pool) as g:  # pylint: disable=protected-access
+        g.create(supports_no_wait=True)
+        g.update(supports_no_wait=True)
+        g.list()
+        g.show()
+        g.delete()
+
+    app_gateway_auth_cert = CliCommandType(
+        path='Microsoft.Network/applicationGateways/{application_gateway_name:gateway_name}/authenticationCertificates/{name:auth_name}',
+        model='ApplicationGatewayAuthenticationCertificate',
+        model_prefix='auth',
+        **ag_kwargs
+    )
+    with self._arm_command_group('network application-gateway auth-cert', app_gateway_auth_cert) as g:  # pylint: disable=protected-access
+        g.create(supports_no_wait=True)
+        g.update(supports_no_wait=True)
+        g.list()
+        g.show()
+        g.delete()
+
     app_gateway_rewrite_ruleset = CliCommandType(
         path='Microsoft.Network/applicationGateways/{application_gateway_name:gateway_name}/rewriteRuleSets/{name:ruleset_name}',
         model='ApplicationGatewayRewriteRuleSet',
@@ -388,6 +411,19 @@ def load_command_table(self, _):
         **ag_kwargs
     )
     with self._arm_command_group('network application-gateway rewrite-rule condition', app_gateway_rewrite_rule_condition) as g:  # pylint: disable=protected-access
+        g.create(supports_no_wait=True)
+        g.update(supports_no_wait=True)
+        g.list()
+        g.show()
+        g.delete()
+
+    app_gateway_ssl_cert = CliCommandType(
+        path='Microsoft.Network/applicationGateways/{application_gateway_name:gateway_name}/sslCertificates/{name:cert_name}',
+        model='ApplicationGatewaySslCertificate',
+        model_prefix='cert',
+        **ag_kwargs
+    )
+    with self._arm_command_group('network application-gateway ssl-cert', app_gateway_ssl_cert) as g:  # pylint: disable=protected-access
         g.create(supports_no_wait=True)
         g.update(supports_no_wait=True)
         g.list()

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -366,7 +366,6 @@ def load_command_table(self, _):
     )
     with self._arm_command_group('network application-gateway rewrite-rule set', app_gateway_rewrite_ruleset) as g:
         g.create()
-        #g.update()
         g.list()
         g.show()
         g.delete(confirmation=True)
@@ -375,11 +374,12 @@ def load_command_table(self, _):
     app_gateway_rewrite_rule = CliCommandType(
         path='Microsoft.Network/applicationGateways/{application_gateway_name:gateway_name}/rewriteRuleSets/{name:ruleset_name}/rewriteRules/{name:rule_name}',
         min_api='2018-12-01',
-        #model='ApplicationGatewayRewriteRule',
-        #model_prefix='rule',
+        model='ApplicationGatewayRewriteRule',
+        model_prefix='rule',
         **ag_kwargs
     )
     with self._arm_command_group('network application-gateway rewrite-rule', app_gateway_rewrite_rule) as g:
+        g.create()
         g.list()
         g.show()
         g.delete()
@@ -393,6 +393,7 @@ def load_command_table(self, _):
     )
 
     with self._arm_command_group('network application-gateway rewrite-rule condition', app_gateway_rewrite_rule_condition) as g:
+        g.create()
         g.list()
         g.show()
         g.delete()

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -379,6 +379,7 @@ def load_command_table(self, _):
     )
     with self._arm_command_group('network application-gateway rewrite-rule', app_gateway_rewrite_rule) as g:
         g.create(supports_no_wait=True)
+        g.update(supports_no_wait=True)
         g.list()
         g.show()
         g.delete()

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -252,38 +252,6 @@ def update_application_gateway(instance, sku=None, capacity=None, tags=None, ena
     return instance
 
 
-def create_ag_authentication_certificate(cmd, resource_group_name, application_gateway_name, item_name,
-                                         cert_data, no_wait=False):
-    AuthCert = cmd.get_models('ApplicationGatewayAuthenticationCertificate')
-    ncf = network_client_factory(cmd.cli_ctx).application_gateways
-    ag = ncf.get(resource_group_name, application_gateway_name)
-    new_cert = AuthCert(data=cert_data, name=item_name)
-    _upsert(ag, 'authentication_certificates', new_cert, 'name')
-    return sdk_no_wait(no_wait, ncf.create_or_update, resource_group_name, application_gateway_name, ag)
-
-
-def update_ag_authentication_certificate(instance, parent, item_name, cert_data):
-    instance.data = cert_data
-    return parent
-
-
-def create_ag_backend_address_pool(cmd, resource_group_name, application_gateway_name, item_name,
-                                   servers=None, no_wait=False):
-    ApplicationGatewayBackendAddressPool = cmd.get_models('ApplicationGatewayBackendAddressPool')
-    ncf = network_client_factory(cmd.cli_ctx)
-    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
-    new_pool = ApplicationGatewayBackendAddressPool(name=item_name, backend_addresses=servers)
-    _upsert(ag, 'backend_address_pools', new_pool, 'name')
-    return sdk_no_wait(no_wait, ncf.application_gateways.create_or_update,
-                       resource_group_name, application_gateway_name, ag)
-
-
-def update_ag_backend_address_pool(instance, parent, item_name, servers=None):
-    if servers is not None:
-        instance.backend_addresses = servers
-    return parent
-
-
 def create_ag_frontend_ip_configuration(cmd, resource_group_name, application_gateway_name, item_name,
                                         public_ip_address=None, subnet=None,
                                         virtual_network_name=None, private_ip_address=None,
@@ -587,26 +555,6 @@ def update_ag_request_routing_rule(cmd, instance, parent, item_name, address_poo
         instance.url_path_map = SubResource(id=url_path_map)
     if rule_type is not None:
         instance.rule_type = rule_type
-    return parent
-
-
-def create_ag_ssl_certificate(cmd, resource_group_name, application_gateway_name, item_name, cert_data,
-                              cert_password, no_wait=False):
-    ApplicationGatewaySslCertificate = cmd.get_models('ApplicationGatewaySslCertificate')
-    ncf = network_client_factory(cmd.cli_ctx)
-    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
-    new_cert = ApplicationGatewaySslCertificate(
-        name=item_name, data=cert_data, password=cert_password)
-    _upsert(ag, 'ssl_certificates', new_cert, 'name')
-    return sdk_no_wait(no_wait, ncf.application_gateways.create_or_update,
-                       resource_group_name, application_gateway_name, ag)
-
-
-def update_ag_ssl_certificate(instance, parent, item_name, cert_data=None, cert_password=None):
-    if cert_data is not None:
-        instance.data = cert_data
-    if cert_password is not None:
-        instance.password = cert_password
     return parent
 
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_rewrite_rulesets.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_rewrite_rulesets.yaml
@@ -1,0 +1,1099 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2019-02-25T21:48:13Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001","name":"cli_test_ag_rewrite_rulesets000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-02-25T21:48:13Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n --sku]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001","name":"cli_test_ag_rewrite_rulesets000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-02-25T21:48:13Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "sku": {"name": "Standard"}, "properties": {"publicIPAllocationMethod":
+      "Static", "publicIPAddressVersion": "IPv4", "idleTimeoutInMinutes": 4}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip create]
+      Connection: [keep-alive]
+      Content-Length: ['166']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --sku]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"pip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
+        ,\r\n  \"etag\": \"W/\\\"372f353c-ad27-43cc-8f0e-09f7bb37ba8e\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"1198e205-47c5-46e5-bfaa-633e9ee93985\"\
+        ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
+        : \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\n\
+        \  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
+        : {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Regional\"\r\n  }\r\n\
+        }"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1ebf210b-5441-491e-b23f-b4889768e6eb?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['683']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n --sku]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1ebf210b-5441-491e-b23f-b4889768e6eb?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n --sku]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1ebf210b-5441-491e-b23f-b4889768e6eb?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network public-ip create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n --sku]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"pip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
+        ,\r\n  \"etag\": \"W/\\\"93a01e66-90be-4f5a-9f38-6a36dd140009\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"1198e205-47c5-46e5-bfaa-633e9ee93985\"\
+        ,\r\n    \"ipAddress\": \"52.180.89.72\",\r\n    \"publicIPAddressVersion\"\
+        : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Static\",\r\n    \"idleTimeoutInMinutes\"\
+        : 4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\
+        ,\r\n  \"sku\": {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Regional\"\
+        \r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['718']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:17 GMT']
+      etag: [W/"93a01e66-90be-4f5a-9f38-6a36dd140009"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n --public-ip-address --sku --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001","name":"cli_test_ag_rewrite_rulesets000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-02-25T21:48:13Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n --public-ip-address --sku --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27cli_test_ag_rewrite_rulesets000001%27%20and%20name%20eq%20%27None%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27&api-version=2018-05-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n --public-ip-address --sku --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27cli_test_ag_rewrite_rulesets000001%27%20and%20name%20eq%20%27pip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27&api-version=2018-05-01
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1","name":"pip1","type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"},"location":"westus"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['337']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {}, "variables": {"appGwID": "[resourceId(\''Microsoft.Network/applicationGateways\'',
+      \''gw1\'')]"}, "resources": [{"name": "gw1Vnet", "type": "Microsoft.Network/virtualNetworks",
+      "location": "westus", "apiVersion": "2015-06-15", "dependsOn": [], "tags": {},
+      "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}, "subnets":
+      [{"name": "default", "properties": {"addressPrefix": "10.0.0.0/24"}}]}}, {"type":
+      "Microsoft.Network/applicationGateways", "name": "gw1", "location": "westus",
+      "tags": {}, "apiVersion": "2018-12-01", "dependsOn": ["Microsoft.Network/virtualNetworks/gw1Vnet"],
+      "properties": {"backendAddressPools": [{"name": "appGatewayBackendPool"}], "backendHttpSettingsCollection":
+      [{"name": "appGatewayBackendHttpSettings", "properties": {"Port": 80, "Protocol":
+      "Http", "CookieBasedAffinity": "disabled", "connectionDraining": {"enabled":
+      false, "drainTimeoutInSec": 1}}}], "frontendIPConfigurations": [{"name": "appGatewayFrontendIP",
+      "properties": {"publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"}}}],
+      "frontendPorts": [{"name": "appGatewayFrontendPort", "properties": {"Port":
+      80}}], "gatewayIPConfigurations": [{"name": "appGatewayFrontendIP", "properties":
+      {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"}}}],
+      "httpListeners": [{"name": "appGatewayHttpListener", "properties": {"FrontendIpConfiguration":
+      {"Id": "[concat(variables(\''appGwID\''), \''/frontendIPConfigurations/appGatewayFrontendIP\'')]"},
+      "FrontendPort": {"Id": "[concat(variables(\''appGwID\''), \''/frontendPorts/appGatewayFrontendPort\'')]"},
+      "Protocol": "http", "SslCertificate": null}}], "sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "requestRoutingRules": [{"Name": "rule1",
+      "properties": {"RuleType": "Basic", "httpListener": {"id": "[concat(variables(\''appGwID\''),
+      \''/httpListeners/appGatewayHttpListener\'')]"}, "backendAddressPool": {"id":
+      "[concat(variables(\''appGwID\''), \''/backendAddressPools/appGatewayBackendPool\'')]"},
+      "backendHttpSettings": {"id": "[concat(variables(\''appGwID\''), \''/backendHttpSettingsCollection/appGatewayBackendHttpSettings\'')]"}}}]},
+      "zones": null}], "outputs": {"applicationGateway": {"type": "object", "value":
+      "[reference(\''gw1\'')]"}}}, "parameters": {}, "mode": "Incremental"}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway create]
+      Connection: [keep-alive]
+      Content-Length: ['2726']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g -n --public-ip-address --sku --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Resources/deployments/ag_deploy_NiMvv9G4dkgdp8R1UaHQ4jm9cCp9cpel","name":"ag_deploy_NiMvv9G4dkgdp8R1UaHQ4jm9cCp9cpel","properties":{"templateHash":"16520338041843947326","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2019-02-25T21:48:22.4032411Z","duration":"PT0.7699705S","correlationId":"2cb7e997-9e33-41ea-83b9-393f9ea4a625","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"applicationGateways","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"gw1Vnet"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1","resourceType":"Microsoft.Network/applicationGateways","resourceName":"gw1"}]}}'}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Resources/deployments/ag_deploy_NiMvv9G4dkgdp8R1UaHQ4jm9cCp9cpel/operationStatuses/08586504755838443459?api-version=2018-05-01']
+      cache-control: [no-cache]
+      content-length: ['1310']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway wait]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n --exists]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/applicationGateways/gw1''
+        under resource group ''cli_test_ag_rewrite_rulesets000001'' was not found."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['220']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-failure-cause: [gateway]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway wait]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n --exists]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
+        ,\r\n  \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
+        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
+        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
+        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
+        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
+        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
+        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
+        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
+        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
+        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
+        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
+        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
+        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
+        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
+        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
+        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
+        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
+        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
+        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
+        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
+        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
+        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
+        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
+        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [],\r\
+        \n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['9048']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:52 GMT']
+      etag: [W/"a3182e56-3841-4df7-a271-4fd04bce4dc3"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule set create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name -n --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
+        ,\r\n  \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
+        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
+        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
+        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
+        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
+        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
+        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
+        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
+        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
+        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
+        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
+        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
+        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
+        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
+        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
+        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
+        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
+        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
+        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
+        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
+        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
+        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
+        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
+        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [],\r\
+        \n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['9048']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:54 GMT']
+      etag: [W/"a3182e56-3841-4df7-a271-4fd04bce4dc3"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1",
+      "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
+      [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
+      "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
+      "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
+      "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+      "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
+      "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
+      "appGatewayBackendPool", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
+      "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
+      1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
+      "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
+      "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
+      "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
+      [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
+      "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
+      "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
+      [{"name": "ruleset1"}], "redirectConfigurations": [], "resourceGuid": "da8453b3-2038-4d5a-8ba3-0ab495fb2ac2",
+      "provisioningState": "Updating"}, "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule set create]
+      Connection: [keep-alive]
+      Content-Length: ['6141']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g --gateway-name -n --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
+        ,\r\n  \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
+        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
+        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
+        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
+        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
+        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
+        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
+        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
+        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
+        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
+        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
+        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
+        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
+        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
+        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
+        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
+        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
+        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
+        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
+        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
+        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
+        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
+        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
+        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
+        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\
+        \n      {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\"\
+        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"rewriteRules\": []\r\n        },\r\n        \"type\": \"\
+        Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n      }\r\n   \
+        \ ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5271e0d9-bb02-4eb2-afea-b20dbe5837ee?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['9586']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:54 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule set show]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name -n]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
+        ,\r\n  \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
+        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
+        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
+        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
+        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
+        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
+        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
+        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
+        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
+        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
+        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
+        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
+        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
+        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
+        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
+        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
+        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
+        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
+        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
+        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
+        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
+        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
+        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
+        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\
+        \n      {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"rewriteRules\": []\r\n        },\r\n        \"type\": \"\
+        Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n      }\r\n   \
+        \ ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['9586']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:54 GMT']
+      etag: [W/"773bb567-f829-4c86-8291-2842f5e525ec"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --sequence --request-headers
+          --response-headers --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
+        ,\r\n  \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
+        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
+        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
+        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
+        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
+        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
+        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
+        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
+        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
+        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
+        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
+        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
+        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
+        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
+        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
+        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
+        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
+        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
+        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
+        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
+        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
+        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
+        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
+        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\
+        \n      {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\"\
+        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"rewriteRules\": []\r\n        },\r\n        \"type\": \"\
+        Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n      }\r\n   \
+        \ ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['9586']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:55 GMT']
+      etag: [W/"773bb567-f829-4c86-8291-2842f5e525ec"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1",
+      "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
+      [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
+      "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
+      "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
+      "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+      "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
+      "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
+      "appGatewayBackendPool", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
+      "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
+      1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
+      "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
+      "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
+      "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
+      [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
+      "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
+      "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1",
+      "properties": {"rewriteRules": [{"name": "rule1", "ruleSequence": 100, "actionSet":
+      {"requestHeaderConfigurations": [{"headerName": "foo", "headerValue": "bar"}],
+      "responseHeaderConfigurations": [{"headerName": "cat", "headerValue": "hat"}]}}]},
+      "name": "ruleset1"}], "redirectConfigurations": [], "resourceGuid": "da8453b3-2038-4d5a-8ba3-0ab495fb2ac2",
+      "provisioningState": "Updating"}, "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule create]
+      Connection: [keep-alive]
+      Content-Length: ['6616']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --sequence --request-headers
+          --response-headers --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
+        ,\r\n  \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
+        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
+        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
+        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
+        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
+        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
+        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
+        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
+        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
+        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
+        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
+        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
+        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
+        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
+        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
+        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
+        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
+        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
+        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
+        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
+        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
+        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
+        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
+        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
+        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\
+        \n      {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\"\
+        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\"\
+        : 100,\r\n              \"conditions\": [],\r\n              \"name\": \"\
+        rule1\",\r\n              \"actionSet\": {\r\n                \"requestHeaderConfigurations\"\
+        : [\r\n                  {\r\n                    \"headerName\": \"foo\"\
+        ,\r\n                    \"headerValue\": \"bar\"\r\n                  }\r\
+        \n                ],\r\n                \"responseHeaderConfigurations\":\
+        \ [\r\n                  {\r\n                    \"headerName\": \"cat\"\
+        ,\r\n                    \"headerValue\": \"hat\"\r\n                  }\r\
+        \n                ]\r\n              }\r\n            }\r\n          ]\r\n\
+        \        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\
+        \r\n      }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8060fb41-a548-4c19-b6c5-c5a3f414012d?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['10168']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 25 Feb 2019 21:48:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Mon, 25 Feb 2019 21:48:57 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQUc6NUZSRVdSSVRFOjVGUlVMRVNFVFNZNEZFSlpNSFVWVXwzRERGNDg5QTMxREE3Mzg0LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_rewrite_rulesets.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_network_app_gateway_rewrite_rulesets.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2019-02-25T21:48:13Z"}}'
+      "date": "2019-03-12T00:43:44Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -11,17 +11,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--location --name --tag]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001","name":"cli_test_ag_rewrite_rulesets000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-02-25T21:48:13Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001","name":"cli_test_ag_rewrite_rulesets000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-12T00:43:44Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:12 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -37,17 +37,17 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n --sku]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001","name":"cli_test_ag_rewrite_rulesets000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-02-25T21:48:13Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001","name":"cli_test_ag_rewrite_rulesets000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-12T00:43:44Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:12 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -66,26 +66,25 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-g -n --sku]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2018-12-01
   response:
-    body: {string: "{\r\n  \"name\": \"pip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
-        ,\r\n  \"etag\": \"W/\\\"372f353c-ad27-43cc-8f0e-09f7bb37ba8e\\\"\",\r\n \
-        \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"1198e205-47c5-46e5-bfaa-633e9ee93985\"\
-        ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
-        : \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\n\
-        \  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\"\
-        : {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Regional\"\r\n  }\r\n\
-        }"}
+    body: {string: "{\r\n  \"name\": \"pip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\",\r\n
+        \ \"etag\": \"W/\\\"866e0026-cc10-439b-8752-07c6e2051739\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"5bab72cc-8a4b-4a42-ada7-18c7cdf191f9\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Static\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Regional\"\r\n
+        \ }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1ebf210b-5441-491e-b23f-b4889768e6eb?api-version=2018-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/0bdf8d99-5d44-4b15-a670-b250cfeda9cc?api-version=2018-12-01']
       cache-control: [no-cache]
       content-length: ['683']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:14 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -102,16 +101,16 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n --sku]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1ebf210b-5441-491e-b23f-b4889768e6eb?api-version=2018-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/0bdf8d99-5d44-4b15-a670-b250cfeda9cc?api-version=2018-12-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:15 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -129,16 +128,16 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n --sku]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1ebf210b-5441-491e-b23f-b4889768e6eb?api-version=2018-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/0bdf8d99-5d44-4b15-a670-b250cfeda9cc?api-version=2018-12-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['29']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:17 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -156,25 +155,24 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n --sku]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1?api-version=2018-12-01
   response:
-    body: {string: "{\r\n  \"name\": \"pip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
-        ,\r\n  \"etag\": \"W/\\\"93a01e66-90be-4f5a-9f38-6a36dd140009\\\"\",\r\n \
-        \ \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"1198e205-47c5-46e5-bfaa-633e9ee93985\"\
-        ,\r\n    \"ipAddress\": \"52.180.89.72\",\r\n    \"publicIPAddressVersion\"\
-        : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Static\",\r\n    \"idleTimeoutInMinutes\"\
-        : 4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\
-        ,\r\n  \"sku\": {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Regional\"\
-        \r\n  }\r\n}"}
+    body: {string: "{\r\n  \"name\": \"pip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\",\r\n
+        \ \"etag\": \"W/\\\"e2a1d9ba-83dd-4d84-a8f6-83dd57a21d4c\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"5bab72cc-8a4b-4a42-ada7-18c7cdf191f9\",\r\n    \"ipAddress\":
+        \"20.189.137.34\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": []\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"sku\":
+        {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Regional\"\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['718']
+      content-length: ['719']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:17 GMT']
-      etag: [W/"93a01e66-90be-4f5a-9f38-6a36dd140009"]
+      date: ['Tue, 12 Mar 2019 00:43:50 GMT']
+      etag: [W/"e2a1d9ba-83dd-4d84-a8f6-83dd57a21d4c"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -192,17 +190,17 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n --public-ip-address --sku --no-wait]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001","name":"cli_test_ag_rewrite_rulesets000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-02-25T21:48:13Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001","name":"cli_test_ag_rewrite_rulesets000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-12T00:43:44Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:19 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -218,7 +216,7 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n --public-ip-address --sku --no-wait]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27cli_test_ag_rewrite_rulesets000001%27%20and%20name%20eq%20%27None%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27&api-version=2018-05-01
@@ -228,7 +226,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:19 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -244,7 +242,7 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n --public-ip-address --sku --no-wait]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27cli_test_ag_rewrite_rulesets000001%27%20and%20name%20eq%20%27pip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27&api-version=2018-05-01
@@ -254,7 +252,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['337']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:19 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -298,18 +296,18 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-g -n --public-ip-address --sku --no-wait]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Resources/deployments/ag_deploy_NiMvv9G4dkgdp8R1UaHQ4jm9cCp9cpel","name":"ag_deploy_NiMvv9G4dkgdp8R1UaHQ4jm9cCp9cpel","properties":{"templateHash":"16520338041843947326","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2019-02-25T21:48:22.4032411Z","duration":"PT0.7699705S","correlationId":"2cb7e997-9e33-41ea-83b9-393f9ea4a625","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"applicationGateways","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"gw1Vnet"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1","resourceType":"Microsoft.Network/applicationGateways","resourceName":"gw1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Resources/deployments/ag_deploy_hl9joCm6aHFFNKV2vu7mi1gqDEbT6unO","name":"ag_deploy_hl9joCm6aHFFNKV2vu7mi1gqDEbT6unO","properties":{"templateHash":"5644567135364368289","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2019-03-12T00:43:54.7519545Z","duration":"PT0.8350896S","correlationId":"bd8ff17c-99dd-481b-97ec-530d655cf0c9","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"applicationGateways","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"gw1Vnet"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1","resourceType":"Microsoft.Network/applicationGateways","resourceName":"gw1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Resources/deployments/ag_deploy_NiMvv9G4dkgdp8R1UaHQ4jm9cCp9cpel/operationStatuses/08586504755838443459?api-version=2018-05-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Resources/deployments/ag_deploy_hl9joCm6aHFFNKV2vu7mi1gqDEbT6unO/operationStatuses/08586492554515607595?api-version=2018-05-01']
       cache-control: [no-cache]
-      content-length: ['1310']
+      content-length: ['1309']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:22 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -325,7 +323,7 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n --exists]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
@@ -336,7 +334,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['220']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:23 GMT']
+      date: ['Tue, 12 Mar 2019 00:43:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -352,91 +350,88 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n --exists]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
   response:
-    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
-        ,\r\n  \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
-        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
-        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
-        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
-        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
-        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
-        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
-        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
-        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
-        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
-        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
-        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
-        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
-        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
-        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
-        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
-        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
-        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
-        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
-        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
-        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
-        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
-        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
-        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [],\r\
-        \n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [],\r\n
+        \   \"redirectConfigurations\": []\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['9048']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:52 GMT']
-      etag: [W/"a3182e56-3841-4df7-a271-4fd04bce4dc3"]
+      date: ['Tue, 12 Mar 2019 00:44:25 GMT']
+      etag: [W/"52bf3130-cb63-4947-aa45-699fd3af3cd7"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -454,91 +449,88 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g --gateway-name -n --no-wait]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
   response:
-    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
-        ,\r\n  \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
-        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
-        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
-        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
-        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
-        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
-        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
-        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
-        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
-        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
-        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
-        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
-        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
-        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
-        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
-        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
-        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
-        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
-        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
-        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
-        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
-        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
-        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
-        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [],\r\
-        \n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [],\r\n
+        \   \"redirectConfigurations\": []\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['9048']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:54 GMT']
-      etag: [W/"a3182e56-3841-4df7-a271-4fd04bce4dc3"]
+      date: ['Tue, 12 Mar 2019 00:44:25 GMT']
+      etag: [W/"52bf3130-cb63-4947-aa45-699fd3af3cd7"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -552,40 +544,40 @@ interactions:
       "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
       "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
       "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
-      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\"",
       "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
       [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
       "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
-      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\"",
       "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
       "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
       "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
-      "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "etag": "W/\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
       "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
       "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
-      "appGatewayBackendPool", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "appGatewayBackendPool", "etag": "W/\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\"",
       "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
       [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
       "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
       "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
       1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
-      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\"",
       "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
       "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
       "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
       "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
       "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
-      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\"",
       "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
       [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
       "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
       "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
       "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
-      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\"",
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\"",
       "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
-      [{"name": "ruleset1"}], "redirectConfigurations": [], "resourceGuid": "da8453b3-2038-4d5a-8ba3-0ab495fb2ac2",
-      "provisioningState": "Updating"}, "etag": "W/\\"a3182e56-3841-4df7-a271-4fd04bce4dc3\\""}'''
+      [{"name": "ruleset1"}], "redirectConfigurations": [], "resourceGuid": "aab025b8-8c53-47cb-9b26-e722b1f3335a",
+      "provisioningState": "Updating"}, "etag": "W/\\"52bf3130-cb63-4947-aa45-699fd3af3cd7\\""}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -595,96 +587,92 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-g --gateway-name -n --no-wait]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
   response:
-    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
-        ,\r\n  \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
-        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
-        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
-        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
-        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
-        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
-        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
-        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
-        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
-        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
-        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
-        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
-        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
-        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
-        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
-        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
-        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
-        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
-        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
-        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
-        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
-        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
-        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
-        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
-        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\
-        \n      {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\"\
-        ,\r\n        \"etag\": \"W/\\\"3bf53ab8-54f0-436d-8b8e-059ead860c70\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"rewriteRules\": []\r\n        },\r\n        \"type\": \"\
-        Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n      }\r\n   \
-        \ ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"711daa47-21b1-41cd-a061-8d761e648449\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"711daa47-21b1-41cd-a061-8d761e648449\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"711daa47-21b1-41cd-a061-8d761e648449\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"711daa47-21b1-41cd-a061-8d761e648449\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"711daa47-21b1-41cd-a061-8d761e648449\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"711daa47-21b1-41cd-a061-8d761e648449\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"711daa47-21b1-41cd-a061-8d761e648449\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"711daa47-21b1-41cd-a061-8d761e648449\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"711daa47-21b1-41cd-a061-8d761e648449\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": []\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5271e0d9-bb02-4eb2-afea-b20dbe5837ee?api-version=2018-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a476ec12-2f00-49ae-a327-31971ec715f7?api-version=2018-12-01']
       cache-control: [no-cache]
       content-length: ['9586']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:54 GMT']
+      date: ['Tue, 12 Mar 2019 00:44:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -703,96 +691,92 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g --gateway-name -n]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
   response:
-    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
-        ,\r\n  \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
-        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
-        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
-        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
-        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
-        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
-        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
-        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
-        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
-        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
-        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
-        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
-        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
-        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
-        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
-        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
-        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
-        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
-        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
-        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
-        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
-        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
-        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
-        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\
-        \n      {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"rewriteRules\": []\r\n        },\r\n        \"type\": \"\
-        Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n      }\r\n   \
-        \ ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": []\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['9586']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:54 GMT']
-      etag: [W/"773bb567-f829-4c86-8291-2842f5e525ec"]
+      date: ['Tue, 12 Mar 2019 00:44:27 GMT']
+      etag: [W/"11c70bea-85bf-4db8-b707-3b938370bebd"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -808,99 +792,95 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       CommandName: [network application-gateway rewrite-rule create]
       Connection: [keep-alive]
-      ParameterSetName: [-g --gateway-name --ruleset-name -n --sequence --request-headers
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --rule-sequence --request-headers
           --response-headers --no-wait]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
   response:
-    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
-        ,\r\n  \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
-        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
-        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
-        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
-        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
-        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
-        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
-        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
-        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
-        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
-        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
-        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
-        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
-        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
-        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
-        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
-        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
-        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
-        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
-        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
-        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
-        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
-        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
-        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\
-        \n      {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\"\
-        ,\r\n        \"etag\": \"W/\\\"773bb567-f829-4c86-8291-2842f5e525ec\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"rewriteRules\": []\r\n        },\r\n        \"type\": \"\
-        Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n      }\r\n   \
-        \ ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"11c70bea-85bf-4db8-b707-3b938370bebd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": []\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['9586']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:55 GMT']
-      etag: [W/"773bb567-f829-4c86-8291-2842f5e525ec"]
+      date: ['Tue, 12 Mar 2019 00:44:27 GMT']
+      etag: [W/"11c70bea-85bf-4db8-b707-3b938370bebd"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -914,44 +894,44 @@ interactions:
       "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
       "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
       "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
-      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"11c70bea-85bf-4db8-b707-3b938370bebd\\"",
       "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
       [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
       "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
-      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"11c70bea-85bf-4db8-b707-3b938370bebd\\"",
       "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
       "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
       "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
-      "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "etag": "W/\\"11c70bea-85bf-4db8-b707-3b938370bebd\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
       "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
       "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
-      "appGatewayBackendPool", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "appGatewayBackendPool", "etag": "W/\\"11c70bea-85bf-4db8-b707-3b938370bebd\\"",
       "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
       [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
       "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
       "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
       1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
-      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"11c70bea-85bf-4db8-b707-3b938370bebd\\"",
       "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
       "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
       "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
       "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
       "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
-      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"11c70bea-85bf-4db8-b707-3b938370bebd\\"",
       "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
       [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
       "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
       "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
       "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
-      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\"",
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"11c70bea-85bf-4db8-b707-3b938370bebd\\"",
       "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
       [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1",
-      "properties": {"rewriteRules": [{"name": "rule1", "ruleSequence": 100, "actionSet":
+      "properties": {"rewriteRules": [{"name": "rule1", "ruleSequence": 123, "actionSet":
       {"requestHeaderConfigurations": [{"headerName": "foo", "headerValue": "bar"}],
       "responseHeaderConfigurations": [{"headerName": "cat", "headerValue": "hat"}]}}]},
-      "name": "ruleset1"}], "redirectConfigurations": [], "resourceGuid": "da8453b3-2038-4d5a-8ba3-0ab495fb2ac2",
-      "provisioningState": "Updating"}, "etag": "W/\\"773bb567-f829-4c86-8291-2842f5e525ec\\""}'''
+      "name": "ruleset1"}], "redirectConfigurations": [], "resourceGuid": "aab025b8-8c53-47cb-9b26-e722b1f3335a",
+      "provisioningState": "Updating"}, "etag": "W/\\"11c70bea-85bf-4db8-b707-3b938370bebd\\""}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -959,107 +939,103 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['6616']
       Content-Type: [application/json; charset=utf-8]
-      ParameterSetName: [-g --gateway-name --ruleset-name -n --sequence --request-headers
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --rule-sequence --request-headers
           --response-headers --no-wait]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.59]
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
   response:
-    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\"\
-        ,\r\n  \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"da8453b3-2038-4d5a-8ba3-0ab495fb2ac2\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\"\
-        : \"Standard_v2\",\r\n      \"capacity\": 2\r\n    },\r\n    \"operationalState\"\
-        : \"Stopped\",\r\n    \"gatewayIPConfigurations\": [\r\n      {\r\n      \
-        \  \"name\": \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\
-        \r\n      }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\"\
-        : [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\"\
-        : \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
-        ,\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
-        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"httpListeners\": [\r\n       \
-        \     {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\
-        \r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n   \
-        \     \"name\": \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\
-        \r\n      }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n    \
-        \  {\r\n        \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"connectionDraining\"\
-        : {\r\n            \"enabled\": false,\r\n            \"drainTimeoutInSec\"\
-        : 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\": false,\r\
-        \n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":\
-        \ [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\
-        \r\n      }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"\
-        name\": \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\"\
-        : false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n    \
-        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\
-        \r\n      }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\"\
-        : [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\
-        \r\n      }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\
-        \n      {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\"\
-        ,\r\n        \"etag\": \"W/\\\"169d2923-55c0-49ed-b50a-327f6bbb6567\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\"\
-        : 100,\r\n              \"conditions\": [],\r\n              \"name\": \"\
-        rule1\",\r\n              \"actionSet\": {\r\n                \"requestHeaderConfigurations\"\
-        : [\r\n                  {\r\n                    \"headerName\": \"foo\"\
-        ,\r\n                    \"headerValue\": \"bar\"\r\n                  }\r\
-        \n                ],\r\n                \"responseHeaderConfigurations\":\
-        \ [\r\n                  {\r\n                    \"headerName\": \"cat\"\
-        ,\r\n                    \"headerValue\": \"hat\"\r\n                  }\r\
-        \n                ]\r\n              }\r\n            }\r\n          ]\r\n\
-        \        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\
-        \r\n      }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"37d9649a-96c5-4638-82fe-4158dabcb36e\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"37d9649a-96c5-4638-82fe-4158dabcb36e\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"37d9649a-96c5-4638-82fe-4158dabcb36e\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"37d9649a-96c5-4638-82fe-4158dabcb36e\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"37d9649a-96c5-4638-82fe-4158dabcb36e\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"37d9649a-96c5-4638-82fe-4158dabcb36e\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"37d9649a-96c5-4638-82fe-4158dabcb36e\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"37d9649a-96c5-4638-82fe-4158dabcb36e\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"37d9649a-96c5-4638-82fe-4158dabcb36e\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        123,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"foo\",\r\n
+        \                   \"headerValue\": \"bar\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": [\r\n                  {\r\n
+        \                   \"headerName\": \"cat\",\r\n                    \"headerValue\":
+        \"hat\"\r\n                  }\r\n                ]\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8060fb41-a548-4c19-b6c5-c5a3f414012d?api-version=2018-12-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/7b059577-b78e-44d5-afb9-eb0576ddf4ce?api-version=2018-12-01']
       cache-control: [no-cache]
       content-length: ['10168']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 25 Feb 2019 21:48:56 GMT']
+      date: ['Tue, 12 Mar 2019 00:44:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1074,12 +1050,2598 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule update]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --rule-sequence --request-headers
+          --response-headers --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        123,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"foo\",\r\n
+        \                   \"headerValue\": \"bar\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": [\r\n                  {\r\n
+        \                   \"headerName\": \"cat\",\r\n                    \"headerValue\":
+        \"hat\"\r\n                  }\r\n                ]\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10168']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:29 GMT']
+      etag: [W/"0998aa36-1ed9-40d1-820f-d60303c9ab44"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1",
+      "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\"",
+      "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
+      [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
+      "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\"",
+      "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
+      "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
+      "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+      "etag": "W/\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
+      "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
+      "appGatewayBackendPool", "etag": "W/\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\"",
+      "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
+      "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
+      1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\"",
+      "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
+      "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
+      "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
+      "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\"",
+      "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
+      [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
+      "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
+      "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\"",
+      "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1",
+      "properties": {"rewriteRules": [{"name": "rule1", "ruleSequence": 321, "conditions":
+      [], "actionSet": {"requestHeaderConfigurations": [{"headerName": "bar", "headerValue":
+      "foo"}], "responseHeaderConfigurations": [{"headerName": "hat", "headerValue":
+      "cat"}]}}]}, "name": "ruleset1"}], "redirectConfigurations": [], "resourceGuid":
+      "aab025b8-8c53-47cb-9b26-e722b1f3335a", "provisioningState": "Updating"}, "etag":
+      "W/\\"0998aa36-1ed9-40d1-820f-d60303c9ab44\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule update]
+      Connection: [keep-alive]
+      Content-Length: ['6634']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --rule-sequence --request-headers
+          --response-headers --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"ccc5f740-eef7-4713-ae5a-7160e7a02eaf\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"ccc5f740-eef7-4713-ae5a-7160e7a02eaf\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"ccc5f740-eef7-4713-ae5a-7160e7a02eaf\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"ccc5f740-eef7-4713-ae5a-7160e7a02eaf\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"ccc5f740-eef7-4713-ae5a-7160e7a02eaf\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"ccc5f740-eef7-4713-ae5a-7160e7a02eaf\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"ccc5f740-eef7-4713-ae5a-7160e7a02eaf\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"ccc5f740-eef7-4713-ae5a-7160e7a02eaf\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"ccc5f740-eef7-4713-ae5a-7160e7a02eaf\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": [\r\n                  {\r\n
+        \                   \"headerName\": \"hat\",\r\n                    \"headerValue\":
+        \"cat\"\r\n                  }\r\n                ]\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/28f78ff6-eb5c-41c1-a4d2-22dc51c6c72f?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['10168']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule update]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --set --remove --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"d38cc2bd-585c-4428-9706-58608a161fb2\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"d38cc2bd-585c-4428-9706-58608a161fb2\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"d38cc2bd-585c-4428-9706-58608a161fb2\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"d38cc2bd-585c-4428-9706-58608a161fb2\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"d38cc2bd-585c-4428-9706-58608a161fb2\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"d38cc2bd-585c-4428-9706-58608a161fb2\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"d38cc2bd-585c-4428-9706-58608a161fb2\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"d38cc2bd-585c-4428-9706-58608a161fb2\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"d38cc2bd-585c-4428-9706-58608a161fb2\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": [\r\n                  {\r\n
+        \                   \"headerName\": \"hat\",\r\n                    \"headerValue\":
+        \"cat\"\r\n                  }\r\n                ]\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10168']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:30 GMT']
+      etag: [W/"d38cc2bd-585c-4428-9706-58608a161fb2"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1",
+      "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"d38cc2bd-585c-4428-9706-58608a161fb2\\"",
+      "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
+      [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
+      "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"d38cc2bd-585c-4428-9706-58608a161fb2\\"",
+      "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
+      "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
+      "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+      "etag": "W/\\"d38cc2bd-585c-4428-9706-58608a161fb2\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
+      "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
+      "appGatewayBackendPool", "etag": "W/\\"d38cc2bd-585c-4428-9706-58608a161fb2\\"",
+      "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
+      "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
+      1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"d38cc2bd-585c-4428-9706-58608a161fb2\\"",
+      "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
+      "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
+      "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
+      "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"d38cc2bd-585c-4428-9706-58608a161fb2\\"",
+      "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
+      [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
+      "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
+      "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"d38cc2bd-585c-4428-9706-58608a161fb2\\"",
+      "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1",
+      "properties": {"rewriteRules": [{"name": "rule1", "ruleSequence": 321, "conditions":
+      [], "actionSet": {"requestHeaderConfigurations": [{"headerName": "bar", "headerValue":
+      "foo"}], "responseHeaderConfigurations": []}}]}, "name": "ruleset1"}], "redirectConfigurations":
+      [], "resourceGuid": "aab025b8-8c53-47cb-9b26-e722b1f3335a", "provisioningState":
+      "Updating"}, "etag": "W/\\"d38cc2bd-585c-4428-9706-58608a161fb2\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule update]
+      Connection: [keep-alive]
+      Content-Length: ['6591']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --set --remove --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"2c516b0b-6293-4df4-b234-f229bac6858c\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"2c516b0b-6293-4df4-b234-f229bac6858c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"2c516b0b-6293-4df4-b234-f229bac6858c\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"2c516b0b-6293-4df4-b234-f229bac6858c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"2c516b0b-6293-4df4-b234-f229bac6858c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"2c516b0b-6293-4df4-b234-f229bac6858c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"2c516b0b-6293-4df4-b234-f229bac6858c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"2c516b0b-6293-4df4-b234-f229bac6858c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"2c516b0b-6293-4df4-b234-f229bac6858c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/36ca69a9-7457-4e0d-871e-a5718d9919c3?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['10024']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule show]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name -n]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10024']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:31 GMT']
+      etag: [W/"8f19b224-bc21-4a17-b5ec-926ee0b26e75"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule list]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10024']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:32 GMT']
+      etag: [W/"8f19b224-bc21-4a17-b5ec-926ee0b26e75"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule condition create]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name --rule-name -n --pattern
+          --ignore-case --negate --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10024']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:32 GMT']
+      etag: [W/"8f19b224-bc21-4a17-b5ec-926ee0b26e75"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1",
+      "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\"",
+      "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
+      [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
+      "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\"",
+      "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
+      "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
+      "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+      "etag": "W/\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
+      "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
+      "appGatewayBackendPool", "etag": "W/\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\"",
+      "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
+      "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
+      1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\"",
+      "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
+      "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
+      "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
+      "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\"",
+      "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
+      [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
+      "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
+      "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\"",
+      "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1",
+      "properties": {"rewriteRules": [{"name": "rule1", "ruleSequence": 321, "conditions":
+      [{"variable": "http_req_Authorization", "pattern": "^Bearer", "negate": true}],
+      "actionSet": {"requestHeaderConfigurations": [{"headerName": "bar", "headerValue":
+      "foo"}], "responseHeaderConfigurations": []}}]}, "name": "ruleset1"}], "redirectConfigurations":
+      [], "resourceGuid": "aab025b8-8c53-47cb-9b26-e722b1f3335a", "provisioningState":
+      "Updating"}, "etag": "W/\\"8f19b224-bc21-4a17-b5ec-926ee0b26e75\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule condition create]
+      Connection: [keep-alive]
+      Content-Length: ['6667']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g --gateway-name --ruleset-name --rule-name -n --pattern
+          --ignore-case --negate --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"83af295b-4778-451a-96c2-7aca6299a1b7\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"83af295b-4778-451a-96c2-7aca6299a1b7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"83af295b-4778-451a-96c2-7aca6299a1b7\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"83af295b-4778-451a-96c2-7aca6299a1b7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"83af295b-4778-451a-96c2-7aca6299a1b7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"83af295b-4778-451a-96c2-7aca6299a1b7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"83af295b-4778-451a-96c2-7aca6299a1b7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"83af295b-4778-451a-96c2-7aca6299a1b7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"83af295b-4778-451a-96c2-7aca6299a1b7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [\r\n                {\r\n                  \"variable\":
+        \"http_req_Authorization\",\r\n                  \"pattern\": \"^Bearer\",\r\n
+        \                 \"ignoreCase\": true,\r\n                  \"negate\": true\r\n
+        \               }\r\n              ],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4e7ac293-3c85-4dab-946f-51c39d439c5d?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['10249']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule condition update]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name --rule-name -n --pattern
+          --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [\r\n                {\r\n                  \"variable\":
+        \"http_req_Authorization\",\r\n                  \"pattern\": \"^Bearer\",\r\n
+        \                 \"ignoreCase\": true,\r\n                  \"negate\": true\r\n
+        \               }\r\n              ],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10249']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:34 GMT']
+      etag: [W/"bed91fbc-13fe-4213-b9af-bd68d72886d7"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1",
+      "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\"",
+      "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
+      [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
+      "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\"",
+      "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
+      "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
+      "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+      "etag": "W/\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
+      "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
+      "appGatewayBackendPool", "etag": "W/\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\"",
+      "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
+      "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
+      1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\"",
+      "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
+      "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
+      "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
+      "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\"",
+      "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
+      [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
+      "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
+      "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\"",
+      "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1",
+      "properties": {"rewriteRules": [{"name": "rule1", "ruleSequence": 321, "conditions":
+      [{"variable": "http_req_Authorization", "pattern": "^Bearers", "ignoreCase":
+      true, "negate": true}], "actionSet": {"requestHeaderConfigurations": [{"headerName":
+      "bar", "headerValue": "foo"}], "responseHeaderConfigurations": []}}]}, "name":
+      "ruleset1"}], "redirectConfigurations": [], "resourceGuid": "aab025b8-8c53-47cb-9b26-e722b1f3335a",
+      "provisioningState": "Updating"}, "etag": "W/\\"bed91fbc-13fe-4213-b9af-bd68d72886d7\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule condition update]
+      Connection: [keep-alive]
+      Content-Length: ['6688']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g --gateway-name --ruleset-name --rule-name -n --pattern
+          --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"c605a313-73c1-48b6-9159-02927deab7a7\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"c605a313-73c1-48b6-9159-02927deab7a7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"c605a313-73c1-48b6-9159-02927deab7a7\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"c605a313-73c1-48b6-9159-02927deab7a7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"c605a313-73c1-48b6-9159-02927deab7a7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"c605a313-73c1-48b6-9159-02927deab7a7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"c605a313-73c1-48b6-9159-02927deab7a7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"c605a313-73c1-48b6-9159-02927deab7a7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"c605a313-73c1-48b6-9159-02927deab7a7\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [\r\n                {\r\n                  \"variable\":
+        \"http_req_Authorization\",\r\n                  \"pattern\": \"^Bearers\",\r\n
+        \                 \"ignoreCase\": true,\r\n                  \"negate\": true\r\n
+        \               }\r\n              ],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/83a45de3-db2f-4936-8af2-7d6642583350?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['10250']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule condition show]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name --rule-name -n]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [\r\n                {\r\n                  \"variable\":
+        \"http_req_Authorization\",\r\n                  \"pattern\": \"^Bearers\",\r\n
+        \                 \"ignoreCase\": true,\r\n                  \"negate\": true\r\n
+        \               }\r\n              ],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10250']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:35 GMT']
+      etag: [W/"5e869701-a4e1-4acf-872f-6d5d0a353245"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule condition list]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name --rule-name]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [\r\n                {\r\n                  \"variable\":
+        \"http_req_Authorization\",\r\n                  \"pattern\": \"^Bearers\",\r\n
+        \                 \"ignoreCase\": true,\r\n                  \"negate\": true\r\n
+        \               }\r\n              ],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10250']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:36 GMT']
+      etag: [W/"5e869701-a4e1-4acf-872f-6d5d0a353245"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule condition delete]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name --rule-name -n --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [\r\n                {\r\n                  \"variable\":
+        \"http_req_Authorization\",\r\n                  \"pattern\": \"^Bearers\",\r\n
+        \                 \"ignoreCase\": true,\r\n                  \"negate\": true\r\n
+        \               }\r\n              ],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10250']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:36 GMT']
+      etag: [W/"5e869701-a4e1-4acf-872f-6d5d0a353245"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1",
+      "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\"",
+      "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
+      [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
+      "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\"",
+      "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
+      "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
+      "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+      "etag": "W/\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
+      "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
+      "appGatewayBackendPool", "etag": "W/\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\"",
+      "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
+      "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
+      1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\"",
+      "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
+      "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
+      "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
+      "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\"",
+      "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
+      [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
+      "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
+      "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\"",
+      "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1",
+      "properties": {"rewriteRules": [{"name": "rule1", "ruleSequence": 321, "conditions":
+      [], "actionSet": {"requestHeaderConfigurations": [{"headerName": "bar", "headerValue":
+      "foo"}], "responseHeaderConfigurations": []}}]}, "name": "ruleset1"}], "redirectConfigurations":
+      [], "resourceGuid": "aab025b8-8c53-47cb-9b26-e722b1f3335a", "provisioningState":
+      "Updating"}, "etag": "W/\\"5e869701-a4e1-4acf-872f-6d5d0a353245\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule condition delete]
+      Connection: [keep-alive]
+      Content-Length: ['6591']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g --gateway-name --ruleset-name --rule-name -n --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"0ca05555-995b-408d-a203-9663edd14114\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"0ca05555-995b-408d-a203-9663edd14114\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"0ca05555-995b-408d-a203-9663edd14114\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"0ca05555-995b-408d-a203-9663edd14114\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"0ca05555-995b-408d-a203-9663edd14114\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"0ca05555-995b-408d-a203-9663edd14114\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"0ca05555-995b-408d-a203-9663edd14114\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"0ca05555-995b-408d-a203-9663edd14114\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"0ca05555-995b-408d-a203-9663edd14114\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6c410b26-96a4-4c33-9840-729edac24978?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['10024']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:37 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule condition list]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name --rule-name]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10024']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:38 GMT']
+      etag: [W/"70f52c69-e43f-451b-808e-72dccbd59bae"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule delete]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"70f52c69-e43f-451b-808e-72dccbd59bae\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": [\r\n            {\r\n              \"ruleSequence\":
+        321,\r\n              \"conditions\": [],\r\n              \"name\": \"rule1\",\r\n
+        \             \"actionSet\": {\r\n                \"requestHeaderConfigurations\":
+        [\r\n                  {\r\n                    \"headerName\": \"bar\",\r\n
+        \                   \"headerValue\": \"foo\"\r\n                  }\r\n                ],\r\n
+        \               \"responseHeaderConfigurations\": []\r\n              }\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['10024']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:39 GMT']
+      etag: [W/"70f52c69-e43f-451b-808e-72dccbd59bae"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1",
+      "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"70f52c69-e43f-451b-808e-72dccbd59bae\\"",
+      "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
+      [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
+      "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"70f52c69-e43f-451b-808e-72dccbd59bae\\"",
+      "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
+      "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
+      "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+      "etag": "W/\\"70f52c69-e43f-451b-808e-72dccbd59bae\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
+      "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
+      "appGatewayBackendPool", "etag": "W/\\"70f52c69-e43f-451b-808e-72dccbd59bae\\"",
+      "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
+      "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
+      1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"70f52c69-e43f-451b-808e-72dccbd59bae\\"",
+      "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
+      "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
+      "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
+      "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"70f52c69-e43f-451b-808e-72dccbd59bae\\"",
+      "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
+      [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
+      "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
+      "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"70f52c69-e43f-451b-808e-72dccbd59bae\\"",
+      "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1",
+      "properties": {"rewriteRules": []}, "name": "ruleset1"}], "redirectConfigurations":
+      [], "resourceGuid": "aab025b8-8c53-47cb-9b26-e722b1f3335a", "provisioningState":
+      "Updating"}, "etag": "W/\\"70f52c69-e43f-451b-808e-72dccbd59bae\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule delete]
+      Connection: [keep-alive]
+      Content-Length: ['6406']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g --gateway-name --ruleset-name -n --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"f90cdfce-54f8-4e02-9917-e4c57d7751cd\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"f90cdfce-54f8-4e02-9917-e4c57d7751cd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"f90cdfce-54f8-4e02-9917-e4c57d7751cd\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"f90cdfce-54f8-4e02-9917-e4c57d7751cd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"f90cdfce-54f8-4e02-9917-e4c57d7751cd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"f90cdfce-54f8-4e02-9917-e4c57d7751cd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"f90cdfce-54f8-4e02-9917-e4c57d7751cd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"f90cdfce-54f8-4e02-9917-e4c57d7751cd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"f90cdfce-54f8-4e02-9917-e4c57d7751cd\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": []\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ccc71515-b4aa-40fa-9318-64033d5aeb88?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['9586']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule list]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name --ruleset-name]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": []\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['9586']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:39 GMT']
+      etag: [W/"749882a2-3388-4d60-bfd7-b70e0fa15257"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule set delete]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name -n -y --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [\r\n
+        \     {\r\n        \"name\": \"ruleset1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/rewriteRuleSets/ruleset1\",\r\n
+        \       \"etag\": \"W/\\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"rewriteRules\": []\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/rewriteRuleSets\"\r\n
+        \     }\r\n    ],\r\n    \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['9586']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:40 GMT']
+      etag: [W/"749882a2-3388-4d60-bfd7-b70e0fa15257"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: 'b''{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1",
+      "location": "westus", "tags": {}, "properties": {"sku": {"name": "Standard_v2",
+      "tier": "Standard_v2", "capacity": 2}, "gatewayIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\"",
+      "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"}], "trustedRootCertificates":
+      [], "sslCertificates": [], "frontendIPConfigurations": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP",
+      "properties": {"privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1"},
+      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "etag": "W/\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\"",
+      "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations"}],
+      "frontendPorts": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort",
+      "properties": {"port": 80, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+      "etag": "W/\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\"", "type": "Microsoft.Network/applicationGateways/frontendPorts"}],
+      "probes": [], "backendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool",
+      "properties": {"backendAddresses": [], "provisioningState": "Updating"}, "name":
+      "appGatewayBackendPool", "etag": "W/\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\"",
+      "type": "Microsoft.Network/applicationGateways/backendAddressPools"}], "backendHttpSettingsCollection":
+      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
+      "requestTimeout": 30, "connectionDraining": {"enabled": false, "drainTimeoutInSec":
+      1}, "pickHostNameFromBackendAddress": false, "provisioningState": "Updating"},
+      "name": "appGatewayBackendHttpSettings", "etag": "W/\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\"",
+      "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"}],
+      "httpListeners": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP"},
+      "frontendPort": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort"},
+      "protocol": "Http", "requireServerNameIndication": false, "provisioningState":
+      "Updating"}, "name": "appGatewayHttpListener", "etag": "W/\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\"",
+      "type": "Microsoft.Network/applicationGateways/httpListeners"}], "urlPathMaps":
+      [], "requestRoutingRules": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1",
+      "properties": {"ruleType": "Basic", "backendAddressPool": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool"},
+      "backendHttpSettings": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "httpListener": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener"},
+      "provisioningState": "Updating"}, "name": "rule1", "etag": "W/\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\"",
+      "type": "Microsoft.Network/applicationGateways/requestRoutingRules"}], "rewriteRuleSets":
+      [], "redirectConfigurations": [], "resourceGuid": "aab025b8-8c53-47cb-9b26-e722b1f3335a",
+      "provisioningState": "Updating"}, "etag": "W/\\"749882a2-3388-4d60-bfd7-b70e0fa15257\\""}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule set delete]
+      Connection: [keep-alive]
+      Content-Length: ['6121']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-g --gateway-name -n -y --no-wait]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"1908f7a5-d990-4689-a428-2fcea049652a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"1908f7a5-d990-4689-a428-2fcea049652a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"1908f7a5-d990-4689-a428-2fcea049652a\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"1908f7a5-d990-4689-a428-2fcea049652a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"1908f7a5-d990-4689-a428-2fcea049652a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"1908f7a5-d990-4689-a428-2fcea049652a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"1908f7a5-d990-4689-a428-2fcea049652a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"1908f7a5-d990-4689-a428-2fcea049652a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [],\r\n
+        \   \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/e203c18a-2ac6-4a5e-a468-40de1e729d19?api-version=2018-12-01']
+      cache-control: [no-cache]
+      content-length: ['9048']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network application-gateway rewrite-rule set list]
+      Connection: [keep-alive]
+      ParameterSetName: [-g --gateway-name]
+      User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          networkmanagementclient/2.6.0rc1 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1?api-version=2018-12-01
+  response:
+    body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1\",\r\n
+        \ \"etag\": \"W/\\\"7f6e2d0f-e15c-4ffd-b9fc-1aa30e45ebd8\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/applicationGateways\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"aab025b8-8c53-47cb-9b26-e722b1f3335a\",\r\n    \"sku\":
+        {\r\n      \"name\": \"Standard_v2\",\r\n      \"tier\": \"Standard_v2\",\r\n
+        \     \"capacity\": 2\r\n    },\r\n    \"operationalState\": \"Stopped\",\r\n
+        \   \"gatewayIPConfigurations\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/gatewayIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"7f6e2d0f-e15c-4ffd-b9fc-1aa30e45ebd8\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/virtualNetworks/gw1Vnet/subnets/default\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/gatewayIPConfigurations\"\r\n
+        \     }\r\n    ],\r\n    \"sslCertificates\": [],\r\n    \"trustedRootCertificates\":
+        [],\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\":
+        \"appGatewayFrontendIP\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\",\r\n
+        \       \"etag\": \"W/\\\"7f6e2d0f-e15c-4ffd-b9fc-1aa30e45ebd8\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/applicationGateways/frontendIPConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/publicIPAddresses/pip1\"\r\n
+        \         },\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"frontendPorts\":
+        [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\",\r\n
+        \       \"etag\": \"W/\\\"7f6e2d0f-e15c-4ffd-b9fc-1aa30e45ebd8\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"httpListeners\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/frontendPorts\"\r\n
+        \     }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\":
+        \"appGatewayBackendPool\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\",\r\n
+        \       \"etag\": \"W/\\\"7f6e2d0f-e15c-4ffd-b9fc-1aa30e45ebd8\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"backendAddresses\": [],\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendAddressPools\"\r\n
+        \     }\r\n    ],\r\n    \"backendHttpSettingsCollection\": [\r\n      {\r\n
+        \       \"name\": \"appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\",\r\n
+        \       \"etag\": \"W/\\\"7f6e2d0f-e15c-4ffd-b9fc-1aa30e45ebd8\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n          \"cookieBasedAffinity\":
+        \"Disabled\",\r\n          \"connectionDraining\": {\r\n            \"enabled\":
+        false,\r\n            \"drainTimeoutInSec\": 1\r\n          },\r\n          \"pickHostNameFromBackendAddress\":
+        false,\r\n          \"requestTimeout\": 30,\r\n          \"requestRoutingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/backendHttpSettingsCollection\"\r\n
+        \     }\r\n    ],\r\n    \"httpListeners\": [\r\n      {\r\n        \"name\":
+        \"appGatewayHttpListener\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\",\r\n
+        \       \"etag\": \"W/\\\"7f6e2d0f-e15c-4ffd-b9fc-1aa30e45ebd8\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendIPConfigurations/appGatewayFrontendIP\"\r\n
+        \         },\r\n          \"frontendPort\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/frontendPorts/appGatewayFrontendPort\"\r\n
+        \         },\r\n          \"protocol\": \"Http\",\r\n          \"requireServerNameIndication\":
+        false,\r\n          \"requestRoutingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/httpListeners\"\r\n
+        \     }\r\n    ],\r\n    \"urlPathMaps\": [],\r\n    \"requestRoutingRules\":
+        [\r\n      {\r\n        \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/requestRoutingRules/rule1\",\r\n
+        \       \"etag\": \"W/\\\"7f6e2d0f-e15c-4ffd-b9fc-1aa30e45ebd8\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/httpListeners/appGatewayHttpListener\"\r\n
+        \         },\r\n          \"backendAddressPool\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendAddressPools/appGatewayBackendPool\"\r\n
+        \         },\r\n          \"backendHttpSettings\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_rewrite_rulesets000001/providers/Microsoft.Network/applicationGateways/gw1/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\r\n
+        \         }\r\n        },\r\n        \"type\": \"Microsoft.Network/applicationGateways/requestRoutingRules\"\r\n
+        \     }\r\n    ],\r\n    \"probes\": [],\r\n    \"rewriteRuleSets\": [],\r\n
+        \   \"redirectConfigurations\": []\r\n  }\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['9048']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 12 Mar 2019 00:44:40 GMT']
+      etag: [W/"7f6e2d0f-e15c-4ffd-b9fc-1aa30e45ebd8"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
       CommandName: [group delete]
       Connection: [keep-alive]
       Content-Length: ['0']
       ParameterSetName: [--name --yes --no-wait]
       User-Agent: [python/3.7.1 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.59]
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_rewrite_rulesets000001?api-version=2018-05-01
@@ -1088,9 +3650,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 25 Feb 2019 21:48:57 GMT']
+      date: ['Tue, 12 Mar 2019 00:44:42 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQUc6NUZSRVdSSVRFOjVGUlVMRVNFVFNZNEZFSlpNSFVWVXwzRERGNDg5QTMxREE3Mzg0LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQUc6NUZSRVdSSVRFOjVGUlVMRVNFVFNLUVdOQ0ZRQ1RBNXw4MDE4QzBDNEM0ODlEMEFELVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -601,6 +601,44 @@ class NetworkAppGatewaySubresourceScenarioTest(ScenarioTest):
         self.cmd('network {res} list -g {rg} --gateway-name {ag}', checks=self.check('length(@)', 1))
 
 
+class NetworkAppGatewayRewriteRuleset(ScenarioTest):
+
+    @ResourceGroupPreparer(name_prefix='cli_test_ag_rewrite_rulesets')
+    def test_network_app_gateway_rewrite_rulesets(self, resource_group):
+
+        self.kwargs.update({
+            'gw': 'gw1',
+            'ip': 'pip1',
+            'set': 'ruleset1',
+            'rule': 'rule1',
+            'var': 'http_req_Authorization'
+        })
+        self.cmd('network public-ip create -g {rg} -n {ip} --sku Standard')
+        self.cmd('network application-gateway create -g {rg} -n {gw} --public-ip-address {ip} --sku Standard_v2 --no-wait')
+        self.cmd('network application-gateway wait -g {rg} -n {gw} --exists')
+
+        # create ruleset
+        self.cmd('network application-gateway rewrite-rule set create -g {rg} --gateway-name {gw} -n {set} --no-wait')
+        self.cmd('network application-gateway rewrite-rule set show -g {rg} --gateway-name {gw} -n {set}')
+
+        # manage rewrite rules
+        self.cmd('network application-gateway rewrite-rule create -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule} --sequence 100 --request-headers foo=bar --response-headers cat=hat --no-wait')
+        self.cmd('network application-gateway rewrite-rule show -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule}')
+        # list
+        # delete
+        # update
+
+        # manage rewrite rule conditions
+        self.cmd('network application-gateway rewrite-rule condition create -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule} --variable {var} --pattern "^Bearer" --ignore-case false --negate --no-wait')
+        self.cmd('network application-gateway rewrite-rule condition create -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule}')
+        # list
+        # delete
+        # update
+
+        self.cmd('network application-gateway rewrite-rule set delete -g {rg} --gateway-name {gw} -n {set}')
+        self.cmd('network application-gateway rewrite-rule set list -g {rg} --gateway-name {gw}')
+
+
 class NetworkAppGatewayPublicIpScenarioTest(ScenarioTest):
 
     @ResourceGroupPreparer(name_prefix='cli_test_ag_public_ip')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -622,20 +622,24 @@ class NetworkAppGatewayRewriteRuleset(ScenarioTest):
         self.cmd('network application-gateway rewrite-rule set show -g {rg} --gateway-name {gw} -n {set}')
 
         # manage rewrite rules
-        self.cmd('network application-gateway rewrite-rule create -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule} --sequence 100 --request-headers foo=bar --response-headers cat=hat --no-wait')
+        self.cmd('network application-gateway rewrite-rule create -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule} --rule-sequence 123 --request-headers foo=bar --response-headers cat=hat --no-wait')
+        self.cmd('network application-gateway rewrite-rule update -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule} --rule-sequence 321 --request-headers bar=foo --response-headers hat=cat --no-wait')
+        self.cmd('network application-gateway rewrite-rule update -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule} --set ruleSequence=321 --remove actionSet.responseHeaderConfigurations 0 --no-wait')
         self.cmd('network application-gateway rewrite-rule show -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule}')
-        # list
-        # delete
-        # update
+        self.cmd('network application-gateway rewrite-rule list -g {rg} --gateway-name {gw} --ruleset-name {set}')
 
         # manage rewrite rule conditions
-        self.cmd('network application-gateway rewrite-rule condition create -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule} --variable {var} --pattern "^Bearer" --ignore-case false --negate --no-wait')
-        self.cmd('network application-gateway rewrite-rule condition create -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule}')
-        # list
-        # delete
-        # update
+        self.cmd('network application-gateway rewrite-rule condition create -g {rg} --gateway-name {gw} --ruleset-name {set} --rule-name {rule} -n {var} --pattern "^Bearer" --ignore-case false --negate --no-wait')
+        self.cmd('network application-gateway rewrite-rule condition update -g {rg} --gateway-name {gw} --ruleset-name {set} --rule-name {rule} -n {var} --pattern "^Bearers" --no-wait')
+        self.cmd('network application-gateway rewrite-rule condition show -g {rg} --gateway-name {gw} --ruleset-name {set} --rule-name {rule} -n {var}')
+        self.cmd('network application-gateway rewrite-rule condition list -g {rg} --gateway-name {gw} --ruleset-name {set} --rule-name {rule}')
+        self.cmd('network application-gateway rewrite-rule condition delete -g {rg} --gateway-name {gw} --ruleset-name {set} --rule-name {rule} -n {var} --no-wait')
+        self.cmd('network application-gateway rewrite-rule condition list -g {rg} --gateway-name {gw} --ruleset-name {set} --rule-name {rule}')
 
-        self.cmd('network application-gateway rewrite-rule set delete -g {rg} --gateway-name {gw} -n {set}')
+        self.cmd('network application-gateway rewrite-rule delete -g {rg} --gateway-name {gw} --ruleset-name {set} -n {rule} --no-wait')
+        self.cmd('network application-gateway rewrite-rule list -g {rg} --gateway-name {gw} --ruleset-name {set}')
+
+        self.cmd('network application-gateway rewrite-rule set delete -g {rg} --gateway-name {gw} -n {set} -y --no-wait')
         self.cmd('network application-gateway rewrite-rule set list -g {rg} --gateway-name {gw}')
 
 


### PR DESCRIPTION
Closes #8428.

For Network, this PR:
- Adds application-gateway rewrite-rule commands and command groups (set and condition).

For Core:
- Adds the ArmCommandGroup, which allows a simplified way of creating entire command groups based on child collections.

And because of some weird behavior in pylint 2.0.0, this makes a bunch of fixes to be compliant with pylint 2.3.0 (sorry). 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
