### PR TITLE
fixed error: 'ObjectsOperations' object has no attribute 'get_current…

### DIFF
--- a/src/command_modules/azure-cli-lab/HISTORY.rst
+++ b/src/command_modules/azure-cli-lab/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.1.7
++++++
+* fixed error: 'ObjectsOperations' object has no attribute 'get_current_user'
+
 0.1.6
 +++++
 * Minor fixes

--- a/src/command_modules/azure-cli-lab/HISTORY.rst
+++ b/src/command_modules/azure-cli-lab/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 0.1.7
 +++++
-* fixed error: 'ObjectsOperations' object has no attribute 'get_current_user'
+* Fixed error: 'ObjectsOperations' object has no attribute 'get_current_user'
 
 0.1.6
 +++++

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
@@ -538,7 +538,7 @@ def _any(collection):
 def _get_current_user_object_id(graph_client):
     from msrestazure.azure_exceptions import CloudError
     try:
-        current_user = graph_client.objects.get_current_user()
+        current_user = graph_client.signed_in_user.get()
         if current_user and current_user.object_id:  # pylint:disable=no-member
             return current_user.object_id  # pylint:disable=no-member
     except CloudError:

--- a/src/command_modules/azure-cli-lab/setup.py
+++ b/src/command_modules/azure-cli-lab/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.6"
+VERSION = "0.1.7"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
…_user'

Fixed an issue were the user would get and error ObjectsOperations' object has no attribute 'get_current_user' when listing VMs in a lab

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
