### PR TITLE
Clean-up for Pylint 2.3

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -20,7 +20,6 @@ from knack.log import get_logger
 from knack.util import CLIError
 from knack.arguments import ArgumentsContext  # pylint: disable=unused-import
 
-
 logger = get_logger(__name__)
 
 EXCLUDED_PARAMS = ['self', 'raw', 'polling', 'custom_headers', 'operation_config',

--- a/src/azure-cli-core/azure/cli/core/_debug.py
+++ b/src/azure-cli-core/azure/cli/core/_debug.py
@@ -7,7 +7,9 @@ import os
 
 from knack.log import get_logger
 from knack.util import CLIError
+
 from .util import should_disable_connection_verify, DISABLE_VERIFY_VARIABLE_NAME
+
 logger = get_logger(__name__)
 
 ADAL_PYTHON_SSL_NO_VERIFY = "ADAL_PYTHON_SSL_NO_VERIFY"

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -5,6 +5,9 @@
 
 from __future__ import print_function
 import argparse
+
+from azure.cli.core.commands import ExtensionCommandSource
+
 from knack.help import (HelpFile as KnackHelpFile, CommandHelpFile as KnackCommandHelpFile,
                         GroupHelpFile as KnackGroupHelpFile, ArgumentGroupRegistry as KnackArgumentGroupRegistry,
                         HelpExample as KnackHelpExample, HelpParameter as KnackHelpParameter,
@@ -12,7 +15,6 @@ from knack.help import (HelpFile as KnackHelpFile, CommandHelpFile as KnackComma
 
 from knack.log import get_logger
 from knack.util import CLIError
-from azure.cli.core.commands import ExtensionCommandSource
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/_help_loaders.py
+++ b/src/azure-cli-core/azure/cli/core/_help_loaders.py
@@ -6,10 +6,11 @@
 import abc
 import os
 import yaml
-from knack.util import CLIError
-from knack.log import get_logger
+
 from azure.cli.core._help import (HelpExample, CliHelpFile)
 
+from knack.util import CLIError
+from knack.log import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -16,13 +16,13 @@ from copy import deepcopy
 from enum import Enum
 from six.moves import BaseHTTPServer
 
-from knack.log import get_logger
-from knack.util import CLIError
-
 from azure.cli.core._environment import get_config_dir
 from azure.cli.core._session import ACCOUNT
 from azure.cli.core.util import get_file_json, in_cloud_console, open_page_in_browser, can_launch_browser
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
+
+from knack.log import get_logger
+from knack.util import CLIError
 
 logger = get_logger(__name__)
 
@@ -482,9 +482,9 @@ class Profile(object):
         if not result and subscription:
             raise CLIError("Subscription '{}' not found. "
                            "Check the spelling and casing and try again.".format(subscription))
-        elif not result and not subscription:
+        if not result and not subscription:
             raise CLIError("No subscription found. Run 'az account set' to select a subscription.")
-        elif len(result) > 1:
+        if len(result) > 1:
             raise CLIError("Multiple subscriptions with the name '{}' found. "
                            "Specify the subscription ID.".format(subscription))
         return result[0]

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -8,8 +8,9 @@ import adal
 
 from msrest.authentication import Authentication
 
-from knack.util import CLIError
 from azure.cli.core.util import in_cloud_console
+
+from knack.util import CLIError
 
 
 class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-methods

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -7,12 +7,12 @@ import os
 from pprint import pformat
 from six.moves import configparser
 
+from azure.cli.core.profiles import API_PROFILES
+from azure.cli.core._config import GLOBAL_CONFIG_DIR
+
 from knack.log import get_logger
 from knack.util import CLIError
 from knack.config import get_config_parser
-
-from azure.cli.core.profiles import API_PROFILES
-from azure.cli.core._config import GLOBAL_CONFIG_DIR
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -15,14 +15,6 @@ import copy
 from importlib import import_module
 import six
 
-from knack.arguments import CLICommandArgument
-from knack.commands import CLICommand, CommandGroup
-from knack.deprecation import ImplicitDeprecated, resolve_deprecate_info
-from knack.invocation import CommandInvoker
-from knack.log import get_logger
-from knack.util import CLIError, CommandResultItem, todict
-from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
-
 # pylint: disable=unused-import
 from azure.cli.core.commands.constants import (
     BLACKLISTED_MODS, DEFAULT_QUERY_TIME_RANGE, CLI_COMMON_KWARGS, CLI_COMMAND_KWARGS, CLI_PARAM_KWARGS,
@@ -32,6 +24,14 @@ from azure.cli.core.commands.parameters import (
 from azure.cli.core.extension import get_extension
 from azure.cli.core.util import get_command_type_kwarg, read_file_content, get_arg_list, poller_classes
 import azure.cli.core.telemetry as telemetry
+
+from knack.arguments import CLICommandArgument
+from knack.commands import CLICommand, CommandGroup
+from knack.deprecation import ImplicitDeprecated, resolve_deprecate_info
+from knack.invocation import CommandInvoker
+from knack.log import get_logger
+from knack.util import CLIError, CommandResultItem, todict
+from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
 
 logger = get_logger(__name__)
 
@@ -326,7 +326,7 @@ class AzCliCommandInvoker(CommandInvoker):
         if len(exceptions) == 1 and not results:
             ex, id_arg = exceptions[0]
             raise ex
-        elif exceptions:
+        if exceptions:
             for exception, id_arg in exceptions:
                 logger.warning('%s: "%s"', id_arg, str(exception))
             if not results:

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -12,17 +12,17 @@ import re
 import copy
 from six import string_types
 
-from knack.arguments import CLICommandArgument, ignore_type
-from knack.introspection import extract_args_from_signature, extract_full_summary_from_signature
-from knack.log import get_logger
-from knack.util import todict, CLIError
-
 from azure.cli.core import AzCommandsLoader, EXCLUDED_PARAMS
 from azure.cli.core.commands import LongRunningOperation, _is_poller
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.validators import IterateValue
 from azure.cli.core.util import shell_safe_json_parse, augment_no_wait_handler_args, get_command_type_kwarg
 from azure.cli.core.profiles import ResourceType, get_sdk
+
+from knack.arguments import CLICommandArgument, ignore_type
+from knack.introspection import extract_args_from_signature, extract_full_summary_from_signature
+from knack.log import get_logger
+from knack.util import todict, CLIError
 
 logger = get_logger(__name__)
 EXCLUDED_NON_CLIENT_PARAMS = list(set(EXCLUDED_PARAMS) - set(['self', 'client']))
@@ -1093,7 +1093,7 @@ def resolve_role_id(cli_ctx, role, scope):
             role_defs = list(client.list(scope, "roleName eq '{}'".format(role)))
             if not role_defs:
                 raise CLIError("Role '{}' doesn't exist.".format(role))
-            elif len(role_defs) > 1:
+            if len(role_defs) > 1:
                 ids = [r.id for r in role_defs]
                 err = "More than one role matches the given name '{}'. Please pick an id from '{}'"
                 raise CLIError(err.format(role, ids))

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -5,14 +5,14 @@
 
 import os
 
-from knack.log import get_logger
-from knack.util import CLIError
-
 from azure.cli.core import __version__ as core_version
 import azure.cli.core._debug as _debug
 from azure.cli.core.extension import EXTENSIONS_MOD_PREFIX
 from azure.cli.core.profiles._shared import get_client_class, SDKProfile
 from azure.cli.core.profiles import ResourceType, CustomResourceType, get_api_version, get_sdk
+
+from knack.log import get_logger
+from knack.util import CLIError
 
 logger = get_logger(__name__)
 UA_AGENT = "AZURECLI/{}".format(core_version)
@@ -166,8 +166,7 @@ def get_data_service_client(cli_ctx, service_type, account_name, account_key, co
                                               'common._error#_ERROR_STORAGE_MISSING_INFO')
         if _ERROR_STORAGE_MISSING_INFO in str(exc):
             raise ValueError(exc)
-        else:
-            raise CLIError('Unable to obtain data client. Check your connection parameters.')
+        raise CLIError('Unable to obtain data client. Check your connection parameters.')
     # TODO: enable Fiddler
     client.request_callback = _get_add_headers_callback(cli_ctx)
     return client

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -7,16 +7,16 @@
 import argparse
 import platform
 
-from knack.arguments import (
-    CLIArgumentType, CaseInsensitiveList, ignore_type, ArgumentsContext)
-from knack.log import get_logger
-from knack.util import CLIError
-
 from azure.cli.core import EXCLUDED_PARAMS
 from azure.cli.core.commands.constants import CLI_PARAM_KWARGS, CLI_POSITIONAL_PARAM_KWARGS
 from azure.cli.core.commands.validators import validate_tag, validate_tags, generate_deployment_name
 from azure.cli.core.decorators import Completer
 from azure.cli.core.profiles import ResourceType
+
+from knack.arguments import (
+    CLIArgumentType, CaseInsensitiveList, ignore_type, ArgumentsContext)
+from knack.log import get_logger
+from knack.util import CLIError
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/commands/progress.py
+++ b/src/azure-cli-core/azure/cli/core/commands/progress.py
@@ -25,7 +25,7 @@ class ProgressViewBase(object):
 
     def clear(self):
         """ resets the view to neutral """
-        pass
+        pass  # pylint: disable=unnecessary-pass
 
 
 class ProgressReporter(object):

--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -6,10 +6,10 @@
 from __future__ import print_function
 import platform
 
+from azure.cli.core.commands.arm import resource_exists
+
 from knack.log import get_logger
 from knack.util import CLIError
-
-from azure.cli.core.commands.arm import resource_exists
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/commands/transform.py
+++ b/src/azure-cli-core/azure/cli/core/commands/transform.py
@@ -5,9 +5,9 @@
 
 import re
 
-import knack.events as events
-
 from azure.cli.core.util import b64_to_hex
+
+import knack.events as events
 
 
 def register_global_transforms(cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -7,9 +7,9 @@ import argparse
 import time
 import random
 
-from knack.log import get_logger
-
 from azure.cli.core.profiles import ResourceType
+
+from knack.log import get_logger
 
 logger = get_logger(__name__)
 
@@ -31,7 +31,7 @@ class IterateValue(list):
 
     Typical use is to allow multiple ID parameter to a show command etc.
     """
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 def validate_tags(ns):

--- a/src/azure-cli-core/azure/cli/core/decorators.py
+++ b/src/azure-cli-core/azure/cli/core/decorators.py
@@ -57,7 +57,7 @@ def hash256_result(func):
         val = func(*args, **kwargs)
         if not val:
             raise ValueError('Return value is None')
-        elif not isinstance(val, str):
+        if not isinstance(val, str):
             raise ValueError('Return value is not string')
         hash_object = hashlib.sha256(val.encode('utf-8'))
         return str(hash_object.hexdigest())

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -8,10 +8,10 @@ import traceback
 import json
 import re
 
+from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
+
 from knack.config import CLIConfig
 from knack.log import get_logger
-
-from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
 
 az_config = CLIConfig(config_dir=GLOBAL_CONFIG_DIR, config_env_var_prefix=ENV_VAR_PREFIX)
 _CUSTOM_EXT_DIR = az_config.get('extension', 'dir', None)

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -4,11 +4,10 @@
 # --------------------------------------------------------------------------------------------
 from pkg_resources import parse_version
 
-from knack.log import get_logger
-
 from azure.cli.core.extension import ext_compat_with_cli, WHEEL_INFO_RE
 from azure.cli.core.extension._index import get_index_extensions
 
+from knack.log import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -16,13 +16,13 @@ from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
 import requests
 from pkg_resources import parse_version
 
-from knack.log import get_logger
-
 from azure.cli.core.util import CLIError, reload_module
 from azure.cli.core.extension import (extension_exists, get_extension_path, get_extensions, get_extension_modname,
                                       get_extension, ext_compat_with_cli, EXT_METADATA_ISPREVIEW,
                                       WheelExtension, DevExtension, ExtensionNotInstalledException, WHEEL_INFO_RE)
 from azure.cli.core.telemetry import set_extension_management_detail
+
+from knack.log import get_logger
 
 from ._homebrew_patch import HomebrewPipPatch
 from ._index import get_index_extensions

--- a/src/azure-cli-core/azure/cli/core/file_util.py
+++ b/src/azure-cli-core/azure/cli/core/file_util.py
@@ -4,9 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 from __future__ import print_function
-from knack.util import CLIError
 
 from azure.cli.core._help import CliCommandHelpFile, CliGroupHelpFile
+
+from knack.util import CLIError
 
 
 def get_all_help(cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/keys.py
+++ b/src/azure-cli-core/azure/cli/core/keys.py
@@ -8,6 +8,7 @@ import os.path
 
 from knack.util import CLIError
 from knack.log import get_logger
+
 logger = get_logger(__name__)
 
 

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -11,14 +11,14 @@ import difflib
 import argparse
 import argcomplete
 
-from knack.log import get_logger
-from knack.parser import CLICommandParser
-from knack.util import CLIError
-
 import azure.cli.core.telemetry as telemetry
 from azure.cli.core.extension import get_extension
 from azure.cli.core.commands import ExtensionCommandSource
 from azure.cli.core.commands.events import EVENT_INVOKER_ON_TAB_COMPLETION
+
+from knack.log import get_logger
+from knack.parser import CLICommandParser
+from knack.util import CLIError
 
 logger = get_logger(__name__)
 
@@ -27,7 +27,7 @@ class IncorrectUsageError(CLIError):
     '''Raised when a command is incorrectly used and the usage should be
     displayed to the user.
     '''
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 class AzCompletionFinder(argcomplete.CompletionFinder):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -203,7 +203,7 @@ class ExecutionResult(object):
             logger.error('Command "%s" => %d. (It did not fail as expected). %s\n', command,
                          self.exit_code, log_val)
             raise AssertionError('The command did not fail as it was expected.')
-        elif not expect_failure and self.exit_code != 0:
+        if not expect_failure and self.exit_code != 0:
             logger.error('Command "%s" => %d. %s\n', command, self.exit_code, log_val)
             raise AssertionError('The command failed. Exit code: {}'.format(self.exit_code))
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py
@@ -27,9 +27,8 @@ class JMESPathCheck(object):  # pylint: disable=too-few-public-methods
             if actual_result:
                 raise JMESPathCheckAssertionError(self._query, self._expected_result, actual_result,
                                                   execution_result.output)
-            else:
-                raise JMESPathCheckAssertionError(self._query, self._expected_result, 'None',
-                                                  execution_result.output)
+            raise JMESPathCheckAssertionError(self._query, self._expected_result, 'None',
+                                              execution_result.output)
 
 
 class JMESPathCheckExists(object):  # pylint: disable=too-few-public-methods
@@ -60,9 +59,8 @@ class JMESPathCheckGreaterThan(object):  # pylint: disable=too-few-public-method
             if actual_result:
                 raise JMESPathCheckAssertionError(self._query, expected_result_format, actual_result,
                                                   execution_result.output)
-            else:
-                raise JMESPathCheckAssertionError(self._query, expected_result_format, 'None',
-                                                  execution_result.output)
+            raise JMESPathCheckAssertionError(self._query, expected_result_format, 'None',
+                                              execution_result.output)
 
 
 class JMESPathPatternCheck(object):  # pylint: disable=too-few-public-methods

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_exception_handler.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_exception_handler.py
@@ -21,12 +21,10 @@ def monitor_exception_handler(ex):
             message = '{}.'.format(error_payload['message']) if error_payload['message'] else 'Operation failed.'
             code = '[Code: "{}"]'.format(error_payload['code']) if error_payload['code'] else ''
             raise CLIError('{} {}'.format(message, code))
-        else:
-            raise CLIError(ex)
-    else:
-        import sys
-        from six import reraise
-        reraise(*sys.exc_info())
+        raise CLIError(ex)
+    import sys
+    from six import reraise
+    reraise(*sys.exc_info())
 
 
 def missing_resource_handler(exception):
@@ -35,5 +33,4 @@ def missing_resource_handler(exception):
 
     if isinstance(exception, HttpOperationError) and exception.response.status_code == 404:
         raise CLIError('Can\'t find the resource.')
-    else:
-        raise CLIError(exception.message)
+    raise CLIError(exception.message)

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_params.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from knack.arguments import CLIArgumentType
-
 from azure.cli.core.util import get_json_object
 
 from azure.cli.core.commands.parameters import (
@@ -19,6 +17,8 @@ from azure.cli.command_modules.monitor.util import get_operator_map, get_aggrega
 from azure.cli.command_modules.monitor.validators import (
     process_webhook_prop, validate_autoscale_recurrence, validate_autoscale_timegrain, get_action_group_validator,
     get_action_group_id_validator, validate_metric_dimension)
+
+from knack.arguments import CLIArgumentType
 
 
 # pylint: disable=line-too-long, too-many-statements

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/actions.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/actions.py
@@ -5,11 +5,12 @@
 
 import argparse
 import antlr4
-from knack.util import CLIError
 
 from azure.cli.command_modules.monitor.util import (
     get_aggregation_map, get_operator_map, get_autoscale_operator_map,
     get_autoscale_aggregation_map, get_autoscale_scale_direction_map)
+
+from knack.util import CLIError
 
 
 def timezone_name_type(value):

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
@@ -3,9 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from knack.log import get_logger
-
 from azure.cli.command_modules.monitor._client_factory import cf_metrics
+
+from knack.log import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/activity_log_alerts.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/activity_log_alerts.py
@@ -222,7 +222,5 @@ def _get_alert_settings(client, resource_group_name, activity_log_alert_name, th
             if throw_if_missing:
                 raise CLIError('Can\'t find activity log alert {} in resource group {}.'.format(activity_log_alert_name,
                                                                                                 resource_group_name))
-            else:
-                return None
-        else:
-            raise CLIError(ex.message)
+            return None
+        raise CLIError(ex.message)

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/metric_alert.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/operations/metric_alert.py
@@ -3,9 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from knack.log import get_logger
-
 from azure.cli.command_modules.monitor.util import get_operator_map, get_aggregation_map
+
+from knack.log import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
@@ -114,10 +114,10 @@ def get_target_resource_validator(dest, required, preserve_resource_group_parame
                                '[--{0}-namespace NAMESPACE]'.format(alias))
         if not name_or_id and required:
             raise usage_error
-        elif name_or_id:
+        if name_or_id:
             if is_valid_resource_id(name_or_id) and any((res_ns, parent, res_type)):
                 raise usage_error
-            elif not is_valid_resource_id(name_or_id):
+            if not is_valid_resource_id(name_or_id):
                 from azure.cli.core.commands.client_factory import get_subscription_id
                 if res_type and '/' in res_type:
                     res_ns = res_ns or res_type.rsplit('/', 1)[0]

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_exception_handler.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_exception_handler.py
@@ -12,8 +12,7 @@ def policy_insights_exception_handler(ex):
     if isinstance(ex, QueryFailureException):
         message = '({}) {}'.format(ex.error.error.code, ex.error.error.message)
         raise CLIError(message)
-    else:
-        import sys
-        from six import reraise
+    import sys
+    from six import reraise
 
-        reraise(*sys.exc_info())
+    reraise(*sys.exc_info())

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/custom.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/custom.py
@@ -3,9 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from knack.util import CLIError
 from msrestazure.tools import is_valid_resource_id, resource_id
+
 from azure.cli.core.commands.client_factory import get_subscription_id
+
+from knack.util import CLIError
 
 
 def list_policy_events(
@@ -424,7 +426,7 @@ def create_policy_remediation(
         policy_assignment_ids = [p.id for p in policy_assignments if p.name.lower() == policy_assignment.lower()]
         if not policy_assignment_ids:
             raise CLIError("No policy assignment with the name '{}' found.".format(policy_assignment))
-        elif len(policy_assignment_ids) > 1:
+        if len(policy_assignment_ids) > 1:
             raise CLIError("Multiple policy assignment with the name '{}' found. "
                            "Specify the policy assignment ID.".format(policy_assignment))
         policy_assignment = policy_assignment_ids[0]
@@ -506,7 +508,7 @@ def _build_remediation_scope(
 
     if management_group:
         return "/providers/Microsoft.Management/managementGroups/{}".format(management_group)
-    elif resource:
+    if resource:
         return _build_resource_id(subscription, resource, resource_group_name,
                                   namespace, resource_type_parent, resource_type)
     return resource_id(subscription=subscription, resource_group=resource_group_name)

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_client_factory.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_client_factory.py
@@ -38,9 +38,8 @@ def get_mariadb_management_client(cli_ctx, **_):
             subscription_id=getenv(SUB_ID_OVERRIDE),
             base_url=rm_uri_override,
             credentials=credentials)
-    else:
-        # Normal production scenario.
-        return get_mgmt_service_client(cli_ctx, MariaDBManagementClient)
+    # Normal production scenario.
+    return get_mgmt_service_client(cli_ctx, MariaDBManagementClient)
 
 
 def get_mysql_management_client(cli_ctx, **_):
@@ -67,9 +66,8 @@ def get_mysql_management_client(cli_ctx, **_):
             subscription_id=getenv(SUB_ID_OVERRIDE),
             base_url=rm_uri_override,
             credentials=credentials)
-    else:
-        # Normal production scenario.
-        return get_mgmt_service_client(cli_ctx, MySQLManagementClient)
+    # Normal production scenario.
+    return get_mgmt_service_client(cli_ctx, MySQLManagementClient)
 
 
 def get_postgresql_management_client(cli_ctx, **_):
@@ -96,9 +94,8 @@ def get_postgresql_management_client(cli_ctx, **_):
             subscription_id=getenv(SUB_ID_OVERRIDE),
             base_url=rm_uri_override,
             credentials=credentials)
-    else:
-        # Normal production scenario.
-        return get_mgmt_service_client(cli_ctx, PostgreSQLManagementClient)
+    # Normal production scenario.
+    return get_mgmt_service_client(cli_ctx, PostgreSQLManagementClient)
 
 
 def cf_mariadb_servers(cli_ctx, _):

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/custom.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/custom.py
@@ -258,7 +258,6 @@ def _server_update_custom_func(instance,
                                administrator_login_password=None,
                                ssl_enforcement=None,
                                tags=None):
-    from azure.mgmt.rdbms.mysql.models import StorageProfile  # pylint: disable=unused-variable
     from importlib import import_module
     server_module_path = instance.__module__
     module = import_module(server_module_path.replace('server', 'server_update_parameters'))

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/validators.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/validators.py
@@ -3,11 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from knack.prompting import prompt_pass, NoTTYException
-from knack.util import CLIError
-
 from azure.cli.core.commands.validators import (
     get_default_location_from_resource_group, validate_tags)
+
+from knack.prompting import prompt_pass, NoTTYException
+from knack.util import CLIError
 
 
 def get_combined_validator(validators):

--- a/src/command_modules/azure-cli-reservations/azure/cli/command_modules/reservations/_exception_handler.py
+++ b/src/command_modules/azure-cli-reservations/azure/cli/command_modules/reservations/_exception_handler.py
@@ -11,7 +11,6 @@ def reservations_exception_handler(ex):
     if isinstance(ex, Error):
         message = ex.error.error.message
         raise CLIError(message)
-    else:
-        import sys
-        from six import reraise
-        reraise(*sys.exc_info())
+    import sys
+    from six import reraise
+    reraise(*sys.exc_info())

--- a/src/command_modules/azure-cli-security/azure/cli/command_modules/security/_validators.py
+++ b/src/command_modules/azure-cli-security/azure/cli/command_modules/security/_validators.py
@@ -8,17 +8,17 @@ from knack.util import CLIError
 
 def validate_alert_status(namespace):
     lower_status = namespace.status.lower()
-    if lower_status != "dismiss" and lower_status != "activate":
+    if lower_status not in ['dismiss', 'activate']:
         raise CLIError('--status can only accept "dismiss" or "activate" values')
 
 
 def validate_auto_provisioning_toggle(namespace):
     lower_toggle = namespace.auto_provision.lower()
-    if lower_toggle != "on" and lower_toggle != "off":
+    if lower_toggle not in ['on', 'off']:
         raise CLIError('--auto-provision can only accept "on" or "off" values')
 
 
 def validate_pricing_tier(namespace):
     pricing_tier = namespace.tier.lower()
-    if pricing_tier != "free" and pricing_tier != "standard":
+    if pricing_tier not in ['free', 'standard']:
         raise CLIError('--tier can only accept "standard" or "free" values')

--- a/src/command_modules/azure-cli-security/azure/cli/command_modules/security/custom.py
+++ b/src/command_modules/azure-cli-security/azure/cli/command_modules/security/custom.py
@@ -46,7 +46,7 @@ def list_security_alerts(client, resource_group_name=None, location=None):
 
         return client.list_subscription_level_alerts_by_region()
 
-    elif resource_group_name:
+    if resource_group_name:
         return client.list_by_resource_group(resource_group_name)
 
     return client.list()
@@ -206,7 +206,7 @@ def list_security_jit_network_access_policies(client, resource_group_name=None, 
 
         return client.list_by_region()
 
-    elif resource_group_name:
+    if resource_group_name:
         return client.list_by_resource_group(resource_group_name)
 
     return client.list()

--- a/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
@@ -8,7 +8,6 @@
 import os
 import time
 
-from knack.log import get_logger
 from OpenSSL import crypto
 
 try:
@@ -59,6 +58,8 @@ from azure.mgmt.compute.models import (VaultCertificate,
                                        SubResource,
                                        UpgradeMode)
 from azure.mgmt.storage.models import StorageAccountCreateParameters
+
+from knack.log import get_logger
 
 from ._client_factory import (resource_client_factory,
                               keyvault_client_factory,
@@ -1216,8 +1217,7 @@ def _get_resource_group_name(cli_ctx, resource_group_name):
         error = getattr(ex, 'Azure Error', ex)
         if error != 'ResourceGroupNotFound':
             return None
-        else:
-            raise
+        raise
 
 
 def _create_resource_group_name(cli_ctx, rg_name, location, tags=None):
@@ -1729,11 +1729,10 @@ def _get_object_id_from_subscription(graph_client, subscription):
     if subscription['user']:
         if subscription['user']['type'] == 'user':
             return _get_object_id_by_upn(graph_client, subscription['user']['name'])
-        elif subscription['user']['type'] == 'servicePrincipal':
+        if subscription['user']['type'] == 'servicePrincipal':
             return _get_object_id_by_spn(graph_client, subscription['user']['name'])
-        else:
-            logger.warning("Unknown user type '%s'",
-                           subscription['user']['type'])
+        logger.warning("Unknown user type '%s'",
+                       subscription['user']['type'])
     else:
         logger.warning('Current credentials are not from a user or service principal. '
                        'Azure Key Vault does not work with certificate credentials.')

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_params.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_params.py
@@ -8,8 +8,6 @@
 import itertools
 from enum import Enum
 
-from knack.arguments import CLIArgumentType, ignore_type
-
 from azure.mgmt.sql.models import (
     Database,
     ElasticPool,
@@ -43,6 +41,8 @@ from azure.cli.core.commands.parameters import (
     get_location_type,
     tags_type
 )
+
+from knack.arguments import CLIArgumentType, ignore_type
 
 from .custom import (
     ClientAuthenticationType,

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
@@ -6,8 +6,6 @@
 # pylint: disable=C0302
 from enum import Enum
 
-from knack.log import get_logger
-
 from azure.cli.core.util import (
     CLIError,
     sdk_no_wait,
@@ -35,6 +33,8 @@ from azure.mgmt.sql.models import (
     Sku,
     StorageKeyType,
 )
+
+from knack.log import get_logger
 
 from ._util import (
     get_sql_capabilities_operations,
@@ -210,17 +210,16 @@ def _find_performance_level_capability(sku, supported_service_level_objectives, 
                         capacity=sku.capacity,
                         capacities=[slo.sku.capacity for slo in supported_service_level_objectives]
                     ))
-            else:
-                raise CLIError(
-                    "Could not find sku in tier '{tier}' with family '{family}', capacity {capacity}."
-                    " Supported families & capacities for '{tier}' are: {skus}. Please specify one of these"
-                    " supported combinations of family and capacity.".format(
-                        tier=sku.tier,
-                        family=sku.family,
-                        capacity=sku.capacity,
-                        skus=[(slo.sku.family, slo.sku.capacity)
-                              for slo in supported_service_level_objectives]
-                    ))
+            raise CLIError(
+                "Could not find sku in tier '{tier}' with family '{family}', capacity {capacity}."
+                " Supported families & capacities for '{tier}' are: {skus}. Please specify one of these"
+                " supported combinations of family and capacity.".format(
+                    tier=sku.tier,
+                    family=sku.family,
+                    capacity=sku.capacity,
+                    skus=[(slo.sku.family, slo.sku.capacity)
+                          for slo in supported_service_level_objectives]
+                ))
     elif sku.family:
         # Error - cannot find based on family alone.
         raise CLIError('If --family is specified, --capacity must also be specified.')
@@ -1922,8 +1921,7 @@ def encryption_protector_update(
     else:
         if kid is None:
             raise CLIError('A uri must be provided if the server_key_type is AzureKeyVault.')
-        else:
-            key_name = _get_server_key_name_from_uri(kid)
+        key_name = _get_server_key_name_from_uri(kid)
 
     return client.create_or_update(
         resource_group_name=resource_group_name,

--- a/src/command_modules/azure-cli-sqlvm/azure/cli/command_modules/sqlvm/custom.py
+++ b/src/command_modules/azure-cli-sqlvm/azure/cli/command_modules/sqlvm/custom.py
@@ -4,9 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 from msrestazure.tools import is_valid_resource_id, resource_id
-from knack.prompting import prompt_pass
-from azure.cli.core.commands import LongRunningOperation
 
+from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import (
     sdk_no_wait
 )
@@ -27,6 +26,8 @@ from azure.mgmt.sqlvirtualmachine.models import (
     ServerConfigurationsManagementSettings,
     SqlVirtualMachine
 )
+
+from knack.prompting import prompt_pass
 
 
 def sqlvm_list(


### PR DESCRIPTION
Pylint 2.3 will be required when we move the CI to Python 3.7. Thus, I am working on getting most of the violations cleaned up so that the switch will be less taxing.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
