### PR TITLE
Restore "required_tooling" and "default_name_tooling" metadata.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -264,7 +264,21 @@ class AzCliCommand(CLICommand):
         self.confirmation = kwargs.get('confirmation', False)
         self.command_kwargs = kwargs
 
+    # pylint: disable=no-self-use
+    def _add_vscode_extension_metadata(self, arg, overrides):
+        """ Adds metadata for use by the VSCode CLI extension. Do
+            not remove or modify without contacting the VSCode team. """
+        if not hasattr(arg.type, 'required_tooling'):
+            required = arg.type.settings.get('required', False)
+            setattr(arg.type, 'required_tooling', required)
+        if 'configured_default' in overrides.settings:
+            def_config = overrides.settings.get('configured_default', None)
+            setattr(arg.type, 'default_name_tooling', def_config)
+
     def _resolve_default_value_from_config_file(self, arg, overrides):
+
+        self._add_vscode_extension_metadata(arg, overrides)
+
         # same blunt mechanism like we handled id-parts, for create command, no name default
         if self.name.split()[-1] == 'create' and overrides.settings.get('metavar', None) == 'NAME':
             return


### PR DESCRIPTION
Should fix the VSCode CLI extension. Adds comments to identify what this logic is and why it should stick around.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
