### PR TITLE
[core] Improve error message when get_file_json / shell_safe_json_parse fails.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -197,7 +197,10 @@ def get_file_json(file_path, throw_on_empty=True, preserve_order=False):
     content = read_file_content(file_path)
     if not content and not throw_on_empty:
         return None
-    return shell_safe_json_parse(content, preserve_order)
+    try:
+        return shell_safe_json_parse(content, preserve_order)
+    except CLIError as ex:
+        raise CLIError("Failed to parse {} with exception:\n    {}".format(file_path, ex))
 
 
 def read_file_content(file_path, allow_binary=False):
@@ -236,6 +239,9 @@ def shell_safe_json_parse(json_or_dict_string, preserve_order=False):
             return ast.literal_eval(json_or_dict_string)
         except SyntaxError:
             raise CLIError(json_ex)
+        except ValueError as ex:
+            logger.debug(ex)  # log the exception which could be a python dict parsing error.
+            raise CLIError(json_ex)  # raise json_ex error which is more readable and likely.
 
 
 def b64encode(s):


### PR DESCRIPTION
Closes #7740  


Note:
We should discuss sometime whether or not the CLI should accept python dict string syntax. I am not sure how often this syntax is used by CLI users. 
Moreover, it complicates the logic in `shell_safe_json_parse`. if a string uses python dict single quotes (invalid json) and also has a syntactical error common to both json and dict strings (extra comma), it is hard to know which error is more relevant to the user. As shell_safe_json_parse technically supports both syntaxes.

 
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
