### PR TITLE
webapp up: Supports resourcegroup and plan as optional arguments & uses local configuration

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -4,7 +4,6 @@ Release History
 ===============
 * functionapp: deprecate `az functionapp devops-build` command. Rename it to `az functionapp devops-pipeline`
 * appservice plan: az appservice plan --sku documentation updated to reflect the supported appserviceplans
-* webapp: az webapp up supports local configuration and sets the values of the arguments on the local configuration on running the command
 * webapp: az webapp up supports optional arguments resourcegroup & plan to override the defaults offered by the command
 * webapp: az webapp ssh handles 'AZURE_CLI_DISABLE_CONNECTION_VERIFICATION' environment variable
 * appserviceplan: az appserviceplan create support for Linux FREE sku

--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -3,6 +3,9 @@
 Release History
 ===============
 * functionapp: deprecate `az functionapp devops-build` command. Rename it to `az functionapp devops-pipeline`
+* appservice plan: az appservice plan --sku documentation updated to reflect the supported appserviceplans
+* webapp: az webapp up supports local configuration and sets the values of the arguments on the local configuration on running the command
+* webapp: az webapp up supports optional arguments resourcegroup & plan to override the defaults offered by the command
 * webapp: az webapp ssh handles 'AZURE_CLI_DISABLE_CONNECTION_VERIFICATION' environment variable
 * appserviceplan: az appserviceplan create support for Linux FREE sku
 * webapp: az webapp up now has a 30s sleep after setting SCM_DO_BUILD_DURING_DEPLOYMENT=true appsetting to handle kudu cold start

--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -3,6 +3,7 @@
 Release History
 ===============
 * functionapp: deprecate `az functionapp devops-build` command. Rename it to `az functionapp devops-pipeline`
+* webapp: Fixing getting the correct username for cloudshell which was causing az webapp up to fail
 * appservice plan: az appservice plan --sku documentation updated to reflect the supported appserviceplans
 * webapp: az webapp up supports optional arguments resourcegroup & plan to override the defaults offered by the command
 * webapp: az webapp ssh handles 'AZURE_CLI_DISABLE_CONNECTION_VERIFICATION' environment variable

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_create_util.py
@@ -263,10 +263,8 @@ def set_location(cmd, sku, location):
     return location
 
 
-def should_create_new_rg(cmd, default_rg, rg_name, is_linux):
-    if (default_rg and _check_resource_group_exists(cmd, default_rg) and
-            _check_resource_group_supports_os(cmd, default_rg, is_linux)):
-        return False
+# check if the RG value to use already exists and follows the OS requirements or new RG to be created
+def should_create_new_rg(cmd, rg_name, is_linux):
     if (_check_resource_group_exists(cmd, rg_name) and
             _check_resource_group_supports_os(cmd, rg_name, is_linux)):
         return False

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -39,8 +39,8 @@ def load_arguments(self, _):
     # pylint: disable=line-too-long
     # PARAMETER REGISTRATION
     name_arg_type = CLIArgumentType(options_list=['--name', '-n'], metavar='NAME')
-    sku_arg_type = CLIArgumentType(help='The pricing tiers, e.g., F1(Free), D1(Shared), B1(Basic Small), B2(Basic Medium), B3(Basic Large), S1(Standard Small), P1(Premium Small), P1V2(Premium V2 Small), PC2 (Premium Container Small), PC3 (Premium Container Medium), PC4 (Premium Container Large)',
-                                   arg_type=get_enum_type(['F1', 'FREE', 'D1', 'SHARED', 'B1', 'B2', 'B3', 'S1', 'S2', 'S3', 'P1', 'P2', 'P3', 'P1V2', 'P2V2', 'P3V2', 'PC2', 'PC3', 'PC4']))
+    sku_arg_type = CLIArgumentType(help='The pricing tiers, e.g., F1(Free), D1(Shared), B1(Basic Small), B2(Basic Medium), B3(Basic Large), S1(Standard Small), P1V2(Premium V2 Small), PC2 (Premium Container Small), PC3 (Premium Container Medium), PC4 (Premium Container Large)',
+                                   arg_type=get_enum_type(['F1', 'FREE', 'D1', 'SHARED', 'B1', 'B2', 'B3', 'S1', 'S2', 'S3', 'P1V2', 'P2V2', 'P3V2', 'PC2', 'PC3', 'PC4']))
     webapp_name_arg_type = CLIArgumentType(configured_default='web', options_list=['--name', '-n'], metavar='NAME',
                                            completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name',
                                            help="name of the web app. You can configure the default using 'az configure --defaults web=<name>'")
@@ -362,6 +362,10 @@ def load_arguments(self, _):
 
     with self.argument_context('webapp up') as c:
         c.argument('name', arg_type=webapp_name_arg_type)
+        c.argument('resource_group_name', arg_type=resource_group_name_type)
+        c.argument('plan', options_list=['--plan', '-p'], configured_default='appserviceplan',
+                   completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'),
+                   help="name of the appserviceplan associated with the webapp")
         c.argument('sku', arg_type=sku_arg_type)
         c.argument('dryrun', help="show summary of the create and deploy operation instead of executing it", default=False, action='store_true')
         c.argument('location', arg_type=get_location_type(self.cli_ctx))

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -2273,8 +2273,8 @@ def get_history_triggered_webjob(cmd, resource_group_name, name, webjob_name, sl
     return client.web_apps.list_triggered_web_job_history(resource_group_name, name, webjob_name)
 
 
-def webapp_up(cmd, name, resource_group_name=None, plan=None, location=None, sku=None, dryrun=False,
-              logs=False, launch_browser=False):  # pylint: disable=too-many-statements, too-many-branches
+def webapp_up(cmd, name, resource_group_name=None, plan=None,  # pylint: disable=too-many-statements, too-many-branches
+              location=None, sku=None, dryrun=False, logs=False, launch_browser=False):
     import os
     from azure.cli.core._profile import Profile
     client = web_client_factory(cmd.cli_ctx)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -2282,6 +2282,8 @@ def webapp_up(cmd, name, resource_group_name=None, plan=None,  # pylint: disable
     src_dir = os.getcwd()
     user = Profile().get_current_account_user()
     user = user.split('@', 1)[0]
+    if len(user.split('#', 1)) > 1:  # on cloudShell user is in format live.com#user@domain.com
+        user = user.split('#', 1)[1]
     logger.info("UserPrefix to use '%s'", user)
     # if dir is empty, show a message in dry run
     do_deployment = False if os.listdir(src_dir) == [] else True

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -2355,12 +2355,6 @@ def webapp_up(cmd, name, resource_group_name=None, plan=None,  # pylint: disable
             """ % (name, asp, rg_str, full_sku, os_val, location, src_path,
                    detected_version, runtime_version)
     create_json = json.loads(dry_run_str)
-    cmd.cli_ctx.config.set_value('defaults', 'group', rg_name)
-    cmd.cli_ctx.config.set_value('defaults', 'sku', full_sku)
-    cmd.cli_ctx.config.set_value('defaults', 'plan', asp)
-    cmd.cli_ctx.config.set_value('defaults', 'location', location)
-    cmd.cli_ctx.config.set_value('defaults', 'web', name)
-
     if dryrun:
         logger.warning("Web app will be created with the below configuration,re-run command "
                        "without the --dryrun flag to create & deploy a new app")
@@ -2412,7 +2406,6 @@ def webapp_up(cmd, name, resource_group_name=None, plan=None,  # pylint: disable
         logger.warning("App service plan '%s' already exists.", asp)
         _show_too_many_apps_warn = get_num_apps_in_asp(cmd, rg_name, asp) > 5
         _create_new_app = should_create_new_app(cmd, rg_name, name)
-    cmd.cli_ctx.config.set_value('defaults', 'plan', asp)
     # create the app
     if _create_new_app:
         logger.warning("Creating app '%s' ...", name)


### PR DESCRIPTION
Fix #9132 ,  Fix #9205, Fix #9050
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).