### PR TITLE
[functionapp] Add Github integration in devops-build commands

### DIFF
--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -261,6 +261,7 @@
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tunnel.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\utils.py" />
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\vsts_cd_provider.py" />
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\_appservice_utils.py" />
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\_client_factory.py" />

--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -253,6 +253,9 @@
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\commands.py" />
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\custom.py" />
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\latest\test_devops_build_commands.py" />
+    <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\latest\test_devops_build_commands_thru_mock.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\latest\test_webapp_commands.py" />
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\latest\test_webapp_commands_thru_mock.py" />
     <Compile Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tunnel.py">

--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -2,7 +2,9 @@
 
 Release History
 ===============
-
+* functionapp: add feature for establishing CI CD to an Azure DevOps pipeline from a Github repository
+* functionapp: in `az functionapp devops-build create`, added `--github-pat` flag to accept Github personal access token
+* functionapp: in `az functionapp devops-build create`, added `--github-repository` flag to accept Github repository that contains a functionapp source code
 * webapp: az webapp up --logs was failing with a error and updating default .NETCORE version to 2.1
 
 0.2.17

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -423,3 +423,5 @@ def load_arguments(self, _):
         c.argument('overwrite_yaml', help="If you have an existing yaml, should it be overwritten?", arg_type=get_three_state_flag(return_label=True), required=False)
         c.argument('allow_force_push', help="If Azure Devops repository is not clean, should it overwrite remote content?", arg_type=get_three_state_flag(return_label=True), required=False)
         c.argument('use_local_settings', help="Use your local settings in your functionapp settings?", arg_type=get_three_state_flag(return_label=True), required=False)
+        c.argument('github_pat', help="Github personal access token for creating pipeline from Github repository", required=False)
+        c.argument('github_repository', help="Fullname of your Github repository (e.g. Azure/azure-cli)", required=False)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -416,7 +416,7 @@ def load_arguments(self, _):
         c.argument('sku', required=False, help='The SKU of the app service plan.')
 
     with self.argument_context('functionapp devops-build create') as c:
-        c.argument('functionapp_name', help="Name of the Azure Function app that you want to use", required=False)
+        c.argument('functionapp_name', help="Name of the Azure function app that you want to use", required=False)
         c.argument('organization_name', help="Name of the Azure DevOps organization that you want to use", required=False)
         c.argument('project_name', help="Name of the Azure DevOps project that you want to use", required=False)
         c.argument('repository_name', help="Name of the Azure DevOps repository that you want to use", required=False)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -416,12 +416,12 @@ def load_arguments(self, _):
         c.argument('sku', required=False, help='The SKU of the app service plan.')
 
     with self.argument_context('functionapp devops-build create') as c:
-        c.argument('functionapp_name', help="Name of the Azure Function App that you want to use", required=False)
+        c.argument('functionapp_name', help="Name of the Azure Function app that you want to use", required=False)
         c.argument('organization_name', help="Name of the Azure DevOps organization that you want to use", required=False)
         c.argument('project_name', help="Name of the Azure DevOps project that you want to use", required=False)
-        c.argument('repository_name', help="Name of the Azure Devops repository that you want to use", required=False)
+        c.argument('repository_name', help="Name of the Azure DevOps repository that you want to use", required=False)
         c.argument('overwrite_yaml', help="If you have an existing yaml, should it be overwritten?", arg_type=get_three_state_flag(return_label=True), required=False)
-        c.argument('allow_force_push', help="If Azure Devops repository is not clean, should it overwrite remote content?", arg_type=get_three_state_flag(return_label=True), required=False)
+        c.argument('allow_force_push', help="If Azure DevOps repository is not clean, should it overwrite remote content?", arg_type=get_three_state_flag(return_label=True), required=False)
         c.argument('use_local_settings', help="Use your local settings in your functionapp settings?", arg_type=get_three_state_flag(return_label=True), required=False)
         c.argument('github_pat', help="Github personal access token for creating pipeline from Github repository", required=False)
         c.argument('github_repository', help="Fullname of your Github repository (e.g. Azure/azure-cli)", required=False)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
@@ -537,7 +537,7 @@ class AzureDevopsBuildInteractive(object):
                                "Please ensure that:{ls}"
                                "1. You are the owner of the subscription, "
                                "or have roleAssignments/write permission.{ls}"
-                               "2. You can perform app registration in Azure Active Directory{ls}"
+                               "2. You can perform app registration in Azure Active Directory.{ls}"
                                "3. The combined length of your organization name, project name and repository name "
                                "is under 68 characters.".format(ls=os.linesep))
         else:

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
@@ -219,7 +219,7 @@ class AzureDevopsBuildInteractive(object):
 
         if github_runtime_language is not None and github_runtime_language != self.functionapp_language:
             raise CLIError("The language stack setting found in the provided repository ({setting}) does not match "
-                           "the language stack your Azure function app ({functionapp}).{ls}"
+                           "the language stack of your Azure function app ({functionapp}).{ls}"
                            "Please look at the FUNCTIONS_WORKER_RUNTIME setting both in your local.settings.json file "
                            "and in your Azure function app's application settings, "
                            "and ensure they match.".format(
@@ -537,8 +537,7 @@ class AzureDevopsBuildInteractive(object):
                                "Please ensure that:{ls}"
                                "1. You are the owner of the subscription, "
                                "or have roleAssignments/write permission.{ls}"
-                               "2. You can perform app registration in https://portal.azure.com/#blade/"
-                               "Microsoft_AAD_IAM/ApplicationsListBlade{ls}"
+                               "2. You can perform app registration in Azure Active Directory{ls}"
                                "3. The combined length of your organization name, project name and repository name "
                                "is under 68 characters.".format(ls=os.linesep))
         else:

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
@@ -537,7 +537,7 @@ class AzureDevopsBuildInteractive(object):
                                "Please ensure that:{ls}"
                                "1. You are the owner of the subscription, "
                                "or have roleAssignments/write permission.{ls}"
-                               "2. You can perform app registration in https://ms.portal.azure.com/#blade/"
+                               "2. You can perform app registration in https://portal.azure.com/#blade/"
                                "Microsoft_AAD_IAM/ApplicationsListBlade{ls}"
                                "3. The combined length of your organization name, project name and repository name "
                                "is under 68 characters.".format(ls=os.linesep))

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
@@ -559,12 +559,14 @@ class AzureDevopsBuildInteractive(object):
                 except GithubIntegrationRequestError as gire:
                     raise CLIError("{error}{ls}{ls}"
                                    "Please ensure your Github personal access token has sufficient permissions.{ls}{ls}"
-                                   "You may visit https://aka.ms/azure-devops-source-repos for more information.".format(
+                                   "You may visit https://aka.ms/azure-devops-source-repos for more "
+                                   "information.".format(
                                        error=gire.message, ls=os.linesep))
                 except GithubContentNotFound:
                     raise CLIError("Failed to create a webhook for the provided Github repository or "
                                    "your repository cannot be accessed.{ls}{ls}"
-                                   "You may visit https://aka.ms/azure-devops-source-repos for more information.".format(
+                                   "You may visit https://aka.ms/azure-devops-source-repos for more "
+                                   "information.".format(
                                        ls=os.linesep))
         else:
             self.logger.warning("Detected a build definition already exists: {name}".format(

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
@@ -402,8 +402,11 @@ class AzureDevopsBuildInteractive(object):
         # Setup a local git repository and create a new commit on top of this context
         try:
             self.adbp.setup_local_git_repository(self.organization_name, self.project_name, self.repository_name)
-        except GitOperationException:
-            raise CLIError("Failed to setup local git repository.")
+        except GitOperationException as goe:
+            raise CLIError("Failed to setup local git repository when running '{message}'{ls}"
+                           "Please ensure you have setup Git user.email and user.name".format(
+                               message=goe.message, ls=os.linesep
+                           ))
 
         self.repository_remote_name = expected_remote_name
         self.logger.warning("Added git remote {remote}".format(remote=expected_remote_name))

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
@@ -182,9 +182,9 @@ class AzureDevopsBuildInteractive(object):
         local_runtime_language = self._find_local_repository_runtime_language()
         if local_runtime_language != self.functionapp_language:
             raise CLIError("The language stack setting found in your local repository ({setting}) does not match "
-                           "the language stack of your Azure Function app in Azure ({functionapp}).{ls}"
+                           "the language stack of your Azure function app in Azure ({functionapp}).{ls}"
                            "Please look at the FUNCTIONS_WORKER_RUNTIME setting both in your local.settings.json file "
-                           "and in your Azure Function app's application settings, "
+                           "and in your Azure function app's application settings, "
                            "and ensure they match.".format(
                                setting=local_runtime_language,
                                functionapp=self.functionapp_language,
@@ -203,9 +203,9 @@ class AzureDevopsBuildInteractive(object):
         github_runtime_language = self._find_github_repository_runtime_language()
         if github_runtime_language is not None and github_runtime_language != self.functionapp_language:
             raise CLIError("The language stack setting found in the provided repository ({setting}) does not match "
-                           "the language stack your Azure Function app ({functionapp}).{ls}"
+                           "the language stack your Azure function app ({functionapp}).{ls}"
                            "Please look at the FUNCTIONS_WORKER_RUNTIME setting both in your local.settings.json file "
-                           "and in your Azure Function app's application settings, "
+                           "and in your Azure function app's application settings, "
                            "and ensure they match.".format(
                                setting=github_runtime_language,
                                functionapp=self.functionapp_language,
@@ -404,7 +404,7 @@ class AzureDevopsBuildInteractive(object):
             self.adbp.setup_local_git_repository(self.organization_name, self.project_name, self.repository_name)
         except GitOperationException as goe:
             raise CLIError("Failed to setup local git repository when running '{message}'{ls}"
-                           "Please ensure you have setup Git user.email and user.name".format(
+                           "Please ensure you have setup git user.email and user.name".format(
                                message=goe.message, ls=os.linesep
                            ))
 
@@ -519,7 +519,7 @@ class AzureDevopsBuildInteractive(object):
                     self.adbp.remove_git_remote(self.organization_name, self.project_name, repository)
                 raise CLIError("To create a build through Azure Pipelines,{ls}"
                                "The command will assign a contributor role to the "
-                               "Azure Function app release service principle.{ls}"
+                               "Azure function app release service principle.{ls}"
                                "Please ensure that:{ls}"
                                "1. You are the owner of the subscription, "
                                "or have roleAssignments/write permission.{ls}"

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
@@ -462,9 +462,7 @@ class AzureDevopsBuildInteractive(object):
             self.logger.warning("https://help.github.com/en/articles/"
                                 "creating-a-personal-access-token-for-the-command-line{ls}".format(ls=os.linesep))
             self.logger.warning("The required Personal Access Token permissions can be found here:")
-            self.logger.warning("https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github"
-                                "?view=azure-devops#repository-permissions-for-personal-"
-                                "access-token-pat-authentication{ls}".format(ls=os.linesep))
+            self.logger.warning("https://aka.ms/azure-devops-source-repos")
 
         while not self.github_pat or not AzureDevopsBuildProvider.check_github_pat(self.github_pat):
             self.github_pat = prompt(msg="Github Personal Access Token: ").strip()
@@ -561,16 +559,12 @@ class AzureDevopsBuildInteractive(object):
                 except GithubIntegrationRequestError as gire:
                     raise CLIError("{error}{ls}{ls}"
                                    "Please ensure your Github personal access token has sufficient permissions.{ls}{ls}"
-                                   "You may visit https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/"
-                                   "github?view=azure-devops#repository-permissions-for-personal-"
-                                   "access-token-pat-authentication for more information.".format(
+                                   "You may visit https://aka.ms/azure-devops-source-repos for more information.".format(
                                        error=gire.message, ls=os.linesep))
                 except GithubContentNotFound:
                     raise CLIError("Failed to create a webhook for the provided Github repository or "
                                    "your repository cannot be accessed.{ls}{ls}"
-                                   "You may visit https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/"
-                                   "github?view=azure-devops#repository-permissions-for-personal-"
-                                   "access-token-pat-authentication for more information.".format(
+                                   "You may visit https://aka.ms/azure-devops-source-repos for more information.".format(
                                        ls=os.linesep))
         else:
             self.logger.warning("Detected a build definition already exists: {name}".format(

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_iteractive.py
@@ -182,9 +182,9 @@ class AzureDevopsBuildInteractive(object):
         local_runtime_language = self._find_local_repository_runtime_language()
         if local_runtime_language != self.functionapp_language:
             raise CLIError("The language stack setting found in your local repository ({setting}) does not match "
-                           "the language stack of your function app in Azure ({functionapp}).{ls}"
+                           "the language stack of your Azure Function app in Azure ({functionapp}).{ls}"
                            "Please look at the FUNCTIONS_WORKER_RUNTIME setting both in your local.settings.json file "
-                           "and in your application settings on your function app in Azure, "
+                           "and in your Azure Function app's application settings, "
                            "and ensure they match.".format(
                                setting=local_runtime_language,
                                functionapp=self.functionapp_language,
@@ -203,9 +203,9 @@ class AzureDevopsBuildInteractive(object):
         github_runtime_language = self._find_github_repository_runtime_language()
         if github_runtime_language is not None and github_runtime_language != self.functionapp_language:
             raise CLIError("The language stack setting found in the provided repository ({setting}) does not match "
-                           "the language stack of your function app in Azure ({functionapp}).{ls}"
+                           "the language stack your Azure Function app ({functionapp}).{ls}"
                            "Please look at the FUNCTIONS_WORKER_RUNTIME setting both in your local.settings.json file "
-                           "and in your application settings on your function app in Azure, "
+                           "and in your Azure Function app's application settings, "
                            "and ensure they match.".format(
                                setting=github_runtime_language,
                                functionapp=self.functionapp_language,
@@ -287,7 +287,7 @@ class AzureDevopsBuildInteractive(object):
             if self.overwrite_yaml is None:
                 self.logger.warning("There is already an azure-pipelines.yml file in your local repository.")
                 self.logger.warning("If you are using a yaml file that was not configured "
-                                    "through this command this process may fail.")
+                                    "through this command, this command may fail.")
                 response = prompt_y_n("Do you want to delete it and create a new one? ")
             else:
                 response = self.overwrite_yaml
@@ -308,7 +308,7 @@ class AzureDevopsBuildInteractive(object):
         if does_yaml_file_exist and self.overwrite_yaml is None:
             self.logger.warning("There is already an azure-pipelines.yml file in the provided Github repository.")
             self.logger.warning("If you are using a yaml file that was not configured "
-                                "through this command this process may fail.")
+                                "through this command, this command may fail.")
             self.overwrite_yaml = prompt_y_n("Do you want to generate a new one? "
                                              "(It will be committed to the master branch of the provided repository)")
 
@@ -329,10 +329,10 @@ class AzureDevopsBuildInteractive(object):
                                    language=lnse.message))
             except GithubContentNotFound:
                 raise CLIError("Sorry, the repository you provided does not exist or "
-                               "you do not have sufficient permission to write to the repository. "
+                               "you do not have sufficient permissions to write to the repository. "
                                "Please provide an access token with the proper permissions.")
             except GithubUnauthorizedError:
-                raise CLIError("Sorry, you do not have sufficient permission to commit "
+                raise CLIError("Sorry, you do not have sufficient permissions to commit "
                                "azure-pipelines.yml to your Github repository.")
 
         # Overwrite yaml file
@@ -352,10 +352,10 @@ class AzureDevopsBuildInteractive(object):
                                    language=lnse.message))
             except GithubContentNotFound:
                 raise CLIError("Sorry, the repository you provided does not exist or "
-                               "you do not have sufficient permission to write to the repository. "
+                               "you do not have sufficient permissions to write to the repository. "
                                "Please provide an access token with the proper permissions.")
             except GithubUnauthorizedError:
-                raise CLIError("Sorry, you do not have sufficient permission to overwrite "
+                raise CLIError("Sorry, you do not have sufficient permissions to overwrite "
                                "azure-pipelines.yml in your Github repository.")
 
     def process_local_repository(self):
@@ -515,11 +515,11 @@ class AzureDevopsBuildInteractive(object):
                 if scenario == "AZURE_DEVOPS":
                     self.adbp.remove_git_remote(self.organization_name, self.project_name, repository)
                 raise CLIError("To create a build through Azure Pipelines,{ls}"
-                               "we need to assign a contributor role to the "
-                               "Azure Functions release service principle.{ls}"
+                               "The command will assign a contributor role to the "
+                               "Azure Function app release service principle.{ls}"
                                "Please ensure that:{ls}"
                                "1. You are the owner of the subscription, "
-                               "or have roleAssignments/write permissions.{ls}"
+                               "or have roleAssignments/write permission.{ls}"
                                "2. You can perform app registration in https://ms.portal.azure.com/#blade/"
                                "Microsoft_AAD_IAM/ApplicationsListBlade{ls}"
                                "3. The combined length of your organization name, project name and repository name "

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_provider.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/azure_devops_build_provider.py
@@ -85,78 +85,118 @@ class AzureDevopsBuildProvider(object):  # pylint: disable=too-many-public-metho
 
     def create_repository(self, organization_name, project_name, repository_name):
         """Create devops repository"""
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.create_repository(repository_name)
 
     def list_repositories(self, organization_name, project_name):
         """List devops repository"""
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.list_repositories()
 
     def list_commits(self, organization_name, project_name, repository_name):
         """List devops commits"""
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.list_commits(repository_name)
 
-    def check_git(self):
+    @staticmethod
+    def check_git():
         """Check if git command does exist"""
         return RepositoryManager.check_git()
 
-    def check_git_local_repository(self):
+    @staticmethod
+    def check_git_local_repository():
         """Check if local git repository does exist"""
         return RepositoryManager.check_git_local_repository()
 
-    def check_git_credential_manager(self):
+    @staticmethod
+    def check_git_credential_manager():
         return RepositoryManager.check_git_credential_manager()
 
     def check_git_remote(self, organization_name, project_name, repository_name):
         """Check if local git remote name does exist"""
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.check_git_remote(repository_name, remote_prefix="azuredevops")
 
     def remove_git_remote(self, organization_name, project_name, repository_name):
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.remove_git_remote(repository_name, remote_prefix="azuredevops")
 
     def get_local_git_remote_name(self, organization_name, project_name, repository_name):
         """Get the local git remote name for current repository"""
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.get_local_git_remote_name(repository_name, remote_prefix="azuredevops")
 
     def get_azure_devops_repository(self, organization_name, project_name, repository_name):
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.get_azure_devops_repository(repository_name)
 
     def get_azure_devops_repo_url(self, organization_name, project_name, repository_name):
         """Get the azure devops repository url"""
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.get_azure_devops_repo_url(repository_name)
 
     def setup_local_git_repository(self, organization_name, project_name, repository_name):
         """Setup a repository locally and push to devops"""
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.setup_local_git_repository(repository_name, remote_prefix="azuredevops")
 
     def get_azure_devops_repository_branches(self, organization_name, project_name, repository_name):
         """Get Azure Devops repository branches"""
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return repository_manager.get_azure_devops_repository_branches(repository_name)
 
     def push_local_to_azure_devops_repository(self, organization_name, project_name, repository_name, force=False):
         """Push local context to Azure Devops repository"""
-        repository_manager = RepositoryManager(organization_name=organization_name,
-                                               project_name=project_name, creds=self._creds)
-        return repository_manager.push_local_to_azure_devops_repository(repository_name, remote_prefix="azuredevops", force=force)
+        repository_manager = RepositoryManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
+        return repository_manager.push_local_to_azure_devops_repository(
+            repository_name,
+            remote_prefix="azuredevops",
+            force=force
+        )
 
     def list_pools(self, organization_name, project_name):
         """List the devops pool resources"""
@@ -165,20 +205,29 @@ class AzureDevopsBuildProvider(object):  # pylint: disable=too-many-public-metho
 
     def get_service_endpoints(self, organization_name, project_name, repository_name):
         """Query a service endpoint detail"""
-        service_endpoint_manager = ServiceEndpointManager(organization_name=organization_name,
-                                                          project_name=project_name, creds=self._creds)
+        service_endpoint_manager = ServiceEndpointManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return service_endpoint_manager.get_service_endpoints(repository_name)
 
     def create_service_endpoint(self, organization_name, project_name, repository_name):
         """Create a service endpoint to allow authentication via ARM service principal"""
-        service_endpoint_manager = ServiceEndpointManager(organization_name=organization_name,
-                                                          project_name=project_name, creds=self._creds)
+        service_endpoint_manager = ServiceEndpointManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return service_endpoint_manager.create_service_endpoint(repository_name)
 
     def list_service_endpoints(self, organization_name, project_name):
         """List the different service endpoints in a project"""
-        service_endpoint_manager = ServiceEndpointManager(organization_name=organization_name,
-                                                          project_name=project_name, creds=self._creds)
+        service_endpoint_manager = ServiceEndpointManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return service_endpoint_manager.list_service_endpoints()
 
     def create_extension(self, organization_name, extension_name, publisher_name):
@@ -194,40 +243,62 @@ class AzureDevopsBuildProvider(object):  # pylint: disable=too-many-public-metho
     def create_devops_build_definition(self, organization_name, project_name, repository_name,
                                        build_definition_name, pool_name):
         """Create a definition for an azure devops build"""
-        builder_manager = BuilderManager(organization_name=organization_name, project_name=project_name,
-                                         repository_name=repository_name, creds=self._creds)
-        return builder_manager.create_devops_build_definition(build_definition_name=build_definition_name, pool_name=pool_name)
+        builder_manager = BuilderManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            repository_name=repository_name,
+            creds=self._creds
+        )
+        return builder_manager.create_devops_build_definition(
+            build_definition_name=build_definition_name,
+            pool_name=pool_name
+        )
 
     def list_build_definitions(self, organization_name, project_name):
         """List the azure devops build definitions within a project"""
-        builder_manager = BuilderManager(organization_name=organization_name,
-                                         project_name=project_name, creds=self._creds)
+        builder_manager = BuilderManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return builder_manager.list_definitions()
 
     def create_build_object(self, organization_name, project_name, build_definition_name, pool_name):
         """Create an azure devops build based off a previous definition"""
-        builder_manager = BuilderManager(organization_name=organization_name,
-                                         project_name=project_name, creds=self._creds)
+        builder_manager = BuilderManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return builder_manager.create_build(build_definition_name, pool_name)
 
     def list_build_objects(self, organization_name, project_name):
         """List already running and builds that have already run in an azure devops project"""
-        builder_manager = BuilderManager(organization_name=organization_name,
-                                         project_name=project_name, creds=self._creds)
+        builder_manager = BuilderManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return builder_manager.list_builds()
 
     def list_artifacts(self, organization_name, project_name, build_id):
         """List the azure devops artifacts from a build"""
-        artifact_manager = ArtifactManager(organization_name=organization_name,
-                                           project_name=project_name, creds=self._creds)
+        artifact_manager = ArtifactManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return artifact_manager.list_artifacts(build_id)
 
     def create_release_definition(self, organization_name, project_name, build_name, artifact_name,
                                   pool_name, service_endpoint_name, release_definition_name, app_type,
                                   functionapp_name, storage_name, resource_name, settings):
         """Create a release definition for azure devops that is for azure functions"""
-        release_manager = ReleaseManager(organization_name=organization_name,
-                                         project_name=project_name, creds=self._creds)
+        release_manager = ReleaseManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return release_manager.create_release_definition(build_name, artifact_name, pool_name,
                                                          service_endpoint_name, release_definition_name,
                                                          app_type, functionapp_name, storage_name,
@@ -235,24 +306,37 @@ class AzureDevopsBuildProvider(object):  # pylint: disable=too-many-public-metho
 
     def list_release_definitions(self, organization_name, project_name):
         """List the release definitions for azure devops"""
-        release_manager = ReleaseManager(organization_name=organization_name,
-                                         project_name=project_name, creds=self._creds)
+        release_manager = ReleaseManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return release_manager.list_release_definitions()
 
     def create_release(self, organization_name, project_name, release_definition_name):
         """Create a release based off a previously defined release definition"""
-        release_manager = ReleaseManager(organization_name=organization_name,
-                                         project_name=project_name, creds=self._creds)
+        release_manager = ReleaseManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return release_manager.create_release(release_definition_name)
 
     def list_releases(self, organization_name, project_name):
         """List the releases of an azure devops project"""
-        release_manager = ReleaseManager(organization_name=organization_name,
-                                         project_name=project_name, creds=self._creds)
+        release_manager = ReleaseManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return release_manager.list_releases()
 
     def get_github_service_endpoints(self, organization_name, project_name, github_repository):
-        service_endpoint_manager = GithubServiceEndpointManager(organization_name=organization_name, project_name=project_name, creds=self._creds)
+        service_endpoint_manager = GithubServiceEndpointManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return service_endpoint_manager.get_github_service_endpoints(github_repository)
 
     def create_github_service_endpoint(self, organization_name, project_name, github_repository, github_pat):
@@ -261,29 +345,48 @@ class AzureDevopsBuildProvider(object):  # pylint: disable=too-many-public-metho
             project_name=project_name,
             creds=self._creds
         )
-        return service_endpoint_manager.create_github_service_endpoint(github_repository, github_pat)
+        return service_endpoint_manager.create_github_service_endpoint(
+            github_repository,
+            github_pat
+        )
 
-    def create_github_build_definition(self, organization_name, project_name, github_repository, build_definition_name, pool_name):
-        builder_manager = BuilderManager(organization_name=organization_name, project_name=project_name, creds=self._creds)
+    def create_github_build_definition(
+            self,
+            organization_name,
+            project_name,
+            github_repository,
+            build_definition_name,
+            pool_name
+    ):
+        builder_manager = BuilderManager(
+            organization_name=organization_name,
+            project_name=project_name,
+            creds=self._creds
+        )
         return builder_manager.create_github_build_definition(build_definition_name, pool_name, github_repository)
 
-    def check_github_pat(self, github_pat):
+    @staticmethod
+    def check_github_pat(github_pat):
         github_user_manager = GithubUserManager()
         return github_user_manager.check_github_pat(github_pat)
 
-    def check_github_repository(self, pat, repository_fullname):
+    @staticmethod
+    def check_github_repository(pat, repository_fullname):
         github_repository_manager = GithubRepositoryManager(pat=pat)
         return github_repository_manager.check_github_repository(repository_fullname)
 
-    def check_github_file(self, pat, repository_fullname, filepath):
+    @staticmethod
+    def check_github_file(pat, repository_fullname, filepath):
         github_repository_manager = GithubRepositoryManager(pat=pat)
         return github_repository_manager.check_github_file(repository_fullname, filepath)
 
-    def get_github_content(self, pat, repository_fullname, filepath):
+    @staticmethod
+    def get_github_content(pat, repository_fullname, filepath):
         github_repository_manager = GithubRepositoryManager(pat=pat)
         return github_repository_manager.get_content(repository_fullname, filepath, get_metadata=False)
 
-    def create_github_yaml(self, pat, language, app_type, repository_fullname, overwrite=False):
+    @staticmethod
+    def create_github_yaml(pat, language, app_type, repository_fullname, overwrite=False):
         github_repository_manager = GithubYamlManager(
             language=language,
             app_type=app_type,

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -2530,11 +2530,14 @@ def ssh_webapp(cmd, resource_group_name, name, slot=None):  # pylint: disable=to
 
 
 def create_devops_build(cmd, functionapp_name=None, organization_name=None, project_name=None,
-                        repository_name=None, overwrite_yaml=None, allow_force_push=None, use_local_settings=None):
+                        repository_name=None, overwrite_yaml=None, allow_force_push=None, use_local_settings=None,
+                        github_pat=None, github_repository=None
+                        ):
     from .azure_devops_build_iteractive import AzureDevopsBuildInteractive
     azure_devops_build_interactive = AzureDevopsBuildInteractive(cmd, logger, functionapp_name,
                                                                  organization_name, project_name, repository_name,
-                                                                 overwrite_yaml, allow_force_push, use_local_settings)
+                                                                 overwrite_yaml, allow_force_push, use_local_settings,
+                                                                 github_pat, github_repository)
     return azure_devops_build_interactive.interactive_azure_devops_build()
 
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -2529,10 +2529,18 @@ def ssh_webapp(cmd, resource_group_name, name, slot=None):  # pylint: disable=to
         create_tunnel_and_session(cmd, resource_group_name, name, port=None, slot=slot)
 
 
-def create_devops_build(cmd, functionapp_name=None, organization_name=None, project_name=None,
-                        repository_name=None, overwrite_yaml=None, allow_force_push=None, use_local_settings=None,
-                        github_pat=None, github_repository=None
-                        ):
+def create_devops_build(
+        cmd,
+        functionapp_name=None,
+        organization_name=None,
+        project_name=None,
+        repository_name=None,
+        overwrite_yaml=None,
+        allow_force_push=None,
+        use_local_settings=None,
+        github_pat=None,
+        github_repository=None
+):
     from .azure_devops_build_iteractive import AzureDevopsBuildInteractive
     azure_devops_build_interactive = AzureDevopsBuildInteractive(cmd, logger, functionapp_name,
                                                                  organization_name, project_name, repository_name,

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+
 import unittest
 import uuid
 import os

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands.py
@@ -8,7 +8,6 @@ import uuid
 import os
 
 from knack.util import CLIError
-from azure_devtools.scenario_tests import AllowLargeResponse, record_only
 from azure_functions_devops_build.exceptions import RoleAssignmentException
 from azure.cli.testsdk import LiveScenarioTest, ResourceGroupPreparer, StorageAccountPreparer, JMESPathCheck
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands_thru_mock.py
@@ -1,0 +1,205 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import unittest
+from mock import MagicMock, patch
+from knack.util import CLIError
+from azure.cli.core.mock import DummyCli
+from azure.cli.command_modules.appservice.azure_devops_build_iteractive import (
+    AzureDevopsBuildInteractive
+)
+
+
+def interactive_patch_path(iteractive_module):
+    return 'azure.cli.command_modules.appservice.azure_devops_build_iteractive.{}'.format(iteractive_module)
+
+
+class TestDevopsBuildCommandsMocked(unittest.TestCase):
+    def setUp(self):
+        mock_logger = MagicMock()
+        mock_cmd = MagicMock()
+        mock_cmd.cli_ctx = DummyCli()
+        self._client = AzureDevopsBuildInteractive(
+            cmd=mock_cmd,
+            logger=mock_logger,
+            functionapp_name=None,
+            organization_name=None,
+            project_name=None,
+            repository_name=None,
+            overwrite_yaml=None,
+            allow_force_push=None,
+            use_local_settings=None,
+            github_pat=None,
+            github_repository=None
+        )
+
+    @patch(interactive_patch_path("prompt_choice_list"))
+    def test_check_scenario_prompt_choice_list(self, prompt_choice_list):
+        self._client.check_scenario()
+        prompt_choice_list.assert_called_once()
+
+    def test_check_scenario_azure_devops(self):
+        self._client.repository_name = "azure_devops_repository"
+        self._client.check_scenario()
+        result = self._client.scenario
+        self.assertEqual(result, "AZURE_DEVOPS")
+
+    def test_check_scenario_github_pat(self):
+        self._client.github_pat = "github_pat"
+        self._client.check_scenario()
+        result = self._client.scenario
+        self.assertEqual(result, "GITHUB_INTEGRATION")
+
+    def test_check_scenario_github_repository(self):
+        self._client.github_repository = "github_repository"
+        self._client.check_scenario()
+        result = self._client.scenario
+        self.assertEqual(result, "GITHUB_INTEGRATION")
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_git"))
+    def test_azure_devops_prechecks_no_git(self, check_git):
+        check_git.return_value = False
+        with self.assertRaises(CLIError):
+            self._client.pre_checks_azure_devops()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_git"))
+    @patch(interactive_patch_path("os.path.exists"))
+    def test_azure_devops_prechecks_no_file(self, exists, check_git):
+        check_git.return_value = True
+        exists.return_value = False
+        with self.assertRaises(CLIError):
+            self._client.pre_checks_azure_devops()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_git"))
+    @patch(interactive_patch_path("os.path.exists"))
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._find_local_repository_runtime_language"))
+    def test_azure_devops_prechecks_no_file(self, _find_local_repository_runtime_language, exists, check_git):
+        check_git.return_value = True
+        exists.return_value = True
+        _find_local_repository_runtime_language.return_value = "node"
+        self._client.functionapp_language = "dotnet"
+        with self.assertRaises(CLIError):
+            self._client.pre_checks_azure_devops()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_git"))
+    @patch(interactive_patch_path("os.path.exists"))
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._find_local_repository_runtime_language"))
+    def test_azure_devops_prechecks(self, _find_local_repository_runtime_language, exists, check_git):
+        check_git.return_value = True
+        exists.return_value = True
+        _find_local_repository_runtime_language.return_value = "node"
+        self._client.functionapp_language = "node"
+        self._client.pre_checks_azure_devops()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_github_file"))
+    def test_github_prechecks_no_file(self, check_github_file):
+        check_github_file.return_value = False
+        with self.assertRaises(CLIError):
+            self._client.pre_checks_github()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_github_file"))
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._find_github_repository_runtime_language"))
+    def test_github_prechecks_wrong_runtime(self, _find_github_repository_runtime_language, check_github_file):
+        check_github_file.return_value = True
+        _find_github_repository_runtime_language.return_value = "node"
+        self._client.functionapp_language = "dotnet"
+        with self.assertRaises(CLIError):
+            self._client.pre_checks_github()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_github_file"))
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._find_github_repository_runtime_language"))
+    def test_github_prechecks_no_runtime(self, _find_github_repository_runtime_language, check_github_file):
+        check_github_file.return_value = True
+        _find_github_repository_runtime_language.return_value = None
+        self._client.functionapp_language = "dotnet"
+        self._client.pre_checks_github()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_github_file"))
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._find_github_repository_runtime_language"))
+    def test_github_prechecks(self, _find_github_repository_runtime_language, check_github_file):
+        check_github_file.return_value = True
+        _find_github_repository_runtime_language.return_value = "dotnet"
+        self._client.functionapp_language = "dotnet"
+        self._client.pre_checks_github()
+
+    @patch(interactive_patch_path("get_app_settings"), MagicMock())
+    @patch(interactive_patch_path("show_webapp"), MagicMock())
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._find_type"), MagicMock())
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._get_functionapp_runtime_language"), MagicMock())
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._get_functionapp_storage_name"), MagicMock())
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._select_functionapp"))
+    def test_process_functionapp_prompt_choice_list(self, _select_functionapp):
+        self._client.process_functionapp()
+        _select_functionapp.assert_called_once()
+
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._create_organization"))
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._select_organization"))
+    @patch(interactive_patch_path("prompt_y_n"))
+    def test_process_organization_prompt_choice_list(self, prompt_y_n, _select_organization, _create_organization):
+        # Choose to select existing organization
+        prompt_y_n.return_value = True
+        self._client.process_organization()
+        _select_organization.assert_called_once()
+
+        # Choose to create a new organization
+        prompt_y_n.return_value = False
+        self._client.process_organization()
+        _create_organization.assert_called_once()
+
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._create_project"))
+    @patch(interactive_patch_path("AzureDevopsBuildInteractive._select_project"))
+    @patch(interactive_patch_path("prompt_y_n"))
+    def test_process_project(self, prompt_y_n, _select_project, _create_project):
+        # Choose to select existing project
+        prompt_y_n.return_value = True
+        self._client.process_project()
+        _select_project.assert_called_once()
+
+        # Choose to create a new project
+        prompt_y_n.return_value = False
+        self._client.process_project()
+        _create_project.assert_called_once()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.create_github_yaml"))
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_github_file"))
+    @patch(interactive_patch_path("prompt_y_n"))
+    def test_process_yaml_github_no_yaml(self, prompt_y_n, check_github_file, create_github_yaml):
+        check_github_file.return_value = False
+        self._client.process_yaml_github()
+        prompt_y_n.assert_not_called()
+        create_github_yaml.assert_called_once()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.create_github_yaml"))
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_github_file"))
+    @patch(interactive_patch_path("prompt_y_n"))
+    def test_process_yaml_github_existing_no_consent(self, prompt_y_n, check_github_file, create_github_yaml):
+        check_github_file.return_value = True
+        prompt_y_n.return_value = False
+        self._client.process_yaml_github()
+        prompt_y_n.assert_called_once()
+        create_github_yaml.assert_not_called()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.create_github_yaml"))
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_github_file"))
+    @patch(interactive_patch_path("prompt_y_n"))
+    def test_process_yaml_github_existing_consent(self, prompt_y_n, check_github_file, create_github_yaml):
+        check_github_file.return_value = True
+        prompt_y_n.return_value = True
+        self._client.process_yaml_github()
+        prompt_y_n.assert_called_once()
+        create_github_yaml.assert_called_once()
+
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.create_github_yaml"))
+    @patch(interactive_patch_path("AzureDevopsBuildProvider.check_github_file"))
+    @patch(interactive_patch_path("prompt_y_n"))
+    def test_process_yaml_github_existing_overwrite(self, prompt_y_n, check_github_file, create_github_yaml):
+        self._client.overwrite_yaml = True
+        check_github_file.return_value = True
+        self._client.process_yaml_github()
+        prompt_y_n.assert_not_called()
+        create_github_yaml.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands_thru_mock.py
@@ -13,10 +13,11 @@ from azure.cli.command_modules.appservice.azure_devops_build_iteractive import (
 
 
 def interactive_patch_path(iteractive_module):
-    return 'azure.cli.command_modules.appservice.azure_devops_build_iteractive.{}'.format(iteractive_module)
+    return "azure.cli.command_modules.appservice.azure_devops_build_iteractive.{}".format(iteractive_module)
 
 
 class TestDevopsBuildCommandsMocked(unittest.TestCase):
+    @patch("azure.cli.command_modules.appservice.azure_devops_build_iteractive.AzureDevopsBuildProvider", new=MagicMock())
     def setUp(self):
         mock_logger = MagicMock()
         mock_cmd = MagicMock()

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands_thru_mock.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+
 import unittest
 from mock import MagicMock, patch
 from knack.util import CLIError

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/utils.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/utils.py
@@ -1,0 +1,8 @@
+def str2bool(v):
+    if v == 'true':
+        retval = True
+    elif v == 'false':
+        retval = False
+    else:
+        retval = None
+    return retval

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/utils.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/utils.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+
 def str2bool(v):
     if v == 'true':
         retval = True

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/utils.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/utils.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 def str2bool(v):
     if v == 'true':
         retval = True

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-functions-devops-build==0.0.14',
+    'azure-functions-devops-build==0.0.15',
     'azure-mgmt-web==0.41.0',
     'azure-mgmt-storage==3.1.1',
     'azure-mgmt-containerregistry==2.7.0',

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-functions-devops-build==0.0.15',
+    'azure-functions-devops-build==0.0.16',
     'azure-mgmt-web==0.41.0',
     'azure-mgmt-storage==3.1.1',
     'azure-mgmt-containerregistry==2.7.0',

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-functions-devops-build==0.0.16',
+    'azure-functions-devops-build==0.0.17',
     'azure-mgmt-web==0.41.0',
     'azure-mgmt-storage==3.1.1',
     'azure-mgmt-containerregistry==2.7.0',

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-functions-devops-build==0.0.18',
+    'azure-functions-devops-build==0.0.19',
     'azure-mgmt-web==0.41.0',
     'azure-mgmt-storage==3.1.1',
     'azure-mgmt-containerregistry==2.7.0',

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-functions-devops-build==0.0.19',
+    'azure-functions-devops-build==0.0.20',
     'azure-mgmt-web==0.41.0',
     'azure-mgmt-storage==3.1.1',
     'azure-mgmt-containerregistry==2.7.0',

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-functions-devops-build==0.0.20',
+    'azure-functions-devops-build==0.0.21',
     'azure-mgmt-web==0.41.0',
     'azure-mgmt-storage==3.1.1',
     'azure-mgmt-containerregistry==2.7.0',

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-functions-devops-build==0.0.17',
+    'azure-functions-devops-build==0.0.18',
     'azure-mgmt-web==0.41.0',
     'azure-mgmt-storage==3.1.1',
     'azure-mgmt-containerregistry==2.7.0',


### PR DESCRIPTION
### Github Functionapp Repository Integration
1. Separate Github repository flow from Azure DevOps repository flow
2. Add Github personal access token authenticated client for Github V3 API request (see [azure-functions-devops-build](https://github.com/Azure/azure-functions-devops-build/commit/3e29984539c6169a384ca3367f16bb6f67bd5c95))
3. Add a feature to check `host.json` and `local.settings.json` files in a Github repository
4. Add a feature to commit `azure-pipelines.yml` to a Github repository
5. Allow Azure DevOps to create a Github service endpoint against a Github repository
6. Allow Github to create a push webhook to Azure DevOps pipelines

### Powershell Support
1. We now support deploying a powershell application via Azure DevOps pipelines.
2. If the powershell functionapp has an extensions.csproj in its directory, we will do a `dotnet restore` first.

### Unittests
1. Add `test_devops_build_commands_thru_mock.py` for testing Azure DevOps / Github workflow before azure-pipelines.yml creation
2. Test command parameters handling and resource selection

### Bug Fix
1. Fix an issue when user install with .MSI in Windows, the packager only includes .pyc files. Since the packaging process happened in D:\ drive, the Python site-package module structure is messed up. This causes the yaml_manager cannot find `build.jinja` in template module. The bug is fixed by changing the Jinja module loader to filesystem loader. [Fix is here](https://github.com/Azure/azure-functions-devops-build/commit/cb71b52ac9ad3b5ed7e75ba36d45033e3bc5d633)
  - This bug affects windows Azure CLI user with .msi installer. Linux installer/package managers including `pip`, `apt-get`, `yum`... are not affected.
  - Checked the version with .msi installer in CI and ensured the bug is fixed.

### Miscellaneous
1. Upgrade [azure-functions-devops-build](https://github.com/Azure/azure-functions-devops-build) to 0.0.21
2. Fix all related linting error in `test_devops_build_commands_thru_mock.py`, `azure_devops_build_iteractive.py` and `azure_devops_build_provider.py`
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
