### PR TITLE
Apply max version of 0.11.7 to applicationinsights.

### DIFF
--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -49,7 +49,7 @@ setup(
     zip_safe=False,
     classifiers=CLASSIFIERS,
     install_requires=[
-        'applicationinsights>=0.11.1',
+        'applicationinsights>=0.11.1,<0.11.8',
         'portalocker==1.2.1',
     ],
     packages=[


### PR DESCRIPTION
Fixing our edge build.

Until Microsoft/ApplicationInsights-Python#161 is fixed, we cannot adopt newer versions of this library.