### PR TITLE
Updating CI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python](https://img.shields.io/pypi/pyversions/azure-cli.svg?maxAge=2592000)](https://pypi.python.org/pypi/azure-cli)
 [![Travis](https://travis-ci.org/Azure/azure-cli.svg?branch=dev)](https://travis-ci.org/Azure/azure-cli)
-[![Build Status](https://dev.azure.com/azure-public/azcli/_apis/build/status/azcli-CI?branchName=dev)](https://dev.azure.com/azure-public/azcli/_build/latest?definitionId=18&branchName=dev)
+[![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/cli/Azure.azure-cli?branchName=dev)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=246&branchName=dev)
 [![Slack](https://img.shields.io/badge/Slack-azurecli.slack.com-blue.svg)](https://azurecli.slack.com)
 
 A great cloud needs great tools; we're excited to introduce *Azure CLI*, our next generation multi-platform command line experience for Azure.


### PR DESCRIPTION
We're migrating our build pipeline into a different Azure Dev Ops organization. Most of this work is complete, and has been running for a few weeks. This updates the badge on the README.