### PR TITLE
BotService 0.1.9: add prepare-deploy and update az bot create

### DIFF
--- a/src/command_modules/azure-cli-botservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-botservice/HISTORY.rst
@@ -6,6 +6,8 @@ Release History
 0.1.9
 +++++
 * Add `az bot prepare-deploy` to prepare for deploying bots via `az webapp`
+* Have `az bot create --kind registration` show password if the password is not provided
+* Have `--endpoint` in `az bot create --kind registration` default empty string instead of being required
 
 0.1.8
 +++++

--- a/src/command_modules/azure-cli-botservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-botservice/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.9
++++++
+* Add `az bot prepare-deploy` to prepare for deploying bots via `az webapp`
+
 0.1.8
 +++++
 * Add "SCM_DO_BUILD_DURING_DEPLOYMENT" to ARM template's Application Settings for v4 Web App Bots

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
@@ -28,6 +28,15 @@ helps['bot prepare-publish'] = """
     short-summary: Add scripts to your local source code directory to
                    be able to publish back using `az bot publish`.
 """
+helps['bot prepare-deploy'] = """
+    type: command
+    short-summary: Add scripts and configuration files to your local source code directory to be able to publish back 
+                   using `az webapp deployment source`.
+    examples:
+        - name: Prepare to use `az webapp` to deploy a Node.js bot by fetching a necessary file.
+          text: |-
+            az bot prepare-deploy --lang Node --code-dir "MyBotCode"
+"""
 helps['bot delete'] = """
     type: command
     short-summary: Delete an existing bot.

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
@@ -30,7 +30,7 @@ helps['bot prepare-publish'] = """
 """
 helps['bot prepare-deploy'] = """
     type: command
-    short-summary: Add scripts and configuration files to your local source code directory to be able to publish back 
+    short-summary: Add scripts and configuration files to your local source code directory to be able to publish back
                    using `az webapp deployment source`.
     examples:
         - name: Prepare to use `az webapp` to deploy a Node.js bot by fetching a necessary file.

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_params.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_params.py
@@ -18,6 +18,14 @@ supported_languages = ['Csharp', 'Node']
 
 # pylint: disable=line-too-long,too-many-statements
 def load_arguments(self, _):
+    with self.argument_context('bot prepare-deploy') as c:
+        c.argument('code_dir', options_list=['--code-dir'], help='The directory to place the generated deployment '
+                                                                 'files in. Defaults to the current directory the '
+                                                                 'command is called from.')
+        c.argument('language', options_list=['--lang'], help='The language or runtime of the bot.',
+                   arg_type=get_enum_type(supported_languages))
+        c.argument('proj_file_path', help='The path to the .csproj file relative to --code-dir.')
+
     with self.argument_context('bot') as c:
         c.argument('resource_group_name', arg_type=resource_group_name_type)
         c.argument('resource_name', options_list=['--name', '-n'],

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/commands.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/commands.py
@@ -54,6 +54,7 @@ def load_command_table(self, _):
         g.custom_command('publish', 'publish_app')
         g.custom_command('download', 'download_app')
         g.custom_command('prepare-publish', 'prepare_publish')
+        g.custom_command('prepare-deploy', 'prepare_webapp_deploy')
 
     with self.command_group('bot', botServices_commandType) as g:
         g.custom_command('show', 'get_bot')

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
@@ -63,7 +63,7 @@ def create(cmd, client, resource_group_name, resource_name, kind, description=No
     bot_kind = 'bot'
     webapp_kind = 'webapp'
     function_kind = 'function'
-    show_password = True if not password else False
+    show_password = False
 
     if resource_name.find(".") > -1:
         logger.warning('"." found in --name parameter ("%s"). "." is an invalid character for Azure Bot resource names '
@@ -87,7 +87,7 @@ def create(cmd, client, resource_group_name, resource_name, kind, description=No
     if not msa_app_id:
 
         logger.info('Microsoft application id not passed as a parameter. Provisioning a new Microsoft application.')
-
+        show_password = True
         msa_app_id, password = ConvergedApp.provision(resource_name)
         logger.info('Microsoft application provisioning successful. Application Id: %s.', msa_app_id)
 

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
@@ -63,6 +63,7 @@ def create(cmd, client, resource_group_name, resource_name, kind, description=No
     bot_kind = 'bot'
     webapp_kind = 'webapp'
     function_kind = 'function'
+    show_password = True if not password else False
 
     if resource_name.find(".") > -1:
         logger.warning('"." found in --name parameter ("%s"). "." is an invalid character for Azure Bot resource names '
@@ -99,7 +100,7 @@ def create(cmd, client, resource_group_name, resource_name, kind, description=No
 
         # Registration bot specific validation
         if not endpoint:
-            raise CLIError('Endpoint is required for creating a registration bot.')
+            endpoint = ''
         if not msa_app_id:
             raise CLIError('Microsoft application id is required for creating a registration bot.')
 
@@ -118,11 +119,14 @@ def create(cmd, client, resource_group_name, resource_name, kind, description=No
         logger.info('Bot parameters client side validation successful.')
         logger.info('Creating bot.')
 
-        return client.bots.create(
+        result = client.bots.create(
             resource_group_name=resource_group_name,
             resource_name=resource_name,
             parameters=parameters
         )
+        if show_password:
+            result['appPassword'] = password
+        return result
     # Web app and function bots require deploying custom ARM templates, we do that in a separate method
     else:
         logger.info('Detected kind %s, validating parameters for the specified kind.', kind)

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
@@ -471,7 +471,7 @@ def prepare_publish(cmd, client, resource_group_name, resource_name, sln_name, p
     logger.info('Bot prepare publish completed successfully.')
 
 
-def prepare_webapp_deploy(cmd, client, language, code_dir=None, proj_file_path=None):
+def prepare_webapp_deploy(language, code_dir=None, proj_file_path=None):
     if not code_dir:
         code_dir = os.getcwd()
         logger.info('--code-dir not provided, defaulting to current working directory: %s\n'
@@ -498,8 +498,8 @@ def prepare_webapp_deploy(cmd, client, language, code_dir=None, proj_file_path=N
         does_file_exist('.deployment')
         csproj_file = os.path.join(code_dir, proj_file_path)
         if not os.path.exists(csproj_file):
-            raise CLIError('%s file not found\nPlease verify the relative path to the .csproj file from the '
-                           '--code-dir', csproj_file)
+            raise CLIError('{0} file not found\nPlease verify the relative path to the .csproj file from the '
+                           '--code-dir'.format(csproj_file))
 
         with open(os.path.join(code_dir, '.deployment'), 'w') as f:
             f.write('[config]\n')

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
@@ -123,9 +123,9 @@ def create(cmd, client, resource_group_name, resource_name, kind, description=No
             resource_group_name=resource_group_name,
             resource_name=resource_name,
             parameters=parameters
-        )
+        ).as_dict()
         if show_password:
-            result['appPassword'] = password
+            result['password'] = password
         return result
     # Web app and function bots require deploying custom ARM templates, we do that in a separate method
     else:

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_create_should_create_registration_bot_without_endpoint.yaml
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_create_should_create_registration_bot_without_endpoint.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2019-03-07T01:10:55Z"}}'
+      "date": "2019-03-20T23:00:40Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -16,12 +16,12 @@ interactions:
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-07T01:10:55Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-20T23:00:40Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['274']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Mar 2019 01:10:55 GMT']
+      date: ['Wed, 20 Mar 2019 23:00:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -46,7 +46,7 @@ interactions:
     body: {string: ''}
     headers:
       cache-control: [no-cache]
-      date: ['Thu, 07 Mar 2019 01:10:56 GMT']
+      date: ['Wed, 20 Mar 2019 23:00:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -104,13 +104,44 @@ interactions:
       cache-control: [no-cache]
       content-length: ['5660']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Mar 2019 01:10:57 GMT']
+      date: ['Wed, 20 Mar 2019 23:00:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
+- request:
+    body: 'b''{"location": "global", "sku": {"name": "F0"}, "kind": "bot", "properties":
+      {"displayName": "cli000002", "endpoint": "", "msaAppId": "9d004134-cd3a-4672-aaea-d8885ca6d276"}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [bot create]
+      Connection: [keep-alive]
+      Content-Length: ['178']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-k -g -n --appid -p]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          azure-mgmt-botservice/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.BotService/botServices/cli000002?api-version=2018-07-12
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.BotService/botServices/cli000002","name":"cli000002","type":"Microsoft.BotService/botServices","etag":"\"6a001434-0000-0000-0000-5c92c6470000\"","location":"global","sku":{"name":"F0"},"kind":"bot","tags":{},"properties":{"displayName":"cli000002","description":null,"iconUrl":"https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png","endpoint":"","msaAppId":"9d004134-cd3a-4672-aaea-d8885ca6d276","developerAppInsightKey":null,"developerAppInsightsApplicationId":null,"luisAppIds":[],"endpointVersion":"3.0","configuredChannels":["webchat"],"enabledChannels":["webchat","directline"],"isDeveloperAppInsightsApiKeySet":false,"publishingCredentials":null,"parameters":null,"allSettings":null,"manifestUrl":null,"storageResourceId":null,"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['933']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 20 Mar 2019 23:01:27 GMT']
+      etag: ['"6a001434-0000-0000-0000-5c92c6470000"']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
 - request:
     body: null
     headers:
@@ -130,9 +161,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 07 Mar 2019 01:10:57 GMT']
+      date: ['Wed, 20 Mar 2019 23:01:28 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdUS0RIQTM2N0NJLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdaQ1NXQlhGNEFULVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_csharp.yaml
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_csharp.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2019-03-20T21:30:43Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-20T21:30:43Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['274']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 20 Mar 2019 21:30:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Wed, 20 Mar 2019 21:30:47 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdEWlREQkJZMk1WLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_csharp_fail_if_deployment_file_exists.yaml
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_csharp_fail_if_deployment_file_exists.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2019-03-20T21:31:16Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-20T21:31:16Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['274']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 20 Mar 2019 21:31:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Wed, 20 Mar 2019 21:31:19 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkczTk5aR01JM01GLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_csharp_no_proj_file.yaml
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_csharp_no_proj_file.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2019-03-20T21:30:59Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-20T21:30:59Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['274']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 20 Mar 2019 21:31:01 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Wed, 20 Mar 2019 21:31:03 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdLTTJPVTNCSEdELVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_node.yaml
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_node.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.21.0]
+    method: GET
+    uri: https://icscratch.blob.core.windows.net/bot-packages/node_v4_publish.zip
+  response:
+    body:
+      string: !!binary |
+        UEsDBBQAAAAIAIyBNE2v/5ZHQgAAAEYAAAALAAAAaWlzbm9kZS55bWzLy09JDSjKT04tLnbOz81N
+        zEvxycxLtVJQcrGKAYqnFyXmKrhl5qQWK2hUWJhpxuQB1WcVx1joWeqZgDl6qRWpSgBQSwMEFAAA
+        AAgAjIE0TUnoJoiGBAAABgoAAAoAAAB3ZWIuY29uZmlntVZdb9s2FH0PkP9wp5cCwWQ22x6GzEoQ
+        NA5goM26OOkwrFtASbTFRiJVkrLsDv3vO6RkWc6SYS8LjBiieT/Ouefeq+nFpippLYyVWiXR6eR1
+        REJlOpdqlUSNW8Y/Rhfnx0fTb+L4+Ij8310hLWVaLeWqMdzBjpayFIRTIz430oic5JKktErn4bix
+        OHKaTKMonNVGZ8JaYSkVhVR573k+X5A24Wu2qQ1uTIiucVJpA0dqqU0VAn5La2mlOzs+6i0L52p7
+        xthKuqJJJ5mumPvEVfaleWR9Iiwtdcoqbp0wzJqMWV7VpbDsAAprhTf3J8dHcXzuI0wPbpz7kFO7
+        hZ9qgtsLYUDfeZeIp4k++NxCSsgIUVd2UtlchaxS1gKvbi3/0hjBuMkKuRbsu9en37PTU3b6A5PK
+        GZ03mY8VOx0jhNXZo3A2xkFvHQdz/1uMWMJOuK03tHyGKsLnV2QZXJBt6lobRwFZSLgdfhOKp6XI
+        k2jJSysiYrsrBVd5CYX0zz3KucplxhGbXMEd/gmygYrJJzsIgod6+xOfptdAKqjzl1O6DVY7oVRA
+        DashNcTheU6KVyKJ+ksR1dwVeFS52MBt5KWbJtFJ1Jvb/dUhf/YEwNSI1iCdfRzjLYfHHuCVRvIO
+        XEIwSwFWW4grSFxYZwPZPk4sla1F5vCYi7RZrdA5YxC9+x7HDSzmO4OABt7VYqsc3yTR7M27y0Vm
+        ZO0isk7X77s+Cb3oTCOikVf4RYWzghpTJtGfO0Y+spDF7x/ZHxf7GnY8+DzOh57Z4byWxjpqhe9p
+        K3NhqC0ECmO66mAYVB7S/e1bCgGFL2tdbC3KX/aVVuEuq5u0lBmoKb2bF0lYOEgze6PBrHJPMPEg
+        fHLbGhdvu0JFHcbO+1+3s1/uZ4u7h/vb+dfovwC8LEvSARAwIHmUsuJ13c0kn/eBRpGS2VKtUfeX
+        EVxt8f0SBPCYS4/CHpz3epaqblwSDTCu529nN5fvZl+jjt67gHxur0FsREqs0GNJdOerzw7jsBcC
+        /RuHQ+M8S9z4cegWdtguo0H3KpXqFeWY+F7NWzS2BZfk1S0hjUpw5ZUj1cAwGpFAPfYHV34U1CXP
+        /LpQJMdDyYqsQcjtqEO7tgMp6Bc4HWdfyDwXaiFWFWrxhAojKr32kyn8mETI+An0F6w97GdDTtko
+        uxEZ7/gj4mAqkzAGwwDrq0ZlRCe4UiwdNcrpBg2Uj6D6NTHzBpbERlqHQLe9ZRK959beFUY3q6Lr
+        5X28XZ6/6SaQCS1gb5RU6JZu+r1baCypPMwtMOzXauNnSdA8erTUrX/SdZDQ2Z6UE2pDo+deg/YM
+        7FUyznQJTVlRc+xBeC2RLOllGAD9DmglOg1V7a3DiMwwfFf+gvaMOG7Gq2Ic0kvkQaj12eAGbwk1
+        X4VgTncvDhDYzc9Xs4fZzQc06loarXzZaM2N9Ntr7HCYxrNusVG8I8keTLi0QYUxxXsDnIK6fhnu
+        Z8lCiP/lLSOQxGnZAPOO0r4iXei9VFD16W5ZjguURHt3P510zd1bQaz/fFGZHiaDk78BUEsBAhQA
+        FAAAAAgAjIE0Ta//lkdCAAAARgAAAAsAAAAAAAAAAQAgAAAAAAAAAGlpc25vZGUueW1sUEsBAhQA
+        FAAAAAgAjIE0TUnoJoiGBAAABgoAAAoAAAAAAAAAAQAgAAAAawAAAHdlYi5jb25maWdQSwUGAAAA
+        AAIAAgBxAAAAGQUAAAAA
+    headers:
+      access-control-allow-origin: ['*']
+      content-length: ['1440']
+      content-md5: [E6DLJkC0VVWR//69sd3XEg==]
+      content-type: [application/zip]
+      date: ['Wed, 20 Mar 2019 19:28:05 GMT']
+      etag: ['0x8D61F4EE9617735']
+      last-modified: ['Thu, 20 Sep 2018 23:15:10 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-blob-type: [BlockBlob]
+      x-ms-lease-status: [unlocked]
+      x-ms-version: ['2009-09-19']
+    status: {code: 200, message: OK}
+version: 1

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_node.yaml
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_node.yaml
@@ -1,5 +1,34 @@
 interactions:
 - request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2019-03-20T21:30:24Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-20T21:30:24Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['274']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 20 Mar 2019 21:30:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
     body: null
     headers:
       Accept: ['*/*']
@@ -42,7 +71,7 @@ interactions:
       content-length: ['1440']
       content-md5: [E6DLJkC0VVWR//69sd3XEg==]
       content-type: [application/zip]
-      date: ['Wed, 20 Mar 2019 19:28:05 GMT']
+      date: ['Wed, 20 Mar 2019 21:30:29 GMT']
       etag: ['0x8D61F4EE9617735']
       last-modified: ['Thu, 20 Sep 2018 23:15:10 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
@@ -50,4 +79,31 @@ interactions:
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2009-09-19']
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Wed, 20 Mar 2019 21:30:30 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdYVUdBQVBaRERKLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_node_fail_if_web_config_exists.yaml
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_node_fail_if_web_config_exists.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2019-03-20T21:31:30Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-20T21:31:30Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['274']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 20 Mar 2019 21:31:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Wed, 20 Mar 2019 21:31:32 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdGQU9JN0FOU0QyLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_node_should_fail_with_proj_file_path.yaml
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_node_should_fail_with_proj_file_path.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2019-03-20T21:30:05Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-20T21:30:05Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['274']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 20 Mar 2019 21:30:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Wed, 20 Mar 2019 21:30:11 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdBRURDV1IzN0dSLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_should_fail_if_code_dir_doesnt_exist.yaml
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/recordings/test_botservice_prepare_deploy_should_fail_if_code_dir_doesnt_exist.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2019-03-20T21:29:38Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-03-20T21:29:38Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['274']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 20 Mar 2019 21:29:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.4.34
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Wed, 20 Mar 2019 21:29:44 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdTQUFPU09IRDZZLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/test_bot_commands.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/test_bot_commands.py
@@ -366,7 +366,7 @@ class BotTests(ScenarioTest):
                  })
 
     @ResourceGroupPreparer(random_name_length=20)
-    def test_botservice_create_should_not_create_registration_bot_without_endpoint(self, resource_group):
+    def test_botservice_create_should_create_registration_bot_without_endpoint(self, resource_group):
         self.kwargs.update({
             'botname': self.create_random_name(prefix='cli', length=15),
             'app_id': str(uuid.uuid4()),
@@ -376,27 +376,7 @@ class BotTests(ScenarioTest):
         # Delete the bot if already exists
         self.cmd('az bot delete -g {rg} -n {botname}')
 
-        with self.assertRaisesRegexp(CLIError, 'Endpoint is required for creating a registration bot.'):
-            self.cmd('az bot create -k registration -g {rg} -n {botname} --appid {app_id} -p {password}')
-
-    @ResourceGroupPreparer(random_name_length=20)
-    def test_botservice_create_should_create_registration_bot_with_endpoint(self, resource_group):
-        self.kwargs.update({
-            'botname': self.create_random_name(prefix='cli', length=15),
-            'app_id': str(uuid.uuid4()),
-            'password': str(uuid.uuid4())
-        })
-
-        # Delete the bot if already exists
-        self.cmd('az bot delete -g {rg} -n {botname}')
-
-        self.cmd('az bot create -k registration -g {rg} -n {botname} --appid {app_id} -p {password} '
-                 '-e https://testurl.com/api/messages',
-                 checks={
-                     self.check('resourceGroup', '{rg}'),
-                     self.check('id', '{botname}'),
-                     self.check('type', 'abs')
-                 })
+        self.cmd('az bot create -k registration -g {rg} -n {botname} --appid {app_id} -p {password}')
 
     @ResourceGroupPreparer(random_name_length=20)
     def test_create_v4_webapp_bot_should_succeed_with_ending_hyphen(self, resource_group):

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/test_bot_commands.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/tests/latest/test_bot_commands.py
@@ -667,7 +667,8 @@ class BotTests(ScenarioTest):
         except Exception as error:
             raise error
 
-    def test_botservice_prepare_deploy_should_fail_if_code_dir_doesnt_exist(self):
+    @ResourceGroupPreparer(random_name_length=20)
+    def test_botservice_prepare_deploy_should_fail_if_code_dir_doesnt_exist(self, resource_group):
         dir_path = 'does_not_exist'
         self.kwargs.update({'dir_path': dir_path,
                             'language': 'Node'})
@@ -680,7 +681,8 @@ class BotTests(ScenarioTest):
         except Exception as error:
             raise error
 
-    def test_botservice_prepare_deploy_node_should_fail_with_proj_file_path(self):
+    @ResourceGroupPreparer(random_name_length=20)
+    def test_botservice_prepare_deploy_node_should_fail_with_proj_file_path(self, resource_group):
         self.kwargs.update({'language': 'Node',
                             'proj_file': 'node_bot/test.csproj'})
         try:
@@ -691,7 +693,8 @@ class BotTests(ScenarioTest):
         except Exception as error:
             raise error
 
-    def test_botservice_prepare_deploy_node(self):
+    @ResourceGroupPreparer(random_name_length=20)
+    def test_botservice_prepare_deploy_node(self, resource_group):
         dir_path = 'node_bot'
         self.kwargs.update({'dir_path': dir_path,
                             'language': 'Node'})
@@ -703,7 +706,8 @@ class BotTests(ScenarioTest):
         assert os.path.exists(os.path.join(dir_path, 'web.config'))
         shutil.rmtree(dir_path)
 
-    def test_botservice_prepare_deploy_csharp(self):
+    @ResourceGroupPreparer(random_name_length=20)
+    def test_botservice_prepare_deploy_csharp(self, resource_group):
         dir_path = 'csharp_bot'
         proj_file = 'test.csproj'
         self.kwargs.update({'dir_path': dir_path,
@@ -722,7 +726,8 @@ class BotTests(ScenarioTest):
             assert d.readline() == 'SCM_SCRIPT_GENERATOR_ARGS=--aspNetCore "{0}"\n'.format(proj_file)
         shutil.rmtree(dir_path)
 
-    def test_botservice_prepare_deploy_csharp_no_proj_file(self):
+    @ResourceGroupPreparer(random_name_length=20)
+    def test_botservice_prepare_deploy_csharp_no_proj_file(self, resource_group):
         self.kwargs.update({'language': 'Csharp'})
         try:
             self.cmd('az bot prepare-deploy --lang {language}')
@@ -732,7 +737,8 @@ class BotTests(ScenarioTest):
         except Exception as error:
             raise error
 
-    def test_botservice_prepare_deploy_csharp_fail_if_deployment_file_exists(self):
+    @ResourceGroupPreparer(random_name_length=20)
+    def test_botservice_prepare_deploy_csharp_fail_if_deployment_file_exists(self, resource_group):
         dir_path = 'csharp_bot'
         proj_file = 'test.csproj'
         self.kwargs.update({'dir_path': dir_path,
@@ -756,7 +762,8 @@ class BotTests(ScenarioTest):
             shutil.rmtree(dir_path)
             raise error
 
-    def test_botservice_prepare_deploy_node_fail_if_web_config_exists(self):
+    @ResourceGroupPreparer(random_name_length=20)
+    def test_botservice_prepare_deploy_node_fail_if_web_config_exists(self, resource_group):
         dir_path = 'node_bot'
         self.kwargs.update({'dir_path': dir_path,
                             'language': 'Node'})

--- a/src/command_modules/azure-cli-botservice/setup.py
+++ b/src/command_modules/azure-cli-botservice/setup.py
@@ -17,7 +17,7 @@ except ImportError:
     cmdclass = {}
 
 
-VERSION = "0.1.8"
+VERSION = "0.1.9"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
- Adds `az bot prepare-deploy` _once_ which is to be used before deploying bots using `az webapp`
- Add tests for `az bot prepare-deploy`
- Cleaned up imports order in `test_bot_commands.py`
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
