### PR TITLE
Skip loading extensions which are not compatible with azure-cli-core version.

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,6 +3,7 @@
 Release History
 ===============
 * auth: polish common AAD service errors with actionables to overcome
+* Fixed issue where the CLI would load extensions that were not compatible with its core version.
 
 2.0.64
 ++++++

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -163,6 +163,8 @@ class MainCommandsLoader(CLICommandsLoader):
 
         def _update_command_table_from_extensions(ext_suppressions):
 
+            from azure.cli.core.extension.operations import check_version_compatibility
+
             def _handle_extension_suppressions(extensions):
                 filtered_extensions = []
                 for ext in extensions:
@@ -180,6 +182,12 @@ class MainCommandsLoader(CLICommandsLoader):
                 allowed_extensions = _handle_extension_suppressions(extensions)
                 module_commands = set(self.command_table.keys())
                 for ext in allowed_extensions:
+                    try:
+                        check_version_compatibility(ext.get_metadata())
+                    except CLIError as ex:
+                        # issue warning and skip loading extensions that aren't compatible with the CLI core
+                        logger.warning(ex)
+                        continue
                     ext_name = ext.name
                     ext_dir = ext.path or get_extension_path(ext_name)
                     sys.path.append(ext_dir)

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -152,9 +152,9 @@ class TestCommandRegistration(unittest.TestCase):
         return ext_name
 
     def _mock_get_extensions():
-        MockExtension = namedtuple('Extension', ['name', 'preview', 'path'])
-        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, path=None),
-                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, path=None)]
+        MockExtension = namedtuple('Extension', ['name', 'preview', 'path', 'get_metadata'])
+        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, path=None, get_metadata=lambda: {}),
+                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, path=None, get_metadata=lambda: {})]
 
     def _mock_load_command_loader(loader, args, name, prefix):
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -144,9 +144,9 @@ class TestParser(unittest.TestCase):
         return ext_name
 
     def _mock_get_extensions():
-        MockExtension = namedtuple('Extension', ['name', 'preview', 'path'])
-        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, path=None),
-                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, path=None)]
+        MockExtension = namedtuple('Extension', ['name', 'preview', 'path', 'get_metadata'])
+        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, path=None, get_metadata=lambda: {}),
+                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, path=None, get_metadata=lambda: {})]
 
     def _mock_load_command_loader(loader, args, name, prefix):
         from enum import Enum

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/custom.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/custom.py
@@ -4,9 +4,11 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.log import get_logger
+from knack.util import CLIError
+
 from azure.cli.core.extension import ExtensionNotInstalledException, get_extension_modname, get_extension
 from azure.cli.core.extension.operations import (reload_extension, update_extension,
-                                                 add_extension, add_extension_to_path)
+                                                 add_extension, add_extension_to_path, _validate_whl_cli_compat)
 
 logger = get_logger(__name__)
 INTERACTIVE_EXTENSION_NAME = 'interactive'
@@ -14,18 +16,27 @@ INTERACTIVE_EXTENSION_NAME = 'interactive'
 
 def start_shell(cmd, update=None, style=None):
     from importlib import import_module
+    from packaging import version
+
     try:
         get_extension(INTERACTIVE_EXTENSION_NAME)
+
         if update:
-            logger.warning("Updating the Interactive extension to the latest available..")
+            logger.warning("Updating the Interactive extension to the latest available...")
             update_extension(cmd, INTERACTIVE_EXTENSION_NAME)
             reload_extension(INTERACTIVE_EXTENSION_NAME)
     except ExtensionNotInstalledException:
-        logger.warning("Installing the Interactive extension..")
+        logger.warning("Installing the Interactive extension...")
         add_extension(cmd, extension_name=INTERACTIVE_EXTENSION_NAME)
 
-    ext_path = get_extension(INTERACTIVE_EXTENSION_NAME).path
-    add_extension_to_path(INTERACTIVE_EXTENSION_NAME, ext_dir=ext_path)
-    interactive_module = get_extension_modname(ext_name=INTERACTIVE_EXTENSION_NAME, ext_dir=ext_path)
+    ext = get_extension(INTERACTIVE_EXTENSION_NAME)
+    try:
+        _validate_whl_cli_compat(ext.get_metadata())
+    except CLIError as ex:
+        msg = '{}\n\nRun `az interactive --update` and try again.'.format(str(ex))
+        raise CLIError(msg)
+
+    add_extension_to_path(INTERACTIVE_EXTENSION_NAME, ext_dir=ext.path)
+    interactive_module = get_extension_modname(ext_name=INTERACTIVE_EXTENSION_NAME, ext_dir=ext.path)
     azext_interactive = import_module(interactive_module)
     azext_interactive.start_shell(cmd, style=style)

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/custom.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/custom.py
@@ -6,9 +6,10 @@
 from knack.log import get_logger
 from knack.util import CLIError
 
-from azure.cli.core.extension import ExtensionNotInstalledException, get_extension_modname, get_extension
-from azure.cli.core.extension.operations import (reload_extension, update_extension,
-                                                 add_extension, add_extension_to_path, _validate_whl_cli_compat)
+from azure.cli.core.extension import (
+    ExtensionNotInstalledException, get_extension_modname, get_extension)
+from azure.cli.core.extension.operations import (
+    reload_extension, update_extension, add_extension, add_extension_to_path, check_version_compatibility)
 
 logger = get_logger(__name__)
 INTERACTIVE_EXTENSION_NAME = 'interactive'
@@ -16,7 +17,6 @@ INTERACTIVE_EXTENSION_NAME = 'interactive'
 
 def start_shell(cmd, update=None, style=None):
     from importlib import import_module
-    from packaging import version
 
     try:
         get_extension(INTERACTIVE_EXTENSION_NAME)
@@ -31,10 +31,9 @@ def start_shell(cmd, update=None, style=None):
 
     ext = get_extension(INTERACTIVE_EXTENSION_NAME)
     try:
-        _validate_whl_cli_compat(ext.get_metadata())
-    except CLIError as ex:
-        msg = '{}\n\nRun `az interactive --update` and try again.'.format(str(ex))
-        raise CLIError(msg)
+        check_version_compatibility(ext.get_metadata())
+    except CLIError:
+        raise CLIError('Run `az interactive --update` and try again.')
 
     add_extension_to_path(INTERACTIVE_EXTENSION_NAME, ext_dir=ext.path)
     interactive_module = get_extension_modname(ext_name=INTERACTIVE_EXTENSION_NAME, ext_dir=ext.path)


### PR DESCRIPTION
Fixes #9241.

While the extension add command prevents installing extensions which are not compatible with the core, if an extension is installed and then the CLI is updated such that the extension is no longer compatible, the CLI would still load that extension, resulting in a potential crash.

This PR ensures that the CLI checks the compatibility of each extension during loading and issues a warning and skips that extension if it is no longer compatible.

Example for `az interactive`:
```
(env) D:\github>az interactive
The 'interactive' extension is not compatible with this version of the CLI.
You have CLI core version 2.0.64 and this extension requires a min of 2.0.50.dev0 and max of 2.0.61.
Run `az interactive --update` and try again.
```

Added custom logic to az interactive to add the final line about running with --update. Otherwise, it would just be the warning.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
