### PR TITLE
AKS: Remove preview flag for Virtual Node

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+2.4.3
+++++++
+* Remove "(PREVIEW)" from Virtual Node commands, "az aks create --enable-addons" and "az aks enable-addons --addons".
+
 2.4.2
 ++++++
 * Fix 'az openshift create' command when used with customer aad client

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -240,7 +240,7 @@ parameters:
         These addons are available:
             http_application_routing - configure ingress with automatic public DNS name creation.
             monitoring - turn on Log Analytics monitoring. Uses the Log Analytics Default Workspace if it exists, else creates one. Specify "--workspace-resource-id" to use an existing workspace.
-            virtual-node - enable AKS Virtual Node (PREVIEW). Requires --subnet-name to provide the name of an existing subnet for the Virtual Node to use.
+            virtual-node - enable AKS Virtual Node. Requires --subnet-name to provide the name of an existing subnet for the Virtual Node to use.
   - name: --disable-rbac
     type: bool
     short-summary: Disable Kubernetes Role-Based Access Control.
@@ -319,7 +319,7 @@ long-summary: |-
     These addons are available:
         http_application_routing - configure ingress with automatic public DNS name creation.
         monitoring - turn on Log Analytics monitoring. Requires "--workspace-resource-id".
-        virtual-node - enable AKS Virtual Node (PREVIEW). Requires --subnet-name to provide the name of an existing subnet for the Virtual Node to use.
+        virtual-node - enable AKS Virtual Node. Requires --subnet-name to provide the name of an existing subnet for the Virtual Node to use.
 parameters:
   - name: --addons -a
     type: string


### PR DESCRIPTION
Since AKS Virual Node has been graduated GA, should we have to remove the old `PREVIEW` tag?

https://azure.microsoft.com/en-us/updates/azure-kubernetes-service-aks-virtual-node-is-now-available/

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
