### PR TITLE
[ppg] create: `--type` is now optional.

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 * vm create: Added --computer-name for setting a vm's computer name.
 * vm/vmss create: `--ssh-key-value` renamed to `--ssh-key-values` and can now accept multiple ssh public key values or paths.
   Note: this is **not** a breaking change. `--ssh-key-value` will be parsed correctly as it matches only `--ssh-key-values`
+* ppg create: `--type`, the proximity placement group type, is now optional.
 
 2.2.20
 ++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -2621,7 +2621,7 @@ def update_image_version(instance, target_regions=None, replica_count=None):
 
 # region Proximity Placement Group
 def create_proximity_placement_group(cmd, client, proximity_placement_group_name, resource_group_name,
-                                     ppg_type, location=None, tags=None):
+                                     ppg_type=None, location=None, tags=None):
     location = location or _get_resource_group_location(cmd.cli_ctx, resource_group_name)
 
     ProximityPlacementGroup = cmd.get_models('ProximityPlacementGroup')


### PR DESCRIPTION
This parameter defaults to standard on the service side if it is not specified.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
