### PR TITLE
[Storage] Fix az storage blob generate-sas returns double url-encoded sas

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.4.1
++++++
+* `storage blob generate-sas`: Fix double url-encoded sas token
+
 2.4.0
 +++++
 * BREAKING CHANGE: `storage blob delete`: remove the return result of command

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -102,7 +102,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.storage_command_oauth('list', 'list_blobs', transform=transform_storage_list_output,
                                 table_transformer=transform_blob_output)
         g.storage_command_oauth('download', 'get_blob_to_path', table_transformer=transform_blob_output)
-        g.storage_custom_command_oauth('generate-sas', 'generate_sas_blob_uri', transform=transform_url)
+        g.storage_custom_command_oauth('generate-sas', 'generate_sas_blob_uri')
         g.storage_custom_command_oauth('url', 'create_blob_url', transform=transform_url)
         g.storage_command_oauth('snapshot', 'snapshot_blob')
         g.storage_command_oauth('update', 'set_blob_properties')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
@@ -85,7 +85,7 @@ class StorageBlobUploadTests(StorageScenarioMixin, ScenarioTest):
         sas = self.storage_cmd('storage blob generate-sas -n {} -c {} --expiry {} --permissions '
                                'r --https-only', account_info, blob_name, container, expiry).output
         self.assertTrue(sas)
-        self.assertIn('sig', sas)
+        self.assertIn('&sig=', sas)
 
         self.storage_cmd('storage blob update -n {} -c {} --content-type application/test-content',
                          account_info, blob_name, container)

--- a/src/command_modules/azure-cli-storage/setup.py
+++ b/src/command_modules/azure-cli-storage/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.4.0"
+VERSION = "2.4.1"
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fix #9072



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
