### PR TITLE
Restricting duplicate key in output json

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/transform.py
+++ b/src/azure-cli-core/azure/cli/core/commands/transform.py
@@ -32,7 +32,7 @@ def _add_resource_group(obj):
             _add_resource_group(array_item)
     elif isinstance(obj, dict):
         try:
-            if 'resourceGroup' not in obj:
+            if 'resourcegroup' not in [x.lower() for x in obj.keys()]:
                 if obj['id']:
                     obj['resourceGroup'] = _parse_id(obj['id'])['resource-group']
         except (KeyError, IndexError, TypeError):

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/latest/test_iot_certificate_commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/latest/test_iot_certificate_commands.py
@@ -71,7 +71,7 @@ class IotHubCertificateTest(ScenarioTest):
         hub = self.create_random_name(prefix='iot-hub-for-cert-test', length=48)
 
         self.cmd('iot hub create -n {0} -g {1} --sku S1'.format(hub, resource_group),
-                 checks=[self.check('resourceGroup', resource_group),
+                 checks=[self.check('resourcegroup', resource_group),
                          self.check('name', hub),
                          self.check('sku.name', 'S1')])
 

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -23,7 +23,7 @@ class IoTHubTest(ScenarioTest):
 
         # Test 'az iot hub create'
         self.cmd('iot hub create -n {0} -g {1} --sku S1 --partition-count 4'.format(hub, rg),
-                 checks=[self.check('resourceGroup', rg),
+                 checks=[self.check('resourcegroup', rg),
                          self.check('location', location),
                          self.check('name', hub),
                          self.check('sku.name', 'S1'),
@@ -45,7 +45,7 @@ class IoTHubTest(ScenarioTest):
         property_to_update = 'properties.operationsMonitoringProperties.events.DeviceTelemetry'
         updated_value = 'Error, Information'
         self.cmd('iot hub update -n {0} --set {1}="{2}"'.format(hub, property_to_update, updated_value),
-                 checks=[self.check('resourceGroup', rg),
+                 checks=[self.check('resourcegroup', rg),
                          self.check('location', location),
                          self.check('name', hub),
                          self.check('sku.name', 'S1'),
@@ -53,7 +53,7 @@ class IoTHubTest(ScenarioTest):
 
         # Test 'az iot hub show'
         self.cmd('iot hub show -n {0}'.format(hub), checks=[
-            self.check('resourceGroup', rg),
+            self.check('resourcegroup', rg),
             self.check('location', location),
             self.check('name', hub),
             self.check('sku.name', 'S1'),
@@ -63,7 +63,7 @@ class IoTHubTest(ScenarioTest):
         # Test 'az iot hub list'
         self.cmd('iot hub list -g {0}'.format(rg), checks=[
             self.check('length([*])', 1),
-            self.check('[0].resourceGroup', rg),
+            self.check('[0].resourcegroup', rg),
             self.check('[0].location', location),
             self.check('[0].name', hub),
             self.check('[0].sku.name', 'S1')

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py
@@ -18,7 +18,7 @@ class IoTDpsTest(ScenarioTest):
         hub_name = self.create_random_name('iot', 20)
 
         self.cmd('iot hub create -n {} -g {} --sku S1'.format(hub_name, group_name),
-                 checks=[self.check('resourceGroup', group_name),
+                 checks=[self.check('resourcegroup', group_name),
                          self.check('name', hub_name),
                          self.check('sku.name', 'S1')])
 


### PR DESCRIPTION
Adding a case-insensitive check to ignore adding a key("resourceGroup") in the output.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
