### PR TITLE
[AKS] Correct --subnet-name parameter for Virtual Nodes add-on

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -224,7 +224,7 @@ parameters:
         These addons are available:
             http_application_routing - configure ingress with automatic public DNS name creation.
             monitoring - turn on Log Analytics monitoring. Uses the Log Analytics Default Workspace if it exists, else creates one. Specify "--workspace-resource-id" to use an existing workspace.
-            virtual-node - enable AKS Virtual Node (PREVIEW). Requires --subnet_name to provide the name of an existing subnet for the Virtual Node to use.
+            virtual-node - enable AKS Virtual Node (PREVIEW). Requires --subnet-name to provide the name of an existing subnet for the Virtual Node to use.
   - name: --disable-rbac
     type: bool
     short-summary: Disable Kubernetes Role-Based Access Control.
@@ -303,7 +303,7 @@ long-summary: |-
     These addons are available:
         http_application_routing - configure ingress with automatic public DNS name creation.
         monitoring - turn on Log Analytics monitoring. Requires "--workspace-resource-id".
-        virtual-node - enable AKS Virtual Node (PREVIEW). Requires --subnet_name to provide the name of an existing subnet for the Virtual Node to use.
+        virtual-node - enable AKS Virtual Node (PREVIEW). Requires --subnet-name to provide the name of an existing subnet for the Virtual Node to use.
 parameters:
   - name: --addons -a
     type: string


### PR DESCRIPTION
This PR updates the help text for the `az aks enable-addons` command to show the correct additional parameter name needed when enabling the Virtual Nodes add-on.

The [CLI reference doc](https://docs.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az-aks-enable-addons) correctly shows this as being `--subnet-name`, not `--subnet_name` as output in the CLI help.

CC: @srrengar 
