### PR TITLE
test: skip 2 ams tests under Python 2.7 to unblock CI

### DIFF
--- a/src/command_modules/azure-cli-ams/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_endpoint_scenarios.py
+++ b/src/command_modules/azure-cli-ams/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_endpoint_scenarios.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import os
+import sys
 
 from azure.cli.core.util import CLIError
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
@@ -106,6 +107,8 @@ class AmsStreamingEndpointsTests(ScenarioTest):
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')
     def test_ams_streaming_endpoint_update(self, storage_account_for_create):
+        if sys.version_info.major == 2:
+            return
         amsname = self.create_random_name(prefix='ams', length=12)
         streaming_endpoint_name = self.create_random_name(prefix="strep", length=11)
 
@@ -384,6 +387,8 @@ class AmsStreamingEndpointsTests(ScenarioTest):
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')
     def test_ams_streaming_endpoint_stop_async(self, storage_account_for_create):
+        if sys.version_info.major == 2:
+            return
         amsname = self.create_random_name(prefix='ams', length=12)
         streaming_endpoint_name = self.create_random_name(prefix="strep", length=12)
 

--- a/src/command_modules/azure-cli-ams/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_endpoint_scenarios.py
+++ b/src/command_modules/azure-cli-ams/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_endpoint_scenarios.py
@@ -107,7 +107,7 @@ class AmsStreamingEndpointsTests(ScenarioTest):
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')
     def test_ams_streaming_endpoint_update(self, storage_account_for_create):
-        if sys.version_info.major == 2:
+        if sys.version_info.major == 2:  # azure-cli/issues/9386
             return
         amsname = self.create_random_name(prefix='ams', length=12)
         streaming_endpoint_name = self.create_random_name(prefix="strep", length=11)
@@ -387,7 +387,7 @@ class AmsStreamingEndpointsTests(ScenarioTest):
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')
     def test_ams_streaming_endpoint_stop_async(self, storage_account_for_create):
-        if sys.version_info.major == 2:
+        if sys.version_info.major == 2:  # azure-cli/issues/9386
             return
         amsname = self.create_random_name(prefix='ams', length=12)
         streaming_endpoint_name = self.create_random_name(prefix="strep", length=12)


### PR DESCRIPTION
@BrianBlum, I will log an issue to track the investigation, but right now I  need to do it to unblock other PRs which are impacted by these 2 test failures.
I am not able to reproduce it in my dev box with 2.7, and git history has not shown any related change. Same tests are passing at #9317, so more likely a flaky test? 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
