### PR TITLE
Support Ubuntu Disco Dingo (#9202)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -478,37 +478,34 @@ jobs:
     inputs:
       ArtifactName: debian
 
+- job: BuildUbuntuDisco
+  displayName: Build Ubuntu Disco Package
+
+  dependsOn: BuildPythonWheel
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Build Artifacts'
+      inputs:
+        artifactName: pypi
 
 
-# - job: BuildDebianWheezy
-#   displayName: Build Debian Wheezy Package
-
-#   dependsOn: BuildPythonWheel
-#   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
-#   pool:
-#     vmImage: 'ubuntu-16.04'
-#   steps:
-#   - task: DownloadBuildArtifacts@0
-#     displayName: 'Download Build Artifacts'
-#     inputs:
-#       artifactName: pypi
+    - task: Bash@3
+      displayName: 'Build Ubuntu Disco Package'
+      inputs:
+        targetType: 'filePath'
+        filePath: scripts/release/debian/pipeline.sh
+      env:
+        DISTRO: disco
+        DISTRO_BASE_IMAGE: ubuntu:disco
 
 
-#   - task: Bash@3
-#     displayName: 'Build Debian Wheezy'
-#     inputs:
-#       targetType: 'filePath'
-#       filePath: scripts/release/debian/pipeline.sh
-#     env:
-#       DISTRO: wheezy
-#       DISTRO_BASE_IMAGE: debian:wheezy
-
-
-#   - task: PublishBuildArtifacts@1
-#     displayName: 'Publish Artifact: debian'
-#     inputs:
-#       ArtifactName: debian
-
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: debian'
+      inputs:
+        ArtifactName: debian
 
 
 - job: BuildDebianJessie


### PR DESCRIPTION
* Support Ubuntu Disco Dingo

These change were already approved and tested in #9202. This PR applies these changes to the `master` branch so that we can extend the previous release to Ubuntu, Disco Dingo.
