### PR TITLE
az configure: supports configuring local defaults 

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -13,7 +13,7 @@ import json
 
 from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
-     open_page_in_browser, can_launch_browser, handle_exception)
+     open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter)
 
 
 class TestUtils(unittest.TestCase):
@@ -305,6 +305,18 @@ class TestHandleException(unittest.TestCase):
         self.assertTrue(mock_logger_error.called)
         self.assertEqual(mock.call(mock_http_error), mock_logger_error.call_args)
         self.assertEqual(ex_result, 1)
+
+    def test_configured_default_setter(self):
+        config = mock.MagicMock()
+        config.use_local_config = None
+        with ConfiguredDefaultSetter(config, True):
+            self.assertEqual(config.use_local_config, True)
+        self.assertIsNone(config.use_local_config)
+
+        config.use_local_config = True
+        with ConfiguredDefaultSetter(config, False):
+            self.assertEqual(config.use_local_config, False)
+        self.assertTrue(config.use_local_config)
 
     @staticmethod
     def _get_mock_HttpOperationError(response_text):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -489,3 +489,20 @@ def check_connectivity(url='https://example.org', max_retries=5, timeout=1):
     stop = timeit.default_timer()
     logger.debug('Connectivity check: %s sec', stop - start)
     return success
+
+
+class ConfiguredDefaultSetter(object):
+
+    def __init__(self, cli_config, use_local_config=None):
+        self.use_local_config = use_local_config
+        if self.use_local_config is None:
+            self.use_local_config = False
+        self.cli_config = cli_config
+        # here we use getattr/setattr to prepare the situation that "use_local_config" might not be available
+        self.original_use_local_config = getattr(cli_config, 'use_local_config', None)
+
+    def __enter__(self):
+        self.cli_config.use_local_config = self.use_local_config
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        setattr(self.cli_config, 'use_local_config', self.original_use_local_config)

--- a/src/command_modules/azure-cli-configure/HISTORY.rst
+++ b/src/command_modules/azure-cli-configure/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 2.0.23
 ++++++
-* Support "local" configuration applicable to a folder
+* Support folder based argument default value configurations
 
 2.0.22
 ++++++

--- a/src/command_modules/azure-cli-configure/HISTORY.rst
+++ b/src/command_modules/azure-cli-configure/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 2.0.23
 ++++++
-* 'az configure' add --list-defaults to show the configures
+* Support "local" configuration applicable to a folder
 
 2.0.22
 ++++++

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_params.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_params.py
@@ -3,14 +3,17 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.core.commands.parameters import get_enum_type
+from azure.cli.core.commands.parameters import get_enum_type, get_three_state_flag
 
 
 def load_arguments(self, _):
 
     with self.argument_context('configure') as c:
         c.argument('defaults', nargs='+', options_list=('--defaults', '-d'))
-        c.argument('list_defaults', arg_type=get_enum_type(['local', 'global']), help='list all applicable defaults')
+        c.argument('list_defaults', options_list=('--list-defaults', '-l'),
+                   arg_type=get_three_state_flag(), help='list all applicable defaults')
+        c.argument('scope', arg_type=get_enum_type(['global', 'local']), default='global',
+                   help='scope of defaults. Using "local" for settings only effective under current folder')
         c.ignore('_subscription')  # ignore the global subscription param
 
     with self.argument_context('cache') as c:

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/custom.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/custom.py
@@ -151,7 +151,7 @@ def handle_configure(cmd, defaults=None, list_defaults=None, scope=None):
     if list_defaults:
         with ConfiguredDefaultSetter(cmd.cli_ctx.config, scope.lower() == 'local'):
             defaults_result = cmd.cli_ctx.config.items(cmd.cli_ctx.config.defaults_section_name)
-        return defaults_result
+        return [x for x in defaults_result if x.get('value')]
 
     # if nothing supplied, we go interactively
     try:

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/custom.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/custom.py
@@ -109,7 +109,7 @@ def _handle_global_configuration(config):
         answers['modify_global_prompt'] = should_modify_global_config
     if not config_exists or should_modify_global_config:
         # no config exists yet so configure global config or user wants to modify global config
-        with ConfiguredDefaultSetter(config):
+        with ConfiguredDefaultSetter(config, False):
             output_index = prompt_choice_list(MSG_PROMPT_GLOBAL_OUTPUT, OUTPUT_LIST,
                                               default=get_default_from_config(config,
                                                                               'core', 'output',

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
@@ -33,7 +33,6 @@ class ConfigureGlobalDefaultsTest(ScenarioTest):
     def tearDown(self):
         self.cmd('configure --defaults global="" global2=""')
         self.cmd('configure --defaults local="" --scope local')
-        shutil.rmtree(self.local_dir)
 
     def test_configure_global_defaults(self):
         import os

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
@@ -35,7 +35,6 @@ class ConfigureGlobalDefaultsTest(ScenarioTest):
         self.cmd('configure --defaults local="" --scope local')
 
     def test_configure_global_defaults(self):
-        import os
         # setiing the az configure defaults
         self.cmd('configure --defaults global=global1')
         self.cmd('configure --defaults global2=global2')

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
@@ -9,6 +9,7 @@ import unittest
 
 from azure.cli.testsdk import ScenarioTest
 
+
 class TestConfigure(unittest.TestCase):
     def test_configure_output_options(self):
         from azure.cli.core._output import AzOutputProducer
@@ -34,7 +35,6 @@ class ConfigureGlobalDefaultsTest(ScenarioTest):
         self.cmd('configure --defaults local="" --scope local')
         shutil.rmtree(self.local_dir)
 
-
     def test_configure_global_defaults(self):
         import os
         # setiing the az configure defaults
@@ -45,7 +45,7 @@ class ConfigureGlobalDefaultsTest(ScenarioTest):
         os.chdir(self.local_dir)
         self.cmd('configure --defaults local=local1 --scope local')
 
-        # test listign defaults
+        # test listing defaults
         res = self.cmd('configure --list-defaults --scope local').get_output_in_json()
         self.assertTrue(len(res), 3)
         actual = set([(x['name'], x['value']) for x in res])

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/tests/latest/test_configure.py
@@ -2,9 +2,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-
+import os
+import shutil
+import tempfile
 import unittest
 
+from azure.cli.testsdk import ScenarioTest
 
 class TestConfigure(unittest.TestCase):
     def test_configure_output_options(self):
@@ -19,6 +22,40 @@ class TestConfigure(unittest.TestCase):
         self.assertEqual(cli_output_options, configure_output_options,
                          "\n{}'s output options: {}\ndon't match az configure's output options ({})."
                          .format(AzOutputProducer.__name__, cli_output_options, configure_output_options))
+
+
+class ConfigureGlobalDefaultsTest(ScenarioTest):
+
+    def setUp(self):
+        self.local_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        self.cmd('configure --defaults global="" global2=""')
+        self.cmd('configure --defaults local="" --scope local')
+        shutil.rmtree(self.local_dir)
+
+
+    def test_configure_global_defaults(self):
+        import os
+        # setiing the az configure defaults
+        self.cmd('configure --defaults global=global1')
+        self.cmd('configure --defaults global2=global2')
+
+        # configure a local setting
+        os.chdir(self.local_dir)
+        self.cmd('configure --defaults local=local1 --scope local')
+
+        # test listign defaults
+        res = self.cmd('configure --list-defaults --scope local').get_output_in_json()
+        self.assertTrue(len(res), 3)
+        actual = set([(x['name'], x['value']) for x in res])
+        expected = set([('local', 'local1'), ('global', 'global1'), ('global2', 'global2')])
+        self.assertTrue(actual == expected)
+        res = self.cmd('configure --list-defaults').get_output_in_json()
+        self.assertEqual(len(res), 2)
+        actual = set([(x['name'], x['value']) for x in res])
+        expected = set([('global', 'global1'), ('global2', 'global2')])
+        self.assertTrue(actual == expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
CC @limingu  @panchagnula 

To do it in command:
```
    az configure --defaults web=web1 --scope local
    az configure --list-defaults --scope local
```

To do it in code
```python
   with ConfiguredDefaultSetter(cmd.cli_ctx.config, True):
       cmd.cli_ctx.config.set_value('defaults', 'group', rg_name)
       cmd.cli_ctx.config.set_value('defaults', 'sku', full_sku)
       cmd.cli_ctx.config.set_value('defaults', 'plan', asp)
       cmd.cli_ctx.config.set_value('defaults', 'location', location)
       cmd.cli_ctx.config.set_value('defaults', 'web', name)
```

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
