### PR TITLE
ad app create: identifier-uris defaults to [] if not provided

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 * `ad app permission add`: support to add permissions on existing api
 * `ad app permission list`: fix a bad error when there is no permissions
 * `ad sp delete`: skip role assignment delete if the current account has no subscription
+* `ad app create`: make --identifier-uris default to empty list if not provided
 
 2.4.2
 +++++

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -675,13 +675,12 @@ def create_application(cmd, display_name, homepage=None, identifier_uris=None,  
                        credential_description=None, app_roles=None):
     graph_client = _graph_client_factory(cmd.cli_ctx)
     key_creds, password_creds, required_accesses = None, None, None
+    if not identifier_uris:
+        identifier_uris = []
     if native_app:
         if identifier_uris:
             raise CLIError("'--identifier-uris' is not required for creating a native application")
-        identifier_uris = ['http://{}'.format(_gen_guid())]  # we will create a temporary one and remove it later
     else:
-        if not identifier_uris:
-            raise CLIError("'--identifier-uris' is required for creating an application")
         password_creds, key_creds = _build_application_creds(password, key_value, key_type, key_usage,
                                                              start_date, end_date, credential_description)
 
@@ -715,8 +714,7 @@ def create_application(cmd, display_name, homepage=None, identifier_uris=None,  
         # AAD graph doesn't have the API to create a native app, aka public client, the recommended hack is
         # to create a web app first, then convert to a native one
         # pylint: disable=protected-access
-        app_patch_param = ApplicationUpdateParameters(identifier_uris=[])
-        app_patch_param.public_client = True
+        app_patch_param = ApplicationUpdateParameters(public_client=True)
         graph_client.applications.patch(result.object_id, app_patch_param)
         result = graph_client.applications.get(result.object_id)
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_native_app_create_scenario.yaml
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_native_app_create_scenario.yaml
@@ -1,745 +1,432 @@
 interactions:
 - request:
-    body: 'b''{"identifierUris": ["http://22bf8f2f-9de7-47c2-a226-140636bfaf43"],
-      "availableToOtherTenants": false, "displayName": "cli-native-000001", "requiredResourceAccess":
-      [{"resourceAccess": [{"type": "Scope", "id": "5778995a-e1bf-45b8-affa-663a9f3f4d04"}],
-      "resourceAppId": "00000002-0000-0000-c000-000000000000"}]}'''
+    body: 'b''{"availableToOtherTenants": false, "requiredResourceAccess": [{"resourceAccess":
+      [{"id": "5778995a-e1bf-45b8-affa-663a9f3f4d04", "type": "Scope"}], "resourceAppId":
+      "00000002-0000-0000-c000-000000000000"}], "displayName": "cli-native-000001",
+      "identifierUris": []}'''
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '312'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - --display-name --native-app --required-resource-accesses
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app create]
+      Connection: [keep-alive]
+      Content-Length: ['267']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--display-name --native-app --required-resource-accesses]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"c4066a5a-0c44-4906-996f-2cf6d49cb63c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"245f5c75-3686-4088-b204-1580c85141e9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":["http://22bf8f2f-9de7-47c2-a226-140636bfaf43"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/logo","logo@odata.mediaContentType":"application/json;odata=minimalmetadata;
-        charset=utf-8","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"d916c40e-521f-4915-914b-a11bbc7de2bb","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"7ae618dd-b219-4e12-b42d-54d50abff31a","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/logo","logo@odata.mediaContentType":"application/json;odata=minimalmetadata;
+        charset=utf-8","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-native-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-native-000001","id":"8a9793d2-63cc-484f-bd0b-fbaaa22d3053","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-native-000001","id":"a31716cb-4b25-4002-8646-c3e4f685ed7b","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-native-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '2230'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:06 GMT
-      duration:
-      - '5235359'
-      expires:
-      - '-1'
-      location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application
-      ocp-aad-diagnostics-server-name:
-      - BI3dniF5gFlLHxF7369p0ZVLYOn1L0xA9R+7IS9QDiw=
-      ocp-aad-session-key:
-      - s9rrVkOPGCR7PYe5ozPzu3xg_oxGS4eYFBgoqIAn79uJPy9FMR_u6Kdc39d7A1qgUHlivZAFpJr_eaUmjc6ytiFZJjA2A_2H9flmUmSD-xt2zNkfAtTd_ApEgAk8197Raxyg0nY4r9up0ypuDDRTHQ.Fszi3kR2697xceezIrGKCG-ogO95o6GGaF9op5LdS1E
-      pragma:
-      - no-cache
-      request-id:
-      - 41360944-74f4-4118-838c-6e36a493212a
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['2182']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:37 GMT']
+      duration: ['10269175']
+      expires: ['-1']
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application']
+      ocp-aad-diagnostics-server-name: [P277HeLOcMoYADlOIgX/5nDH/EQ2eMVFV4LkO8IWIBk=]
+      ocp-aad-session-key: [UvrAuQWbBknELcPFQFgU6t8EE8oVBXEpHp1ExCY6t2zlV6vP3MsrkonPvWbcUVv4PhIkKZWkuhiydguLM6K25fQ9YKxSJ7D584RkZ11NYMOaKfMt5Lmjo1TZDtALOVFBcPUHDAYyKllStW8-Hd28lQ.kqTEAItQWRaRoxNWErSrKSzgceiQrA_Smv8Pj-eBOqc]
+      pragma: [no-cache]
+      request-id: [7ca11be1-e853-4df3-a703-e558ce8177db]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
 - request:
-    body: '{"identifierUris": [], "publicClient": true}'
+    body: '{"publicClient": true}'
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - --display-name --native-app --required-resource-accesses
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app create]
+      Connection: [keep-alive]
+      Content-Length: ['22']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--display-name --native-app --required-resource-accesses]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/c4066a5a-0c44-4906-996f-2cf6d49cb63c?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/d916c40e-521f-4915-914b-a11bbc7de2bb?api-version=1.6
   response:
-    body:
-      string: ''
+    body: {string: ''}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      date:
-      - Tue, 12 Mar 2019 19:40:07 GMT
-      duration:
-      - '2334100'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - sYypgmyv9KLBQcszlFTAA6Klt8R5H4hoowy5e3DKXFI=
-      ocp-aad-session-key:
-      - CIbuUuYreT2bmK1vHzisyDobCpl0pYaLxwW1TySmN6NGEHGW0FnEiy4k2dMV0im2GpnYqYPSEB68PEEVrMrRQAr85N0e1vbChJlPloygsYhEDz-7rtPZ0s1urcAkT0ulslA_eaBOKdJUDNTQ7GkXfQ.ZFME70Jdk-3CANUvS8d8aKKTQdP56o_F25YeGF6ki3c
-      pragma:
-      - no-cache
-      request-id:
-      - dae2405f-2873-418c-a7f3-c173d6d1c60f
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 204
-      message: No Content
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      date: ['Tue, 19 Mar 2019 17:11:37 GMT']
+      duration: ['3187224']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [7zDIRrVJqjSZfhHAIvOE5P1Iegs1wlixjPO7KsOVy0Y=]
+      ocp-aad-session-key: [sqnvGJgnvOyMZYOon1JvWrLHlee1YMTIYjusWYNaD43a5Sh_FnZoAGmOVXuoNPZuCp20UjAvW8BXA8I1znFECpuaxK-9bUdYcRhX1qZY1HlFBA6oY9uJkH6Rd859da_0AjclVYNW6p4or3S_muYUQg.9SeYTInOQmimbWFU85e3JYdorZvzsB1888U6m1YrAAw]
+      pragma: [no-cache]
+      request-id: [2e98ed01-a141-46f5-b003-7b05b042c19c]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --display-name --native-app --required-resource-accesses
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app create]
+      Connection: [keep-alive]
+      ParameterSetName: [--display-name --native-app --required-resource-accesses]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/c4066a5a-0c44-4906-996f-2cf6d49cb63c?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/d916c40e-521f-4915-914b-a11bbc7de2bb?api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"c4066a5a-0c44-4906-996f-2cf6d49cb63c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"245f5c75-3686-4088-b204-1580c85141e9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"d916c40e-521f-4915-914b-a11bbc7de2bb","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"7ae618dd-b219-4e12-b42d-54d50abff31a","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-native-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-native-000001","id":"8a9793d2-63cc-484f-bd0b-fbaaa22d3053","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-native-000001","id":"a31716cb-4b25-4002-8646-c3e4f685ed7b","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-native-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '2099'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:07 GMT
-      duration:
-      - '604762'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - XC37a6rlJsCeGLMfJenTNZI4+ije7D/luiwxI9jCogI=
-      ocp-aad-session-key:
-      - FO-8UstWEIF7Vjqvh-6umJUswo_h2K-K7FKGOLRjCQqyxSWyVx9uXN_OoAJ1_e1mR-UhIf2Qeosdv5N22u19NDQ6qfzrRChoiU4oA7whWsuZIRx91_edC1i2viBeUsj9QCzjTgQDqxAOYsCOPljwBw.tg6GF7IJ1AhjnhvoBUHGZyfsX8wXB_rc7aDuUbGIouI
-      pragma:
-      - no-cache
-      request-id:
-      - bfa8819d-cfb2-44a6-a26e-c9931a66b3c2
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['2096']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:38 GMT']
+      duration: ['2326691']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [Ww4JZ3phP63mdXQAX3Q+w5V7Po6AayFlRCSGeKGwhtg=]
+      ocp-aad-session-key: [IitbC2kBoxi4wj55tLqJ5VOxhPqtMJU31uDMiBRyD1nyjSpd8B_Wiq9TPoP9BN6oTf8Y6v4gcYgQOaNpAr1cRF5eqpzuGaUUWujQ6ziynmYnAFQtB2-VPYjZBkHB1JWiHkwD98LPeTntNhX_aWpYpQ.M9tPcwsFuSWCAzmcPRcWUXo6Nn3I8UR_e4YXE9d_HPU]
+      pragma: [no-cache]
+      request-id: [708598ab-756b-459b-b006-b4cbfa2e0dbf]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id --required-resource-accesses
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      ParameterSetName: [--id --required-resource-accesses]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27245f5c75-3686-4088-b204-1580c85141e9%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%277ae618dd-b219-4e12-b42d-54d50abff31a%27%29&api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '121'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:07 GMT
-      duration:
-      - '540670'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - kU2w10RodSRmFDDKfAx6uHxQPwDam6n6u8zYQa+I0/o=
-      ocp-aad-session-key:
-      - T9jHGK_rFMOg6GB3L-cgYsUTZ6Gte-R53xbgveMO9l9cc8HQUfXvH-0dTm8zwR5EKDP2z9Jx4qELsptBU_w0r2J_DEkGFPsY19QazXuH7PEWkyDvdUebfcsn5N9tyhK9kCfJV9S_fiomTCncZMnj1Q.r8D6D_ouFCfN1-CzFkXf1DOfuWqiYSB-6n-iLMxT6WI
-      pragma:
-      - no-cache
-      request-id:
-      - 537c8849-75bc-4da6-a338-da722db2e8dc
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:38 GMT']
+      duration: ['2189781']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [Ww4JZ3phP63mdXQAX3Q+w5V7Po6AayFlRCSGeKGwhtg=]
+      ocp-aad-session-key: [YPhrSoDDKqF7HbEduA-N5_1rNQsF-ey1p-LUgzVTXVh5idXU_aOjHeBc2_Lv52G3n7CP1o1n-r-U42U7WXRNZYkn3VhzsvZDMwx9p699c2OztSHxHGcrbcYAE8iS0k_Z0NEbuAnR6UKtdPD--EGEDw.rMp1NJP8_rPNz4cwcSAt177OpkqZwQmKFAifUR1ZYME]
+      pragma: [no-cache]
+      request-id: [d8b15fc1-9479-4b82-ae3a-835b00b22c4c]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id --required-resource-accesses
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      ParameterSetName: [--id --required-resource-accesses]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27245f5c75-3686-4088-b204-1580c85141e9%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%277ae618dd-b219-4e12-b42d-54d50abff31a%27&api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"c4066a5a-0c44-4906-996f-2cf6d49cb63c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"245f5c75-3686-4088-b204-1580c85141e9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"d916c40e-521f-4915-914b-a11bbc7de2bb","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"7ae618dd-b219-4e12-b42d-54d50abff31a","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-native-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-native-000001","id":"8a9793d2-63cc-484f-bd0b-fbaaa22d3053","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-native-000001","id":"a31716cb-4b25-4002-8646-c3e4f685ed7b","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-native-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '2102'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:08 GMT
-      duration:
-      - '625432'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - gumqaGrQuKMWKx5qR6D+EntZzHCdF7Gxbt/YYl8BbgU=
-      ocp-aad-session-key:
-      - EK3O4p5r-k1TLPgsagl_aIhJc7JsQGM4S6stsFK0c6WZa4LopwSha3Vee_3f8zRXeposZDQXbTkSnBbkqwHm0nwp4-33ewv1QD0KI51i0yKFmRP7f9STrh6UoUj3khwli0gkEn__djd_D_aRVIsrqA.r8ZMJ_3YfPTNxEQUG83KHnP4ixZFphPNmyAidpKk3BU
-      pragma:
-      - no-cache
-      request-id:
-      - 87ab5737-a064-47a2-b149-c6a83a440691
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['2099']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:39 GMT']
+      duration: ['2631323']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [s1AYRiKTN8Zyk5kxIB0PtqEoINriycEcNdfPJWLTOYA=]
+      ocp-aad-session-key: [qLTqVCDgM_lQURjnOGc9fnm-aVmw0zo5EuT2K0GExvfA5dE80UMJ41mvUv1jzJOutsoH2qP0zG18lKS_gT6pw_rW3cnMWePA4bu46CFR-V2dS2EEAwMhbU2jy8F5dvujsp4v89t3ojL0PM2KgZOm2A.ZU4MOR7WhUW4T9v5mkBmzBmux2G7M0KYK1b-NavJD0g]
+      pragma: [no-cache]
+      request-id: [0b1b6e9f-1a8b-4422-b926-89edb541e858]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id --required-resource-accesses
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      ParameterSetName: [--id --required-resource-accesses]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/c4066a5a-0c44-4906-996f-2cf6d49cb63c?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/d916c40e-521f-4915-914b-a11bbc7de2bb?api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"c4066a5a-0c44-4906-996f-2cf6d49cb63c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"245f5c75-3686-4088-b204-1580c85141e9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"d916c40e-521f-4915-914b-a11bbc7de2bb","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"7ae618dd-b219-4e12-b42d-54d50abff31a","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-native-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-native-000001","id":"8a9793d2-63cc-484f-bd0b-fbaaa22d3053","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-native-000001","id":"a31716cb-4b25-4002-8646-c3e4f685ed7b","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-native-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '2099'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:08 GMT
-      duration:
-      - '615657'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - oi9XMYqRsHd5ZQSxIzkIjFq6as38XTrETSJ9U1cLD+4=
-      ocp-aad-session-key:
-      - zwEOzEQBe4WwiagOvYLm9Lre5ailhYP1m8Ko6EFhleaYghFKxbiwgRR_bZtrtXgRGX0qU5pvFscn_cpFnpQnUkbJuGCmzysjXWjhE7hiVRxZ6aSWEiaXsjRhzYkP_HtbY3MZA1gMPM203ToXbmdGoQ.Gs5EFih0-_wuf7sWJ6gMf02Ig3JqDKWtbPDmrssQykg
-      pragma:
-      - no-cache
-      request-id:
-      - 4eb6772b-493e-49f7-b26b-e6ad166e922f
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['2096']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:39 GMT']
+      duration: ['1216357']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [dWCANOa3JjPDcseMBZksFWn7gO0rsnL3G7snEFR71w8=]
+      ocp-aad-session-key: [vPH-IGcnEkp59mwAw9k77Iaf1JSMk5diP6btoHLock18hs3az3WOruFPSFfplLblEhKTO-QkEnexKseJbKH7Av8eIVg2TJq8GQpY_X40fKkfzIopEDDQLPdzntD1xNjAXI8bNjXTeecu5NtpsmJsXQ.pldIXJMlBUQwEWjS7zX08KJ7ZYzCBmtsgk4BlrGcMDY]
+      pragma: [no-cache]
+      request-id: [8fbef55f-87d5-4afa-9d6a-7e28a7b8812d]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id --required-resource-accesses
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      ParameterSetName: [--id --required-resource-accesses]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27245f5c75-3686-4088-b204-1580c85141e9%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%277ae618dd-b219-4e12-b42d-54d50abff31a%27%29&api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '121'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:08 GMT
-      duration:
-      - '549295'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - J4iPke7YPfBuYA4E3b307ck09pRqAOuzQKQ03+b041M=
-      ocp-aad-session-key:
-      - EMhDZcaUz1z-V1OIZUSOfTeZ93HgQ6ulFcHCyeUUdZUF5VhLeJMYIdfwWZAQoYPo2wZZVhhZXSnnqulGotpHgtC8L_t21ZaC8oAhmU-yRRdW7VOgYNLSQXz02FNkm8E1YwL8Lfg3c9dyGERo-mqQOA.jyWjtmYbZUBPcyYQrMPbdjUos4CWpAFjUaYpB-NwXl8
-      pragma:
-      - no-cache
-      request-id:
-      - b29ca638-8ec3-4a60-9c56-c206d2aec801
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:40 GMT']
+      duration: ['873704']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [s1AYRiKTN8Zyk5kxIB0PtqEoINriycEcNdfPJWLTOYA=]
+      ocp-aad-session-key: [lWHEssPxHz1fCFwHyKBiqrb4Bwr8AVi9rjxYg1Akgm5RQNd7ONpXdAr_yE96lRKrx3fK0er01iHbpPL0FLstf0zygua8I350rYhA-J5EBVDPE4lH_1VUJ8M4wblFB5_t5LmaN-p2KYSbrTnBo8ZVRQ.I3EFQj_lX0Iamw2tVrj-ZXfBHTQtT-3lQ0dmoQwHqBk]
+      pragma: [no-cache]
+      request-id: [2c4970bc-7f3e-4340-92b7-43c4bb28a068]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id --required-resource-accesses
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      ParameterSetName: [--id --required-resource-accesses]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27245f5c75-3686-4088-b204-1580c85141e9%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%277ae618dd-b219-4e12-b42d-54d50abff31a%27&api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"c4066a5a-0c44-4906-996f-2cf6d49cb63c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"245f5c75-3686-4088-b204-1580c85141e9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"d916c40e-521f-4915-914b-a11bbc7de2bb","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"7ae618dd-b219-4e12-b42d-54d50abff31a","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-native-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-native-000001","id":"8a9793d2-63cc-484f-bd0b-fbaaa22d3053","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-native-000001","id":"a31716cb-4b25-4002-8646-c3e4f685ed7b","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-native-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '2102'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:08 GMT
-      duration:
-      - '600690'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - smDzeL4bkZOf2IZ45+oQ9cb0D2p+UcizCJoyGyQLD1w=
-      ocp-aad-session-key:
-      - Mc53_gUO-VPVmPt5Nu_7cmPqu9EmPw_PzChJThNBpUFgJWkArXbHt5XThfVGmIyArDhzdlLkW1l4q8ONduwMBJP45WLDqWd-SxnRf69OJ13ZV2uDtDFj1Uc9c6W9rHLD4cQfOXpC7LAP_N7GpGcE4w.HPSBufiY7jHn-rUxAJZzoqk6V8H3Ej8f9ABm76jYd1g
-      pragma:
-      - no-cache
-      request-id:
-      - 506d1bb0-75b3-42be-8fd9-0617b00c1068
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['2099']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:40 GMT']
+      duration: ['6345462']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [zZ1f4XOAaTeupg8OmIBOPbaDV65tJpuytfDxxeFsj0o=]
+      ocp-aad-session-key: [gam8pwhw6TMtjbgEUY38Q93BzTpBJbmBsed7o4uvJxmZ22DPnD57FmWqCUTRCQfB0FqTgF6fKoghGUg_lPAv-qeeemMkZrQNabk6LFHQ1ya9nE9q9qwQZdPXAZ6F-qDejTt_CVJXuTzl_iPVAA0fBw._auHaZoNXYVkLKIrWS60TLYrkJgZpdadZqtiDqCitjw]
+      pragma: [no-cache]
+      request-id: [c9ae3f85-b2cb-4f2f-b4af-2b3826a69a3b]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
 - request:
-    body: '{"requiredResourceAccess": [{"resourceAccess": [{"type": "Scope", "id":
-      "311a71cc-e848-46a1-bdf8-97ff7156d8e6"}], "resourceAppId": "00000002-0000-0000-c000-000000000000"}]}'
+    body: '{"requiredResourceAccess": [{"resourceAccess": [{"id": "311a71cc-e848-46a1-bdf8-97ff7156d8e6",
+      "type": "Scope"}], "resourceAppId": "00000002-0000-0000-c000-000000000000"}]}'
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app update
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - --id --required-resource-accesses
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app update]
+      Connection: [keep-alive]
+      Content-Length: ['172']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--id --required-resource-accesses]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/c4066a5a-0c44-4906-996f-2cf6d49cb63c?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/d916c40e-521f-4915-914b-a11bbc7de2bb?api-version=1.6
   response:
-    body:
-      string: ''
+    body: {string: ''}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      date:
-      - Tue, 12 Mar 2019 19:40:09 GMT
-      duration:
-      - '2381157'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - 3abjruB1Cy3okP0vEppZNocrEoQDzP7wunknChspjP8=
-      ocp-aad-session-key:
-      - NnFaDbmBrQUPuJgE1QaBa1kQciKR4G907GzrR5axJoR7HWXH0frd3WGpbt_wTtAKm1MIK50xJXvjASmg3t0DXT6pXfm-IHVTWD1z9aKQuYVrlVYMCEC3UVNktPmkyomYyF_S_wnqKcuqYOVRKTSRbQ.hbawRCUdbwSGlMrpn9Na0S6adkgC6msJE3Shfq-iqgo
-      pragma:
-      - no-cache
-      request-id:
-      - d9a72cb0-dcdd-4dda-aea5-d74a48d789c7
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 204
-      message: No Content
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      date: ['Tue, 19 Mar 2019 17:11:40 GMT']
+      duration: ['3239854']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [7zDIRrVJqjSZfhHAIvOE5P1Iegs1wlixjPO7KsOVy0Y=]
+      ocp-aad-session-key: [yCDDgFBGeznZS2REMIpKAGk0idH-n_v9PskOvTDXNFkA5m9ddOAFZL6YahNQREw9LP0ywJURc4YP7brjPwvRS3fMU9QhmqEHf2_yAJeX23-nGlxGJG-mKD8dnTUBUx1QSi4bw7K_SsRoJ_aVKvMV0A.Pq4KoFZhtqsC-Q0YA2H-JwRomQnRRPq0A5StQeg0gsE]
+      pragma: [no-cache]
+      request-id: [95473560-e8e4-43fc-95be-ffecf8c97542]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app show]
+      Connection: [keep-alive]
+      ParameterSetName: [--id]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27245f5c75-3686-4088-b204-1580c85141e9%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%277ae618dd-b219-4e12-b42d-54d50abff31a%27%29&api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '121'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:09 GMT
-      duration:
-      - '529076'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - uuC4ojITP59NTpteQfARMJzW3Ur1U9x1ysBSRndTeew=
-      ocp-aad-session-key:
-      - y2v9i_9XGZ1eQuHnmx4TkWZtEtgVuxb8ulKUEp76sInNtS2Zaqf6SIN-0Ri1XAxeTJt0SzZ6EIDKFaSQpAeBPdLk-538PWZ4qe8mq7eE2sl90834Z3FIu-l629S1O_H6uKO2dshe3XceVo87kf0czw.RQ5r-ACdHH1EkTNflHFfAHx7or7TPRMHQV7_fifLM5o
-      pragma:
-      - no-cache
-      request-id:
-      - 3dcdc7fc-c28f-4045-a9e5-a18b840cbe7b
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:41 GMT']
+      duration: ['2220450']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [7zDIRrVJqjSZfhHAIvOE5P1Iegs1wlixjPO7KsOVy0Y=]
+      ocp-aad-session-key: [2GtWcb6MgbEC5CXsmd_u6hZxeFYTNDmaATSNjK5XwhSRKMDulPqvbISUFoebKv8n5FUPwLBVi88Dd-6G7CfmKGgPUaFBs9VfwbPTvSWitqGQXAIme1sNkNdwT1jsxemoGxTdw-Ab6h5TrSlqjVfoxw.CxMJxAi64XNDSZgl-5Dcu_iaXyQA6h8bJRCfIAdK17U]
+      pragma: [no-cache]
+      request-id: [d33049ab-1ed7-4a15-b547-23aacb345e98]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app show]
+      Connection: [keep-alive]
+      ParameterSetName: [--id]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27245f5c75-3686-4088-b204-1580c85141e9%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%277ae618dd-b219-4e12-b42d-54d50abff31a%27&api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"c4066a5a-0c44-4906-996f-2cf6d49cb63c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"245f5c75-3686-4088-b204-1580c85141e9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"d916c40e-521f-4915-914b-a11bbc7de2bb","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"7ae618dd-b219-4e12-b42d-54d50abff31a","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-native-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-native-000001","id":"8a9793d2-63cc-484f-bd0b-fbaaa22d3053","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-native-000001","id":"a31716cb-4b25-4002-8646-c3e4f685ed7b","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-native-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '2102'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:09 GMT
-      duration:
-      - '1034348'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - iBe0QwUqe2kxvM0RuOLDPalMes+SCbjDZc1pXmRLqq4=
-      ocp-aad-session-key:
-      - H6m0UYF8kJzJ5AgITbBXBLbx6LvQbTgi8WlTCH4pcbnKDETuOW1-lTze79kbRInIpXhmvTm9rhF3t3SsBjHwdXhJbsIoqUA7rxGJn74srvFjU9nW3izlko3KsQLDUWlX--dVXwSjF2pMbN9xltijkw.ggjorcHAwZTsjccn7QbePq5k3GHANdlgHFPYS9SDTPI
-      pragma:
-      - no-cache
-      request-id:
-      - 49b3b722-d59e-4312-91cd-7763c155aeb7
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['2099']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:41 GMT']
+      duration: ['810484']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [Ww4JZ3phP63mdXQAX3Q+w5V7Po6AayFlRCSGeKGwhtg=]
+      ocp-aad-session-key: [4EPntZ0HhwVM41nhX7Gooe5v3ylhFXyDP-WXelVHcQQcf2Oqa9TJ5XQJ-Zfmcxc1nFLbYeJu0VyDvU4i-8LQa7c2upAWc2CrMzCNsG7tSTv7Bll8fjy4u5m2YOnJInnBk3wEKXNpyZxaUBvHmdJrTQ.xMeOCJx2tjnp-q5R6jYO465hevyckHJPdiiH9K6aadA]
+      pragma: [no-cache]
+      request-id: [48b82bff-d512-4ffe-8847-80caec367b0e]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ad app show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id
-      User-Agent:
-      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
-        azure-graphrbac/0.52.0 Azure-SDK-For-Python AZURECLI/2.0.60
-      accept-language:
-      - en-US
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app show]
+      Connection: [keep-alive]
+      ParameterSetName: [--id]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/c4066a5a-0c44-4906-996f-2cf6d49cb63c?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/d916c40e-521f-4915-914b-a11bbc7de2bb?api-version=1.6
   response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"c4066a5a-0c44-4906-996f-2cf6d49cb63c","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"245f5c75-3686-4088-b204-1580c85141e9","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/c4066a5a-0c44-4906-996f-2cf6d49cb63c/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"d916c40e-521f-4915-914b-a11bbc7de2bb","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"7ae618dd-b219-4e12-b42d-54d50abff31a","appRoles":[],"availableToOtherTenants":false,"displayName":"cli-native-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/d916c40e-521f-4915-914b-a11bbc7de2bb/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-native-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-native-000001","id":"8a9793d2-63cc-484f-bd0b-fbaaa22d3053","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-native-000001","id":"a31716cb-4b25-4002-8646-c3e4f685ed7b","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-native-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-native-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":true,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'}
     headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '2099'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Tue, 12 Mar 2019 19:40:09 GMT
-      duration:
-      - '1072336'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - 8FSoKn5C+xKnzMxVB24u9W0B3o/Ls6Mt3pri2fVg6OA=
-      ocp-aad-session-key:
-      - odtqmKJHF17CwvBEjbe7Ez-lGk6c2JJ4uHHSkXpQPiNgZ4MYh1zyWDZr2oPSmF5ElzISkx3gGyfIgYoB7By4AUon1WCVkOBOR9_fITBR7hfQ7KPJ2jA8ZzuoR6Bktln6bdJOdLfgX5c-EMVv-zLYTQ.Z3_E1xLjPVoug06UlkqNcwrDUjGIh3J9LJ61mZUmqdY
-      pragma:
-      - no-cache
-      request-id:
-      - 39e82d3b-5669-4f19-bde8-1e1f77e7dccd
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['2096']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:11:42 GMT']
+      duration: ['970321']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [P277HeLOcMoYADlOIgX/5nDH/EQ2eMVFV4LkO8IWIBk=]
+      ocp-aad-session-key: [toqxnLBUzBnC_VOyCiBxPFiAw5ttimkWlVLAFKXwEN9mCKUcV4na-7NN9a46A-ViinL_aJnqMV28jqbBSoW6P_aqdzFI-wSEPn-szQp6gApnpsryEjxdbh6TdLg9aI2n6Oup5cSOCYITrd43QtyhXQ.sHL64B1rewoXDZMawF0CkJDKyYa_KASDZBC1By7wgpU]
+      pragma: [no-cache]
+      request-id: [ac8d963a-afb8-4849-be97-53d0e03c11a3]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_web_app_no_identifier_uris_other_tenants_create_scenario.yaml
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_web_app_no_identifier_uris_other_tenants_create_scenario.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: 'b''{"availableToOtherTenants": true, "displayName": "cli-web-000001", "identifierUris":
+      []}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [ad app create]
+      Connection: [keep-alive]
+      Content-Length: ['94']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--display-name --available-to-other-tenants]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"d3382cd2-0a21-4726-b697-d308ef1ad445","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"d296f16e-1a41-4778-ae1a-6a2cd1db2f8a","appRoles":[],"availableToOtherTenants":true,"displayName":"cli-web-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/d3382cd2-0a21-4726-b697-d308ef1ad445/Microsoft.DirectoryServices.Application/logo","logo@odata.mediaContentType":"application/json;odata=minimalmetadata;
+        charset=utf-8","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/d3382cd2-0a21-4726-b697-d308ef1ad445/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-web-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-web-000001","id":"813c0ec1-254d-4ead-b5c9-c8f1b824566f","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-web-000001 on your behalf.","userConsentDisplayName":"Access
+        cli-web-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMultipleOrgs","tokenEncryptionKeyId":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['2052']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Tue, 19 Mar 2019 17:12:08 GMT']
+      duration: ['10359325']
+      expires: ['-1']
+      location: ['https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/d3382cd2-0a21-4726-b697-d308ef1ad445/Microsoft.DirectoryServices.Application']
+      ocp-aad-diagnostics-server-name: [P277HeLOcMoYADlOIgX/5nDH/EQ2eMVFV4LkO8IWIBk=]
+      ocp-aad-session-key: [eBLMTpecbOUCAsZ6ZFF0gGFIJOSwzRoC4ukGP_XUbBRmdEHwbyCIBpRfMxxAqEKw95T6B4Jv14_8Qfc1U9jhwvb73D4_-aN_F1beZKCbszCX8-_4-4pcG-7efnK5gfHAjuU0OFRCVE_Wgzrm9kdqnw.iPtIdsCrPftTxI0HRaNKO-d-dk_y-64rjlaIICASHuI]
+      pragma: [no-cache]
+      request-id: [2ca26a8a-70db-4e54-88cb-b10007547796]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+version: 1

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -88,6 +88,15 @@ class ServicePrincipalExpressCreateScenarioTest(ScenarioTest):
         except Exception:
             self.cmd('ad app delete --id {id}')
 
+    def test_web_app_no_identifier_uris_other_tenants_create_scenario(self):
+        self.kwargs = {
+            'web_app_name': self.create_random_name('cli-web-', 20)
+        }
+
+        result = self.cmd("ad app create --display-name {web_app_name} --available-to-other-tenants true", checks=[
+            self.exists('appId')
+        ])
+
 
 class ApplicationSetScenarioTest(ScenarioTest):
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -93,7 +93,7 @@ class ServicePrincipalExpressCreateScenarioTest(ScenarioTest):
             'web_app_name': self.create_random_name('cli-web-', 20)
         }
 
-        result = self.cmd("ad app create --display-name {web_app_name} --available-to-other-tenants true", checks=[
+        self.cmd("ad app create --display-name {web_app_name} --available-to-other-tenants true", checks=[
             self.exists('appId')
         ])
 


### PR DESCRIPTION
- `ad app create` no longer requires `--identifier-uris`
  - `--identifier-uris` defaults to `[]` if not provided
  - rerecorded tests and added new test
  - minor refactoring around identifier-uris and native app creation
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
