### PR TITLE
Fix redis export args

### DIFF
--- a/src/command_modules/azure-cli-redis/HISTORY.rst
+++ b/src/command_modules/azure-cli-redis/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.4.3
++++++
+* Minor fixes.
+
 0.4.2
 +++++
 * Minor fixes.

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/custom.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/custom.py
@@ -21,7 +21,7 @@ wrong_vmsize_error = CLIError('Invalid VM size. Example for Valid values: '
 # pylint: disable=unused-argument
 def cli_redis_export(cmd, client, resource_group_name, name, prefix, container, file_format=None):
     from azure.mgmt.redis.models import ExportRDBParameters
-    parameters = ExportRDBParameters(prefix, container, file_format)
+    parameters = ExportRDBParameters(prefix=prefix, container=container, format=file_format)
     return client.export_data(resource_group_name, name, parameters)
 
 

--- a/src/command_modules/azure-cli-redis/setup.py
+++ b/src/command_modules/azure-cli-redis/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.4.2"
+VERSION = "0.4.3"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
This fixes the issue #9287.

As the module `azure-mgmt-redis` expects named args,
https://github.com/Azure/azure-sdk-for-python/blob/400f9b9bc9dd316222e75f636fd7dd6717d46293/azure-mgmt-redis/azure/mgmt/redis/models/export_rdb_parameters_py3.py#L39
```
    def __init__(self, *, prefix: str, container: str, format: str=None, **kwargs) -> None:
```

This PR updates the module `azure-cli-redis` 0.4.2 to align with the `azure-mgmt-redis` 6.0.0 .

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
