### PR TITLE
Pin wheel version.

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -71,7 +71,7 @@ DEPENDENCIES = [
     'requests>=2.20.0',
     'six',
     'tabulate>=0.7.7',
-    'wheel',
+    'wheel==0.30.0',
     'azure-mgmt-resource==2.1.0'
 ]
 

--- a/src/command_modules/azure-cli-extension/setup.py
+++ b/src/command_modules/azure-cli-extension/setup.py
@@ -31,9 +31,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-cli-core',
-    'pip',
-    'wheel',
+    'azure-cli-core'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
CLI extensions rely on wheel files containing metadata and thus require they be built using wheel 0.29.0 or 0.30.0.  Recent releases are not compatible and updating the CLI results in wheel 0.31.1.  This PR pins the version.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
