### PR TITLE
Add powershell to WINDOWS_RUNTIMES

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 * webapp: az webapp ssh handles 'AZURE_CLI_DISABLE_CONNECTION_VERIFICATION' environment variable
 * appserviceplan: az appserviceplan create support for Linux FREE sku
 * webapp: az webapp up now has a 30s sleep after setting SCM_DO_BUILD_DURING_DEPLOYMENT=true appsetting to handle kudu cold start
+* functionapp: `az functionapp create` supports a runtime of `powershell` on Windows
 
 0.2.18
 ++++++

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -29,7 +29,7 @@ MULTI_CONTAINER_TYPES = ['COMPOSE', 'KUBE']
 FTPS_STATE_TYPES = ['AllAllowed', 'FtpsOnly', 'Disabled']
 OS_TYPES = ['Windows', 'Linux']
 LINUX_RUNTIMES = ['dotnet', 'node', 'python']
-WINDOWS_RUNTIMES = ['dotnet', 'node', 'java']
+WINDOWS_RUNTIMES = ['dotnet', 'node', 'java', 'powershell']
 
 # pylint: disable=too-many-statements
 


### PR DESCRIPTION
This adds support for `powershell` as a runtime option on Windows for `az functionapp create`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
