### PR TITLE
Enable Homebrew Build for PR validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -240,7 +240,7 @@ jobs:
   displayName: Build Homebrew Formula
 
   dependsOn: BuildPythonWheel
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
+  condition: succeeded()
   pool:
     vmImage: 'ubuntu-16.04'
   steps:


### PR DESCRIPTION
The build has been broken a number of times lately, in ways that would be caught if building the Hombrew Formula were part of PR validation. I'm turning it on to help catch these issues sooner rather than later.