### PR TITLE
[Storage] move hook addition outside of function def

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -699,8 +699,6 @@ def get_source_file_or_blob_service_client(cmd, namespace):
 
 def add_progress_callback(cmd, namespace):
     def _update_progress(current, total):
-        hook = cmd.cli_ctx.get_progress_controller(det=True)
-        _update_progress.hook = hook
         message = getattr(_update_progress, 'message', 'Alive')
         reuse = getattr(_update_progress, 'reuse', False)
 
@@ -708,6 +706,9 @@ def add_progress_callback(cmd, namespace):
             hook.add(message=message, value=current, total_val=total)
             if total == current and not reuse:
                 hook.end()
+
+    hook = cmd.cli_ctx.get_progress_controller(det=True)
+    _update_progress.hook = hook
 
     if not namespace.no_progress:
         namespace.progress_callback = _update_progress


### PR DESCRIPTION
---
-hook does not get added if the callback if never called (happens when no file/blobs are found with a batch upload/download).
-Moving this outside ensures the hook is always added.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
