### PR TITLE
Run CI for all branches in this repo by default.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,9 +5,7 @@ trigger:
   batch: true
   branches:
     include:
-    - master
-    - dev
-    - release
+    - '*'
 
 jobs:
 - job: ExtractMetadata


### PR DESCRIPTION
This will enable white-listing of branches for private-preview drops in our edge release pipeline.