### PR TITLE
graph: support admin consent

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -201,7 +201,7 @@ helps['ad app permission'] = """
 helps['ad app permission grant'] = """
     type: command
     short-summary: Grant the app an API Delegated permissions
-    long-summary: for application permissions, please use "ad app permission admin-consent"
+    long-summary: for Application permissions, please use "ad app permission admin-consent"
     examples:
         - name: Grant a native application with permissions to access an existing API with TTL of 2 years
           text: az ad app permission grant --id e042ec79-34cd-498f-9d9f-1234234 --api a0322f79-57df-498f-9d9f-12678 --expires 2

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -200,10 +200,16 @@ helps['ad app permission'] = """
 """
 helps['ad app permission grant'] = """
     type: command
-    short-summary: Grant the app an API permission
+    short-summary: Grant the app an API Delegated permissions
+    long-summary: for application permissions, please use "ad app permission admin-consent"
     examples:
         - name: Grant a native application with permissions to access an existing API with TTL of 2 years
           text: az ad app permission grant --id e042ec79-34cd-498f-9d9f-1234234 --api a0322f79-57df-498f-9d9f-12678 --expires 2
+"""
+helps['ad app permission admin-consent'] = """
+    type: command
+    short-summary: grant Application & Delegated permissions through admin-consent.
+    long-summary: you must login as a directory administrator
 """
 helps['ad app permission list'] = """
     type: command

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
@@ -146,6 +146,7 @@ def load_command_table(self, _):
         g.custom_command('permission add', 'add_permission')
         g.custom_command('permission delete', 'delete_permission')
         g.custom_command('permission list-grants', 'list_permission_grants')
+        g.custom_command('permission admin-consent', 'admin_consent')
         g.generic_update_command('update', setter_name='patch_application', setter_type=role_custom,
                                  getter_name='show_application', getter_type=role_custom,
                                  custom_func_name='update_application', custom_func_type=role_custom)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -814,7 +814,7 @@ def admin_consent(cmd, identifier):
     from azure.cli.core.commands.client_factory import UA_AGENT
     from azure.cli.core.util import should_disable_connection_verify
     if cmd.cli_ctx.cloud.name != AZURE_PUBLIC_CLOUD.name:
-        raise CLIError('This command does not function yet in solverign clouds')
+        raise CLIError('This command is not yet supported on sovereign clouds')
     # we will leverage portal endpoints to get admin consent done
     graph_client = _graph_client_factory(cmd.cli_ctx)
     application = show_application(graph_client.applications, identifier)


### PR DESCRIPTION
With this, CLI will do exactly like the "Grant Permission" button in portal and hence both "Application" and "Delegated" permissions can be handled.

This addresses the lingering ask in #7177 and #8310 

//CC @paolosalvatori @jianghaolu 


- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
