### PR TITLE
Add MSI Test Job to ADO

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ jobs:
           "$env:SYSTEM_ARTIFACTSDIRECTORY/msi/Microsoft Azure CLI.msi"
           "/norestart"
         )
-        Start-Process "msiexec.exe" -Arguments $InstallArgs -Wait -NoNewWindow
+        Start-Process "msiexec.exe" -ArgumentList $InstallArgs -Wait -NoNewWindow
         az --version
         az self-test
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,7 @@ jobs:
   displayName: Test Windows MSI
 
   dependsOn: BuildWindowsMSI
-  condition: succeeded()
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ jobs:
       script: |
         $InstallArgs = @(
           "/I"
-          "$env:SYSTEM_ARTIFACTSDIRECTORY/msi/Microsoft Azure CLI.msi"
+          "\"$env:SYSTEM_ARTIFACTSDIRECTORY/msi/Microsoft Azure CLI.msi\""
           "/norestart"
         )
         Start-Process "msiexec.exe" -ArgumentList $InstallArgs -Wait -NoNewWindow

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,10 +120,14 @@ jobs:
       script: |
         $InstallArgs = @(
           "/I"
-          "\"$env:SYSTEM_ARTIFACTSDIRECTORY/msi/Microsoft Azure CLI.msi\""
+          '"$env:SYSTEM_ARTIFACTSDIRECTORY/msi/Microsoft Azure CLI.msi"'
           "/norestart"
+          "/L*v"
+          ".\install_logs.txt"
         )
         Start-Process "msiexec.exe" -ArgumentList $InstallArgs -Wait -NoNewWindow
+        Get-Content .\install_logs.txt
+
         az --version
         az self-test
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - task: DownloadBuildArtigacts@0
+  - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'
     inputs:
       artifactName: msi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,31 @@ jobs:
 
       ArtifactName: msi
 
+- job: TestWindowsMSI
+  displayName: TestWindowsMSI
 
+  dependsOn: BuildWindowsMSI
+  condition: succeeded()
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - task: DownloadBuildArtigacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      artifactName: msi
+
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        $InstallArgs = @(
+          "/I"
+          "$env:SYSTEM_ARTIFACTSDIRECTORY/msi/Microsoft Azure CLI.msi"
+          "/norestart"
+        )
+        Start-Process "msiexec.exe" -Arguments $InstallArgs -Wait -NoNewWindow
+        az --version
+        az self-test
 
 - job: BuildDockerImage
   displayName: Build Docker Image

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ jobs:
       ArtifactName: msi
 
 - job: TestWindowsMSI
-  displayName: TestWindowsMSI
+  displayName: Test Windows MSI
 
   dependsOn: BuildWindowsMSI
   condition: succeeded()
@@ -115,6 +115,7 @@ jobs:
       artifactName: msi
 
   - task: PowerShell@2
+    displayName: Install and Load CLI
     inputs:
       targetType: inline
       script: |


### PR DESCRIPTION
Fixes #9133

This will install the CLI using the MSI built in the previous phase, the run an `az --version` and an `az self-test`