### PR TITLE
Fix az network express-route port update

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -6,6 +6,10 @@ Release History
 * `application-gateway rewrite-rule`: Add `list-request-headers` and `list-response-headers` commands.
 * `application-gateway rewrite-rule condition`: Add `list-server-variables` command.
 
+2.3.6
+++++
+* `express-route port update`: Fixed an issue where updating link state on an express-route port would throw an unknown attribute exception.
+
 2.3.5
 +++++
 * `application-gateway`: Add `rewrite-rule` command group.

--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -5,9 +5,6 @@ Release History
 
 * `application-gateway rewrite-rule`: Add `list-request-headers` and `list-response-headers` commands.
 * `application-gateway rewrite-rule condition`: Add `list-server-variables` command.
-
-2.3.6
-++++
 * `express-route port update`: Fixed an issue where updating link state on an express-route port would throw an unknown attribute exception.
 
 2.3.5

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1923,7 +1923,7 @@ def create_express_route_port(cmd, resource_group_name, express_route_port_name,
 
 def update_express_route_port(cmd, instance, tags=None):
     with cmd.update_context(instance) as c:
-        c.update_param('tags', tags, True)
+        c.set_param('tags', tags, True)
     return instance
 
 


### PR DESCRIPTION
Fixes a bug where running update on an express-route port throws an
unknown attribute error.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [N/A] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
