### PR TITLE
[Botservice] Switched default version to v4 from v3

### DIFF
--- a/src/command_modules/azure-cli-botservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-botservice/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.9
++++++
+* Defaulted `az bot create` to create a v4 bot (instead of v3). Users must specify `-v v3` to create a v3 bot
+
 0.1.8
 +++++
 * Add "SCM_DO_BUILD_DURING_DEPLOYMENT" to ARM template's Application Settings for v4 Web App Bots

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
@@ -31,7 +31,7 @@ logger = get_logger(__name__)
 def create(cmd, client, resource_group_name, resource_name, kind, description=None, display_name=None,  # pylint: disable=too-many-locals
            endpoint=None, msa_app_id=None, password=None, tags=None, storageAccountName=None,
            location='Central US', sku_name='F0', appInsightsLocation='South Central US',
-           language='Csharp', version='v3'):
+           language='Csharp', version='v4'):
     """Create a WebApp, Function, or Channels Registration Bot on Azure.
 
     This method is directly called via "bot create"
@@ -471,7 +471,7 @@ def prepare_publish(cmd, client, resource_group_name, resource_name, sln_name, p
     logger.info('Bot prepare publish completed successfully.')
 
 
-def publish_app(cmd, client, resource_group_name, resource_name, code_dir=None, proj_file_path=None, version='v3',  # pylint:disable=too-many-statements
+def publish_app(cmd, client, resource_group_name, resource_name, code_dir=None, proj_file_path=None, version='v4',  # pylint:disable=too-many-statements
                 keep_node_modules=None, timeout=None):
     """Publish local bot code to Azure.
 


### PR DESCRIPTION
Fixes Microsoft/botbuilder-tools#1016

Per issue, when using `az bot create...` without supplying a version number, it defaults to `v3`. This makes it default to `v4`.

Test results:

![image](https://user-images.githubusercontent.com/40401643/54397253-1809f580-4673-11e9-89ac-26a7ae79944a.png)

Recommendations:

[botservice]
Reviewer: @stevengum 	

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
