### PR TITLE
Fix the dev branch build

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -91,6 +91,7 @@ DEPENDENCIES = [
     'azure-cli-network',
     'azure-cli-nspkg',
     'azure-cli-policyinsights',
+    'azure-cli-privatedns',
     'azure-cli-profile',
     'azure-cli-rdbms',
     'azure-cli-redis',


### PR DESCRIPTION
Having the command module missing from this manifest means poet doesn't discover it's dependencies when it goes to create a Homebrew manifest.