### PR TITLE
test: backup the repository for git deployment testing

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/package.json
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "yugangw-web-app",
+  "version": "1.0.0",
+  "engines": {"node": "4.5.0"},
+  "dependencies": {
+    "express": "^4.14.0"
+  }
+}

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/package.json
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yugangw-web-app",
+  "name": "test-web-app",
   "version": "1.0.0",
   "engines": {"node": "4.5.0"},
   "dependencies": {

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/process.json
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/process.json
@@ -1,0 +1,13 @@
+{
+  "name"        : "worker",
+  "script"      : "server.js",
+  "instances"   : 1,
+  "merge_logs"  : true,
+  "log_date_format" : "YYYY-MM-DD HH:mm Z",
+  "watch": ["server.js"],
+  "watch_options": {
+    "followSymlinks": true,
+    "usePolling"   : true,
+    "interval"    : 5
+  }
+}

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/server.js
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/server.js
@@ -1,0 +1,19 @@
+var express = require('express');
+var app = express();
+var port = process.env.PORT || 3000;
+var server = app.listen(port,function(){
+    console.log("We have started our server on port 3000");
+});
+
+app.get('/', function (req, res) {
+  var hostname = req.headers.host.split(":")[0];
+
+  if(hostname.startsWith("admin."))
+    res.send("this is admin response!");
+  else {
+    console.log('PORT is:' + process.env.PORT)
+    console.error("Something wrong");
+    console.log("Something normal");
+    res.send('Hello world 4 using Node ' + process.version);
+  }
+});

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/server.js
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/sample-repo-for-deployment-test/server.js
@@ -14,6 +14,6 @@ app.get('/', function (req, res) {
     console.log('PORT is:' + process.env.PORT)
     console.error("Something wrong");
     console.log("Something normal");
-    res.send('Hello world 4 using Node ' + process.version);
+    res.send('Hello world from Node ' + process.version);
   }
 });

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -20,6 +20,10 @@ TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
 # pylint: disable=line-too-long
 
+# In the future, for any reasons the repository get removed, the source code is under "sample-repo-for-deployment-test"
+# you can use to rebuild the repository
+TEST_REPO_URL = 'https://github.com/yugangw-msft/azure-site-test.git'
+
 
 class WebappBasicE2ETest(ScenarioTest):
     @ResourceGroupPreparer()
@@ -122,7 +126,8 @@ class WebappQuickCreateTest(ScenarioTest):
         webapp_name = self.create_random_name(prefix='webapp-quick-cd', length=24)
         plan = self.create_random_name(prefix='plan-quick', length=24)
         self.cmd('appservice plan create -g {} -n {}'.format(resource_group, plan))
-        self.cmd('webapp create -g {} -n {} --plan {} --deployment-source-url https://github.com/yugangw-msft/azure-site-test.git -r "node|6.12"'.format(resource_group, webapp_name, plan))
+        self.cmd('webapp create -g {} -n {} --plan {} --deployment-source-url {} -r "node|6.12"'.format(
+            resource_group, webapp_name, plan, TEST_REPO_URL))
         time.sleep(30)  # 30 seconds should be enough for the deployment finished(Skipped under playback mode)
         r = requests.get('http://{}.azurewebsites.net'.format(webapp_name))
         # verify the web page
@@ -168,7 +173,8 @@ class WebappQuickCreateTest(ScenarioTest):
         webapp_name = self.create_random_name(prefix='webapp-linux-cd', length=24)
         plan = 'plan-quick-linux-cd'
         self.cmd('appservice plan create -g {} -n {} --is-linux'.format(resource_group, plan))
-        self.cmd('webapp create -g {} -n {} --plan {} -u https://github.com/yugangw-msft/azure-site-test.git -r "node|6.11"'.format(resource_group, webapp_name, plan))
+        self.cmd('webapp create -g {} -n {} --plan {} -u {} -r "node|6.11"'.format(resource_group, webapp_name,
+                                                                                   plan, TEST_REPO_URL))
         time.sleep(45)  # 45 seconds should be enough for the deployment finished(Skipped under playback mode)
         r = requests.get('http://{}.azurewebsites.net'.format(webapp_name), timeout=240)
         # verify the web page
@@ -195,7 +201,8 @@ class AppServiceLogTest(ScenarioTest):
         webapp_name = self.create_random_name(prefix='webapp-win-log', length=24)
         plan = self.create_random_name(prefix='win-log', length=24)
         self.cmd('appservice plan create -g {} -n {}'.format(resource_group, plan))
-        self.cmd('webapp create -g {} -n {} --plan {} --deployment-source-url https://github.com/yugangw-msft/azure-site-test.git -r "node|6.12"'.format(resource_group, webapp_name, plan))
+        self.cmd('webapp create -g {} -n {} --plan {} --deployment-source-url {} -r "node|6.12"'.format(
+            resource_group, webapp_name, plan, TEST_REPO_URL))
         time.sleep(30)  # 30 seconds should be enough for the deployment finished(Skipped under playback mode)
 
         # sanity check the traces


### PR DESCRIPTION
Fix #4680. Creating a public repository under Azure organization is a over-kill, but this PR backs the code for people to rebuild hte repository later.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
