### PR TITLE
[Botservice] Allow different casings of language input into CLI

### DIFF
--- a/src/command_modules/azure-cli-botservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-botservice/HISTORY.rst
@@ -23,6 +23,7 @@ Release History
     * This message only appears if the `--code-dir` doesn't contain a package.json.
 * `az bot prepare-deploy` returns `true` if successful and has helpful verbose logging.
 * Add more available Application Insights regions to `az bot create -v v3`
+* Normalize language input from CLI so user can use any case when entering Csharp, Javascript, Typescript
 
 0.1.10
 ++++++

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
@@ -80,6 +80,17 @@ def __prepare_configuration_file(cmd, resource_group_name, kudu_client, folder_p
                 existing[key] = value
             f.write(json.dumps(existing))
 
+def _normalize_language(language):
+    languages = {
+        CSHARP.lower(): CSHARP,
+        JAVASCRIPT.lower(): JAVASCRIPT,
+        TYPESCRIPT.lower(): TYPESCRIPT,
+    }
+
+    try:
+        return languages[language.lower()]
+    except KeyError:
+        raise CLIError('Unsupported language. Supported languages: {0}'.format(', '.join(languages).title()))
 
 def create(cmd, client, resource_group_name, resource_name, kind, msa_app_id, password, language=None,  # pylint: disable=too-many-locals, too-many-statements
            description=None, display_name=None, endpoint=None, tags=None, storageAccountName=None,
@@ -156,6 +167,7 @@ def create(cmd, client, resource_group_name, resource_name, kind, msa_app_id, pa
         if not language:
             raise CLIError("You must pass in a language when creating a {0} or {1} bot. See 'az bot create --help'."
                            .format(webapp_kind, function_kind))
+        language = _normalize_language(language)
 
         bot_template_type = __bot_template_validator(version, deploy_echo)
 
@@ -510,6 +522,7 @@ def prepare_publish(cmd, client, resource_group_name, resource_name, sln_name, p
 
 
 def prepare_webapp_deploy(language, code_dir=None, proj_file_path=None):
+    language = _normalize_language(language)
     if not code_dir:
         code_dir = os.getcwd()
         logger.info('--code-dir not provided, defaulting to current working directory: %s\n'


### PR DESCRIPTION
I got sick of accidentally typing CSharp instead of Csharp and having to look up whether to use Typescript or TypeScript, so I added a function to accept all casings and return an error if there's a non-case typo.

Recommend @stevengum for review. It was an easy fix for a minor annoyance; I won't be offended if you don't merge 😄 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
