### PR TITLE
Disable MSI Test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,8 @@ jobs:
   displayName: Test Windows MSI
 
   dependsOn: BuildWindowsMSI
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
+  # condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
+  condition: false
   pool:
     vmImage: 'vs2017-win2016'
   steps:


### PR DESCRIPTION
It seems that msiexec isn't enough, and that the updated Azure CLI is not being tested after it's installed on the agent. We need to take a look at this, but until we get it working we'll have to manually test the MSI installer.