### PR TITLE
create-for-rbac: remove the deprecation version on --password

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -97,7 +97,7 @@ def load_arguments(self, _):
 
     with self.argument_context('ad sp create-for-rbac') as c:
         c.argument('password', options_list=['--password', '-p'], arg_group='Credential',
-                   deprecate_info=c.deprecate(expiration='2.1.0', hide=False), help="If missing, CLI will generate a strong password")
+                   deprecate_info=c.deprecate(hide=False), help="If missing, CLI will generate a strong password")
 
     with self.argument_context('ad sp credential reset') as c:
         c.argument('password', options_list=['--password', '-p'], arg_group='Credential',


### PR DESCRIPTION
Per suggestion from security team, we need to pull the plug earlier, so unlikely we will wait till 2.1.
I plan to remove it in May

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
