### PR TITLE
Allow enable-multiple-write-locations on Cosmos DB account update

### DIFF
--- a/src/command_modules/azure-cli-cosmosdb/HISTORY.rst
+++ b/src/command_modules/azure-cli-cosmosdb/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.2.9
++++++
+* Introducing support for --enable-multiple-write-locations on account update
+
 0.2.8
 +++++
 * Introduce `network-rule` subgroup with commands `add`, `remove`, and `list` for managing VNET rules of a Cosmos DB account

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/custom.py
@@ -189,10 +189,8 @@ def cli_cosmosdb_update(client,
 
     if enable_multiple_write_locations is None:
         enable_multiple_write_locations = existing.enable_multiple_write_locations
-    elif enable_multiple_write_locations != existing.enable_multiple_write_locations and \
-            enable_multiple_write_locations:
-        raise CLIError("Cannot convert account from single master to multi master")
-    elif enable_multiple_write_locations != existing.enable_multiple_write_locations:
+    elif enable_multiple_write_locations != existing.enable_multiple_write_locations \
+            and not enable_multiple_write_locations:
         logger.warning("Updating the account from multi master to single master will take 24 hours to complete.")
 
     params = DatabaseAccountCreateUpdateParameters(

--- a/src/command_modules/azure-cli-cosmosdb/setup.py
+++ b/src/command_modules/azure-cli-cosmosdb/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.2.8"
+VERSION = "0.2.9"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
This change removes the CLIError when users attempt to switch the --enable-multiple-write-locations flag from false to true on Cosmos DB account update.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
