### PR TITLE
Adding script that consolidates our existing install instructions

### DIFF
--- a/scripts/release/debian/Dockerfile.install_test
+++ b/scripts/release/debian/Dockerfile.install_test
@@ -14,8 +14,6 @@ ADD . .
 RUN dos2unix ./deb_install.sh
 
 FROM $base AS execution
-RUN apt-get update
-RUN apt-get install -y curl apt-transport-https lsb-release gnupg
 
 COPY --from=builder ./deb_install.sh ./deb_install.sh
 

--- a/scripts/release/debian/Dockerfile.install_test
+++ b/scripts/release/debian/Dockerfile.install_test
@@ -12,7 +12,7 @@ RUN apt-get install -y curl apt-transport-https lsb-release gnupg dos2unix
 ADD . .
 
 RUN dos2unix ./deb_install.sh
-RUN cat ./deb_install.sh | bash
+RUN ./deb_install.sh -y
 
 
 CMD ["/bin/bash", "-c", "az --version && az self-test"]

--- a/scripts/release/debian/Dockerfile.install_test
+++ b/scripts/release/debian/Dockerfile.install_test
@@ -1,0 +1,18 @@
+# This dockerfile is meant to test deb_install.sh
+# To execute it, run the following command from the directory containing this file:
+#   docker build -t deb-install -f Dockerfile.install_test .
+# Optionally, one can test specific version of a Debian based linux distro by providing the "base" argument in the form
+# of an image ID or tag.
+ARG base=ubuntu
+FROM $base
+
+RUN apt-get update
+RUN apt-get install -y curl apt-transport-https lsb-release gnupg dos2unix
+
+ADD . .
+
+RUN dos2unix ./deb_install.sh
+RUN cat ./deb_install.sh | bash
+
+
+CMD ["/bin/bash", "-c", "az --version && az self-test"]

--- a/scripts/release/debian/Dockerfile.install_test
+++ b/scripts/release/debian/Dockerfile.install_test
@@ -4,15 +4,21 @@
 # Optionally, one can test specific version of a Debian based linux distro by providing the "base" argument in the form
 # of an image ID or tag.
 ARG base=ubuntu
-FROM $base
+FROM $base AS builder
 
 RUN apt-get update
-RUN apt-get install -y curl apt-transport-https lsb-release gnupg dos2unix
+RUN apt-get install -y dos2unix
 
 ADD . .
 
 RUN dos2unix ./deb_install.sh
-RUN ./deb_install.sh -y
 
+FROM $base AS execution
+RUN apt-get update
+RUN apt-get install -y curl apt-transport-https lsb-release gnupg
+
+COPY --from=builder ./deb_install.sh ./deb_install.sh
+
+RUN ./deb_install.sh -y
 
 CMD ["/bin/bash", "-c", "az --version && az self-test"]

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -34,6 +34,8 @@ function assert_consent {
     fi
 }
 
+global_consent=0 # Artificially giving global consent after review-feedback. Remove this line to enable interactive mode
+
 assert_consent "Add Microsoft as a trusted package signer?" ${global_consent}
 set -v
 curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg
@@ -41,7 +43,8 @@ set +v
 
 assert_consent "Add the Azure CLI Repository to your apt sources?" ${global_consent}
 set -v
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \
+CLI_REPO=$(lsb_release -cs)
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ ${CLI_REPO} main" \
     > /etc/apt/sources.list.d/azure-cli.list
 apt-get update
 set +v

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#######################################################################################################################
+# This script does three fundamental things:                                                                          #
+#   1. Add Microsoft's GPG Key has a trusted source of apt packages.                                                  #
+#   2. Add Microsoft's repositories as a source for apt packages.                                                     #
+#   3. Installs the Azure CLI from those repositories.                                                                #
+# Given the nature of this script, it must be executed with elevated privledges, i.e. with `sudo`.                    #
+#                                                                                                                     #
+# Remember, with great power comes great responsibility.                                                              #
+#                                                                                                                     #
+# Do not be in the habit of executing scripts from the internet with root-level access to your machine. Only trust    #
+# well-known publishers.                                                                                              #
+#######################################################################################################################
+
+set -ev
+
+apt-get install -y curl apt-transport-https lsb-release gnupg
+
+curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg
+
+AZ_REPO=$(lsb_release -cs)
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" \
+    > /etc/apt/sources.list.d/azure-cli.list
+
+apt-get update
+apt-get install -y azure-cli

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -36,6 +36,12 @@ function assert_consent {
 
 global_consent=0 # Artificially giving global consent after review-feedback. Remove this line to enable interactive mode
 
+assert_consent "Add packages necessary to modify your apt-package sources?" ${global_consent}
+set -v
+apt-get update
+apt-get install apt-transport-https lsb-release gnupg curl
+set +v
+
 assert_consent "Add Microsoft as a trusted package signer?" ${global_consent}
 set -v
 curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -39,7 +39,7 @@ global_consent=0 # Artificially giving global consent after review-feedback. Rem
 assert_consent "Add packages necessary to modify your apt-package sources?" ${global_consent}
 set -v
 apt-get update
-apt-get install apt-transport-https lsb-release gnupg curl
+apt-get install -y apt-transport-https lsb-release gnupg curl
 set +v
 
 assert_consent "Add Microsoft as a trusted package signer?" ${global_consent}

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -5,7 +5,7 @@
 #   1. Add Microsoft's GPG Key has a trusted source of apt packages.                                                  #
 #   2. Add Microsoft's repositories as a source for apt packages.                                                     #
 #   3. Installs the Azure CLI from those repositories.                                                                #
-# Given the nature of this script, it must be executed with elevated privledges, i.e. with `sudo`.                    #
+# Given the nature of this script, it must be executed with elevated privileges, i.e. with `sudo`.                    #
 #                                                                                                                     #
 # Remember, with great power comes great responsibility.                                                              #
 #                                                                                                                     #

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -39,7 +39,6 @@ set -v
 curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg
 set +v
 
-
 assert_consent "Add the Azure CLI Repository to your apt sources?" ${global_consent}
 set -v
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \

--- a/scripts/release/debian/test_deb_install.sh
+++ b/scripts/release/debian/test_deb_install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+base_images=("ubuntu:xenial" "ubuntu:bionic" "debian:stretch" "debian:jessie")
+
+set -e
+
+for image in ${base_images[@]}; do
+    docker build --build-arg base=${image} s-t deb-installer:current -f Dockerfile.install_test .
+    docker run -it --rm deb-installer:current
+done

--- a/scripts/release/debian/test_deb_installer.ps1
+++ b/scripts/release/debian/test_deb_installer.ps1
@@ -1,0 +1,14 @@
+$baseImages = @("ubuntu:xenial", "ubuntu:bionic", "debian:stretch","debian:jessie")
+
+foreach ($image in $baseImages) {
+    docker build --build-arg base=${image} -t deb-installer:current -f Dockerfile.install_test .
+    $result = $LastExitState
+    if ($result -ne 0) {
+        exit $result
+    }
+    docker run -it --rm deb-installer:current
+    $result = $LastExitState
+    if ($result -ne 0) {
+        exit $result
+    }
+}

--- a/scripts/release/debian/test_deb_installer.ps1
+++ b/scripts/release/debian/test_deb_installer.ps1
@@ -2,12 +2,12 @@ $baseImages = @("ubuntu:xenial", "ubuntu:bionic", "debian:stretch","debian:jessi
 
 foreach ($image in $baseImages) {
     docker build --build-arg base=${image} -t deb-installer:current -f Dockerfile.install_test .
-    $result = $LastExitState
+    $result = $LastExitCode
     if ($result -ne 0) {
         exit $result
     }
     docker run -it --rm deb-installer:current
-    $result = $LastExitState
+    $result = $LastExitCode
     if ($result -ne 0) {
         exit $result
     }


### PR DESCRIPTION
/cc @achandmsft @sptramer

This consolidates the instructions that are currently found [here](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest) into a single script. The idea is that we can tell Debian/Ubuntu users to just execute `sudo curl -sL https://aka.ms/InstallAzureCLIDeb | bash`.

Because they will need to use `sudo` to do this, I've added a conspicuous warning that they should try to refrain from sudo executing scripts from sources other than well trusted entities.