### PR TITLE
Update Homebrew requirements file with applicationinsights ceiling

### DIFF
--- a/scripts/release/homebrew/docker/requirements.txt
+++ b/scripts/release/homebrew/docker/requirements.txt
@@ -2,3 +2,4 @@ homebrew-pypi-poet~=0.10.0
 jinja2~=2.10
 requests>=2.20.0
 cryptography >=2.0.0,<2.5
+applicationinsights >=0.11.1,<0.11.8


### PR DESCRIPTION
Adding constraints to applicationsinsights version on Homebrew installer. This should fix the dev branch's build.