### PR TITLE
3842802: Automatic name server delegation in parent zone when child z…

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 * `application-gateway rewrite-rule`: Add `list-request-headers` and `list-response-headers` commands.
 * `application-gateway rewrite-rule condition`: Add `list-server-variables` command.
 * `express-route port update`: Fixed an issue where updating link state on an express-route port would throw an unknown attribute exception.
+* `dns zone create`: Add auto name server delegation in parent during child zone creation 
 
 2.3.5
 +++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1828,6 +1828,12 @@ helps['network dns zone create'] = """
         - name: Create a DNS zone using a fully qualified domain name.
           text: >
             az network dns zone create -g MyResourceGroup -n www.mysite.com
+        - name: Create a DNS zone with delegation in the parent within the same subscription and resource group
+          text: >
+            az network dns zone create -g MyResourceGroup -n books.mysite.com -p mysite.com
+        - name: Create a DNS zone with delegation in the parent in different subscription
+          text: >
+            az network dns zone create -g MyResourceGroup -n books.mysite.com -p /subscriptions/**67e2/resourceGroups/OtherRg/providers/Microsoft.Network/dnszones/mysite.com"
 """
 
 helps['network dns zone delete'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1833,7 +1833,7 @@ helps['network dns zone create'] = """
             az network dns zone create -g MyResourceGroup -n books.mysite.com -p mysite.com
         - name: Create a DNS zone with delegation in the parent in different subscription
           text: >
-            az network dns zone create -g MyResourceGroup -n books.mysite.com -p /subscriptions/**67e2/resourceGroups/OtherRg/providers/Microsoft.Network/dnszones/mysite.com"
+            az network dns zone create -g MyResourceGroup -n books.mysite.com -p "/subscriptions/**67e2/resourceGroups/OtherRg/providers/Microsoft.Network/dnszones/mysite.com"
 """
 
 helps['network dns zone delete'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -441,6 +441,7 @@ def load_arguments(self, _):
 
     with self.argument_context('network dns record-set ns') as c:
         c.argument('dname', options_list=['--nsdname', '-d'], help='Name server domain name.')
+        c.argument('subscription_id', options_list=['--subscriptionid', '-s'], help='Subscription id to add name server record')
 
     with self.argument_context('network dns record-set ptr') as c:
         c.argument('dname', options_list=['--ptrdname', '-d'], help='PTR target domain name.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -395,7 +395,7 @@ def load_arguments(self, _):
         c.ignore('if_none_match')
 
     with self.argument_context('network dns zone create') as c:
-        c.extra('parent_zone_name', options_list=['--parent-name', '-p'], help='Specify if parent zone exists for this zone and delegation for the child zone in the parent is to be added.')
+        c.argument('parent_zone_name', options_list=['--parent-name', '-p'], help='Specify if parent zone exists for this zone and delegation for the child zone in the parent is to be added.')
 
     with self.argument_context('network dns record-set') as c:
         c.argument('target_resource', min_api='2018-05-01', help='ID of an Azure resource from which the DNS resource value is taken.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -394,6 +394,9 @@ def load_arguments(self, _):
     with self.argument_context('network dns zone update') as c:
         c.ignore('if_none_match')
 
+    with self.argument_context('network dns zone create') as c:
+        c.extra('parent_zone_name', options_list=['--parent-name', '-p'], help='Specify if parent zone exists for this zone and delegation for the child zone in the parent is to be added.')
+
     with self.argument_context('network dns record-set') as c:
         c.argument('target_resource', min_api='2018-05-01', help='ID of an Azure resource from which the DNS resource value is taken.')
         for item in ['record_type', 'record_set_type']:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1086,6 +1086,7 @@ def add_dns_delegation(cmd, created_zone, parent_zone_name, resource_group_name,
             print(ex)
             print('Could not add delegation in \'{}\'\n'.format(parent_zone_name), file=sys.stderr)
 
+
 def create_dns_zone(cmd, client, resource_group_name, zone_name, parent_zone_name=None, tags=None,
                     if_none_match=False, zone_type='Public', resolution_vnets=None, registration_vnets=None):
     Zone = cmd.get_models('Zone', resource_type=ResourceType.MGMT_NETWORK_DNS)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1100,7 +1100,7 @@ def add_dns_delegation(cmd, child_zone, parent_zone, child_rg, child_zone_name):
             for dname in child_zone.name_servers:
                 add_dns_ns_record(cmd, parent_rg, parent_zone_name, record_set_name, dname, parent_subscription_id)
             print('Delegation added succesfully in \'{}\'\n'.format(parent_zone_name), file=sys.stderr)
-        except (Exception, SystemExit) as ex:
+        except CloudError as ex:
             logger.error(ex)
             print('Could not add delegation in \'{}\'\n'.format(parent_zone_name), file=sys.stderr)
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1094,7 +1094,7 @@ def add_dns_delegation(cmd, child_zone, parent_zone, child_rg, child_zone_name):
         parent_subscription_id = id_parts['subscription']
         parent_zone_name = id_parts['name']
 
-    if all(v is not None for v in [parent_zone_name, parent_rg, child_zone_name, child_zone]) and child_zone_name.endswith(parent_zone_name):
+    if all([parent_zone_name, parent_rg, child_zone_name, child_zone]) and child_zone_name.endswith(parent_zone_name):
         record_set_name = child_zone_name.replace('.' + parent_zone_name, '')
         try:
             for dname in child_zone.name_servers:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1118,7 +1118,7 @@ def create_dns_zone(cmd, client, resource_group_name, zone_name, parent_zone_nam
     created_zone = client.create_or_update(resource_group_name, zone_name, zone,
                                            if_none_match='*' if if_none_match else None)
 
-    if parent_zone_name is not None:
+    if cmd.supported_api_version(min_api='2016-04-01') and parent_zone_name is not None:
         logger.info('Attempting to add delegation in the parent zone')
         add_dns_delegation(cmd, created_zone, parent_zone_name, resource_group_name, zone_name)
     return created_zone
@@ -1450,7 +1450,8 @@ def add_dns_ns_record(cmd, resource_group_name, zone_name, record_set_name, dnam
     NsRecord = cmd.get_models('NsRecord', resource_type=ResourceType.MGMT_NETWORK_DNS)
     record = NsRecord(nsdname=dname)
     record_type = 'ns'
-    return _add_save_record(cmd, record, record_type, record_set_name, resource_group_name, zone_name, subscription_id=subscription_id)
+    return _add_save_record(cmd, record, record_type, record_set_name,
+                            resource_group_name, zone_name, subscription_id=subscription_id)
 
 
 def add_dns_ptr_record(cmd, resource_group_name, zone_name, record_set_name, dname):
@@ -1603,7 +1604,8 @@ def _add_record(record_set, record, record_type, is_list=False):
 
 def _add_save_record(cmd, record, record_type, record_set_name, resource_group_name, zone_name,
                      is_list=True, subscription_id=None):
-    ncf = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_NETWORK_DNS, subscription_id=subscription_id).record_sets
+    ncf = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_NETWORK_DNS,
+                                  subscription_id=subscription_id).record_sets
     try:
         record_set = ncf.get(resource_group_name, zone_name, record_set_name, record_type)
     except CloudError:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_dns_delegation.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_dns_delegation.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2019-04-01T08:09:59Z"}}'
+      "date": "2019-04-02T08:44:27Z"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -11,17 +11,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [--location --name --tag]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_dns000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001","name":"cli_test_dns000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-04-01T08:09:59Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001","name":"cli_test_dns000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-04-02T08:44:27Z"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['384']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:07 GMT']
+      date: ['Tue, 02 Apr 2019 08:44:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -39,18 +39,18 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-n -g]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com","name":"books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e7f9-df5562e8d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2,"zoneType":"Public"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com","name":"books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-9b15-254e30e9d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2,"zoneType":"Public"}}'}
     headers:
       cache-control: [private]
       content-length: ['576']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:15 GMT']
-      etag: [00000002-0000-0000-e7f9-df5562e8d401]
+      date: ['Tue, 02 Apr 2019 08:44:39 GMT']
+      etag: [00000002-0000-0000-9b15-254e30e9d401]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -67,18 +67,18 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-n -g]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com","name":"books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e7f9-df5562e8d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2,"zoneType":"Public"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com","name":"books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-9b15-254e30e9d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2,"zoneType":"Public"}}'}
     headers:
       cache-control: [private]
       content-length: ['576']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:17 GMT']
-      etag: [00000002-0000-0000-e7f9-df5562e8d401]
+      date: ['Tue, 02 Apr 2019 08:44:40 GMT']
+      etag: [00000002-0000-0000-9b15-254e30e9d401]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -99,23 +99,23 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-n -g -p]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/nursery.books.com?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/nursery.books.com","name":"nursery.books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-2867-a15b62e8d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-03.azure-dns.com.","ns2-03.azure-dns.net.","ns3-03.azure-dns.org.","ns4-03.azure-dns.info."],"numberOfRecordSets":2,"zoneType":"Public"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/nursery.books.com","name":"nursery.books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-0541-ff5230e9d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2,"zoneType":"Public"}}'}
     headers:
       cache-control: [private]
       content-length: ['592']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:26 GMT']
-      etag: [00000002-0000-0000-2867-a15b62e8d401]
+      date: ['Tue, 02 Apr 2019 08:44:47 GMT']
+      etag: [00000002-0000-0000-0541-ff5230e9d401]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
       x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
@@ -127,7 +127,7 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-n -g -p]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
@@ -138,7 +138,7 @@ interactions:
       cache-control: [private]
       content-length: ['228']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:26 GMT']
+      date: ['Tue, 02 Apr 2019 08:44:47 GMT']
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -147,7 +147,7 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "NSRecords": [{"nsdname": "ns1-03.azure-dns.com."}]}}'
+    body: '{"properties": {"TTL": 3600, "NSRecords": [{"nsdname": "ns1-02.azure-dns.com."}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -157,18 +157,18 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-n -g -p]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"cd9f68c2-2984-41cb-ab2c-03d996c07983","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"5cbacc5a-ccc1-4b2c-9599-807e46792859","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [private]
       content-length: ['479']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:28 GMT']
-      etag: [cd9f68c2-2984-41cb-ab2c-03d996c07983]
+      date: ['Tue, 02 Apr 2019 08:44:49 GMT']
+      etag: [5cbacc5a-ccc1-4b2c-9599-807e46792859]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -185,18 +185,18 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-n -g -p]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"cd9f68c2-2984-41cb-ab2c-03d996c07983","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"5cbacc5a-ccc1-4b2c-9599-807e46792859","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [private]
       content-length: ['479']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:29 GMT']
-      etag: [cd9f68c2-2984-41cb-ab2c-03d996c07983]
+      date: ['Tue, 02 Apr 2019 08:44:50 GMT']
+      etag: [5cbacc5a-ccc1-4b2c-9599-807e46792859]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -207,9 +207,9 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "cd9f68c2-2984-41cb-ab2c-03d996c07983", "properties": {"TTL":
-      3600, "targetResource": {}, "NSRecords": [{"nsdname": "ns1-03.azure-dns.com."},
-      {"nsdname": "ns2-03.azure-dns.net."}]}}'
+    body: '{"etag": "5cbacc5a-ccc1-4b2c-9599-807e46792859", "properties": {"TTL":
+      3600, "targetResource": {}, "NSRecords": [{"nsdname": "ns1-02.azure-dns.com."},
+      {"nsdname": "ns2-02.azure-dns.net."}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -219,18 +219,18 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-n -g -p]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"a15bbd7a-13c6-4e19-a172-a24889d93a0b","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"2cf1c6cc-a327-4b29-a3eb-1e4d79d36344","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."},{"nsdname":"ns2-02.azure-dns.net."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [private]
       content-length: ['515']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:31 GMT']
-      etag: [a15bbd7a-13c6-4e19-a172-a24889d93a0b]
+      date: ['Tue, 02 Apr 2019 08:44:51 GMT']
+      etag: [2cf1c6cc-a327-4b29-a3eb-1e4d79d36344]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -249,18 +249,18 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-n -g -p]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"a15bbd7a-13c6-4e19-a172-a24889d93a0b","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"2cf1c6cc-a327-4b29-a3eb-1e4d79d36344","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."},{"nsdname":"ns2-02.azure-dns.net."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [private]
       content-length: ['515']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:32 GMT']
-      etag: [a15bbd7a-13c6-4e19-a172-a24889d93a0b]
+      date: ['Tue, 02 Apr 2019 08:44:52 GMT']
+      etag: [2cf1c6cc-a327-4b29-a3eb-1e4d79d36344]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -271,9 +271,9 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "a15bbd7a-13c6-4e19-a172-a24889d93a0b", "properties": {"TTL":
-      3600, "targetResource": {}, "NSRecords": [{"nsdname": "ns1-03.azure-dns.com."},
-      {"nsdname": "ns2-03.azure-dns.net."}, {"nsdname": "ns3-03.azure-dns.org."}]}}'
+    body: '{"etag": "2cf1c6cc-a327-4b29-a3eb-1e4d79d36344", "properties": {"TTL":
+      3600, "targetResource": {}, "NSRecords": [{"nsdname": "ns1-02.azure-dns.com."},
+      {"nsdname": "ns2-02.azure-dns.net."}, {"nsdname": "ns3-02.azure-dns.org."}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -283,18 +283,18 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-n -g -p]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"93f80207-d474-4cf8-bc2b-55dde8547e7a","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"94467bef-8000-4792-9fbf-f6fc60f34d59","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."},{"nsdname":"ns2-02.azure-dns.net."},{"nsdname":"ns3-02.azure-dns.org."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [private]
       content-length: ['551']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:33 GMT']
-      etag: [93f80207-d474-4cf8-bc2b-55dde8547e7a]
+      date: ['Tue, 02 Apr 2019 08:44:53 GMT']
+      etag: [94467bef-8000-4792-9fbf-f6fc60f34d59]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -313,18 +313,18 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-n -g -p]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"93f80207-d474-4cf8-bc2b-55dde8547e7a","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"94467bef-8000-4792-9fbf-f6fc60f34d59","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."},{"nsdname":"ns2-02.azure-dns.net."},{"nsdname":"ns3-02.azure-dns.org."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [private]
       content-length: ['551']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:34 GMT']
-      etag: [93f80207-d474-4cf8-bc2b-55dde8547e7a]
+      date: ['Tue, 02 Apr 2019 08:44:54 GMT']
+      etag: [94467bef-8000-4792-9fbf-f6fc60f34d59]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -335,10 +335,10 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "93f80207-d474-4cf8-bc2b-55dde8547e7a", "properties": {"TTL":
-      3600, "targetResource": {}, "NSRecords": [{"nsdname": "ns1-03.azure-dns.com."},
-      {"nsdname": "ns2-03.azure-dns.net."}, {"nsdname": "ns3-03.azure-dns.org."},
-      {"nsdname": "ns4-03.azure-dns.info."}]}}'
+    body: '{"etag": "94467bef-8000-4792-9fbf-f6fc60f34d59", "properties": {"TTL":
+      3600, "targetResource": {}, "NSRecords": [{"nsdname": "ns1-02.azure-dns.com."},
+      {"nsdname": "ns2-02.azure-dns.net."}, {"nsdname": "ns3-02.azure-dns.org."},
+      {"nsdname": "ns4-02.azure-dns.info."}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -348,25 +348,25 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       ParameterSetName: [-n -g -p]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"a1856d07-8d25-4e9d-b5cf-340354dfc3d6","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."},{"nsdname":"ns4-03.azure-dns.info."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"c50880f8-6a47-49e0-8ac2-050d5c7a6b0e","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."},{"nsdname":"ns2-02.azure-dns.net."},{"nsdname":"ns3-02.azure-dns.org."},{"nsdname":"ns4-02.azure-dns.info."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [private]
       content-length: ['588']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:36 GMT']
-      etag: [a1856d07-8d25-4e9d-b5cf-340354dfc3d6]
+      date: ['Tue, 02 Apr 2019 08:44:56 GMT']
+      etag: [c50880f8-6a47-49e0-8ac2-050d5c7a6b0e]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -378,18 +378,18 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-n -g]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com","name":"books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e7f9-df5562e8d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":3,"zoneType":"Public"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com","name":"books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-9b15-254e30e9d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":3,"zoneType":"Public"}}'}
     headers:
       cache-control: [private]
       content-length: ['576']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:38 GMT']
-      etag: [00000002-0000-0000-e7f9-df5562e8d401]
+      date: ['Tue, 02 Apr 2019 08:44:57 GMT']
+      etag: [00000002-0000-0000-9b15-254e30e9d401]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -408,18 +408,18 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-n -g --zone-name]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
   response:
-    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"a1856d07-8d25-4e9d-b5cf-340354dfc3d6","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."},{"nsdname":"ns4-03.azure-dns.info."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"c50880f8-6a47-49e0-8ac2-050d5c7a6b0e","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."},{"nsdname":"ns2-02.azure-dns.net."},{"nsdname":"ns3-02.azure-dns.org."},{"nsdname":"ns4-02.azure-dns.info."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
     headers:
       cache-control: [private]
       content-length: ['588']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:40 GMT']
-      etag: [a1856d07-8d25-4e9d-b5cf-340354dfc3d6]
+      date: ['Tue, 02 Apr 2019 08:44:59 GMT']
+      etag: [c50880f8-6a47-49e0-8ac2-050d5c7a6b0e]
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -439,18 +439,18 @@ interactions:
       Content-Length: ['0']
       ParameterSetName: [-g -n -y]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com?api-version=2018-05-01
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897030429793803a9cc72ba?api-version=2018-05-01']
+      azure-asyncoperation: ['https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897915025971209d1578bc0?api-version=2018-05-01']
       cache-control: [private]
       content-length: ['0']
-      date: ['Mon, 01 Apr 2019 08:10:42 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationResults/delzone636897030429793803a9cc72ba?api-version=2018-05-01']
+      date: ['Tue, 02 Apr 2019 08:45:03 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationResults/delzone636897915025971209d1578bc0?api-version=2018-05-01']
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -467,16 +467,16 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n -y]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897030429793803a9cc72ba?api-version=2018-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897915025971209d1578bc0?api-version=2018-05-01
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [private]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:46 GMT']
+      date: ['Tue, 02 Apr 2019 08:45:06 GMT']
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -496,18 +496,18 @@ interactions:
       Content-Length: ['0']
       ParameterSetName: [-g -n -y]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/nursery.books.com?api-version=2018-05-01
   response:
     body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897030500323726f0f72f11?api-version=2018-05-01']
+      azure-asyncoperation: ['https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone6368979150941982003f1fff64?api-version=2018-05-01']
       cache-control: [private]
       content-length: ['0']
-      date: ['Mon, 01 Apr 2019 08:10:50 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationResults/delzone636897030500323726f0f72f11?api-version=2018-05-01']
+      date: ['Tue, 02 Apr 2019 08:45:09 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationResults/delzone6368979150941982003f1fff64?api-version=2018-05-01']
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -524,16 +524,16 @@ interactions:
       Connection: [keep-alive]
       ParameterSetName: [-g -n -y]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897030500323726f0f72f11?api-version=2018-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone6368979150941982003f1fff64?api-version=2018-05-01
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [private]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 01 Apr 2019 08:10:53 GMT']
+      date: ['Tue, 02 Apr 2019 08:45:12 GMT']
       server: [Microsoft-IIS/10.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -553,7 +553,7 @@ interactions:
       Content-Length: ['0']
       ParameterSetName: [--name --yes --no-wait]
       User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
-          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.61]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_dns000001?api-version=2018-05-01
@@ -562,9 +562,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Mon, 01 Apr 2019 08:10:59 GMT']
+      date: ['Tue, 02 Apr 2019 08:45:19 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGRE5TSFpHR1M1VEJFVlNYR1NCUlhOT0FYTUlXVU1FSEoyUnwzNDZFNUUwRThBN0REMjQyLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGRE5TRUhCVDdIVkxESExHM0hMM1FZNUJWMkhTWEhXTjcyTnxBOTlGRUM4NTk1QjkyMzRCLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_dns_delegation.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/recordings/test_dns_delegation.yaml
@@ -1,0 +1,573 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
+      "date": "2019-04-01T08:09:59Z"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [--location --name --tag]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_dns000001?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001","name":"cli_test_dns000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-04-01T08:09:59Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"location": "global", "properties": {"zoneType": "Public"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      Content-Length: ['60']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com","name":"books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e7f9-df5562e8d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2,"zoneType":"Public"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['576']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:15 GMT']
+      etag: [00000002-0000-0000-e7f9-df5562e8d401]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone show]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com","name":"books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e7f9-df5562e8d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2,"zoneType":"Public"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['576']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:17 GMT']
+      etag: [00000002-0000-0000-e7f9-df5562e8d401]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "global", "properties": {"zoneType": "Public"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      Content-Length: ['60']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-n -g -p]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/nursery.books.com?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/nursery.books.com","name":"nursery.books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-2867-a15b62e8d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-03.azure-dns.com.","ns2-03.azure-dns.net.","ns3-03.azure-dns.org.","ns4-03.azure-dns.info."],"numberOfRecordSets":2,"zoneType":"Public"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['592']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:26 GMT']
+      etag: [00000002-0000-0000-2867-a15b62e8d401]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g -p]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''nursery''
+        does not exist in resource group ''cli_test_dns000001'' of subscription ''1333e1d7-c01f-4118-a100-501f3fb967e2''."}'}
+    headers:
+      cache-control: [private]
+      content-length: ['228']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:26 GMT']
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"properties": {"TTL": 3600, "NSRecords": [{"nsdname": "ns1-03.azure-dns.com."}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      Content-Length: ['82']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-n -g -p]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"cd9f68c2-2984-41cb-ab2c-03d996c07983","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['479']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:28 GMT']
+      etag: [cd9f68c2-2984-41cb-ab2c-03d996c07983]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g -p]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"cd9f68c2-2984-41cb-ab2c-03d996c07983","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['479']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:29 GMT']
+      etag: [cd9f68c2-2984-41cb-ab2c-03d996c07983]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"etag": "cd9f68c2-2984-41cb-ab2c-03d996c07983", "properties": {"TTL":
+      3600, "targetResource": {}, "NSRecords": [{"nsdname": "ns1-03.azure-dns.com."},
+      {"nsdname": "ns2-03.azure-dns.net."}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-n -g -p]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"a15bbd7a-13c6-4e19-a172-a24889d93a0b","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['515']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:31 GMT']
+      etag: [a15bbd7a-13c6-4e19-a172-a24889d93a0b]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g -p]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"a15bbd7a-13c6-4e19-a172-a24889d93a0b","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['515']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:32 GMT']
+      etag: [a15bbd7a-13c6-4e19-a172-a24889d93a0b]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"etag": "a15bbd7a-13c6-4e19-a172-a24889d93a0b", "properties": {"TTL":
+      3600, "targetResource": {}, "NSRecords": [{"nsdname": "ns1-03.azure-dns.com."},
+      {"nsdname": "ns2-03.azure-dns.net."}, {"nsdname": "ns3-03.azure-dns.org."}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-n -g -p]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"93f80207-d474-4cf8-bc2b-55dde8547e7a","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['551']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:33 GMT']
+      etag: [93f80207-d474-4cf8-bc2b-55dde8547e7a]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g -p]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"93f80207-d474-4cf8-bc2b-55dde8547e7a","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['551']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:34 GMT']
+      etag: [93f80207-d474-4cf8-bc2b-55dde8547e7a]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"etag": "93f80207-d474-4cf8-bc2b-55dde8547e7a", "properties": {"TTL":
+      3600, "targetResource": {}, "NSRecords": [{"nsdname": "ns1-03.azure-dns.com."},
+      {"nsdname": "ns2-03.azure-dns.net."}, {"nsdname": "ns3-03.azure-dns.org."},
+      {"nsdname": "ns4-03.azure-dns.info."}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone create]
+      Connection: [keep-alive]
+      Content-Length: ['267']
+      Content-Type: [application/json; charset=utf-8]
+      ParameterSetName: [-n -g -p]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"a1856d07-8d25-4e9d-b5cf-340354dfc3d6","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."},{"nsdname":"ns4-03.azure-dns.info."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['588']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:36 GMT']
+      etag: [a1856d07-8d25-4e9d-b5cf-340354dfc3d6]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone show]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com","name":"books.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e7f9-df5562e8d401","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"maxNumberOfRecordsPerRecordSet":null,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":3,"zoneType":"Public"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['576']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:38 GMT']
+      etag: [00000002-0000-0000-e7f9-df5562e8d401]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns record-set ns show]
+      Connection: [keep-alive]
+      ParameterSetName: [-n -g --zone-name]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com/NS/nursery?api-version=2018-05-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/1333e1d7-c01f-4118-a100-501f3fb967e2\/resourceGroups\/cli_test_dns000001\/providers\/Microsoft.Network\/dnszones\/books.com\/NS\/nursery","name":"nursery","type":"Microsoft.Network\/dnszones\/NS","etag":"a1856d07-8d25-4e9d-b5cf-340354dfc3d6","properties":{"fqdn":"nursery.books.com.","TTL":3600,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."},{"nsdname":"ns4-03.azure-dns.info."}],"targetResource":{},"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['588']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:40 GMT']
+      etag: [a1856d07-8d25-4e9d-b5cf-340354dfc3d6]
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [-g -n -y]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/books.com?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897030429793803a9cc72ba?api-version=2018-05-01']
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Mon, 01 Apr 2019 08:10:42 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationResults/delzone636897030429793803a9cc72ba?api-version=2018-05-01']
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone delete]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n -y]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897030429793803a9cc72ba?api-version=2018-05-01
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      cache-control: [private]
+      content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:46 GMT']
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [-g -n -y]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsZones/nursery.books.com?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897030500323726f0f72f11?api-version=2018-05-01']
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Mon, 01 Apr 2019 08:10:50 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationResults/delzone636897030500323726f0f72f11?api-version=2018-05-01']
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [network dns zone delete]
+      Connection: [keep-alive]
+      ParameterSetName: [-g -n -y]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          azure-mgmt-dns/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns000001/providers/Microsoft.Network/dnsOperationStatuses/delzone636897030500323726f0f72f11?api-version=2018-05-01
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      cache-control: [private]
+      content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 01 Apr 2019 08:10:53 GMT']
+      server: [Microsoft-IIS/10.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      ParameterSetName: [--name --yes --no-wait]
+      User-Agent: [python/3.7.2 (Windows-10-10.0.17763-SP0) msrest/0.6.4 msrest_azure/0.6.0
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python AZURECLI/2.0.60]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_dns000001?api-version=2018-05-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Mon, 01 Apr 2019 08:10:59 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGRE5TSFpHR1M1VEJFVlNYR1NCUlhOT0FYTUlXVU1FSEoyUnwzNDZFNUUwRThBN0REMjQyLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+    status: {code: 202, message: Accepted}
+version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
@@ -179,13 +179,12 @@ class DnsScenarioTest(ScenarioTest):
         self.cmd('network dns record-set ns show -n {record_set_name} -g {rg} --zone-name {parent_zone_name}',
                  checks=self.check('length(nsRecords)', child_name_server_count))
 
-        #clean up by deleting the created resources
+        # clean up by deleting the created resources
         self.cmd('network dns zone delete -g {rg} -n {parent_zone_name} -y',
                  checks=self.is_empty())
 
         self.cmd('network dns zone delete -g {rg} -n {child_zone_name} -y',
                  checks=self.is_empty())
-
 
     @ResourceGroupPreparer(name_prefix='cli_test_dns')
     def test_private_dns(self, resource_group):


### PR DESCRIPTION
…one created

- Enable DNS name server delegation when a DNS zone is created whose parent zone is already hosted in Azure.
- For successful resolution of the newly added child zone, an NS record must exist in the parent containing the name servers of the newly created child zone.
- Achieve this additional step as part of zone creation when user indicates the parent zone details as part of -p or --parent-name parameter

**Current state**
- It supports parent zone present in same resource group & subscription as the child zone being created.

**Intended future state**
- Since the parent zone might reside in another subscription, we propose to accept FQDN(fully qualified domain name) of the parent and extract resource group , subscription details

**Open Question ?**
Would it be possible to create two resources in different subscriptions as part of this single cmd ?
If so how ? 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
