### PR TITLE
Add a new argument '--expand' to 'az policy state list'

### DIFF
--- a/scripts/dependency/requirements.Darwin.external.txt
+++ b/scripts/dependency/requirements.Darwin.external.txt
@@ -42,7 +42,7 @@ azure-mgmt-msi==0.2.0
 azure-mgmt-network==2.6.0
 azure-mgmt-privatedns==0.1.0
 azure-mgmt-nspkg==2.0.0
-azure-mgmt-policyinsights==0.2.0
+azure-mgmt-policyinsights==0.3.1
 azure-mgmt-rdbms==1.7.0
 azure-mgmt-recoveryservices==0.1.0
 azure-mgmt-recoveryservicesbackup==0.1.1

--- a/scripts/dependency/requirements.Linux.external.txt
+++ b/scripts/dependency/requirements.Linux.external.txt
@@ -42,7 +42,7 @@ azure-mgmt-msi==0.2.0
 azure-mgmt-network==2.6.0
 azure-mgmt-privatedns==0.1.0
 azure-mgmt-nspkg==2.0.0
-azure-mgmt-policyinsights==0.2.0
+azure-mgmt-policyinsights==0.3.1
 azure-mgmt-rdbms==1.7.0
 azure-mgmt-recoveryservices==0.1.0
 azure-mgmt-recoveryservicesbackup==0.1.1

--- a/src/command_modules/azure-cli-policyinsights/HISTORY.rst
+++ b/src/command_modules/azure-cli-policyinsights/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.1.3
+++++++++++++++++++
+* Add support for `--expand PolicyEvaluationDetails` to query policy evaluation details on the resource.
+
 0.1.2
 ++++++++++++++++++
 * Minor fixes

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_help.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_help.py
@@ -127,6 +127,9 @@ helps['policy state list'] = """
         - name: Get latest policy states in current subscription aggregating results based on some properties specifying multiple groupings.
           text: >
               az policy state list --apply "groupby((policyAssignmentId, policySetDefinitionId, policyDefinitionReferenceId, policyDefinitionId, resourceId))/groupby((policyAssignmentId, policySetDefinitionId, policyDefinitionReferenceId, policyDefinitionId), aggregate($count as numNonCompliantResources))"
+        - name: Get latest policy states for a resource including policy evaluation details.
+          text: >
+              az policy state list --resource "myKeyVault" --namespace "Microsoft.KeyVault" --resource-type "vaults" -g "myresourcegroup" --expand PolicyEvaluationDetails
 """
 helps['policy state summarize'] = """
     type: command

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_params.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_params.py
@@ -9,7 +9,7 @@ from azure.cli.command_modules.resource._completers import (
     get_policy_set_completion_list, get_policy_completion_list,
     get_policy_assignment_completion_list, get_providers_completion_list, get_resource_types_completion_list)
 
-from ._validators import validate_resource
+from ._validators import (validate_resource, validate_expand)
 
 from ._completers import get_policy_remediation_completion_list
 
@@ -110,9 +110,15 @@ def load_arguments(self, _):
             options_list=['--all'],
             action='store_true',
             help='Within the specified time interval, get all policy states instead of the latest only.')
+        c.argument(
+            'expand_clause',
+            validator=validate_expand,
+            options_list=['--expand'],
+            arg_group='Query Option',
+            help='Expand expression using OData notation.')
 
     with self.argument_context('policy state summarize') as c:
-        c.ignore('all_results', 'order_by_clause', 'select_clause', 'apply_clause')
+        c.ignore('all_results', 'order_by_clause', 'select_clause', 'apply_clause', 'expand_clause')
 
     with self.argument_context('policy remediation') as c:
         c.argument('remediation_name', options_list=['--name', '-n'],

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_validators.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_validators.py
@@ -16,7 +16,7 @@ def validate_resource(cmd, namespace):  # pylint: disable=unused-argument
                 raise CLIError('--resource-type is required if --resource is not a resource ID.')
 
 
-def validate_resourceScopeRequired(cmd, namespace):
+def validate_resourceRequired(cmd, namespace):
     if not namespace.resource:
         raise CLIError('--resource is required for the operation.')
 
@@ -25,4 +25,4 @@ def validate_resourceScopeRequired(cmd, namespace):
 
 def validate_expand(cmd, namespace):
     if namespace.expand_clause is not None:
-        validate_resourceScopeRequired(cmd, namespace)
+        validate_resourceRequired(cmd, namespace)

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_validators.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_validators.py
@@ -15,11 +15,13 @@ def validate_resource(cmd, namespace):  # pylint: disable=unused-argument
             if not namespace.resource_type:
                 raise CLIError('--resource-type is required if --resource is not a resource ID.')
 
+
 def validate_resourceScopeRequired(cmd, namespace):
     if not namespace.resource:
         raise CLIError('--resource is required for the operation.')
-    else:
-        validate_resource(cmd, namespace)
+
+    validate_resource(cmd, namespace)
+
 
 def validate_expand(cmd, namespace):
     if namespace.expand_clause is not None:

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_validators.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_validators.py
@@ -16,7 +16,7 @@ def validate_resource(cmd, namespace):  # pylint: disable=unused-argument
                 raise CLIError('--resource-type is required if --resource is not a resource ID.')
 
 
-def validate_resourceRequired(cmd, namespace):
+def validate_resource_required(cmd, namespace):
     if not namespace.resource:
         raise CLIError('--resource is required for the operation.')
 
@@ -25,4 +25,4 @@ def validate_resourceRequired(cmd, namespace):
 
 def validate_expand(cmd, namespace):
     if namespace.expand_clause is not None:
-        validate_resourceRequired(cmd, namespace)
+        validate_resource_required(cmd, namespace)

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_validators.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/_validators.py
@@ -14,3 +14,13 @@ def validate_resource(cmd, namespace):  # pylint: disable=unused-argument
                 raise CLIError('--namespace is required if --resource is not a resource ID.')
             if not namespace.resource_type:
                 raise CLIError('--resource-type is required if --resource is not a resource ID.')
+
+def validate_resourceScopeRequired(cmd, namespace):
+    if not namespace.resource:
+        raise CLIError('--resource is required for the operation.')
+    else:
+        validate_resource(cmd, namespace)
+
+def validate_expand(cmd, namespace):
+    if namespace.expand_clause is not None:
+        validate_resourceScopeRequired(cmd, namespace)

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/custom.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/custom.py
@@ -115,7 +115,8 @@ def list_policy_states(
         select_clause=None,
         top_value=None,
         filter_clause=None,
-        apply_clause=None):
+        apply_clause=None,
+        expand_clause=None):
 
     from azure.mgmt.policyinsights.models import QueryOptions
 
@@ -126,7 +127,8 @@ def list_policy_states(
         from_property=from_value,
         to=to_value,
         filter=filter_clause,
-        apply=apply_clause)
+        apply=apply_clause,
+        expand=expand_clause)
 
     policy_states_resource = 'latest'
     if all_results is True:

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/tests/latest/recordings/test_policy_insights.yaml
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/tests/latest/recordings/test_policy_insights.yaml
@@ -2,993 +2,1651 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -m --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/centraluseuapnsggroup/providers/microsoft.network/networksecuritygroups/centraluseuapnsg/securityrules/cleanuptool-3389-corpnet-647940a2-6f30-49cd-a7cb-9dfb2c313c43","numRecords":176},{"@odata.id":null,"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/centraluseuapnsggroup/providers/microsoft.network/networksecuritygroups/centraluseuapnsg/securityrules/cleanuptool-3389-corpnet-647940a2-6f30-49cd-a7cb-9dfb2c313c43","numRecords":176}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":0,"value":[]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1449']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '202'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-tenant-policy-insights-requests:
+      - '199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -m --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aatestrg/providers/microsoft.analysisservices/servers/rashmianalysisservices","numRecords":8},{"@odata.id":null,"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aatestrg/providers/microsoft.analysisservices/servers/rashmianalysisservices","numRecords":8}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/4e4179ff39194a62bad4ef3e","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/paposkrotest/providers/microsoft.compute/virtualmachines/paposkrotest","numRecords":8},{"@odata.id":null,"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/1e4e70f9cd4846268b6998ee","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/paposkrotest/providers/microsoft.compute/virtualmachines/paposkrotest","numRecords":8}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1266']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:39 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-tenant-policy-insights-requests:
+      - '199'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -m --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":22205,"nonCompliantPolicies":24},"policyAssignments":[{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","policySetDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policysetdefinitions/335cefd2-ab16-430f-b364-974a170eb1d5","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8''","nonCompliantResources":22205,"nonCompliantPolicies":2},"policyDefinitions":[{"policyDefinitionReferenceId":"4337452039094051187","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''4337452039094051187''","nonCompliantResources":20983}},{"policyDefinitionReferenceId":"15521232277412542086","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''15521232277412542086''","nonCompliantResources":17044}}]},{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","policySetDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policysetdefinitions/335cefd2-ab16-430f-b364-974a170eb1d5","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''","nonCompliantResources":22205,"nonCompliantPolicies":2},"policyDefinitions":[{"policyDefinitionReferenceId":"4337452039094051187","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''4337452039094051187''","nonCompliantResources":20983}},{"policyDefinitionReferenceId":"15521232277412542086","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest4/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''15521232277412542086''","nonCompliantResources":17044}}]}]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":19,"nonCompliantPolicies":5,"resourceDetails":[{"complianceState":"noncompliant","count":19}],"policyDetails":[{"complianceState":"noncompliant","count":5}]},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/4e4179ff39194a62bad4ef3e","policySetDefinitionId":"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/4e4179ff39194a62bad4ef3e''","nonCompliantResources":19,"nonCompliantPolicies":0,"resourceDetails":[{"complianceState":"noncompliant","count":19}]},"policyDefinitions":[]},{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/1e4e70f9cd4846268b6998ee","policySetDefinitionId":"/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/1e4e70f9cd4846268b6998ee''","nonCompliantResources":19,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":19}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyDefinitions":[{"policyDefinitionReferenceId":"vnetenableddosprotectionmonitoring","policyDefinitionId":"/providers/microsoft.authorization/policydefinitions/a7aca53f-2ed4-4466-a25e-0b45ade68efd","effect":"auditifnotexists","results":{"queryResultsUri":"https://management.azure.com/providers/Microsoft.Management/managementGroups/azgovtest5/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/1e4e70f9cd4846268b6998ee''
+        and PolicyDefinitionId eq ''/providers/microsoft.authorization/policydefinitions/a7aca53f-2ed4-4466-a25e-0b45ade68efd''
+        and PolicyDefinitionReferenceId eq ''vnetenableddosprotectionmonitoring''","nonCompliantResources":1,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":1}]}}]}]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['6568']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '3727'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-tenant-policy-insights-requests:
+      - '198'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/centraluseuapnsggroup/providers/microsoft.network/networksecuritygroups/centraluseuapnsg/securityrules/cleanuptool-3389-corpnet-647940a2-6f30-49cd-a7cb-9dfb2c313c43","numRecords":176},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/centraluseuapnsggroup/providers/microsoft.network/networksecuritygroups/centraluseuapnsg/securityrules/cleanuptool-3389-corpnet-647940a2-6f30-49cd-a7cb-9dfb2c313c43","numRecords":176}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/argh/providers/microsoft.authorization/policyassignments/77fec4647f8442e3b7ce96db","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/argh/providers/microsoft.network/networksecuritygroups/portlockdown-westeurope","numRecords":46373},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/argh/providers/microsoft.authorization/policyassignments/beb85152cea0475ba4942c26","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/argh/providers/microsoft.network/networksecuritygroups/portlockdown-westeurope","numRecords":46373}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1425']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1281'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '599'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aatestrg/providers/microsoft.analysisservices/servers/rashmianalysisservices","numRecords":8},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aatestrg/providers/microsoft.analysisservices/servers/rashmianalysisservices","numRecords":8}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/88deedb1a79843fa9b3cd693","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/testyoshen/providers/microsoft.compute/virtualmachines/largevm","numRecords":14},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/88deedb1a79843fa9b3cd693","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/testyoshen/providers/microsoft.compute/virtualmachines/yoshentest","numRecords":13}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1242']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:49 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1203'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '599'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":18536,"nonCompliantPolicies":23},"policyAssignments":[{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","policySetDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policysetdefinitions/335cefd2-ab16-430f-b364-974a170eb1d5","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8''","nonCompliantResources":18536,"nonCompliantPolicies":2},"policyDefinitions":[{"policyDefinitionReferenceId":"4337452039094051187","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''4337452039094051187''","nonCompliantResources":17506}},{"policyDefinitionReferenceId":"15521232277412542086","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''15521232277412542086''","nonCompliantResources":13720}}]},{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","policySetDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policysetdefinitions/335cefd2-ab16-430f-b364-974a170eb1d5","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''","nonCompliantResources":18536,"nonCompliantPolicies":2},"policyDefinitions":[{"policyDefinitionReferenceId":"4337452039094051187","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''4337452039094051187''","nonCompliantResources":17506}},{"policyDefinitionReferenceId":"15521232277412542086","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''15521232277412542086''","nonCompliantResources":13720}}]}]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":1711,"nonCompliantPolicies":93,"resourceDetails":[{"complianceState":"noncompliant","count":1711}],"policyDetails":[{"complianceState":"noncompliant","count":93}]},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/88deedb1a79843fa9b3cd693","policySetDefinitionId":"/providers/Microsoft.Authorization/policySetDefinitions/89c6cddc-1c73-4ac1-b19c-54d1a15a42f2","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/88deedb1a79843fa9b3cd693''","nonCompliantResources":980,"nonCompliantPolicies":0,"resourceDetails":[{"complianceState":"noncompliant","count":980}]},"policyDefinitions":[]},{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/cf3396c38714442ca6afc500","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/cf3396c38714442ca6afc500''","nonCompliantResources":46,"nonCompliantPolicies":0,"resourceDetails":[{"complianceState":"noncompliant","count":46}]},"policyDefinitions":[]}]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['6496']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '2528'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '599'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationalinsights/workspaces/defaultworkspace-0b88dfdb-55b3-4fb0-b474-5b6dcbe6b2ef-eus/linkedservices/security","numRecords":116},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationalinsights/workspaces/defaultworkspace-0b88dfdb-55b3-4fb0-b474-5b6dcbe6b2ef-eus/linkedservices/security","numRecords":82}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.authorization/policyassignments/677b0cab4d454f52bf46a52f","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationsmanagement/solutions/containerinsights(defaultworkspace-d0610b27-9663-4c05-89f8-5b4be01e86a5-eus)","numRecords":24},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.authorization/policyassignments/677b0cab4d454f52bf46a52f","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationsmanagement/solutions/containerinsights(kubernetes-loganalytics-workspace-build506)","numRecords":5}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1530']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1567'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '598'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationsmanagement/solutions/changetracking(defaultworkspace-0b88dfdb-55b3-4fb0-b474-5b6dcbe6b2ef-eus)","numRecords":3},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationsmanagement/solutions/changetracking(defaultworkspace-0b88dfdb-55b3-4fb0-b474-5b6dcbe6b2ef-eus)","numRecords":3}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.authorization/policyassignments/677b0cab4d454f52bf46a52f","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationalinsights/workspaces/defaultworkspace-d0610b27-9663-4c05-89f8-5b4be01e86a5-eus","numRecords":1},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.authorization/policyassignments/677b0cab4d454f52bf46a52f","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationsmanagement/solutions/logicappsmanagement(defaultworkspace-d0610b27-9663-4c05-89f8-5b4be01e86a5-eus)","numRecords":1}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1508']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1561'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '598'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":7,"nonCompliantPolicies":3},"policyAssignments":[{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","policySetDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policysetdefinitions/335cefd2-ab16-430f-b364-974a170eb1d5","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''","nonCompliantResources":7,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"4337452039094051187","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''4337452039094051187''","nonCompliantResources":7}}]},{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c''","nonCompliantResources":7,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''","nonCompliantResources":7}}]}]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":6,"nonCompliantPolicies":3,"resourceDetails":[{"complianceState":"noncompliant","count":6}],"policyDetails":[{"complianceState":"noncompliant","count":3}]},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464''","nonCompliantResources":3,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":3}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/providers/microsoft.authorization/policydefinitions/0a914e76-4921-4c19-b460-a2d36003525a","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464''
+        and PolicyDefinitionId eq ''/providers/microsoft.authorization/policydefinitions/0a914e76-4921-4c19-b460-a2d36003525a''","nonCompliantResources":3,"resourceDetails":[{"complianceState":"noncompliant","count":3}],"policyDetails":[{"complianceState":"noncompliant","count":1}]}}]},{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.authorization/policyassignments/677b0cab4d454f52bf46a52f","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/defaultresourcegroup-eus/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.authorization/policyassignments/677b0cab4d454f52bf46a52f''","nonCompliantResources":4,"nonCompliantPolicies":0,"resourceDetails":[{"complianceState":"noncompliant","count":4}]},"policyDefinitions":[]}]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['4558']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:57 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '3692'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '597'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba","numRecords":1},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba","numRecords":1}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp","numRecords":1}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1636']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:58 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '946'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '596'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba","numRecords":1},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba","numRecords":1}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp","numRecords":1},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/88deedb1a79843fa9b3cd693","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp","numRecords":1}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1633']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:07:59 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1567'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '595'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":1,"nonCompliantPolicies":3},"policyAssignments":[{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","policySetDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policysetdefinitions/335cefd2-ab16-430f-b364-974a170eb1d5","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''","nonCompliantResources":1,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"4337452039094051187","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''
-        and PolicyDefinitionReferenceId eq ''4337452039094051187''","nonCompliantResources":1}}]},{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c''","nonCompliantResources":1,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''","nonCompliantResources":1}}]}]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":1,"nonCompliantPolicies":2,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":2}]},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef''","nonCompliantResources":1,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef''
+        and PolicyDefinitionId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207''","nonCompliantResources":1,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":1}]}}]},{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/88deedb1a79843fa9b3cd693","policySetDefinitionId":"/providers/Microsoft.Authorization/policySetDefinitions/89c6cddc-1c73-4ac1-b19c-54d1a15a42f2","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/88deedb1a79843fa9b3cd693''","nonCompliantResources":1,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyDefinitions":[{"policyDefinitionReferenceId":"auditdiagnosticsetting","policyDefinitionId":"/providers/microsoft.authorization/policydefinitions/7f89b1eb-583c-429a-8828-af049802c1d9","effect":"auditifnotexists","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/88deedb1a79843fa9b3cd693''
+        and PolicyDefinitionId eq ''/providers/microsoft.authorization/policydefinitions/7f89b1eb-583c-429a-8828-af049802c1d9''
+        and PolicyDefinitionReferenceId eq ''auditdiagnosticsetting''","nonCompliantResources":1,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":1}]}}]}]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['5083']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '5392'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '597'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --namespace --resource-type -g --from --to --filter --apply --select
+        --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut","numRecords":2},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/95816fce53454b15a7ed803d","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut","numRecords":1}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":0,"value":[]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1571']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '271'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '594'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --namespace --resource-type -g --from --to --filter --apply --select
+        --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut","numRecords":6},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut","numRecords":6}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/8eb0d51fd4dc4b43aebb3b96","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test","numRecords":1},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/b9d524217e864c71bca195b5","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test","numRecords":1}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1568']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:03 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1427'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '593'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --namespace --resource-type -g --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":1,"nonCompliantPolicies":7},"policyAssignments":[{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c''","nonCompliantResources":1,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''","nonCompliantResources":1}}]},{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest2/providers/microsoft.authorization/policyassignments/e9ad4ab40dfb4549a998cfcc","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest2/providers/microsoft.authorization/policyassignments/e9ad4ab40dfb4549a998cfcc''","nonCompliantResources":1,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/omssecurityintresourcegroup/providers/microsoft.keyvault/vaults/omssecuritydevkeyvalut/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest2/providers/microsoft.authorization/policyassignments/e9ad4ab40dfb4549a998cfcc''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''","nonCompliantResources":1}}]}]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":1,"nonCompliantPolicies":6,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":6}]},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/4f3dae2da43841f2ba625495","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/4f3dae2da43841f2ba625495''","nonCompliantResources":1,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/a5ad9428-4cf9-4e9e-b2a5-f345f9b57202","effect":"deployifnotexists","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/4f3dae2da43841f2ba625495''
+        and PolicyDefinitionId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/a5ad9428-4cf9-4e9e-b2a5-f345f9b57202''","nonCompliantResources":1,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":1}]}}]},{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/00810acb83044ed1b084bfb5","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/00810acb83044ed1b084bfb5''","nonCompliantResources":1,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/8df0e928-692c-4cce-8ed1-444423ac0253","effect":"auditifnotexists","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test/providers/microsoft.keyvault/vaults/cluster-test/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/00810acb83044ed1b084bfb5''
+        and PolicyDefinitionId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/8df0e928-692c-4cce-8ed1-444423ac0253''","nonCompliantResources":1,"resourceDetails":[{"complianceState":"noncompliant","count":1}],"policyDetails":[{"complianceState":"noncompliant","count":1}]}}]}]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['4765']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '5088'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '596'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --namespace --resource-type --parent -g --from --to --filter --apply
+        --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test-cluster-1/providers/microsoft.network/virtualnetworks/VNet-test-1/subnets/Subnet-0/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default","numRecords":2},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default","numRecords":2}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test-cluster-1/providers/microsoft.network/virtualnetworks/VNet-test-1/subnets/Subnet-0/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":0,"value":[]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1551']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '305'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '598'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --namespace --resource-type --parent -g --from --to --filter --apply
+        --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test-cluster-1/providers/microsoft.network/virtualnetworks/VNet-test-1/subnets/Subnet-0/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/22005cc594164636a6444db8","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default","numRecords":6},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/1ef5d536aec743a0aa801c1a","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default","numRecords":6}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test-cluster-1/providers/microsoft.network/virtualnetworks/VNet-test-1/subnets/Subnet-0/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":0,"value":[]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1548']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '597'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --namespace --resource-type --parent -g --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test-cluster-1/providers/microsoft.network/virtualnetworks/VNet-test-1/subnets/Subnet-0/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":1,"nonCompliantPolicies":7},"policyAssignments":[{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c''","nonCompliantResources":1,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policyassignments/186044306c044a1d8c0ff76c''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''","nonCompliantResources":1}}]},{"policyAssignmentId":"/providers/microsoft.management/managementgroups/azgovtest2/providers/microsoft.authorization/policyassignments/e9ad4ab40dfb4549a998cfcc","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest2/providers/microsoft.authorization/policyassignments/e9ad4ab40dfb4549a998cfcc''","nonCompliantResources":1,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mms-wcus/providers/microsoft.network/virtualnetworks/mms-wcus-vnet/subnets/default/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/providers/microsoft.management/managementgroups/azgovtest2/providers/microsoft.authorization/policyassignments/e9ad4ab40dfb4549a998cfcc''
-        and PolicyDefinitionId eq ''/providers/microsoft.management/managementgroups/azgovtest1/providers/microsoft.authorization/policydefinitions/022d9357-5a90-46f7-9554-21d30ce4c32d''","nonCompliantResources":1}}]}]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test-cluster-1/providers/microsoft.network/virtualnetworks/VNet-test-1/subnets/Subnet-0/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test-cluster-1/providers/microsoft.network/virtualnetworks/VNet-test-1/subnets/Subnet-0/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akhe-sf-test-cluster-1/providers/microsoft.network/virtualnetworks/VNet-test-1/subnets/Subnet-0/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":0,"nonCompliantPolicies":0,"resourceDetails":[],"policyDetails":[]},"policyAssignments":[]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['4737']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:07 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1126'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '595'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -s --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/335cefd2-ab16-430f-b364-974a170eb1d5/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/335cefd2-ab16-430f-b364-974a170eb1d5/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":0,"value":[]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest2/providers/microsoft.authorization/policyassignments/8828df941b124d42841bfe69","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest2/providers/microsoft.compute/virtualmachines/jilimmmm","numRecords":2},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest2/providers/microsoft.authorization/policyassignments/8828df941b124d42841bfe69","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest2/providers/microsoft.network/networksecuritygroups/jilimmmm-nsg","numRecords":2}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['286']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:08 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1565'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '594'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -s --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/335cefd2-ab16-430f-b364-974a170eb1d5/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/335cefd2-ab16-430f-b364-974a170eb1d5/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":0,"value":[]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":0,"value":[]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['285']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:09 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '592'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -s --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/335cefd2-ab16-430f-b364-974a170eb1d5/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/335cefd2-ab16-430f-b364-974a170eb1d5/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/335cefd2-ab16-430f-b364-974a170eb1d5/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/335cefd2-ab16-430f-b364-974a170eb1d5/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":0,"nonCompliantPolicies":0},"policyAssignments":[]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/762007ec-c5ba-41ae-a52d-db0834bea096/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":0,"nonCompliantPolicies":0,"resourceDetails":[],"policyDetails":[]},"policyAssignments":[]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1046']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:10 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1069'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '596'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -d --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/c7330451f3e34e54ae6712e1","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.keyvault/vaults/rashmi-kv-test","numRecords":1},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/f6f08ec4878644d7bc5e020b","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.keyvault/vaults/rashmi-kv-test","numRecords":1}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.containerregistry/registries/azgovpolicy","numRecords":7},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-admin/nestedendpoints/gov-int-nus-policy-admin","numRecords":3}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1534']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1606'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '593'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -d --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/17bd552d9ec84b538893a691","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.keyvault/vaults/rashmi-kv-test5","numRecords":3},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/7fd638704a88457e8c0ae077","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.keyvault/vaults/rashmi-kv-test5","numRecords":3}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.containerregistry/registries/azgovpolicy/runs/ca4","numRecords":1},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.containerregistry/registries/azgovpolicy/runs/ca1","numRecords":1}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['1533']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1569'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '592'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -d --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":5,"nonCompliantPolicies":7},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/cfe746abc6f341c58872a005","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/cfe746abc6f341c58872a005''","nonCompliantResources":5,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016","effect":"deployifnotexists","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/cfe746abc6f341c58872a005''
-        and PolicyDefinitionId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016''","nonCompliantResources":5}}]},{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/f6f08ec4878644d7bc5e020b","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/f6f08ec4878644d7bc5e020b''","nonCompliantResources":5,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016","effect":"deployifnotexists","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rashmi-kv-test/providers/microsoft.authorization/policyassignments/f6f08ec4878644d7bc5e020b''
-        and PolicyDefinitionId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/25bf1e2a-6004-47ad-9bd1-2a40dd6de016''","nonCompliantResources":5}}]}]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":62,"nonCompliantPolicies":2,"resourceDetails":[{"complianceState":"noncompliant","count":62}],"policyDetails":[{"complianceState":"noncompliant","count":2}]},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef''","nonCompliantResources":57,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":57}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef''
+        and PolicyDefinitionId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207''","nonCompliantResources":57,"resourceDetails":[{"complianceState":"noncompliant","count":57}],"policyDetails":[{"complianceState":"noncompliant","count":1}]}}]},{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimaus/providers/microsoft.authorization/policyassignments/689b77c53cf84f84bc9860a8","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimaus/providers/microsoft.authorization/policyassignments/689b77c53cf84f84bc9860a8''","nonCompliantResources":5,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":5}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimaus/providers/microsoft.authorization/policyassignments/689b77c53cf84f84bc9860a8''
+        and PolicyDefinitionId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207''","nonCompliantResources":5,"resourceDetails":[{"complianceState":"noncompliant","count":5}],"policyDetails":[{"complianceState":"noncompliant","count":1}]}}]}]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['4798']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '5317'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '591'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -a --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/96e22f7846e94bb186ae3a01","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/microsoft.keyvault/vaults/tipinteuskeyvault","numRecords":21}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/camarvin/providers/microsoft.compute/virtualmachines/zone/extensions/microsoft.powershell.dsc","numRecords":14},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/elpere/providers/microsoft.compute/virtualmachines/elperetest/extensions/dscextension","numRecords":11}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['868']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1488'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '591'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -a --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/96e22f7846e94bb186ae3a01","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/microsoft.keyvault/vaults/tipinteuskeyvault","numRecords":1}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/elpere/providers/microsoft.network/networkinterfaces/elperetest-singledat651","numRecords":1},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ilidemitest/providers/microsoft.healthcareapis/services/ilidemi-healthcare-test","numRecords":1}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['865']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:14 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1460'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '590'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -a --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":1,"nonCompliantPolicies":1},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/96e22f7846e94bb186ae3a01","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/96e22f7846e94bb186ae3a01''","nonCompliantResources":1,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/92395f89-8960-42cc-95ae-62d3d1a921fc","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/96e22f7846e94bb186ae3a01/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/96e22f7846e94bb186ae3a01''
-        and PolicyDefinitionId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/92395f89-8960-42cc-95ae-62d3d1a921fc''","nonCompliantResources":1}}]}]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":342,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":342}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464''","nonCompliantResources":342,"nonCompliantPolicies":1,"resourceDetails":[{"complianceState":"noncompliant","count":342}],"policyDetails":[{"complianceState":"noncompliant","count":1}]},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/providers/microsoft.authorization/policydefinitions/0a914e76-4921-4c19-b460-a2d36003525a","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/3c3059c96b0940f0995f9464/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false) and PolicyAssignmentId
+        eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/3c3059c96b0940f0995f9464''
+        and PolicyDefinitionId eq ''/providers/microsoft.authorization/policydefinitions/0a914e76-4921-4c19-b460-a2d36003525a''","nonCompliantResources":342,"resourceDetails":[{"complianceState":"noncompliant","count":342}],"policyDetails":[{"complianceState":"noncompliant","count":1}]}}]}]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['2755']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '2998'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '589'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy event list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy event list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -a -g --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest/providers/Microsoft.Authorization/policyAssignments/1c95b94c9c394a8eb4f1d8a6/providers/Microsoft.PolicyInsights/policyEvents/default/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/microsoft.authorization/policyassignments/bc916e4f3ab54030822a11b3","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/microsoft.keyvault/vaults/tipinteuskeyvault","numRecords":21}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest/providers/Microsoft.Authorization/policyAssignments/1c95b94c9c394a8eb4f1d8a6/providers/Microsoft.PolicyInsights/policyEvents/$metadata#default","@odata.count":0,"value":[]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['988']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '302'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '595'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -a -g --from --to --filter --apply --select --order-by --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest/providers/Microsoft.Authorization/policyAssignments/1c95b94c9c394a8eb4f1d8a6/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$orderby=numRecords%20desc&$select=policyAssignmentId%2C%20resourceId%2C%20numRecords&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false&$apply=groupby%28%28policyAssignmentId%2C%20resourceId%29%2C%20aggregate%28%24count%20as%20numRecords%29%29
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/microsoft.authorization/policyassignments/bc916e4f3ab54030822a11b3","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/microsoft.keyvault/vaults/tipinteuskeyvault","numRecords":1}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest/providers/Microsoft.Authorization/policyAssignments/1c95b94c9c394a8eb4f1d8a6/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":0,"value":[]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['985']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '301'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '588'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [policy state summarize]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.5 (Windows-10-10.0.16299-SP0) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.29 azure-mgmt-policyinsights/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.34]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state summarize
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -a -g --from --to --filter --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04&$top=2&$from=2018-04-04T00%3A00%3A00.000Z&$to=2018-05-22T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest/providers/Microsoft.Authorization/policyAssignments/1c95b94c9c394a8eb4f1d8a6/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-07-01-preview&$top=2&$from=2019-03-01T00%3A00%3A00.000Z&$to=2019-04-17T00%3A00%3A00.000Z&$filter=isCompliant%20eq%20false
   response:
-    body: {string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false","nonCompliantResources":1,"nonCompliantPolicies":1},"policyAssignments":[{"policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/microsoft.authorization/policyassignments/bc916e4f3ab54030822a11b3","policySetDefinitionId":"","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/microsoft.authorization/policyassignments/bc916e4f3ab54030822a11b3''","nonCompliantResources":1,"nonCompliantPolicies":1},"policyDefinitions":[{"policyDefinitionReferenceId":"","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/92395f89-8960-42cc-95ae-62d3d1a921fc","effect":"audit","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/Microsoft.Authorization/policyAssignments/bc916e4f3ab54030822a11b3/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$from=2018-04-04
-        00:00:00Z&$to=2018-05-22 00:00:00Z&$filter=(isCompliant eq false) and IsCompliant
-        eq false and PolicyAssignmentId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/tipkeyvaultresourcegroup/providers/microsoft.authorization/policyassignments/bc916e4f3ab54030822a11b3''
-        and PolicyDefinitionId eq ''/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/92395f89-8960-42cc-95ae-62d3d1a921fc''","nonCompliantResources":1}}]}]}]}'}
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest/providers/Microsoft.Authorization/policyAssignments/1c95b94c9c394a8eb4f1d8a6/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary","@odata.count":1,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest/providers/Microsoft.Authorization/policyAssignments/1c95b94c9c394a8eb4f1d8a6/providers/Microsoft.PolicyInsights/policyStates/$metadata#summary/$entity","results":{"queryResultsUri":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/jilimpolicytest/providers/Microsoft.Authorization/policyAssignments/1c95b94c9c394a8eb4f1d8a6/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$from=2019-03-01
+        00:00:00Z&$to=2019-04-17 00:00:00Z&$filter=(isCompliant eq false)","nonCompliantResources":0,"nonCompliantPolicies":0,"resourceDetails":[],"policyDetails":[]},"policyAssignments":[]}]}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['3075']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 May 2018 00:08:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: ['Accept-Encoding,Accept-Encoding']
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '1117'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '594'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - policy state list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource --expand --top
+      User-Agent:
+      - python/3.7.3 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-policyinsights/0.3.1
+        Azure-SDK-For-Python AZURECLI/2.0.62
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-07-01-preview&$top=2&$expand=PolicyEvaluationDetails
+  response:
+    body:
+      string: '{"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest","@odata.count":2,"value":[{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","timestamp":"2019-04-18T20:41:34.0346017Z","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policyassignments/88deedb1a79843fa9b3cd693","policyDefinitionId":"/providers/microsoft.authorization/policydefinitions/7f89b1eb-583c-429a-8828-af049802c1d9","effectiveParameters":"","isCompliant":false,"subscriptionId":"d0610b27-9663-4c05-89f8-5b4be01e86a5","resourceType":"/Microsoft.Network/trafficManagerProfiles","resourceLocation":"global","resourceGroup":"govintpolicyrp","resourceTags":"tbd","policyAssignmentName":"88deedb1a79843fa9b3cd693","policyAssignmentOwner":"tbd","policyAssignmentParameters":"","policyAssignmentScope":"/subscriptions/00000000-0000-0000-0000-000000000000","policyDefinitionName":"7f89b1eb-583c-429a-8828-af049802c1d9","policyDefinitionAction":"auditifnotexists","policyDefinitionCategory":"tbd","policySetDefinitionId":"/providers/Microsoft.Authorization/policySetDefinitions/89c6cddc-1c73-4ac1-b19c-54d1a15a42f2","policySetDefinitionName":"89c6cddc-1c73-4ac1-b19c-54d1a15a42f2","policySetDefinitionOwner":"","policySetDefinitionCategory":"","policySetDefinitionParameters":"","managementGroupIds":"ArtTest2,ArtTest1,72f988bf-86f1-41af-91ab-2d7cd011db47","policyDefinitionReferenceId":"auditdiagnosticsetting","complianceState":"NonCompliant","policyEvaluationDetails":{"ifNotExistsDetails":{"totalResources":0}}},{"@odata.id":null,"@odata.context":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp/providers/Microsoft.PolicyInsights/policyStates/$metadata#latest/$entity","timestamp":"2019-04-18T20:41:34.03457Z","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp","policyAssignmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.authorization/policyassignments/a02d10810ef84c77b956a1ef","policyDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.authorization/policydefinitions/796de0a7-4bc4-40e4-98b2-1ee2bf359207","effectiveParameters":"","isCompliant":false,"subscriptionId":"d0610b27-9663-4c05-89f8-5b4be01e86a5","resourceType":"/Microsoft.Network/trafficManagerProfiles","resourceLocation":"global","resourceGroup":"govintpolicyrp","resourceTags":"tbd","policyAssignmentName":"a02d10810ef84c77b956a1ef","policyAssignmentOwner":"tbd","policyAssignmentParameters":"","policyAssignmentScope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/GovIntPolicyRP","policyDefinitionName":"796de0a7-4bc4-40e4-98b2-1ee2bf359207","policyDefinitionAction":"audit","policyDefinitionCategory":"tbd","policySetDefinitionId":"","policySetDefinitionName":"","policySetDefinitionOwner":"","policySetDefinitionCategory":"","policySetDefinitionParameters":"","managementGroupIds":"ArtTest2,ArtTest1,72f988bf-86f1-41af-91ab-2d7cd011db47","policyDefinitionReferenceId":"","complianceState":"NonCompliant","policyEvaluationDetails":{"evaluatedExpressions":[{"result":"True","expression":"tags","path":"tags","expressionValue":{"Test":"Test"},"targetValue":"CostCenter","operator":"NotContainsKey"}]}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4069'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Apr 2019 21:31:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-policy-insights-requests:
+      - '587'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/tests/latest/test_policyinsights_scenario.py
+++ b/src/command_modules/azure-cli-policyinsights/azure/cli/command_modules/policyinsights/tests/latest/test_policyinsights_scenario.py
@@ -15,19 +15,19 @@ class PolicyInsightsTests(ScenarioTest):
         apply_clause = '--apply "groupby((policyAssignmentId, resourceId), aggregate($count as numRecords))"'
         select_clause = '--select "policyAssignmentId, resourceId, numRecords"'
         order_by_clause = '--order-by "numRecords desc"'
-        from_clause = '--from "2018-04-04T00:00:00"'
-        to_clause = '--to "2018-05-22T00:00:00"'
+        from_clause = '--from "2019-03-01T00:00:00"'
+        to_clause = '--to "2019-04-17T00:00:00"'
         scopes = [
-            '-m "azgovtest4"',
+            '-m "azgovtest5"',
             '',
             '-g "defaultresourcegroup-eus"',
-            '--resource "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/eastusnsggroup/providers/microsoft.network/networksecuritygroups/eastusnsg/securityrules/allow-joba"',
-            '--resource "omssecuritydevkeyvalut" --namespace "microsoft.keyvault" --resource-type "vaults" -g "omssecurityintresourcegroup"',
-            '--resource "default" --namespace "microsoft.network" --resource-type "subnets" --parent "virtualnetworks/mms-wcus-vnet" -g "mms-wcus"',
-            '-s "335cefd2-ab16-430f-b364-974a170eb1d5"',
-            '-d "25bf1e2a-6004-47ad-9bd1-2a40dd6de016"',
-            '-a "96e22f7846e94bb186ae3a01"',
-            '-a "bc916e4f3ab54030822a11b3" -g "tipkeyvaultresourcegroup" '
+            '--resource "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/govintpolicyrp/providers/microsoft.network/trafficmanagerprofiles/gov-int-policy-rp"',
+            '--resource "cluster-test" --namespace "microsoft.keyvault" --resource-type "vaults" -g "akhe-sf-test"',
+            '--resource "Subnet-0" --namespace "microsoft.network" --resource-type "subnets" --parent "virtualnetworks/VNet-test-1" -g "akhe-sf-test-cluster-1"',
+            '-s "762007ec-c5ba-41ae-a52d-db0834bea096"',
+            '-d "796de0a7-4bc4-40e4-98b2-1ee2bf359207"',
+            '-a "3c3059c96b0940f0995f9464"',
+            '-a "1c95b94c9c394a8eb4f1d8a6" -g "jilimpolicytest" '
         ]
 
         for scope in scopes:
@@ -66,6 +66,14 @@ class PolicyInsightsTests(ScenarioTest):
                 assert len(summary["policyAssignments"][0]["policyDefinitions"]) >= 0
                 if len(summary["policyAssignments"][0]["policyDefinitions"]) > 0:
                     assert summary["policyAssignments"][0]["policyDefinitions"][0]["results"] is not None
+
+        states = self.cmd('az policy state list {} {} {}'.format(
+            scopes[3],
+            '--expand PolicyEvaluationDetails',
+            top_clause
+        ), checks=[
+            self.check('length([?complianceState==`NonCompliant`].policyEvaluationDetails)', 2)
+        ])
 
     @ResourceGroupPreparer(name_prefix='cli_test_remediation')
     @StorageAccountPreparer(name_prefix='cliremediation')

--- a/src/command_modules/azure-cli-policyinsights/setup.py
+++ b/src/command_modules/azure-cli-policyinsights/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -33,7 +33,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-policyinsights==0.2.0',
+    'azure-mgmt-policyinsights==0.3.1',
     'azure-cli-core',
 ]
 


### PR DESCRIPTION
Add support for `az policy state list --expand PolicyEvaluationDetails` to query policy evaluation details on the resource.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
