### PR TITLE
[Core] Improve `get_all_help` and `az self-test`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/file_util.py
+++ b/src/azure-cli-core/azure/cli/core/file_util.py
@@ -7,11 +7,13 @@ from __future__ import print_function
 
 from azure.cli.core._help import CliCommandHelpFile, CliGroupHelpFile
 
-from knack.help import HelpAuthoringException
+from knack.log import get_logger
 from knack.util import CLIError
 
+logger = get_logger(__name__)
 
-def get_all_help(cli_ctx):
+
+def get_all_help(cli_ctx, skip=True):
     invoker = cli_ctx.invocation
     help_ctx = cli_ctx.help_cls(cli_ctx)
     if not invoker:
@@ -27,6 +29,7 @@ def get_all_help(cli_ctx):
             sub_parser_keys.append(cmd)
             sub_parser_values.append(parser)
     help_files = []
+    help_errors = {}
     for cmd, parser in zip(sub_parser_keys, sub_parser_values):
         try:
             help_ctx.update_loaders_with_help_file_contents(cmd.split())
@@ -34,10 +37,13 @@ def get_all_help(cli_ctx):
                 else CliCommandHelpFile(help_ctx, cmd, parser)
             help_file.load(parser)
             help_files.append(help_file)
-        except HelpAuthoringException:
-            raise
         except Exception as ex:  # pylint: disable=broad-except
-            print("Skipped '{}' due to '{}'".format(cmd, ex))
+            if skip:
+                logger.warning("Skipping '%s': %s", cmd, ex)
+            else:
+                help_errors[cmd] = "Error '{}': {}".format(cmd, ex)
+    if help_errors:
+        raise CLIError(help_errors)
     help_files = sorted(help_files, key=lambda x: x.command)
     return help_files
 

--- a/src/azure-cli-core/azure/cli/core/file_util.py
+++ b/src/azure-cli-core/azure/cli/core/file_util.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 from azure.cli.core._help import CliCommandHelpFile, CliGroupHelpFile
 
+from knack.help import HelpAuthoringException
 from knack.util import CLIError
 
 
@@ -33,6 +34,8 @@ def get_all_help(cli_ctx):
                 else CliCommandHelpFile(help_ctx, cmd, parser)
             help_file.load(parser)
             help_files.append(help_file)
+        except HelpAuthoringException:
+            raise
         except Exception as ex:  # pylint: disable=broad-except
             print("Skipped '{}' due to '{}'".format(cmd, ex))
     help_files = sorted(help_files, key=lambda x: x.command)

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -183,7 +183,7 @@ def check_cli(cmd):
 
     print('Retrieving all help...')
     try:
-        get_all_help(cmd.cli_ctx)
+        get_all_help(cmd.cli_ctx, skip=False)
         print('Help loaded OK.\n')
     except Exception as ex:  # pylint: disable=broad-except
         exceptions['load_help'] = ex


### PR DESCRIPTION
Fix #8846.

`get_all_help` is used in several different use cases. In many of those cases, you do not want the operation to fail because of an error. You want a non-failing best effort. For self-test, we DO want the command to fail for any help authoring errors. So, this introduces a kwarg (which defaults to False to be a non-breaking change) which lets the developer decide whether authoring errors fail `get_all_help`.  Here's the output of `az self-test` with a problematic command (you'll have to image the pretty colors):

```
(env) E:\github>az self-test
This command has been deprecated and will be removed in a future release.
Running CLI self-test.

Loading all commands and arguments...
Commands loaded OK.

Retrieving all help...
Error occurred loading help!

{'load_help': CLIError({'network cross-connection peering update': "Error 'network cross-connection peering update': Help entry fields 'min_profile' and 'max_profile' are no longer supported. Please use 'supported-profiles' or 'unsupported-profiles'."},)}
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
