### PR TITLE
role assignment: drop default group name when --scope is provided

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
@@ -87,14 +87,9 @@ def validate_cert(namespace):
 
 def process_assignment_namespace(cmd, namespace):
     from azure.cli.core.util import ConfiguredDefaultSetter
-    if namespace.resource_group_name and namespace.scope:
-        with ConfiguredDefaultSetter(cmd.cli_ctx.config, 'local'):
-            defaults_result = cmd.cli_ctx.config.items(cmd.cli_ctx.config.defaults_section_name)
-        if next((x for x in defaults_result if x.get('value') == namespace.resource_group_name and
-                 x.get('name') == 'group'), None):
-            namespace.resource_group_name = None  # drop configured defaults
-        else:
-            raise CLIError('usage error: --resource RESOURCE_GROUP | --scope')
+    resource_group = namespace.resource_group_name
+    if namespace.scope and resource_group and getattr(resource_group, 'is_default', None):
+        namespace.resource_group_name = None  # drop configured defaults
 
 
 def process_msi_namespace(cmd, namespace):

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
@@ -85,6 +85,18 @@ def validate_cert(namespace):
         namespace.cert = x509
 
 
+def process_assignment_namespace(cmd, namespace):
+    from azure.cli.core.util import ConfiguredDefaultSetter
+    if namespace.resource_group_name and namespace.scope:
+        with ConfiguredDefaultSetter(cmd.cli_ctx.config, 'local'):
+            defaults_result = cmd.cli_ctx.config.items(cmd.cli_ctx.config.defaults_section_name)
+        if next((x for x in defaults_result if x.get('value') == namespace.resource_group_name and
+                 x.get('name') == 'group'), None):
+            namespace.resource_group_name = None  # drop configured defaults
+        else:
+            raise CLIError('usage error: --resource RESOURCE_GROUP | --scope')
+
+
 def process_msi_namespace(cmd, namespace):
     get_default_location_from_resource_group(cmd, namespace)
     validate_tags(namespace)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
@@ -85,8 +85,7 @@ def validate_cert(namespace):
         namespace.cert = x509
 
 
-def process_assignment_namespace(cmd, namespace):
-    from azure.cli.core.util import ConfiguredDefaultSetter
+def process_assignment_namespace(_, namespace):
     resource_group = namespace.resource_group_name
     if namespace.scope and resource_group and getattr(resource_group, 'is_default', None):
         namespace.resource_group_name = None  # drop configured defaults

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_validators.py
@@ -85,7 +85,7 @@ def validate_cert(namespace):
         namespace.cert = x509
 
 
-def process_assignment_namespace(_, namespace):
+def process_assignment_namespace(cmd, namespace):  # pylint: disable=unused-argument
     resource_group = namespace.resource_group_name
     if namespace.scope and resource_group and getattr(resource_group, 'is_default', None):
         namespace.resource_group_name = None  # drop configured defaults

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/commands.py
@@ -12,7 +12,7 @@ from azure.cli.core.commands import CliCommandType
 from ._client_factory import (_auth_client_factory, _graph_client_factory,
                               _msi_user_identities_operations, _msi_operations_operations)
 
-from ._validators import process_msi_namespace
+from ._validators import process_msi_namespace, process_assignment_namespace
 
 
 def transform_definition_list(result):
@@ -130,9 +130,9 @@ def load_command_table(self, _):
         g.custom_command('update', 'update_role_definition')
 
     with self.command_group('role assignment') as g:
-        g.custom_command('delete', 'delete_role_assignments')
-        g.custom_command('list', 'list_role_assignments', table_transformer=transform_assignment_list)
-        g.custom_command('create', 'create_role_assignment')
+        g.custom_command('delete', 'delete_role_assignments', validator=process_assignment_namespace)
+        g.custom_command('list', 'list_role_assignments', validator=process_assignment_namespace, table_transformer=transform_assignment_list)
+        g.custom_command('create', 'create_role_assignment', validator=process_assignment_namespace)
         g.custom_command('list-changelogs', 'list_role_assignment_change_logs')
 
     with self.command_group('ad app', client_factory=get_graph_client_applications, resource_type=PROFILE_TYPE,

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_role_assignment_handle_conflicted_assignments.yaml
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/recordings/test_role_assignment_handle_conflicted_assignments.yaml
@@ -1,0 +1,1313 @@
+interactions:
+- request:
+    body: '{"location": "westus", "tags": {"cause": "automation", "date": "2019-05-08T18:11:53Z",
+      "product": "azurecli"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --location --name --tag
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 resourcemanagementclient/2.1.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_role_assign000001?api-version=2018-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001","name":"cli_role_assign000001","location":"westus","tags":{"cause":"automation","date":"2019-05-08T18:11:53Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '384'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:11:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: 'b''{"passwordProfile": {"password": "Test123456789", "forceChangePasswordNextLogin":
+      false}, "mailNickname": "testuser000002", "accountEnabled": true, "userPrincipalName":
+      "testuser000002@azuresdkteam.onmicrosoft.com", "displayName": "tester123"}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad user create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '245'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --display-name --password --user-principal-name
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8910b5b8-1e16-4e56-9675-87136d692696","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2019-05-08T18:11:57Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"tester123","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"testuser000002","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2019-05-08T18:11:57.1104088Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/8910b5b8-1e16-4e56-9675-87136d692696/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"testuser000002@azuresdkteam.onmicrosoft.com","userState":null,"userStateChangedOn":null,"userType":"Member"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1575'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 08 May 2019 18:11:56 GMT
+      duration:
+      - '2195532'
+      expires:
+      - '-1'
+      location:
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/8910b5b8-1e16-4e56-9675-87136d692696/Microsoft.DirectoryServices.User
+      ocp-aad-diagnostics-server-name:
+      - PkCvv/QKIhw9uu/OmXUHm5LBeaURLjYgLYT6Rc6GAzs=
+      ocp-aad-session-key:
+      - X0y_Hpe6fHn_gfYbyvTnGbSMJqUOJxCJT2iIygHmjpLDAj8IcMzzGHdFi6BqLGqdgjasvpmvC20Sm663bVgquvAolFeOAJqqeHnUK4D6B5DpNUTzm_xJJJfk1swqRq3DzzO4RsipiD9JDDqLxBtL8Q.23USsPnSnTO9mp6rCgoWktCAa3k-A4nRW3QVJGX1EPI
+      pragma:
+      - no-cache
+      request-id:
+      - b8e4a148-67b8-4731-a998-fb08c36d1f3f
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - group show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 resourcemanagementclient/2.1.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_role_assign000001?api-version=2018-05-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001","name":"cli_role_assign000001","location":"westus","tags":{"cause":"automation","date":"2019-05-08T18:11:53Z","product":"azurecli"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '384'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment create
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-authorization/0.50.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2018-01-01-preview&$filter=roleName%20eq%20%27reader%27
+  response:
+    body:
+      string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
+        you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[],"dataActions":[],"notDataActions":[]}],"createdOn":"2015-02-02T21:55:09.8806423Z","updatedOn":"2019-02-05T21:24:35.7424745Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '615'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; HttpOnly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-request-charge:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27testuser000002%40azuresdkteam.onmicrosoft.com%27
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8910b5b8-1e16-4e56-9675-87136d692696","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2019-05-08T18:11:57Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"tester123","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"testuser000002","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2019-05-08T18:11:57Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/8910b5b8-1e16-4e56-9675-87136d692696/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"testuser000002@azuresdkteam.onmicrosoft.com","userState":null,"userStateChangedOn":null,"userType":"Member"}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1570'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 08 May 2019 18:12:13 GMT
+      duration:
+      - '522119'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - YPCVOwAR3XOdfRvDdWZX3yHf1fnOOll9dsEetoCYv9Y=
+      ocp-aad-session-key:
+      - iNWmrkqETQzhKgHKkzg-YvgsI-feTTSt96tcloLOU7u9xrQcl2KeERg2rxM4OrXj13CGlOn1VVCewmd-NvyM749i6Gi8kOFM6cR3zG1YRyheUJpaw7VSX4vQS_r1gY5moXjXlo0AdCH4VnXJxhy-4Q.utq8UG7kGy2wadrOdtpd8SCTldVw8nP7ow96LxPDGKw
+      pragma:
+      - no-cache
+      request-id:
+      - 1e51e29e-b41c-485e-9099-725dff7388b7
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"principalId": "8910b5b8-1e16-4e56-9675-87136d692696",
+      "roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '233'
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie:
+      - x-ms-gateway-slice=Production
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-authorization/0.50.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2018-01-01-preview
+  response:
+    body:
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"8910b5b8-1e16-4e56-9675-87136d692696","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001","createdOn":"2019-05-08T18:12:14.1062691Z","updatedOn":"2019-05-08T18:12:14.1062691Z","createdBy":null,"updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '891'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; HttpOnly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-ms-request-charge:
+      - '3'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27testuser000002%40azuresdkteam.onmicrosoft.com%27
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8910b5b8-1e16-4e56-9675-87136d692696","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2019-05-08T18:11:57Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"tester123","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"testuser000002","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2019-05-08T18:11:57Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/8910b5b8-1e16-4e56-9675-87136d692696/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"testuser000002@azuresdkteam.onmicrosoft.com","userState":null,"userStateChangedOn":null,"userType":"Member"}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1570'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 08 May 2019 18:12:17 GMT
+      duration:
+      - '525510'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - 3tNvVkm/Zj7QKWAs1YPTXA5TJ87jXEFFrif+RYkOm5g=
+      ocp-aad-session-key:
+      - kQLKQywlQLj_XJw6f9rSN02KNT98cnRnR1HyttBMnQOylF0ZxzZaMKlGYeNsA_MSjx234v7q11DPjeWJsoC0J717qnhMTxcfcy2fXepr-6Qi-c6iEervNkFK24LhMzV-uF0zeWI88YiPoiTpuZBFww.zTCzujIo_dCtyxT5YjFC0v6Qe6j7FPHyukP6Crj-d2Y
+      pragma:
+      - no-cache
+      request-id:
+      - 819dfec5-f725-4f25-b2a5-233a7336394b
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment list
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-authorization/0.50.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?api-version=2018-01-01-preview&$filter=principalId%20eq%20%278910b5b8-1e16-4e56-9675-87136d692696%27
+  response:
+    body:
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"8910b5b8-1e16-4e56-9675-87136d692696","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001","createdOn":"2019-05-08T18:12:15.9102121Z","updatedOn":"2019-05-08T18:12:15.9102121Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '937'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; HttpOnly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-request-charge:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment list
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie:
+      - x-ms-gateway-slice=Production
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-authorization/0.50.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2018-01-01-preview&$filter=roleName%20eq%20%27reader%27
+  response:
+    body:
+      string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
+        you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[],"dataActions":[],"notDataActions":[]}],"createdOn":"2015-02-02T21:55:09.8806423Z","updatedOn":"2019-02-05T21:24:35.7424745Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '615'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; HttpOnly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-request-charge:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment list
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie:
+      - x-ms-gateway-slice=Production
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-authorization/0.50.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2018-01-01-preview
+  response:
+    body:
+      string: "{\"value\":[{\"properties\":{\"roleName\":\"73a8d45b-8fbc-4ef0-840d-b9b3a7460112\",\"type\":\"CustomRole\",\"description\":\"Can
+        monitor compute, network and storage, and restart virtual machines\",\"assignableScopes\":[\"/subscriptions/00000000-0000-0000-0000-000000000000\"],\"permissions\":[{\"actions\":[\"Microsoft.Compute/*/read\",\"Microsoft.Compute/virtualMachines/start/action\",\"Microsoft.Compute/virtualMachines/restart/action\",\"Microsoft.Network/*/read\",\"Microsoft.Storage/*/read\",\"Microsoft.Authorization/*/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Resources/subscriptions/resourceGroups/resources/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*\"],\"notDataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write\"]}],\"createdOn\":\"2019-03-04T03:59:03.7254414Z\",\"updatedOn\":\"2019-03-04T03:59:03.7254414Z\",\"createdBy\":\"89ed5be8-ff97-41b5-ab11-055e1e3cc34b\",\"updatedBy\":\"89ed5be8-ff97-41b5-ab11-055e1e3cc34b\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4adcc96e-0796-4b7e-851c-9b43b4a38547\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4adcc96e-0796-4b7e-851c-9b43b4a38547\"},{\"properties\":{\"roleName\":\"cli-test-role3rbqkom\",\"type\":\"CustomRole\",\"description\":\"Can
+        monitor compute, network and storage, and restart virtual machines\",\"assignableScopes\":[\"/subscriptions/00000000-0000-0000-0000-000000000000\"],\"permissions\":[{\"actions\":[\"Microsoft.Compute/*/read\",\"Microsoft.Compute/virtualMachines/start/action\",\"Microsoft.Compute/virtualMachines/restart/action\",\"Microsoft.Network/*/read\",\"Microsoft.Storage/*/read\",\"Microsoft.Authorization/*/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Resources/subscriptions/resourceGroups/resources/read\",\"Microsoft.Insights/alertRules/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-08-14T21:07:16.8263727Z\",\"updatedOn\":\"2018-08-14T21:07:16.8263727Z\",\"createdBy\":\"e7e158d3-7cdc-47cd-8825-5859d7ab2b55\",\"updatedBy\":\"e7e158d3-7cdc-47cd-8825-5859d7ab2b55\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b48251d5-e1fb-4bb2-9b74-bc0c169c1c32\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b48251d5-e1fb-4bb2-9b74-bc0c169c1c32\"},{\"properties\":{\"roleName\":\"cli-test-rolecklmqeq\",\"type\":\"CustomRole\",\"description\":\"Can
+        monitor compute, network and storage, and restart virtual machines\",\"assignableScopes\":[\"/subscriptions/00000000-0000-0000-0000-000000000000\"],\"permissions\":[{\"actions\":[\"Microsoft.Compute/*/read\",\"Microsoft.Compute/virtualMachines/start/action\",\"Microsoft.Compute/virtualMachines/restart/action\",\"Microsoft.Network/*/read\",\"Microsoft.Storage/*/read\",\"Microsoft.Authorization/*/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Resources/subscriptions/resourceGroups/resources/read\",\"Microsoft.Insights/alertRules/*\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*\"],\"notDataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write\"]}],\"createdOn\":\"2018-10-04T20:58:03.9279197Z\",\"updatedOn\":\"2018-10-04T20:58:03.9279197Z\",\"createdBy\":\"e7e158d3-7cdc-47cd-8825-5859d7ab2b55\",\"updatedBy\":\"e7e158d3-7cdc-47cd-8825-5859d7ab2b55\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/f9bd3e9e-d623-4a99-afc9-c473b673605c\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"f9bd3e9e-d623-4a99-afc9-c473b673605c\"},{\"properties\":{\"roleName\":\"cli-test-rolegq62oio\",\"type\":\"CustomRole\",\"description\":\"Can
+        monitor compute, network and storage, and restart virtual machines\",\"assignableScopes\":[\"/subscriptions/00000000-0000-0000-0000-000000000000\"],\"permissions\":[{\"actions\":[\"Microsoft.Compute/*/read\",\"Microsoft.Compute/virtualMachines/start/action\",\"Microsoft.Compute/virtualMachines/restart/action\",\"Microsoft.Network/*/read\",\"Microsoft.Storage/*/read\",\"Microsoft.Authorization/*/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Resources/subscriptions/resourceGroups/resources/read\",\"Microsoft.Insights/alertRules/*\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*\"],\"notDataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write\"]}],\"createdOn\":\"2018-10-04T20:54:33.3439081Z\",\"updatedOn\":\"2018-10-04T20:54:33.3439081Z\",\"createdBy\":\"e7e158d3-7cdc-47cd-8825-5859d7ab2b55\",\"updatedBy\":\"e7e158d3-7cdc-47cd-8825-5859d7ab2b55\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b656d6f3-d1d7-4090-bb7b-86200aa9f9ab\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b656d6f3-d1d7-4090-bb7b-86200aa9f9ab\"},{\"properties\":{\"roleName\":\"CoAdministrator\",\"type\":\"CustomRole\",\"description\":\"Read,
+        monitor and restart virtual machines\",\"assignableScopes\":[\"/subscriptions/00000000-0000-0000-0000-000000000000\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.Authorization/*\",\"Microsoft.Support/*\",\"Microsoft.ClassicCompute/virtualMachines/restart/action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-06-14T22:25:04.1831924Z\",\"updatedOn\":\"2018-06-14T22:25:04.1831924Z\",\"createdBy\":\"5963f50c-7c43-405c-af7e-53294de76abd\",\"updatedBy\":\"5963f50c-7c43-405c-af7e-53294de76abd\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/abec5297-d72c-4fbc-acaf-868482d345c2\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"abec5297-d72c-4fbc-acaf-868482d345c2\"},{\"properties\":{\"roleName\":\"AcrPush\",\"type\":\"BuiltInRole\",\"description\":\"acr
+        push\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ContainerRegistry/registries/pull/read\",\"Microsoft.ContainerRegistry/registries/push/write\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-10-29T17:52:32.5201177Z\",\"updatedOn\":\"2018-11-13T23:26:19.9749249Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8311e382-0749-4cb8-b61a-304f252e45ec\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8311e382-0749-4cb8-b61a-304f252e45ec\"},{\"properties\":{\"roleName\":\"API
+        Management Service Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can
+        manage service and the APIs\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ApiManagement/service/*\",\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8650193Z\",\"updatedOn\":\"2019-02-05T21:24:17.7502607Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/312a565d-c81f-4fd8-895a-4e21e48d571c\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"312a565d-c81f-4fd8-895a-4e21e48d571c\"},{\"properties\":{\"roleName\":\"AcrPull\",\"type\":\"BuiltInRole\",\"description\":\"acr
+        pull\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ContainerRegistry/registries/pull/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-10-22T19:01:56.8227182Z\",\"updatedOn\":\"2018-11-13T23:22:03.2302457Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"7f951dda-4ed3-4680-a7ca-43fe172d538d\"},{\"properties\":{\"roleName\":\"AcrImageSigner\",\"type\":\"BuiltInRole\",\"description\":\"acr
+        image signer\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ContainerRegistry/registries/sign/write\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-03-15T23:23:08.4038322Z\",\"updatedOn\":\"2018-10-29T19:06:24.9004422Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6cef56e8-d556-48e5-a04f-b8e64114680f\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6cef56e8-d556-48e5-a04f-b8e64114680f\"},{\"properties\":{\"roleName\":\"AcrDelete\",\"type\":\"BuiltInRole\",\"description\":\"acr
+        delete\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ContainerRegistry/registries/artifacts/delete\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2019-03-11T20:19:31.6682804Z\",\"updatedOn\":\"2019-03-11T20:24:38.9845104Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"c2f4ef07-c644-48eb-af81-4b1b4947fb11\"},{\"properties\":{\"roleName\":\"AcrQuarantineReader\",\"type\":\"BuiltInRole\",\"description\":\"acr
+        quarantine data reader\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ContainerRegistry/registries/quarantineRead/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-03-16T00:27:39.9596835Z\",\"updatedOn\":\"2018-10-29T19:16:24.3521233Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/cdda3590-29a3-44f6-95f2-9f980659eb04\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"cdda3590-29a3-44f6-95f2-9f980659eb04\"},{\"properties\":{\"roleName\":\"AcrQuarantineWriter\",\"type\":\"BuiltInRole\",\"description\":\"acr
+        quarantine data writer\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ContainerRegistry/registries/quarantineRead/read\",\"Microsoft.ContainerRegistry/registries/quarantineWrite/write\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-03-16T00:26:37.5871820Z\",\"updatedOn\":\"2018-10-29T19:22:29.9285629Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/c8d4ff99-41c3-41a8-9f60-21dfdad59608\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"c8d4ff99-41c3-41a8-9f60-21dfdad59608\"},{\"properties\":{\"roleName\":\"API
+        Management Service Operator Role\",\"type\":\"BuiltInRole\",\"description\":\"Can
+        manage service but not the APIs\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ApiManagement/service/*/read\",\"Microsoft.ApiManagement/service/backup/action\",\"Microsoft.ApiManagement/service/delete\",\"Microsoft.ApiManagement/service/managedeployments/action\",\"Microsoft.ApiManagement/service/read\",\"Microsoft.ApiManagement/service/restore/action\",\"Microsoft.ApiManagement/service/updatecertificate/action\",\"Microsoft.ApiManagement/service/updatehostname/action\",\"Microsoft.ApiManagement/service/write\",\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.ApiManagement/service/users/keys/read\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-11-09T00:03:42.1194019Z\",\"updatedOn\":\"2016-11-18T23:56:25.4682649Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e022efe7-f5ba-4159-bbe4-b44f577e9b61\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e022efe7-f5ba-4159-bbe4-b44f577e9b61\"},{\"properties\":{\"roleName\":\"API
+        Management Service Reader Role\",\"type\":\"BuiltInRole\",\"description\":\"Read-only
+        access to service and APIs\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ApiManagement/service/*/read\",\"Microsoft.ApiManagement/service/read\",\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.ApiManagement/service/users/keys/read\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-11-09T00:26:45.1540473Z\",\"updatedOn\":\"2017-01-23T23:10:34.8876776Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/71522526-b88f-4d52-b57f-d31fc3546d0d\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"71522526-b88f-4d52-b57f-d31fc3546d0d\"},{\"properties\":{\"roleName\":\"Application
+        Insights Component Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can
+        manage Application Insights components\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/components/*\",\"Microsoft.Insights/webtests/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:37.1625138Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ae349356-3a1b-4a5e-921d-050484c6347e\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ae349356-3a1b-4a5e-921d-050484c6347e\"},{\"properties\":{\"roleName\":\"Application
+        Insights Snapshot Debugger\",\"type\":\"BuiltInRole\",\"description\":\"Gives
+        user permission to use Application Insights Snapshot Debugger features\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/components/*/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-04-19T21:25:12.3728747Z\",\"updatedOn\":\"2017-04-19T23:34:59.9511581Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/08954f03-6346-4c2e-81c0-ec3a5cfae23b\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"08954f03-6346-4c2e-81c0-ec3a5cfae23b\"},{\"properties\":{\"roleName\":\"Automation
+        Job Operator\",\"type\":\"BuiltInRole\",\"description\":\"Create and Manage
+        Jobs using Automation Runbooks.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups/read\",\"Microsoft.Automation/automationAccounts/jobs/read\",\"Microsoft.Automation/automationAccounts/jobs/resume/action\",\"Microsoft.Automation/automationAccounts/jobs/stop/action\",\"Microsoft.Automation/automationAccounts/jobs/streams/read\",\"Microsoft.Automation/automationAccounts/jobs/suspend/action\",\"Microsoft.Automation/automationAccounts/jobs/write\",\"Microsoft.Automation/automationAccounts/jobs/output/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-04-19T20:52:41.0020018Z\",\"updatedOn\":\"2018-08-14T22:08:48.1147327Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4fe576fe-1146-4730-92eb-48519fa6bf9f\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4fe576fe-1146-4730-92eb-48519fa6bf9f\"},{\"properties\":{\"roleName\":\"Automation
+        Runbook Operator\",\"type\":\"BuiltInRole\",\"description\":\"Read Runbook
+        properties - to be able to create Jobs of the runbook.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Automation/automationAccounts/runbooks/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-04-19T20:47:49.5640674Z\",\"updatedOn\":\"2017-04-25T01:00:45.6444999Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5fb5aef8-1081-4b8e-bb16-9d5d0385bab5\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5fb5aef8-1081-4b8e-bb16-9d5d0385bab5\"},{\"properties\":{\"roleName\":\"Automation
+        Operator\",\"type\":\"BuiltInRole\",\"description\":\"Automation Operators
+        are able to start, stop, suspend, and resume jobs\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups/read\",\"Microsoft.Automation/automationAccounts/jobs/read\",\"Microsoft.Automation/automationAccounts/jobs/resume/action\",\"Microsoft.Automation/automationAccounts/jobs/stop/action\",\"Microsoft.Automation/automationAccounts/jobs/streams/read\",\"Microsoft.Automation/automationAccounts/jobs/suspend/action\",\"Microsoft.Automation/automationAccounts/jobs/write\",\"Microsoft.Automation/automationAccounts/jobSchedules/read\",\"Microsoft.Automation/automationAccounts/jobSchedules/write\",\"Microsoft.Automation/automationAccounts/linkedWorkspace/read\",\"Microsoft.Automation/automationAccounts/read\",\"Microsoft.Automation/automationAccounts/runbooks/read\",\"Microsoft.Automation/automationAccounts/schedules/read\",\"Microsoft.Automation/automationAccounts/schedules/write\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Automation/automationAccounts/jobs/output/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-08-18T01:05:03.3916130Z\",\"updatedOn\":\"2018-05-10T20:12:39.6978200Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/d3881f73-407a-4167-8283-e981cbba0404\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"d3881f73-407a-4167-8283-e981cbba0404\"},{\"properties\":{\"roleName\":\"Avere
+        Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can create and manage
+        an Avere vFXT cluster.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Compute/*/read\",\"Microsoft.Compute/availabilitySets/*\",\"Microsoft.Compute/virtualMachines/*\",\"Microsoft.Compute/disks/*\",\"Microsoft.Network/*/read\",\"Microsoft.Network/networkInterfaces/*\",\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.Network/virtualNetworks/subnets/read\",\"Microsoft.Network/virtualNetworks/subnets/join/action\",\"Microsoft.Network/virtualNetworks/subnets/joinViaServiceEndpoint/action\",\"Microsoft.Network/networkSecurityGroups/join/action\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/*/read\",\"Microsoft.Storage/storageAccounts/*\",\"Microsoft.Support/*\",\"Microsoft.Resources/subscriptions/resourceGroups/resources/read\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete\",\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\",\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write\"],\"notDataActions\":[]}],\"createdOn\":\"2019-03-18T20:00:58.9207889Z\",\"updatedOn\":\"2019-03-29T00:35:59.8924565Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4f8fab4f-1852-4a58-a46a-8eaf358af14a\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4f8fab4f-1852-4a58-a46a-8eaf358af14a\"},{\"properties\":{\"roleName\":\"Avere
+        Operator\",\"type\":\"BuiltInRole\",\"description\":\"Used by the Avere vFXT
+        cluster to manage the cluster\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Compute/virtualMachines/read\",\"Microsoft.Network/networkInterfaces/read\",\"Microsoft.Network/networkInterfaces/write\",\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.Network/virtualNetworks/subnets/read\",\"Microsoft.Network/virtualNetworks/subnets/join/action\",\"Microsoft.Network/networkSecurityGroups/join/action\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/blobServices/containers/delete\",\"Microsoft.Storage/storageAccounts/blobServices/containers/read\",\"Microsoft.Storage/storageAccounts/blobServices/containers/write\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete\",\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\",\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write\"],\"notDataActions\":[]}],\"createdOn\":\"2019-03-18T20:02:38.3399857Z\",\"updatedOn\":\"2019-03-29T00:26:37.9205875Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/c025889f-8102-4ebf-b32c-fc0c6f0c6bd9\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"c025889f-8102-4ebf-b32c-fc0c6f0c6bd9\"},{\"properties\":{\"roleName\":\"Azure
+        Kubernetes Service Cluster Admin Role\",\"type\":\"BuiltInRole\",\"description\":\"List
+        cluster admin credential action.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ContainerService/managedClusters/listClusterAdminCredential/action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-08-15T21:38:18.5953853Z\",\"updatedOn\":\"2018-08-15T21:47:19.4427524Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8\"},{\"properties\":{\"roleName\":\"Azure
+        Kubernetes Service Cluster User Role\",\"type\":\"BuiltInRole\",\"description\":\"List
+        cluster user credential action.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ContainerService/managedClusters/listClusterUserCredential/action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-08-15T22:04:53.4037241Z\",\"updatedOn\":\"2018-08-15T22:06:51.5961392Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4abbcc35-e782-43d8-92c5-2d3f1bd2253f\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4abbcc35-e782-43d8-92c5-2d3f1bd2253f\"},{\"properties\":{\"roleName\":\"Azure
+        Maps Data Reader (Preview)\",\"type\":\"BuiltInRole\",\"description\":\"Grants
+        access to read map related data from an Azure maps account.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[],\"notActions\":[],\"dataActions\":[\"Microsoft.Maps/accounts/data/read\"],\"notDataActions\":[]}],\"createdOn\":\"2018-10-05T19:47:03.4723070Z\",\"updatedOn\":\"2018-10-05T19:48:52.8066321Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/423170ca-a8f6-4b0f-8487-9e4eb8f49bfa\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"423170ca-a8f6-4b0f-8487-9e4eb8f49bfa\"},{\"properties\":{\"roleName\":\"Azure
+        Stack Registration Owner\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage Azure Stack registrations.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.AzureStack/registrations/products/listDetails/action\",\"Microsoft.AzureStack/registrations/products/read\",\"Microsoft.AzureStack/registrations/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-11-13T23:42:06.2161827Z\",\"updatedOn\":\"2017-11-13T23:54:02.4007080Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6f12a6df-dd06-4f3e-bcb1-ce8be600526a\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6f12a6df-dd06-4f3e-bcb1-ce8be600526a\"},{\"properties\":{\"roleName\":\"Backup
+        Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage backup
+        service,but can't create vaults and give access to others\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.RecoveryServices/locations/*\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/operationResults/*\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/*\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/refreshContainers/action\",\"Microsoft.RecoveryServices/Vaults/backupJobs/*\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/action\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupManagementMetaData/*\",\"Microsoft.RecoveryServices/Vaults/backupOperationResults/*\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/*\",\"Microsoft.RecoveryServices/Vaults/backupProtectableItems/*\",\"Microsoft.RecoveryServices/Vaults/backupProtectedItems/*\",\"Microsoft.RecoveryServices/Vaults/backupProtectionContainers/*\",\"Microsoft.RecoveryServices/Vaults/backupSecurityPIN/*\",\"Microsoft.RecoveryServices/Vaults/backupUsageSummaries/read\",\"Microsoft.RecoveryServices/Vaults/certificates/*\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/*\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/*\",\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/*\",\"Microsoft.RecoveryServices/Vaults/usages/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.RecoveryServices/Vaults/backupstorageconfig/*\",\"Microsoft.RecoveryServices/Vaults/backupconfig/*\",\"Microsoft.RecoveryServices/Vaults/backupValidateOperation/action\",\"Microsoft.RecoveryServices/Vaults/write\",\"Microsoft.RecoveryServices/Vaults/backupOperations/read\",\"Microsoft.RecoveryServices/Vaults/backupEngines/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/backupProtectionIntent/*\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectableContainers/read\",\"Microsoft.RecoveryServices/locations/backupStatus/action\",\"Microsoft.RecoveryServices/locations/backupPreValidateProtection/action\",\"Microsoft.RecoveryServices/locations/backupValidateFeatures/action\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/write\",\"Microsoft.RecoveryServices/operations/read\",\"Microsoft.RecoveryServices/locations/operationStatus/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectionIntents/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-01-03T13:12:15.7321344Z\",\"updatedOn\":\"2018-10-17T13:36:21.1616745Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5e467623-bb1f-42f4-a55d-6e525e11384b\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5e467623-bb1f-42f4-a55d-6e525e11384b\"},{\"properties\":{\"roleName\":\"Billing
+        Reader\",\"type\":\"BuiltInRole\",\"description\":\"Allows read access to
+        billing data\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Billing/*/read\",\"Microsoft.Commerce/*/read\",\"Microsoft.Consumption/*/read\",\"Microsoft.Management/managementGroups/read\",\"Microsoft.CostManagement/*/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-04-25T02:13:38.9054151Z\",\"updatedOn\":\"2018-09-26T17:45:09.2227236Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64\"},{\"properties\":{\"roleName\":\"Backup
+        Operator\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage backup
+        services, except removal of backup, vault creation and giving access to others\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/backup/action\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationsStatus/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/provisionInstantItemRecovery/action\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/restore/action\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/revokeInstantItemRecovery/action\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/write\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/refreshContainers/action\",\"Microsoft.RecoveryServices/Vaults/backupJobs/*\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/action\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupManagementMetaData/read\",\"Microsoft.RecoveryServices/Vaults/backupOperationResults/*\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectableItems/*\",\"Microsoft.RecoveryServices/Vaults/backupProtectedItems/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectionContainers/read\",\"Microsoft.RecoveryServices/Vaults/backupUsageSummaries/read\",\"Microsoft.RecoveryServices/Vaults/certificates/write\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/write\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/*\",\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/write\",\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.RecoveryServices/Vaults/backupstorageconfig/*\",\"Microsoft.RecoveryServices/Vaults/backupValidateOperation/action\",\"Microsoft.RecoveryServices/Vaults/backupOperations/read\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/operations/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/write\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/inquire/action\",\"Microsoft.RecoveryServices/Vaults/backupEngines/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/backupProtectionIntent/write\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/backupProtectionIntent/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectableContainers/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/items/read\",\"Microsoft.RecoveryServices/locations/backupStatus/action\",\"Microsoft.RecoveryServices/locations/backupPreValidateProtection/action\",\"Microsoft.RecoveryServices/locations/backupValidateFeatures/action\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/write\",\"Microsoft.RecoveryServices/operations/read\",\"Microsoft.RecoveryServices/locations/operationStatus/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectionIntents/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-01-03T13:21:11.8947640Z\",\"updatedOn\":\"2018-10-17T13:35:18.6198865Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00c29273-979b-4161-815c-10b084fb9324\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"00c29273-979b-4161-815c-10b084fb9324\"},{\"properties\":{\"roleName\":\"Backup
+        Reader\",\"type\":\"BuiltInRole\",\"description\":\"Can view backup services,
+        but can't make changes\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/operationsStatus/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/read\",\"Microsoft.RecoveryServices/Vaults/backupJobs/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupJobs/read\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/action\",\"Microsoft.RecoveryServices/Vaults/backupJobsExport/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupManagementMetaData/read\",\"Microsoft.RecoveryServices/Vaults/backupOperationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectedItems/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectionContainers/read\",\"Microsoft.RecoveryServices/Vaults/backupUsageSummaries/read\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/Vaults/backupstorageconfig/read\",\"Microsoft.RecoveryServices/Vaults/backupconfig/read\",\"Microsoft.RecoveryServices/Vaults/backupOperations/read\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/operations/read\",\"Microsoft.RecoveryServices/Vaults/backupEngines/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/backupProtectionIntent/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/items/read\",\"Microsoft.RecoveryServices/locations/backupStatus/action\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/*\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/write\",\"Microsoft.RecoveryServices/operations/read\",\"Microsoft.RecoveryServices/locations/operationStatus/read\",\"Microsoft.RecoveryServices/Vaults/backupProtectionIntents/read\",\"Microsoft.RecoveryServices/Vaults/usages/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-01-03T13:18:41.3893065Z\",\"updatedOn\":\"2018-10-17T13:32:59.2941632Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/a795c7a0-d4a2-40c1-ae25-d81f01202912\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"a795c7a0-d4a2-40c1-ae25-d81f01202912\"},{\"properties\":{\"roleName\":\"Blockchain
+        Member Node Access (Preview)\",\"type\":\"BuiltInRole\",\"description\":\"Allows
+        for access to Blockchain Member nodes\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Blockchain/blockchainMembers/transactionNodes/read\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Blockchain/blockchainMembers/transactionNodes/connect/action\"],\"notDataActions\":[]}],\"createdOn\":\"2018-12-21T10:33:01.9604839Z\",\"updatedOn\":\"2018-12-21T10:33:58.0042162Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/31a002a1-acaf-453e-8a5b-297c9ca1ea24\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"31a002a1-acaf-453e-8a5b-297c9ca1ea24\"},{\"properties\":{\"roleName\":\"BizTalk
+        Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage BizTalk
+        services, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.BizTalkServices/BizTalk/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T20:42:18.8978210Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5e3c6656-6cfa-4708-81fe-0de47ac73342\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5e3c6656-6cfa-4708-81fe-0de47ac73342\"},{\"properties\":{\"roleName\":\"CDN
+        Endpoint Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can manage
+        CDN endpoints, but can\u2019t grant access to other users.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\",\"Microsoft.Cdn/profiles/endpoints/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\",\"updatedOn\":\"2016-05-31T23:13:52.6231539Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/426e0c7f-0c7e-4658-b36f-ff54d6c29b45\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"426e0c7f-0c7e-4658-b36f-ff54d6c29b45\"},{\"properties\":{\"roleName\":\"CDN
+        Endpoint Reader\",\"type\":\"BuiltInRole\",\"description\":\"Can view CDN
+        endpoints, but can\u2019t make changes.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\",\"Microsoft.Cdn/profiles/endpoints/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\",\"updatedOn\":\"2016-05-31T23:13:53.1585846Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/871e35f6-b5c1-49cc-a043-bde969a0f2cd\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"871e35f6-b5c1-49cc-a043-bde969a0f2cd\"},{\"properties\":{\"roleName\":\"CDN
+        Profile Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can manage
+        CDN profiles and their endpoints, but can\u2019t grant access to other users.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\",\"Microsoft.Cdn/profiles/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\",\"updatedOn\":\"2016-05-31T23:13:53.7051278Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ec156ff8-a8d1-4d15-830c-5b80698ca432\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ec156ff8-a8d1-4d15-830c-5b80698ca432\"},{\"properties\":{\"roleName\":\"CDN
+        Profile Reader\",\"type\":\"BuiltInRole\",\"description\":\"Can view CDN profiles
+        and their endpoints, but can\u2019t make changes.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Cdn/edgenodes/read\",\"Microsoft.Cdn/operationresults/*\",\"Microsoft.Cdn/profiles/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-01-23T02:48:46.4996252Z\",\"updatedOn\":\"2016-05-31T23:13:54.2283001Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8f96442b-4075-438f-813d-ad51ab4019af\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8f96442b-4075-438f-813d-ad51ab4019af\"},{\"properties\":{\"roleName\":\"Classic
+        Network Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage classic networks, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicNetwork/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:39.7576926Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b34d265f-36f7-4a0d-a4d4-e158ca92e90f\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b34d265f-36f7-4a0d-a4d4-e158ca92e90f\"},{\"properties\":{\"roleName\":\"Classic
+        Storage Account Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage classic storage accounts, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicStorage/storageAccounts/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:30.8964641Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/86e8f5dc-a6e9-4c67-9d15-de283e8eac25\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"86e8f5dc-a6e9-4c67-9d15-de283e8eac25\"},{\"properties\":{\"roleName\":\"Classic
+        Storage Account Key Operator Service Role\",\"type\":\"BuiltInRole\",\"description\":\"Classic
+        Storage Account Key Operators are allowed to list and regenerate keys on Classic
+        Storage Accounts\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ClassicStorage/storageAccounts/listkeys/action\",\"Microsoft.ClassicStorage/storageAccounts/regeneratekey/action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-04-13T18:22:52.1461100Z\",\"updatedOn\":\"2017-04-13T20:54:03.0505986Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/985d6b00-f706-48f5-a6fe-d0ca12fb668d\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"985d6b00-f706-48f5-a6fe-d0ca12fb668d\"},{\"properties\":{\"roleName\":\"ClearDB
+        MySQL DB Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage ClearDB MySQL databases, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\",\"successbricks.cleardb/databases/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T20:42:23.2893077Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9106cda0-8a86-4e81-b686-29a22c54effe\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9106cda0-8a86-4e81-b686-29a22c54effe\"},{\"properties\":{\"roleName\":\"Classic
+        Virtual Machine Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage classic virtual machines, but not access to them, and not the virtual
+        network or storage account they\u2019re connected to.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicCompute/domainNames/*\",\"Microsoft.ClassicCompute/virtualMachines/*\",\"Microsoft.ClassicNetwork/networkSecurityGroups/join/action\",\"Microsoft.ClassicNetwork/reservedIps/link/action\",\"Microsoft.ClassicNetwork/reservedIps/read\",\"Microsoft.ClassicNetwork/virtualNetworks/join/action\",\"Microsoft.ClassicNetwork/virtualNetworks/read\",\"Microsoft.ClassicStorage/storageAccounts/disks/read\",\"Microsoft.ClassicStorage/storageAccounts/images/read\",\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.ClassicStorage/storageAccounts/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-04-25T00:37:56.5416086Z\",\"updatedOn\":\"2019-02-05T21:24:43.0770473Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/d73bb868-a0df-4d4d-bd69-98a00b01fccb\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"d73bb868-a0df-4d4d-bd69-98a00b01fccb\"},{\"properties\":{\"roleName\":\"Cognitive
+        Services User\",\"type\":\"BuiltInRole\",\"description\":\"Lets you read and
+        list keys of Cognitive Services.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.CognitiveServices/*/read\",\"Microsoft.CognitiveServices/accounts/listkeys/action\",\"Microsoft.Insights/alertRules/read\",\"Microsoft.Insights/diagnosticSettings/read\",\"Microsoft.Insights/logDefinitions/read\",\"Microsoft.Insights/metricdefinitions/read\",\"Microsoft.Insights/metrics/read\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/operations/read\",\"Microsoft.Resources/subscriptions/operationresults/read\",\"Microsoft.Resources/subscriptions/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[\"Microsoft.CognitiveServices/*\"],\"notDataActions\":[]}],\"createdOn\":\"2018-08-08T23:23:43.7701274Z\",\"updatedOn\":\"2019-02-13T19:53:56.7209248Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"a97b65f3-24c7-4388-baec-2e87135dc908\"},{\"properties\":{\"roleName\":\"Cognitive
+        Services Data Reader (Preview)\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you read Cognitive Services data.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[],\"notActions\":[],\"dataActions\":[\"Microsoft.CognitiveServices/*/read\"],\"notDataActions\":[]}],\"createdOn\":\"2019-02-13T20:02:12.6849986Z\",\"updatedOn\":\"2019-02-13T22:53:55.1675290Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b59867f0-fa02-499b-be73-45a86b5b3e1c\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b59867f0-fa02-499b-be73-45a86b5b3e1c\"},{\"properties\":{\"roleName\":\"Cognitive
+        Services Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        create, read, update, delete and manage keys of Cognitive Services.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.CognitiveServices/*\",\"Microsoft.Features/features/read\",\"Microsoft.Features/providers/features/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/diagnosticSettings/*\",\"Microsoft.Insights/logDefinitions/read\",\"Microsoft.Insights/metricdefinitions/read\",\"Microsoft.Insights/metrics/read\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/deployments/operations/read\",\"Microsoft.Resources/subscriptions/operationresults/read\",\"Microsoft.Resources/subscriptions/read\",\"Microsoft.Resources/subscriptions/resourcegroups/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-08-08T23:18:39.2257848Z\",\"updatedOn\":\"2018-09-14T00:53:37.7546808Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68\"},{\"properties\":{\"roleName\":\"CosmosBackupOperator\",\"type\":\"BuiltInRole\",\"description\":\"Can
+        submit restore request for a Cosmos DB database or a container for an account\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.DocumentDB/databaseAccounts/backup/action\",\"Microsoft.DocumentDB/databaseAccounts/restore/action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-12-07T19:47:14.9651560Z\",\"updatedOn\":\"2018-12-07T19:52:21.9969834Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/db7b14f2-5adf-42da-9f96-f2ee17bab5cb\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"db7b14f2-5adf-42da-9f96-f2ee17bab5cb\"},{\"properties\":{\"roleName\":\"Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage everything except access to resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*\"],\"notActions\":[\"Microsoft.Authorization/*/Delete\",\"Microsoft.Authorization/*/Write\",\"Microsoft.Authorization/elevateAccess/Action\",\"Microsoft.Blueprint/blueprintAssignments/write\",\"Microsoft.Blueprint/blueprintAssignments/delete\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:38.4580610Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b24988ac-6180-42a0-ab88-20f7382dd24c\"},{\"properties\":{\"roleName\":\"Cosmos
+        DB Account Reader Role\",\"type\":\"BuiltInRole\",\"description\":\"Can read
+        Azure Cosmos DB Accounts data\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.DocumentDB/*/read\",\"Microsoft.DocumentDB/databaseAccounts/readonlykeys/action\",\"Microsoft.Insights/MetricDefinitions/read\",\"Microsoft.Insights/Metrics/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-10-30T17:53:54.6005577Z\",\"updatedOn\":\"2018-02-21T01:36:59.6186231Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fbdf93bf-df7d-467e-a4d2-9458aa1360c8\"},{\"properties\":{\"roleName\":\"Cost
+        Management Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can view
+        costs and manage cost configuration (e.g. budgets, exports)\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Consumption/*\",\"Microsoft.CostManagement/*\",\"Microsoft.Billing/billingPeriods/read\",\"Microsoft.Resources/subscriptions/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-03-14T16:09:22.8834827Z\",\"updatedOn\":\"2018-09-26T17:45:55.2723170Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/434105ed-43f6-45c7-a02f-909b2ba83430\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"434105ed-43f6-45c7-a02f-909b2ba83430\"},{\"properties\":{\"roleName\":\"Cost
+        Management Reader\",\"type\":\"BuiltInRole\",\"description\":\"Can view cost
+        data and configuration (e.g. budgets, exports)\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Consumption/*/read\",\"Microsoft.CostManagement/*/read\",\"Microsoft.Billing/billingPeriods/read\",\"Microsoft.Resources/subscriptions/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-03-14T16:09:22.8834827Z\",\"updatedOn\":\"2018-09-26T17:46:55.5932301Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/72fafb9e-0641-4937-9268-a91bfd8191a3\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"72fafb9e-0641-4937-9268-a91bfd8191a3\"},{\"properties\":{\"roleName\":\"Data
+        Box Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage
+        everything under Data Box Service except giving access to others.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\",\"Microsoft.Databox/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-07-27T08:28:42.7140210Z\",\"updatedOn\":\"2018-07-27T08:36:56.3827309Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/add466c9-e687-43fc-8d98-dfcf8d720be5\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"add466c9-e687-43fc-8d98-dfcf8d720be5\"},{\"properties\":{\"roleName\":\"Data
+        Box Reader\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage Data
+        Box Service except creating order or editing order details and giving access
+        to others.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Databox/*/read\",\"Microsoft.Databox/jobs/listsecrets/action\",\"Microsoft.Databox/jobs/listcredentials/action\",\"Microsoft.Databox/locations/availableSkus/action\",\"Microsoft.Databox/locations/validateAddress/action\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-07-27T08:26:21.9284772Z\",\"updatedOn\":\"2019-04-29T07:30:10.4407109Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/028f4ed7-e2a9-465e-a8f4-9c0ffdfdc027\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"028f4ed7-e2a9-465e-a8f4-9c0ffdfdc027\"},{\"properties\":{\"roleName\":\"Data
+        Factory Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Create and
+        manage data factories, as well as child resources within them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.DataFactory/dataFactories/*\",\"Microsoft.DataFactory/factories/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:24.1715226Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/673868aa-7521-48a0-acc6-0f60742d39f5\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"673868aa-7521-48a0-acc6-0f60742d39f5\"},{\"properties\":{\"roleName\":\"Data
+        Purger\",\"type\":\"BuiltInRole\",\"description\":\"Can purge analytics data\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Insights/components/*/read\",\"Microsoft.Insights/components/purge/action\",\"Microsoft.OperationalInsights/workspaces/*/read\",\"Microsoft.OperationalInsights/workspaces/purge/action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-04-30T22:39:49.6167700Z\",\"updatedOn\":\"2018-04-30T22:44:15.1171162Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/150f5e0c-0603-4f03-8c7f-cf70034c4e90\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"150f5e0c-0603-4f03-8c7f-cf70034c4e90\"},{\"properties\":{\"roleName\":\"Data
+        Lake Analytics Developer\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you submit, monitor, and manage your own jobs but not create or delete Data
+        Lake Analytics accounts.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.BigAnalytics/accounts/*\",\"Microsoft.DataLakeAnalytics/accounts/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.BigAnalytics/accounts/Delete\",\"Microsoft.BigAnalytics/accounts/TakeOwnership/action\",\"Microsoft.BigAnalytics/accounts/Write\",\"Microsoft.DataLakeAnalytics/accounts/Delete\",\"Microsoft.DataLakeAnalytics/accounts/TakeOwnership/action\",\"Microsoft.DataLakeAnalytics/accounts/Write\",\"Microsoft.DataLakeAnalytics/accounts/dataLakeStoreAccounts/Write\",\"Microsoft.DataLakeAnalytics/accounts/dataLakeStoreAccounts/Delete\",\"Microsoft.DataLakeAnalytics/accounts/storageAccounts/Write\",\"Microsoft.DataLakeAnalytics/accounts/storageAccounts/Delete\",\"Microsoft.DataLakeAnalytics/accounts/firewallRules/Write\",\"Microsoft.DataLakeAnalytics/accounts/firewallRules/Delete\",\"Microsoft.DataLakeAnalytics/accounts/computePolicies/Write\",\"Microsoft.DataLakeAnalytics/accounts/computePolicies/Delete\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-10-20T00:33:29.3115234Z\",\"updatedOn\":\"2017-08-18T00:00:17.0411642Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/47b7735b-770e-4598-a7da-8b91488b4c88\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"47b7735b-770e-4598-a7da-8b91488b4c88\"},{\"properties\":{\"roleName\":\"DevTest
+        Labs User\",\"type\":\"BuiltInRole\",\"description\":\"Lets you connect, start,
+        restart, and shutdown your virtual machines in your Azure DevTest Labs.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Compute/availabilitySets/read\",\"Microsoft.Compute/virtualMachines/*/read\",\"Microsoft.Compute/virtualMachines/deallocate/action\",\"Microsoft.Compute/virtualMachines/read\",\"Microsoft.Compute/virtualMachines/restart/action\",\"Microsoft.Compute/virtualMachines/start/action\",\"Microsoft.DevTestLab/*/read\",\"Microsoft.DevTestLab/labs/claimAnyVm/action\",\"Microsoft.DevTestLab/labs/createEnvironment/action\",\"Microsoft.DevTestLab/labs/ensureCurrentUserProfile/action\",\"Microsoft.DevTestLab/labs/formulas/delete\",\"Microsoft.DevTestLab/labs/formulas/read\",\"Microsoft.DevTestLab/labs/formulas/write\",\"Microsoft.DevTestLab/labs/policySets/evaluatePolicies/action\",\"Microsoft.DevTestLab/labs/virtualMachines/claim/action\",\"Microsoft.DevTestLab/labs/virtualmachines/listApplicableSchedules/action\",\"Microsoft.DevTestLab/labs/virtualMachines/getRdpFileContents/action\",\"Microsoft.Network/loadBalancers/backendAddressPools/join/action\",\"Microsoft.Network/loadBalancers/inboundNatRules/join/action\",\"Microsoft.Network/networkInterfaces/*/read\",\"Microsoft.Network/networkInterfaces/join/action\",\"Microsoft.Network/networkInterfaces/read\",\"Microsoft.Network/networkInterfaces/write\",\"Microsoft.Network/publicIPAddresses/*/read\",\"Microsoft.Network/publicIPAddresses/join/action\",\"Microsoft.Network/publicIPAddresses/read\",\"Microsoft.Network/virtualNetworks/subnets/join/action\",\"Microsoft.Resources/deployments/operations/read\",\"Microsoft.Resources/deployments/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/listKeys/action\"],\"notActions\":[\"Microsoft.Compute/virtualMachines/vmSizes/read\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-06-08T21:52:45.0657582Z\",\"updatedOn\":\"2019-05-08T11:27:34.8855476Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/76283e04-6283-4c54-8f91-bcf1374a3c64\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"76283e04-6283-4c54-8f91-bcf1374a3c64\"},{\"properties\":{\"roleName\":\"DocumentDB
+        Account Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage DocumentDB accounts, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.DocumentDb/databaseAccounts/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:22.5964810Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5bd9cd88-fe45-4216-938b-f97437e15450\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5bd9cd88-fe45-4216-938b-f97437e15450\"},{\"properties\":{\"roleName\":\"DNS
+        Zone Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage
+        DNS zones and record sets in Azure DNS, but does not let you control who has
+        access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/dnsZones/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-10-15T23:33:25.9730842Z\",\"updatedOn\":\"2016-05-31T23:13:40.3710365Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/befefa01-2a29-4197-83a8-272ff33ce314\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"befefa01-2a29-4197-83a8-272ff33ce314\"},{\"properties\":{\"roleName\":\"EventGrid
+        EventSubscription Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage EventGrid event subscription operations.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.EventGrid/eventSubscriptions/*\",\"Microsoft.EventGrid/topicTypes/eventSubscriptions/read\",\"Microsoft.EventGrid/locations/eventSubscriptions/read\",\"Microsoft.EventGrid/locations/topicTypes/eventSubscriptions/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-10-08T23:27:28.3130743Z\",\"updatedOn\":\"2019-01-08T00:06:34.3543171Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/428e0ff0-5e57-4d9c-a221-2c70d0e0a443\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"428e0ff0-5e57-4d9c-a221-2c70d0e0a443\"},{\"properties\":{\"roleName\":\"EventGrid
+        EventSubscription Reader\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you read EventGrid event subscriptions.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.EventGrid/eventSubscriptions/read\",\"Microsoft.EventGrid/topicTypes/eventSubscriptions/read\",\"Microsoft.EventGrid/locations/eventSubscriptions/read\",\"Microsoft.EventGrid/locations/topicTypes/eventSubscriptions/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-10-09T17:29:28.1417894Z\",\"updatedOn\":\"2019-01-08T00:05:40.2884365Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/2414bbcf-6497-4faf-8c65-045460748405\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"2414bbcf-6497-4faf-8c65-045460748405\"},{\"properties\":{\"roleName\":\"Graph
+        Owner\",\"type\":\"BuiltInRole\",\"description\":\"Create and manage all aspects
+        of the Enterprise Graph - Ontology, Schema mapping, Conflation and Conversational
+        AI and Ingestions\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.EnterpriseKnowledgeGraph/services/conflation/read\",\"Microsoft.EnterpriseKnowledgeGraph/services/conflation/write\",\"Microsoft.EnterpriseKnowledgeGraph/services/sourceschema/read\",\"Microsoft.EnterpriseKnowledgeGraph/services/sourceschema/write\",\"Microsoft.EnterpriseKnowledgeGraph/services/knowledge/read\",\"Microsoft.EnterpriseKnowledgeGraph/services/knowledge/write\",\"Microsoft.EnterpriseKnowledgeGraph/services/intentclassification/read\",\"Microsoft.EnterpriseKnowledgeGraph/services/intentclassification/write\",\"Microsoft.EnterpriseKnowledgeGraph/services/ingestion/read\",\"Microsoft.EnterpriseKnowledgeGraph/services/ingestion/write\",\"Microsoft.EnterpriseKnowledgeGraph/services/ontology/read\",\"Microsoft.EnterpriseKnowledgeGraph/services/ontology/write\",\"Microsoft.EnterpriseKnowledgeGraph/services/delete\",\"Microsoft.EnterpriseKnowledgeGraph/operations/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2019-02-23T21:07:22.5844236Z\",\"updatedOn\":\"2019-02-28T20:21:18.9318073Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b60367af-1334-4454-b71e-769d9a4f83d9\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b60367af-1334-4454-b71e-769d9a4f83d9\"},{\"properties\":{\"roleName\":\"HDInsight
+        Domain Services Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can
+        Read, Create, Modify and Delete Domain Services related operations needed
+        for HDInsight Enterprise Security Package\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.AAD/*/read\",\"Microsoft.AAD/domainServices/*/read\",\"Microsoft.AAD/domainServices/oucontainer/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-09-12T22:42:51.7451109Z\",\"updatedOn\":\"2018-09-12T23:06:45.7641599Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8d8d5a11-05d3-4bda-a417-a08778121c7c\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8d8d5a11-05d3-4bda-a417-a08778121c7c\"},{\"properties\":{\"roleName\":\"Intelligent
+        Systems Account Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage Intelligent Systems accounts, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.IntelligentSystems/accounts/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T20:32:00.9996357Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/03a6d094-3444-4b3d-88af-7477090a9e5e\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"03a6d094-3444-4b3d-88af-7477090a9e5e\"},{\"properties\":{\"roleName\":\"Key
+        Vault Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage
+        key vaults, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.KeyVault/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.KeyVault/locations/deletedVaults/purge/action\",\"Microsoft.KeyVault/hsmPools/*\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-02-25T17:08:28.5184971Z\",\"updatedOn\":\"2019-02-05T21:24:49.5373075Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/f25e0fa2-a7c8-4377-a976-54943a77a395\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"f25e0fa2-a7c8-4377-a976-54943a77a395\"},{\"properties\":{\"roleName\":\"Knowledge
+        Consumer\",\"type\":\"BuiltInRole\",\"description\":\"Knowledge Read permission
+        to consume Enterprise Graph Knowledge using entity search and graph query\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.EnterpriseKnowledgeGraph/services/knowledge/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2019-02-23T21:23:31.4037552Z\",\"updatedOn\":\"2019-02-28T20:25:00.7369384Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ee361c5d-f7b5-4119-b4b6-892157c8f64c\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ee361c5d-f7b5-4119-b4b6-892157c8f64c\"},{\"properties\":{\"roleName\":\"Lab
+        Creator\",\"type\":\"BuiltInRole\",\"description\":\"Lets you create, manage,
+        delete your managed labs under your Azure Lab Accounts.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.LabServices/labAccounts/*/read\",\"Microsoft.LabServices/labAccounts/createLab/action\",\"Microsoft.LabServices/labAccounts/sizes/getRegionalAvailability/action\",\"Microsoft.LabServices/labAccounts/getRegionalAvailability/action\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-01-18T23:38:58.1036141Z\",\"updatedOn\":\"2018-09-05T19:52:12.4859631Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b97fb8bc-a8b2-4522-a38b-dd33c7e65ead\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b97fb8bc-a8b2-4522-a38b-dd33c7e65ead\"},{\"properties\":{\"roleName\":\"Log
+        Analytics Reader\",\"type\":\"BuiltInRole\",\"description\":\"Log Analytics
+        Reader can view and search all monitoring data as well as and view monitoring
+        settings, including viewing the configuration of Azure diagnostics on all
+        Azure resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.OperationalInsights/workspaces/analytics/query/action\",\"Microsoft.OperationalInsights/workspaces/search/action\",\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.OperationalInsights/workspaces/sharedKeys/read\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-05-02T00:20:28.1449012Z\",\"updatedOn\":\"2018-01-30T18:08:26.0438523Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/73c42c96-874c-492b-b04d-ab87d138a893\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"73c42c96-874c-492b-b04d-ab87d138a893\"},{\"properties\":{\"roleName\":\"Log
+        Analytics Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Log Analytics
+        Contributor can read all monitoring data and edit monitoring settings. Editing
+        monitoring settings includes adding the VM extension to VMs; reading storage
+        account keys to be able to configure collection of logs from Azure Storage;
+        creating and configuring Automation accounts; adding solutions; and configuring
+        Azure diagnostics on all Azure resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.Automation/automationAccounts/*\",\"Microsoft.ClassicCompute/virtualMachines/extensions/*\",\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.Compute/virtualMachines/extensions/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/diagnosticSettings/*\",\"Microsoft.OperationalInsights/*\",\"Microsoft.OperationsManagement/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourcegroups/deployments/*\",\"Microsoft.Storage/storageAccounts/listKeys/action\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-04-25T21:51:45.3174711Z\",\"updatedOn\":\"2018-01-30T18:08:26.6376126Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"92aaf0da-9dab-42b6-94a3-d43ce8d16293\"},{\"properties\":{\"roleName\":\"Logic
+        App Operator\",\"type\":\"BuiltInRole\",\"description\":\"Lets you read, enable
+        and disable logic app.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*/read\",\"Microsoft.Insights/diagnosticSettings/*/read\",\"Microsoft.Insights/metricDefinitions/*/read\",\"Microsoft.Logic/*/read\",\"Microsoft.Logic/workflows/disable/action\",\"Microsoft.Logic/workflows/enable/action\",\"Microsoft.Logic/workflows/validate/action\",\"Microsoft.Resources/deployments/operations/read\",\"Microsoft.Resources/subscriptions/operationresults/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\",\"Microsoft.Web/connectionGateways/*/read\",\"Microsoft.Web/connections/*/read\",\"Microsoft.Web/customApis/*/read\",\"Microsoft.Web/serverFarms/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-04-28T21:33:30.4656007Z\",\"updatedOn\":\"2018-01-10T23:14:26.9539724Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/515c2055-d9d4-4321-b1b9-bd0c9a0f79fe\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"515c2055-d9d4-4321-b1b9-bd0c9a0f79fe\"},{\"properties\":{\"roleName\":\"Logic
+        App Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage
+        logic app, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicStorage/storageAccounts/listKeys/action\",\"Microsoft.ClassicStorage/storageAccounts/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/diagnosticSettings/*\",\"Microsoft.Insights/logdefinitions/*\",\"Microsoft.Insights/metricDefinitions/*\",\"Microsoft.Logic/*\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/operationresults/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/listkeys/action\",\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.Support/*\",\"Microsoft.Web/connectionGateways/*\",\"Microsoft.Web/connections/*\",\"Microsoft.Web/customApis/*\",\"Microsoft.Web/serverFarms/join/action\",\"Microsoft.Web/serverFarms/read\",\"Microsoft.Web/sites/functions/listSecrets/action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-04-28T21:33:30.4656007Z\",\"updatedOn\":\"2018-01-10T23:11:44.8580600Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/87a39d53-fc1b-424a-814c-f7e04687dc9e\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"87a39d53-fc1b-424a-814c-f7e04687dc9e\"},{\"properties\":{\"roleName\":\"Managed
+        Application Operator Role\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you read and perform actions on Managed Application resources\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.Solutions/applications/read\",\"Microsoft.Solutions/*/action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-07-27T00:59:33.7988813Z\",\"updatedOn\":\"2019-02-20T01:09:55.1593079Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/c7393b34-138c-406f-901b-d8cf2b17e6ae\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"c7393b34-138c-406f-901b-d8cf2b17e6ae\"},{\"properties\":{\"roleName\":\"Managed
+        Applications Reader\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        read resources in a managed app and request JIT access.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Solutions/jitRequests/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-09-06T00:33:58.3651522Z\",\"updatedOn\":\"2018-09-06T00:33:58.3651522Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b9331d33-8a36-4f8c-b097-4f54124fdb44\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b9331d33-8a36-4f8c-b097-4f54124fdb44\"},{\"properties\":{\"roleName\":\"Managed
+        Identity Operator\",\"type\":\"BuiltInRole\",\"description\":\"Read and Assign
+        User Assigned Identity\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ManagedIdentity/userAssignedIdentities/*/read\",\"Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action\",\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-12-14T19:52:04.3924594Z\",\"updatedOn\":\"2017-12-14T22:16:00.1483256Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"f1a07417-d97a-45cb-824c-7a7467783830\"},{\"properties\":{\"roleName\":\"Managed
+        Identity Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Create,
+        Read, Update, and Delete User Assigned Identity\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ManagedIdentity/userAssignedIdentities/*/read\",\"Microsoft.ManagedIdentity/userAssignedIdentities/*/write\",\"Microsoft.ManagedIdentity/userAssignedIdentities/*/delete\",\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-12-14T19:53:42.8804692Z\",\"updatedOn\":\"2017-12-14T22:17:02.2740594Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e40ec5ca-96e0-45a2-b4ff-59039f2c2b59\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e40ec5ca-96e0-45a2-b4ff-59039f2c2b59\"},{\"properties\":{\"roleName\":\"Management
+        Group Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Management
+        Group Contributor Role\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Management/managementGroups/delete\",\"Microsoft.Management/managementGroups/read\",\"Microsoft.Management/managementGroups/subscriptions/delete\",\"Microsoft.Management/managementGroups/subscriptions/write\",\"Microsoft.Management/managementGroups/write\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-06-22T00:28:29.0523964Z\",\"updatedOn\":\"2018-07-10T20:51:26.6132189Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5d58bcaf-24a5-4b20-bdb6-eed9f69fbe4c\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5d58bcaf-24a5-4b20-bdb6-eed9f69fbe4c\"},{\"properties\":{\"roleName\":\"Management
+        Group Reader\",\"type\":\"BuiltInRole\",\"description\":\"Management Group
+        Reader Role\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Management/managementGroups/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-06-22T00:31:03.4295347Z\",\"updatedOn\":\"2018-07-10T20:49:42.5630340Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ac63b705-f282-497d-ac71-919bf39d939d\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ac63b705-f282-497d-ac71-919bf39d939d\"},{\"properties\":{\"roleName\":\"Monitoring
+        Metrics Publisher\",\"type\":\"BuiltInRole\",\"description\":\"Enables publishing
+        metrics against Azure resources\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Insights/Register/Action\",\"Microsoft.Support/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Insights/Metrics/Write\"],\"notDataActions\":[]}],\"createdOn\":\"2018-08-14T00:36:16.5610279Z\",\"updatedOn\":\"2018-08-14T00:37:18.1465065Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/3913510d-42f4-4e42-8a64-420c390055eb\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"3913510d-42f4-4e42-8a64-420c390055eb\"},{\"properties\":{\"roleName\":\"Monitoring
+        Reader\",\"type\":\"BuiltInRole\",\"description\":\"Can read all monitoring
+        data.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.OperationalInsights/workspaces/search/action\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-09-21T19:19:52.4939376Z\",\"updatedOn\":\"2018-01-30T18:08:27.2626250Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/43d0d8ad-25c7-4714-9337-8ba259a9fe05\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"43d0d8ad-25c7-4714-9337-8ba259a9fe05\"},{\"properties\":{\"roleName\":\"Network
+        Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage networks,
+        but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-06-02T00:18:27.3542698Z\",\"updatedOn\":\"2016-05-31T23:14:00.3326359Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4d97b98b-1d4f-4787-a291-c67834d212e7\"},{\"properties\":{\"roleName\":\"Monitoring
+        Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Can read all monitoring
+        data and update monitoring settings.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.AlertsManagement/alerts/*\",\"Microsoft.AlertsManagement/alertsSummary/*\",\"Microsoft.Insights/actiongroups/*\",\"Microsoft.Insights/activityLogAlerts/*\",\"Microsoft.Insights/AlertRules/*\",\"Microsoft.Insights/components/*\",\"Microsoft.Insights/DiagnosticSettings/*\",\"Microsoft.Insights/eventtypes/*\",\"Microsoft.Insights/LogDefinitions/*\",\"Microsoft.Insights/metricalerts/*\",\"Microsoft.Insights/MetricDefinitions/*\",\"Microsoft.Insights/Metrics/*\",\"Microsoft.Insights/Register/Action\",\"Microsoft.Insights/scheduledqueryrules/*\",\"Microsoft.Insights/webtests/*\",\"Microsoft.OperationalInsights/workspaces/intelligencepacks/*\",\"Microsoft.OperationalInsights/workspaces/savedSearches/*\",\"Microsoft.OperationalInsights/workspaces/search/action\",\"Microsoft.OperationalInsights/workspaces/sharedKeys/action\",\"Microsoft.OperationalInsights/workspaces/storageinsightconfigs/*\",\"Microsoft.Support/*\",\"Microsoft.WorkloadMonitor/monitors/*\",\"Microsoft.WorkloadMonitor/notificationSettings/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2016-09-21T19:21:08.4345976Z\",\"updatedOn\":\"2019-01-14T15:24:41.2168372Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"749f88d5-cbae-40b8-bcfc-e573ddc772fa\"},{\"properties\":{\"roleName\":\"New
+        Relic APM Account Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage New Relic Application Performance Management accounts and applications,
+        but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\",\"NewRelic.APM/accounts/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T20:42:16.2033878Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5d28c62d-5b37-4476-8438-e587778df237\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5d28c62d-5b37-4476-8438-e587778df237\"},{\"properties\":{\"roleName\":\"Owner\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage everything, including access to resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:32.2101122Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8e3af657-a8ff-443c-a75c-2fe8c4bcb635\"},{\"properties\":{\"roleName\":\"Reader\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you view everything, but not make any changes.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:35.7424745Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"acdd72a7-3385-48ef-bd42-f606fba81ae7\"},{\"properties\":{\"roleName\":\"Redis
+        Cache Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage
+        Redis caches, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Cache/redis/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:48.2353169Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e0f68234-74aa-48ed-b826-c38b57376e17\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e0f68234-74aa-48ed-b826-c38b57376e17\"},{\"properties\":{\"roleName\":\"Reader
+        and Data Access\",\"type\":\"BuiltInRole\",\"description\":\"Lets you view
+        everything but will not let you delete or create a storage account or contained
+        resource. It will also allow read/write access to all data contained in a
+        storage account via access to storage account keys.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/listKeys/action\",\"Microsoft.Storage/storageAccounts/ListAccountSas/action\",\"Microsoft.Storage/storageAccounts/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-03-27T23:20:46.1498906Z\",\"updatedOn\":\"2019-04-04T23:41:26.1056261Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/c12c1c16-33a1-487b-954d-41c89c60f349\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"c12c1c16-33a1-487b-954d-41c89c60f349\"},{\"properties\":{\"roleName\":\"Resource
+        Policy Contributor (Preview)\",\"type\":\"BuiltInRole\",\"description\":\"(Preview)
+        Backfilled users from EA, with rights to create/modify resource policy, create
+        support ticket and read resources/hierarchy.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.Authorization/policyassignments/*\",\"Microsoft.Authorization/policydefinitions/*\",\"Microsoft.Authorization/policysetdefinitions/*\",\"Microsoft.PolicyInsights/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-08-25T19:08:01.3861639Z\",\"updatedOn\":\"2018-01-30T18:08:27.8272264Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/36243c78-bf99-498c-9df9-86d9f8d28608\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"36243c78-bf99-498c-9df9-86d9f8d28608\"},{\"properties\":{\"roleName\":\"Scheduler
+        Job Collections Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage Scheduler job collections, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Scheduler/jobcollections/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T20:42:24.8360756Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/188a0f2f-5c9e-469b-ae67-2aa5ce574b94\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"188a0f2f-5c9e-469b-ae67-2aa5ce574b94\"},{\"properties\":{\"roleName\":\"Search
+        Service Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage Search services, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Search/searchServices/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T20:42:21.8687229Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7ca78c08-252a-4471-8644-bb5ff32d4ba0\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"7ca78c08-252a-4471-8644-bb5ff32d4ba0\"},{\"properties\":{\"roleName\":\"Security
+        Admin\",\"type\":\"BuiltInRole\",\"description\":\"Security Admin Role\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Authorization/policyAssignments/*\",\"Microsoft.Authorization/policyDefinitions/*\",\"Microsoft.Authorization/policySetDefinitions/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Management/managementGroups/read\",\"Microsoft.operationalInsights/workspaces/*/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Security/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-05-03T07:51:23.0917487Z\",\"updatedOn\":\"2019-03-12T21:12:48.6350160Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fb1c8493-542b-48eb-b624-b4c8fea62acd\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fb1c8493-542b-48eb-b624-b4c8fea62acd\"},{\"properties\":{\"roleName\":\"Security
+        Manager (Legacy)\",\"type\":\"BuiltInRole\",\"description\":\"This is a legacy
+        role. Please use Security Administrator instead\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.ClassicCompute/*/read\",\"Microsoft.ClassicCompute/virtualMachines/*/write\",\"Microsoft.ClassicNetwork/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Security/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-06-22T17:45:15.8986455Z\",\"updatedOn\":\"2018-03-08T18:18:48.6183620Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/e3d13bf0-dd5a-482e-ba6b-9b8433878d10\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"e3d13bf0-dd5a-482e-ba6b-9b8433878d10\"},{\"properties\":{\"roleName\":\"Security
+        Reader\",\"type\":\"BuiltInRole\",\"description\":\"Security Reader Role\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.operationalInsights/workspaces/*/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Security/*/read\",\"Microsoft.Support/*\",\"Microsoft.Management/managementGroups/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-05-03T07:48:49.0516559Z\",\"updatedOn\":\"2018-06-28T17:27:23.1065610Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"39bc4728-0917-49c7-9d2c-d95423bc2eb4\"},{\"properties\":{\"roleName\":\"Spatial
+        Anchors Account Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage spatial anchors in your account, but not delete them\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[],\"notActions\":[],\"dataActions\":[\"Microsoft.MixedReality/SpatialAnchorsAccounts/create/action\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/discovery/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/properties/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/query/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/submitdiag/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/write\"],\"notDataActions\":[]}],\"createdOn\":\"2018-12-21T17:57:41.1420864Z\",\"updatedOn\":\"2019-02-13T06:13:39.8686435Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8bbe83f1-e2a6-4df7-8cb4-4e04d4e5c827\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8bbe83f1-e2a6-4df7-8cb4-4e04d4e5c827\"},{\"properties\":{\"roleName\":\"Site
+        Recovery Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage Site Recovery service except vault creation and role assignment\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\",\"Microsoft.RecoveryServices/locations/allocateStamp/action\",\"Microsoft.RecoveryServices/Vaults/certificates/write\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/*\",\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/*\",\"Microsoft.RecoveryServices/vaults/replicationAlertSettings/*\",\"Microsoft.RecoveryServices/vaults/replicationEvents/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/*\",\"Microsoft.RecoveryServices/vaults/replicationJobs/*\",\"Microsoft.RecoveryServices/vaults/replicationPolicies/*\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/*\",\"Microsoft.RecoveryServices/Vaults/storageConfig/*\",\"Microsoft.RecoveryServices/Vaults/tokenInfo/read\",\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.RecoveryServices/Vaults/vaultTokens/read\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/*\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-05-19T13:46:17.4592776Z\",\"updatedOn\":\"2017-06-29T05:31:19.7240473Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6670b86e-a3f7-4917-ac9b-5d6ab1be4567\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6670b86e-a3f7-4917-ac9b-5d6ab1be4567\"},{\"properties\":{\"roleName\":\"Site
+        Recovery Operator\",\"type\":\"BuiltInRole\",\"description\":\"Lets you failover
+        and failback but not perform other Site Recovery management operations\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\",\"Microsoft.RecoveryServices/locations/allocateStamp/action\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\",\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/vaults/replicationAlertSettings/read\",\"Microsoft.RecoveryServices/vaults/replicationEvents/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/checkConsistency/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/reassociateGateway/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/renewcertificate/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/replicationNetworkMappings/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectableItems/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/applyRecoveryPoint/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/failoverCommit/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/plannedFailover/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/recoveryPoints/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/repairReplication/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/reProtect/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/testFailover/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/testFailoverCleanup/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/unplannedFailover/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/updateMobilityService/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionContainerMappings/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders/refreshProvider/action\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/replicationStorageClassificationMappings/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationvCenters/read\",\"Microsoft.RecoveryServices/vaults/replicationJobs/*\",\"Microsoft.RecoveryServices/vaults/replicationPolicies/read\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/failoverCommit/action\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/plannedFailover/action\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/read\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/reProtect/action\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/testFailover/action\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/testFailoverCleanup/action\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/unplannedFailover/action\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/*\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/read\",\"Microsoft.RecoveryServices/Vaults/tokenInfo/read\",\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.RecoveryServices/Vaults/vaultTokens/read\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-05-19T13:47:50.1341148Z\",\"updatedOn\":\"2017-06-29T05:42:27.1715639Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/494ae006-db33-4328-bf46-533a6560a3ca\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"494ae006-db33-4328-bf46-533a6560a3ca\"},{\"properties\":{\"roleName\":\"Spatial
+        Anchors Account Reader\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        locate and read properties of spatial anchors in your account\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[],\"notActions\":[],\"dataActions\":[\"Microsoft.MixedReality/SpatialAnchorsAccounts/discovery/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/properties/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/query/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/submitdiag/read\"],\"notDataActions\":[]}],\"createdOn\":\"2018-12-21T17:57:42.9271004Z\",\"updatedOn\":\"2019-02-13T06:16:15.3170663Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5d51204f-eb77-4b1c-b86a-2ec626c49413\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5d51204f-eb77-4b1c-b86a-2ec626c49413\"},{\"properties\":{\"roleName\":\"Site
+        Recovery Reader\",\"type\":\"BuiltInRole\",\"description\":\"Lets you view
+        Site Recovery status but not perform other management operations\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.RecoveryServices/locations/allocatedStamp/read\",\"Microsoft.RecoveryServices/Vaults/extendedInformation/read\",\"Microsoft.RecoveryServices/Vaults/monitoringAlerts/read\",\"Microsoft.RecoveryServices/Vaults/monitoringConfigurations/notificationConfiguration/read\",\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/refreshContainers/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/operationResults/read\",\"Microsoft.RecoveryServices/Vaults/registeredIdentities/read\",\"Microsoft.RecoveryServices/vaults/replicationAlertSettings/read\",\"Microsoft.RecoveryServices/vaults/replicationEvents/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/replicationNetworkMappings/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectableItems/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/recoveryPoints/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionContainerMappings/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/replicationStorageClassificationMappings/read\",\"Microsoft.RecoveryServices/vaults/replicationFabrics/replicationvCenters/read\",\"Microsoft.RecoveryServices/vaults/replicationJobs/read\",\"Microsoft.RecoveryServices/vaults/replicationPolicies/read\",\"Microsoft.RecoveryServices/vaults/replicationRecoveryPlans/read\",\"Microsoft.RecoveryServices/Vaults/storageConfig/read\",\"Microsoft.RecoveryServices/Vaults/tokenInfo/read\",\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.RecoveryServices/Vaults/vaultTokens/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-05-19T13:35:40.0093634Z\",\"updatedOn\":\"2017-05-26T19:54:51.3933250Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/dbaa88c4-0c30-4179-9fb3-46319faa6149\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"dbaa88c4-0c30-4179-9fb3-46319faa6149\"},{\"properties\":{\"roleName\":\"Spatial
+        Anchors Account Owner\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage spatial anchors in your account, including deleting them\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[],\"notActions\":[],\"dataActions\":[\"Microsoft.MixedReality/SpatialAnchorsAccounts/create/action\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/delete\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/discovery/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/properties/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/query/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/submitdiag/read\",\"Microsoft.MixedReality/SpatialAnchorsAccounts/write\"],\"notDataActions\":[]}],\"createdOn\":\"2018-12-21T17:57:43.5489832Z\",\"updatedOn\":\"2019-02-13T06:15:31.8572222Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/70bbe301-9835-447d-afdd-19eb3167307c\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"70bbe301-9835-447d-afdd-19eb3167307c\"},{\"properties\":{\"roleName\":\"SQL
+        Managed Instance Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets
+        you manage SQL Managed Instances and required network configuration, but can\u2019t
+        give access to others.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Network/networkSecurityGroups/*\",\"Microsoft.Network/routeTables/*\",\"Microsoft.Sql/locations/*/read\",\"Microsoft.Sql/managedInstances/*\",\"Microsoft.Support/*\",\"Microsoft.Network/virtualNetworks/subnets/*\",\"Microsoft.Network/virtualNetworks/*\",\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/metrics/read\",\"Microsoft.Insights/metricDefinitions/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2018-12-10T22:57:14.2937983Z\",\"updatedOn\":\"2019-04-25T17:59:01.7432149Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4939a1f6-9ae0-4e48-a1e0-f2cbe897382d\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"4939a1f6-9ae0-4e48-a1e0-f2cbe897382d\"},{\"properties\":{\"roleName\":\"SQL
+        DB Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage
+        SQL databases, but not access to them. Also, you can't manage their security-related
+        policies or their parent SQL servers.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Sql/locations/*/read\",\"Microsoft.Sql/servers/databases/*\",\"Microsoft.Sql/servers/read\",\"Microsoft.Support/*\",\"Microsoft.Insights/metrics/read\",\"Microsoft.Insights/metricDefinitions/read\"],\"notActions\":[\"Microsoft.Sql/managedInstances/databases/currentSensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/recommendedSensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/securityAlertPolicies/*\",\"Microsoft.Sql/managedInstances/databases/sensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/*\",\"Microsoft.Sql/managedInstances/securityAlertPolicies/*\",\"Microsoft.Sql/managedInstances/vulnerabilityAssessments/*\",\"Microsoft.Sql/servers/databases/auditingPolicies/*\",\"Microsoft.Sql/servers/databases/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditRecords/read\",\"Microsoft.Sql/servers/databases/connectionPolicies/*\",\"Microsoft.Sql/servers/databases/currentSensitivityLabels/*\",\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/extendedAuditingSettings/*\",\"Microsoft.Sql/servers/databases/recommendedSensitivityLabels/*\",\"Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels/*\",\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/securityMetrics/*\",\"Microsoft.Sql/servers/databases/sensitivityLabels/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessments/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\",\"Microsoft.Sql/servers/vulnerabilityAssessments/*\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-28T22:44:35.8649670Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9b7fa17d-e63e-47b0-bb0a-15c516ac86ec\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9b7fa17d-e63e-47b0-bb0a-15c516ac86ec\"},{\"properties\":{\"roleName\":\"SQL
+        Security Manager\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage
+        the security-related policies of SQL servers and databases, but not access
+        to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/virtualNetworks/subnets/joinViaServiceEndpoint/action\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Sql/managedInstances/databases/currentSensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/recommendedSensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/securityAlertPolicies/*\",\"Microsoft.Sql/managedInstances/databases/sensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/*\",\"Microsoft.Sql/managedInstances/securityAlertPolicies/*\",\"Microsoft.Sql/managedInstances/vulnerabilityAssessments/*\",\"Microsoft.Sql/servers/auditingPolicies/*\",\"Microsoft.Sql/servers/auditingSettings/*\",\"Microsoft.Sql/servers/extendedAuditingSettings/read\",\"Microsoft.Sql/servers/databases/auditingPolicies/*\",\"Microsoft.Sql/servers/databases/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditRecords/read\",\"Microsoft.Sql/servers/databases/connectionPolicies/*\",\"Microsoft.Sql/servers/databases/currentSensitivityLabels/*\",\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/extendedAuditingSettings/read\",\"Microsoft.Sql/servers/databases/read\",\"Microsoft.Sql/servers/databases/recommendedSensitivityLabels/*\",\"Microsoft.Sql/servers/databases/schemas/read\",\"Microsoft.Sql/servers/databases/schemas/tables/columns/read\",\"Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels/*\",\"Microsoft.Sql/servers/databases/schemas/tables/read\",\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/securityMetrics/*\",\"Microsoft.Sql/servers/databases/sensitivityLabels/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessments/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\",\"Microsoft.Sql/servers/firewallRules/*\",\"Microsoft.Sql/servers/read\",\"Microsoft.Sql/servers/securityAlertPolicies/*\",\"Microsoft.Sql/servers/vulnerabilityAssessments/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-06-16T18:44:40.4607572Z\",\"updatedOn\":\"2019-02-28T22:44:34.5368160Z\",\"createdBy\":null,\"updatedBy\":\"yaiyun\"},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"056cd41c-7e88-42e1-933e-88ba6a50c9c3\"},{\"properties\":{\"roleName\":\"Storage
+        Account Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage storage accounts, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/diagnosticSettings/*\",\"Microsoft.Network/virtualNetworks/subnets/joinViaServiceEndpoint/action\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Storage/storageAccounts/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-06-02T00:18:27.3542698Z\",\"updatedOn\":\"2017-08-21T07:43:20.3060994Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"17d1049b-9a84-46fb-8f53-869881c3d3ab\"},{\"properties\":{\"roleName\":\"SQL
+        Server Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage
+        SQL servers and databases, but not access to them, and not their security
+        -related policies.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Sql/locations/*/read\",\"Microsoft.Sql/servers/*\",\"Microsoft.Support/*\",\"Microsoft.Insights/metrics/read\",\"Microsoft.Insights/metricDefinitions/read\"],\"notActions\":[\"Microsoft.Sql/managedInstances/databases/currentSensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/recommendedSensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/securityAlertPolicies/*\",\"Microsoft.Sql/managedInstances/databases/sensitivityLabels/*\",\"Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/*\",\"Microsoft.Sql/managedInstances/securityAlertPolicies/*\",\"Microsoft.Sql/managedInstances/vulnerabilityAssessments/*\",\"Microsoft.Sql/servers/auditingPolicies/*\",\"Microsoft.Sql/servers/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditingPolicies/*\",\"Microsoft.Sql/servers/databases/auditingSettings/*\",\"Microsoft.Sql/servers/databases/auditRecords/read\",\"Microsoft.Sql/servers/databases/connectionPolicies/*\",\"Microsoft.Sql/servers/databases/currentSensitivityLabels/*\",\"Microsoft.Sql/servers/databases/dataMaskingPolicies/*\",\"Microsoft.Sql/servers/databases/extendedAuditingSettings/*\",\"Microsoft.Sql/servers/databases/recommendedSensitivityLabels/*\",\"Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels/*\",\"Microsoft.Sql/servers/databases/securityAlertPolicies/*\",\"Microsoft.Sql/servers/databases/securityMetrics/*\",\"Microsoft.Sql/servers/databases/sensitivityLabels/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessments/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentScans/*\",\"Microsoft.Sql/servers/databases/vulnerabilityAssessmentSettings/*\",\"Microsoft.Sql/servers/extendedAuditingSettings/*\",\"Microsoft.Sql/servers/securityAlertPolicies/*\",\"Microsoft.Sql/servers/vulnerabilityAssessments/*\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-28T22:44:36.5466043Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437\"},{\"properties\":{\"roleName\":\"Storage
+        Account Key Operator Service Role\",\"type\":\"BuiltInRole\",\"description\":\"Storage
+        Account Key Operators are allowed to list and regenerate keys on Storage Accounts\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/listkeys/action\",\"Microsoft.Storage/storageAccounts/regeneratekey/action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-04-13T18:26:11.5770570Z\",\"updatedOn\":\"2017-04-13T20:57:14.5990198Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/81a9662b-bebf-436f-a333-f67b29880f12\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"81a9662b-bebf-436f-a333-f67b29880f12\"},{\"properties\":{\"roleName\":\"Storage
+        Blob Data Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Allows
+        for read, write and delete access to Azure Storage blob containers and data\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/delete\",\"Microsoft.Storage/storageAccounts/blobServices/containers/read\",\"Microsoft.Storage/storageAccounts/blobServices/containers/write\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete\",\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\",\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write\"],\"notDataActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\":\"2019-03-05T21:44:46.5230342Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"ba92f5b4-2d11-453d-a403-e96b0029c9fe\"},{\"properties\":{\"roleName\":\"Storage
+        Blob Data Owner\",\"type\":\"BuiltInRole\",\"description\":\"Allows for full
+        access to Azure Storage blob containers and data, including assigning POSIX
+        access control.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/*\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*\"],\"notDataActions\":[]}],\"createdOn\":\"2018-12-04T07:02:58.2775257Z\",\"updatedOn\":\"2019-03-05T21:49:18.2237690Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"b7e6dc6d-f1e8-4753-8033-0f276bb0955b\"},{\"properties\":{\"roleName\":\"Storage
+        Blob Data Reader\",\"type\":\"BuiltInRole\",\"description\":\"Allows for read
+        access to Azure Storage blob containers and data\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/read\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read\"],\"notDataActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\":\"2019-03-05T21:53:53.2032320Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/2a2b9908-6ea1-4ae2-8e65-a410df84e7d1\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"2a2b9908-6ea1-4ae2-8e65-a410df84e7d1\"},{\"properties\":{\"roleName\":\"Storage
+        Queue Data Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Allows
+        for read, write, and delete access to Azure Storage queues and queue messages\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/delete\",\"Microsoft.Storage/storageAccounts/queueServices/queues/read\",\"Microsoft.Storage/storageAccounts/queueServices/queues/write\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/delete\",\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/read\",\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/write\"],\"notDataActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\":\"2019-03-05T21:58:02.7367128Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"974c5e8b-45b9-4653-ba55-5f855dd0fb88\"},{\"properties\":{\"roleName\":\"Storage
+        Queue Data Message Processor\",\"type\":\"BuiltInRole\",\"description\":\"Allows
+        for peek, receive, and delete access to Azure Storage queue messages\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/read\",\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/process/action\"],\"notDataActions\":[]}],\"createdOn\":\"2019-01-28T22:27:04.8947111Z\",\"updatedOn\":\"2019-03-05T22:05:46.1259125Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8a0f0c08-91a1-4084-bc3d-661d67233fed\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"8a0f0c08-91a1-4084-bc3d-661d67233fed\"},{\"properties\":{\"roleName\":\"Storage
+        Queue Data Message Sender\",\"type\":\"BuiltInRole\",\"description\":\"Allows
+        for sending of Azure Storage queue messages\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/add/action\"],\"notDataActions\":[]}],\"createdOn\":\"2019-01-28T22:28:34.7459724Z\",\"updatedOn\":\"2019-03-05T22:11:49.6383892Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/c6a89b2d-59bc-44d0-9896-0f6e12d7b80a\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"c6a89b2d-59bc-44d0-9896-0f6e12d7b80a\"},{\"properties\":{\"roleName\":\"Storage
+        Queue Data Reader\",\"type\":\"BuiltInRole\",\"description\":\"Allows for
+        read access to Azure Storage queues and queue messages\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/read\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Storage/storageAccounts/queueServices/queues/messages/read\"],\"notDataActions\":[]}],\"createdOn\":\"2017-12-21T00:01:24.7972312Z\",\"updatedOn\":\"2019-03-05T22:17:32.1779262Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/19e7f393-937e-4f77-808e-94535e297925\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"19e7f393-937e-4f77-808e-94535e297925\"},{\"properties\":{\"roleName\":\"Support
+        Request Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        create and manage Support requests\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2017-06-22T22:25:37.8053068Z\",\"updatedOn\":\"2017-06-23T01:06:24.2399631Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e\"},{\"properties\":{\"roleName\":\"Traffic
+        Manager Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage Traffic Manager profiles, but does not let you control who has access
+        to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/trafficManagerProfiles/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-10-15T23:33:25.9730842Z\",\"updatedOn\":\"2016-05-31T23:13:44.1458854Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/a4b10055-b0c7-44c2-b00f-c7b5b3550cf7\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"a4b10055-b0c7-44c2-b00f-c7b5b3550cf7\"},{\"properties\":{\"roleName\":\"Virtual
+        Machine Administrator Login\",\"type\":\"BuiltInRole\",\"description\":\"View
+        Virtual Machines in the portal and login as administrator\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Network/publicIPAddresses/read\",\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.Network/loadBalancers/read\",\"Microsoft.Network/networkInterfaces/read\",\"Microsoft.Compute/virtualMachines/*/read\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Compute/virtualMachines/login/action\",\"Microsoft.Compute/virtualMachines/loginAsAdmin/action\"],\"notDataActions\":[]}],\"createdOn\":\"2018-02-09T18:36:13.3315744Z\",\"updatedOn\":\"2018-05-09T22:17:57.0514548Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/1c0163c0-47e6-4577-8991-ea5c82e286e4\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"1c0163c0-47e6-4577-8991-ea5c82e286e4\"},{\"properties\":{\"roleName\":\"User
+        Access Administrator\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage user access to Azure resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"*/read\",\"Microsoft.Authorization/*\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-02-05T21:24:12.6807454Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"18d7d88d-d35e-4fb5-a5c3-7773c20a72d9\"},{\"properties\":{\"roleName\":\"Virtual
+        Machine User Login\",\"type\":\"BuiltInRole\",\"description\":\"View Virtual
+        Machines in the portal and login as a regular user.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Network/publicIPAddresses/read\",\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.Network/loadBalancers/read\",\"Microsoft.Network/networkInterfaces/read\",\"Microsoft.Compute/virtualMachines/*/read\"],\"notActions\":[],\"dataActions\":[\"Microsoft.Compute/virtualMachines/login/action\"],\"notDataActions\":[]}],\"createdOn\":\"2018-02-09T18:36:13.3315744Z\",\"updatedOn\":\"2018-05-09T22:18:52.2780979Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/fb879df8-f326-4884-b1cf-06f3ad86be52\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"fb879df8-f326-4884-b1cf-06f3ad86be52\"},{\"properties\":{\"roleName\":\"Virtual
+        Machine Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you
+        manage virtual machines, but not access to them, and not the virtual network
+        or storage account they're connected to.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Compute/availabilitySets/*\",\"Microsoft.Compute/locations/*\",\"Microsoft.Compute/virtualMachines/*\",\"Microsoft.Compute/virtualMachineScaleSets/*\",\"Microsoft.DevTestLab/schedules/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Network/applicationGateways/backendAddressPools/join/action\",\"Microsoft.Network/loadBalancers/backendAddressPools/join/action\",\"Microsoft.Network/loadBalancers/inboundNatPools/join/action\",\"Microsoft.Network/loadBalancers/inboundNatRules/join/action\",\"Microsoft.Network/loadBalancers/probes/join/action\",\"Microsoft.Network/loadBalancers/read\",\"Microsoft.Network/locations/*\",\"Microsoft.Network/networkInterfaces/*\",\"Microsoft.Network/networkSecurityGroups/join/action\",\"Microsoft.Network/networkSecurityGroups/read\",\"Microsoft.Network/publicIPAddresses/join/action\",\"Microsoft.Network/publicIPAddresses/read\",\"Microsoft.Network/virtualNetworks/read\",\"Microsoft.Network/virtualNetworks/subnets/join/action\",\"Microsoft.RecoveryServices/locations/*\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/backupProtectionIntent/write\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/*/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/read\",\"Microsoft.RecoveryServices/Vaults/backupFabrics/protectionContainers/protectedItems/write\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/read\",\"Microsoft.RecoveryServices/Vaults/backupPolicies/write\",\"Microsoft.RecoveryServices/Vaults/read\",\"Microsoft.RecoveryServices/Vaults/usages/read\",\"Microsoft.RecoveryServices/Vaults/write\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.SqlVirtualMachine/*\",\"Microsoft.Storage/storageAccounts/listKeys/action\",\"Microsoft.Storage/storageAccounts/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-06-02T00:18:27.3542698Z\",\"updatedOn\":\"2018-10-16T16:16:51.7928187Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"9980e02c-c2be-4d73-94e8-173b1dc7cf3c\"},{\"properties\":{\"roleName\":\"Web
+        Plan Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage
+        the web plans for websites, but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\",\"Microsoft.Web/serverFarms/*\",\"Microsoft.Web/hostingEnvironments/Join/Action\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-02-02T21:55:09.8806423Z\",\"updatedOn\":\"2019-03-26T18:17:34.5018645Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b\"},{\"properties\":{\"roleName\":\"Website
+        Contributor\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage websites
+        (not web plans), but not access to them.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.Authorization/*/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Insights/components/*\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\",\"Microsoft.Web/certificates/*\",\"Microsoft.Web/listSitesAssignedToHostName/read\",\"Microsoft.Web/serverFarms/join/action\",\"Microsoft.Web/serverFarms/read\",\"Microsoft.Web/sites/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2015-05-12T23:10:23.6193952Z\",\"updatedOn\":\"2019-02-05T21:24:46.9407288Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"de139f84-1756-47ae-9be6-808fbbe84772\"},{\"properties\":{\"roleName\":\"Azure
+        Service Bus Data Owner - Preview\",\"type\":\"BuiltInRole\",\"description\":\"Allows
+        for full access to Azure Service Bus resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.ServiceBus/*\"],\"notActions\":[],\"dataActions\":[\"Microsoft.ServiceBus/*\"],\"notDataActions\":[]}],\"createdOn\":\"2019-04-16T21:33:36.7445745Z\",\"updatedOn\":\"2019-04-16T21:49:47.8821693Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/090c5cfd-751d-490a-894a-3ce6f1109419\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"090c5cfd-751d-490a-894a-3ce6f1109419\"},{\"properties\":{\"roleName\":\"Azure
+        Event Hubs Data Owner - Preview\",\"type\":\"BuiltInRole\",\"description\":\"Allows
+        for full access to Azure Event Hubs resources.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.EventHub/*\"],\"notActions\":[],\"dataActions\":[\"Microsoft.EventHub/*\"],\"notDataActions\":[]}],\"createdOn\":\"2019-04-16T21:34:29.8656362Z\",\"updatedOn\":\"2019-04-16T21:47:34.9961212Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/f526a384-b230-433a-b45c-95f59c4a2dec\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"f526a384-b230-433a-b45c-95f59c4a2dec\"},{\"properties\":{\"roleName\":\"HDInsight
+        Cluster Operator\",\"type\":\"BuiltInRole\",\"description\":\"Lets you read
+        and modify HDInsight cluster configurations.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.HDInsight/*/read\",\"Microsoft.HDInsight/clusters/getGatewaySettings/action\",\"Microsoft.HDInsight/clusters/updateGatewaySettings/action\",\"Microsoft.HDInsight/clusters/configurations/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Resources/deployments/operations/read\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Authorization/*/read\",\"Microsoft.Support/*\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2019-04-20T00:03:01.7110732Z\",\"updatedOn\":\"2019-04-28T02:34:17.4679314Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/61ed4efc-fab3-44fd-b111-e24485cc132a\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"61ed4efc-fab3-44fd-b111-e24485cc132a\"},{\"properties\":{\"roleName\":\"Cosmos
+        DB Operator\",\"type\":\"BuiltInRole\",\"description\":\"Lets you manage Azure
+        Cosmos DB accounts, but not access data in them. Prevents access to account
+        keys and connection strings.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.DocumentDb/databaseAccounts/*\",\"Microsoft.Insights/alertRules/*\",\"Microsoft.Authorization/*/read\",\"Microsoft.ResourceHealth/availabilityStatuses/read\",\"Microsoft.Resources/deployments/*\",\"Microsoft.Resources/subscriptions/resourceGroups/read\",\"Microsoft.Support/*\"],\"notActions\":[\"Microsoft.DocumentDB/databaseAccounts/readonlyKeys/*\",\"Microsoft.DocumentDB/databaseAccounts/regenerateKey/*\",\"Microsoft.DocumentDB/databaseAccounts/listKeys/*\",\"Microsoft.DocumentDB/databaseAccounts/listConnectionStrings/*\"],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2019-04-26T17:01:17.0169383Z\",\"updatedOn\":\"2019-04-26T19:26:46.6326968Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/230815da-be43-4aae-9cb4-875f7bd000aa\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"230815da-be43-4aae-9cb4-875f7bd000aa\"},{\"properties\":{\"roleName\":\"Hybrid
+        Server Resource Administrator\",\"type\":\"BuiltInRole\",\"description\":\"Can
+        read, write, delete, and re-onboard Hybrid servers to the Hybrid Resource
+        Provider.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.HybridCompute/machines/*\",\"Microsoft.HybridCompute/*/read\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2019-04-29T21:39:32.3132923Z\",\"updatedOn\":\"2019-05-06T20:08:25.3180258Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/48b40c6e-82e0-4eb3-90d5-19e40f49b624\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"48b40c6e-82e0-4eb3-90d5-19e40f49b624\"},{\"properties\":{\"roleName\":\"Hybrid
+        Server Onboarding\",\"type\":\"BuiltInRole\",\"description\":\"Can onboard
+        new Hybrid servers to the Hybrid Resource Provider.\",\"assignableScopes\":[\"/\"],\"permissions\":[{\"actions\":[\"Microsoft.HybridCompute/machines/read\",\"Microsoft.HybridCompute/machines/write\"],\"notActions\":[],\"dataActions\":[],\"notDataActions\":[]}],\"createdOn\":\"2019-04-29T22:36:28.1873756Z\",\"updatedOn\":\"2019-05-06T20:09:17.9364269Z\",\"createdBy\":null,\"updatedBy\":null},\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/5d1e5ee4-7c68-4a71-ac8b-0739630a3dfb\",\"type\":\"Microsoft.Authorization/roleDefinitions\",\"name\":\"5d1e5ee4-7c68-4a71-ac8b-0739630a3dfb\"}]}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '138628'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; HttpOnly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-request-charge:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"objectIds": ["8910b5b8-1e16-4e56-9675-87136d692696"], "includeDirectoryObjectReferences":
+      true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8910b5b8-1e16-4e56-9675-87136d692696","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2019-05-08T18:11:57Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"tester123","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"testuser000002","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2019-05-08T18:11:57Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/8910b5b8-1e16-4e56-9675-87136d692696/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"testuser000002@azuresdkteam.onmicrosoft.com","userState":null,"userStateChangedOn":null,"userType":"Member"}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1570'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 08 May 2019 18:12:18 GMT
+      duration:
+      - '761520'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - tqsvrwCmDhrCSNHu2t6CdV0LI4CjAgREZGXRcEu5W18=
+      ocp-aad-session-key:
+      - RfxfMUtNQe54EtBN-tHyMxPPZZtaAcMrfIklbXsaesf_d2xBVLGyOpn4BgWSLaeNoEdwrg1EKthbfmWzggEMi6qTCc-S4TKgvXu-FKMlvGi3CC99_6-vjqdegcx4vf2X0S0TuECyglvF3CXV2Nmzow.uyYjApApCXCFr5PCz2ujEIVTDVPHjGXRv9M2b4qhnZ0
+      pragma:
+      - no-cache
+      request-id:
+      - 5d36a861-f9e1-4adc-bce6-78cd9955abe7
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27testuser000002%40azuresdkteam.onmicrosoft.com%27
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8910b5b8-1e16-4e56-9675-87136d692696","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2019-05-08T18:11:57Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"tester123","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"testuser000002","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2019-05-08T18:11:57Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/8910b5b8-1e16-4e56-9675-87136d692696/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"testuser000002@azuresdkteam.onmicrosoft.com","userState":null,"userStateChangedOn":null,"userType":"Member"}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1570'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 08 May 2019 18:12:18 GMT
+      duration:
+      - '552540'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - R7GE/wZDw5mYOVlPUsy4LuVepndfwrdQz1ATlcVdHv4=
+      ocp-aad-session-key:
+      - USH73cNuEi8dj1XmjzJX3ZA0AOwvzO85-5xyxsnD4Yz5bXB2YNNg8TW9XvH58Gtg95G8maxdgAUadHUrkbKniV55T-oQof0l8Msi2e9ob9eEJ2pXWAVhWsvzc2ITaGSsPDJJIRWX3rZnlCU2JBOq3g.LiuopWzfja0qQzNnTME4DJpShQR6j0kEa8Ca2PUxZyk
+      pragma:
+      - no-cache
+      request-id:
+      - 70808f75-64f3-4f75-853f-aeb0618de5a4
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment delete
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-authorization/0.50.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?api-version=2018-01-01-preview&$filter=principalId%20eq%20%278910b5b8-1e16-4e56-9675-87136d692696%27
+  response:
+    body:
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"8910b5b8-1e16-4e56-9675-87136d692696","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001","createdOn":"2019-05-08T18:12:15.9102121Z","updatedOn":"2019-05-08T18:12:15.9102121Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '937'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; HttpOnly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-request-charge:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment delete
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie:
+      - x-ms-gateway-slice=Production
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-authorization/0.50.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2018-01-01-preview&$filter=roleName%20eq%20%27reader%27
+  response:
+    body:
+      string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
+        you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[],"dataActions":[],"notDataActions":[]}],"createdOn":"2015-02-02T21:55:09.8806423Z","updatedOn":"2019-02-05T21:24:35.7424745Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '615'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; HttpOnly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-request-charge:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie:
+      - x-ms-gateway-slice=Production
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-authorization/0.50.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2018-01-01-preview
+  response:
+    body:
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"8910b5b8-1e16-4e56-9675-87136d692696","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001","createdOn":"2019-05-08T18:12:15.9102121Z","updatedOn":"2019-05-08T18:12:15.9102121Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_role_assign000001/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '925'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; HttpOnly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+      x-ms-request-charge:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27testuser000002%40azuresdkteam.onmicrosoft.com%27
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8910b5b8-1e16-4e56-9675-87136d692696","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2019-05-08T18:11:57Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"tester123","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"testuser000002","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2019-05-08T18:11:57Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/8910b5b8-1e16-4e56-9675-87136d692696/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"testuser000002@azuresdkteam.onmicrosoft.com","userState":null,"userStateChangedOn":null,"userType":"Member"}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1570'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 08 May 2019 18:12:21 GMT
+      duration:
+      - '536764'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - wIQemZ+5vqMn85aXsgJ+yzAwtRuiwLPflul5H4QC6Xs=
+      ocp-aad-session-key:
+      - VATdgFaUA4bzS8Tqs7BCgedFjVB6Ha925mysqfWC0_ZaxpFbnurB7waPMwZ6Kj9zXVknnbgy-XQw8EtSH37669nptHkPUNg7eh4IFyb4SPgGH785v6sZqqH7sGXOEtmz6znwEmHJMQueK8XE5xwLHQ.wCb-wmu_SAKcPOY15wZJ96JbB0miJUs3Qie7zGwLcw0
+      pragma:
+      - no-cache
+      request-id:
+      - 78bbb0e1-0f0c-4c38-bfde-55c0b7333482
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - role assignment list
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --assignee --role --scope
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-mgmt-authorization/0.50.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?api-version=2018-01-01-preview&$filter=principalId%20eq%20%278910b5b8-1e16-4e56-9675-87136d692696%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 08 May 2019 18:12:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; HttpOnly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-request-charge:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad user delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --upn-or-object-id
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users/testuser000002%40azuresdkteam.onmicrosoft.com?api-version=1.6
+  response:
+    body:
+      string: ''
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 08 May 2019 18:12:23 GMT
+      duration:
+      - '1193621'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - MjPAJVvgC3key9HyT1tst0r01pKZJnpyPQ4YiB+LaOA=
+      ocp-aad-session-key:
+      - _jBuHLh1PExQuYk7sPDUo756940N2AmzPFinygChCninentvb6INITXFhI4HWkCKwehSCJ6BpuzikGX9oehclqL4g1Lhkdne3VKSN8rfAAS1iQ0DFZSeoEwVWKOPfRfWpZXvFCRTJwV7z1WoBVVY9A.t7WWN-WheRbw5VX3SOV-Z3vnaxEG99hdiICHHV_JavM
+      pragma:
+      - no-cache
+      request-id:
+      - 37b4bf8e-2cc8-47b5-a4d7-0fe32688c88e
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - group delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --name --yes --no-wait
+      User-Agent:
+      - python/3.5.4 (Windows-10-10.0.17763-SP0) msrest/0.6.6 msrest_azure/0.6.0 resourcemanagementclient/2.1.0
+        Azure-SDK-For-Python AZURECLI/2.0.64
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_role_assign000001?api-version=2018-05-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 08 May 2019 18:12:23 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZST0xFOjVGQVNTSUdOMk9SQTJTQzZHQUdQTkc2TFJEUFRZVlpDNERHVXxCN0E1QkY2RUE1RDY0RkU1LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -317,7 +317,6 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
                 self.cmd('configure --default group=""')
                 self.cmd('ad user delete --upn-or-object-id {upn}')
 
-
     @ResourceGroupPreparer(name_prefix='cli_role_audit')
     @AllowLargeResponse()
     def test_role_assignment_audits(self, resource_group):

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -289,6 +289,35 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
             finally:
                 self.cmd('ad user delete --upn-or-object-id {upn}')
 
+    @ResourceGroupPreparer(name_prefix='cli_role_assign')
+    @AllowLargeResponse()
+    def test_role_assignment_handle_conflicted_assignments(self, resource_group):
+        if self.run_under_service_principal():
+            return  # this test delete users which are beyond a SP's capacity, so quit...
+
+        with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
+            user = self.create_random_name('testuser', 15)
+            self.kwargs.update({
+                'upn': user + '@azuresdkteam.onmicrosoft.com',
+                'nsg': 'nsg1'
+            })
+
+            self.cmd('ad user create --display-name tester123 --password Test123456789 --user-principal-name {upn}')
+            time.sleep(15)  # By-design, it takes some time for RBAC system propagated with graph object change
+
+            try:
+                self.cmd('configure --default group=' + resource_group)
+                # test role assignments on a resource group
+                rg_id = self.cmd('group show -n {rg}').get_output_in_json()['id']
+                self.cmd('role assignment create --assignee {upn} --role reader --scope ' + rg_id)
+                self.cmd('role assignment list --assignee {upn} --role reader --scope ' + rg_id, checks=self.check('length([])', 1))
+                self.cmd('role assignment delete --assignee {upn} --role reader --scope ' + rg_id)
+                self.cmd('role assignment list --assignee {upn} --role reader --scope ' + rg_id, checks=self.check('length([])', 0))
+            finally:
+                self.cmd('configure --default group=""')
+                self.cmd('ad user delete --upn-or-object-id {upn}')
+
+
     @ResourceGroupPreparer(name_prefix='cli_role_audit')
     @AllowLargeResponse()
     def test_role_assignment_audits(self, resource_group):


### PR DESCRIPTION
Fix #6178 

This could become a general pattern that I can move the code to core, but so far only `role assignment` commands have such a ask, hence I am holding on that.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
