### PR TITLE
refactor LICENSE.txt to make github even more happier

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright (c) 2016 Microsoft Azure
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Microsoft Azure
+Copyright (c) 2016 Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
GitHub looks for files named `LICENSE` to determine the kind of license used by a repo.

I have modified the contents for more conformance to standards.