### PR TITLE
Add --rm to clean up container after exiting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ We maintain a Docker image preconfigured with the Azure CLI.
 See our [Docker tags](https://hub.docker.com/r/microsoft/azure-cli/tags/) for available versions.
 
 ```bash
-$ docker run -v ${HOME}:/root -it microsoft/azure-cli:<version>
+$ docker run -v ${HOME}:/root -it --rm microsoft/azure-cli:<version>
 ```
 
 For automated builds triggered by pushes to this repo, see [azuresdk/azure-cli-python](https://hub.docker.com/r/azuresdk/azure-cli-python/tags).
 For example:
 ```bash
-docker run -v ${HOME}:/root -it azuresdk/azure-cli-python:dev
+docker run -v ${HOME}:/root -it --rm azuresdk/azure-cli-python:dev
 ```
 
 ### Edge Builds


### PR DESCRIPTION
I'm thinking we'd want to add the `--rm` flag to clean up the Docker container after usage?



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
