### PR TITLE
ACR: update os_type deprecation info to point to the correct flag

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
@@ -63,7 +63,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('no_logs', help="Do not show logs after successfully queuing the build.", action='store_true')
         c.argument('no_wait', help="Do not wait for the run to complete and return immediately after queuing the run.", action='store_true')
         c.argument('no_format', help="Indicates whether the logs should be displayed in raw format", action='store_true')
-        c.argument('os_type', options_list=['--os'], help='The operating system type required for the build.', arg_type=get_enum_type(OsType), deprecate_info=c.deprecate(redirect='platform', hide=True))
+        c.argument('os_type', options_list=['--os'], help='The operating system type required for the build.', arg_type=get_enum_type(OsType), deprecate_info=c.deprecate(target='--os', redirect='--platform', hide=True))
         c.argument('platform', help="The platform where build/task is run, Eg, 'windows' and 'linux'. When it's used in build commands, it also can be specified in 'os/arch/variant' format for the resulting image. Eg, linux/arm/v7. The 'arch' and 'variant' parts are optional.")
         c.argument('target', help='The name of the target build stage.')
         c.argument('auth_mode', help='Auth mode of the source registry.', arg_type=get_enum_type(SourceRegistryLoginMode))


### PR DESCRIPTION
Before: `Argument 'os_type' has been deprecated and will be removed in a future release. Use 'platform' instead.`

After: `Option '--os' has been deprecated and will be removed in a future release. Use 'platform' instead.`

Relates to #9024

/cc @tjprescott  -  not sure if #9024 should be closed after this; maybe there's a better issue for managing the deprecation information on docs?

/cc @djyou  + @northtyphoon as fyi

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
