### PR TITLE
login: redirect to the latest landing page

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth_landing_pages/ok.html
+++ b/src/azure-cli-core/azure/cli/core/auth_landing_pages/ok.html
@@ -7,6 +7,6 @@
 </head>
 <body>
     <h4>You have logged into Microsoft Azure!</h4>
-    <p>You can close this window, or we will redirect you to the <a href="https://docs.microsoft.com/en-us/cli/azure/">Azure CLI documents</a> in 10 seconds.</p>
+    <p>You can close this window, or we will redirect you to the <a href="https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest">Azure CLI documents</a> in 10 seconds.</p>
 </body>
 </html>


### PR DESCRIPTION
Looks like the old link was tweaked by doc team hence is not quite valid any more, with that, can we just redirect to the new landing page?

//CC: @achandmsft @marstr   


- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
