### PR TITLE
Make the RPM Spec flexible to EL7 vs EL8

### DIFF
--- a/scripts/release/rpm/Dockerfile.centos
+++ b/scripts/release/rpm/Dockerfile.centos
@@ -1,9 +1,10 @@
-ARG base_image=centos:centos7
+ARG tag=centos7
 
-FROM $base_image AS build-env
+FROM centos:${tag} AS build-env
 ARG cli_version=dev
 
-RUN yum install -y wget rpm-build gcc libffi-devel python-devel openssl-devel make bash coreutils diffutils patch dos2unix
+RUN yum update
+RUN yum install -y wget rpm-build gcc libffi-devel python-devel openssl-devel make bash coreutils diffutils patch dos2unix python2-virtualenv
 
 WORKDIR /azure-cli
 
@@ -11,7 +12,7 @@ COPY . .
 
 RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
     REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
-    cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.el7.x86_64.rpm /azure-cli-dev.rpm
+    cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.*.x86_64.rpm /azure-cli-dev.rpm
 
 FROM $base_image AS execution-env
 

--- a/scripts/release/rpm/Dockerfile.centos
+++ b/scripts/release/rpm/Dockerfile.centos
@@ -3,7 +3,7 @@ ARG tag=centos7
 FROM centos:${tag} AS build-env
 ARG cli_version=dev
 
-RUN yum update
+RUN yum update -y
 RUN yum install -y wget rpm-build gcc libffi-devel python-devel openssl-devel make bash coreutils diffutils patch dos2unix python2-virtualenv
 
 WORKDIR /azure-cli
@@ -14,7 +14,10 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
     REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.*.x86_64.rpm /azure-cli-dev.rpm
 
-FROM $base_image AS execution-env
+FROM centos:${tag} AS execution-env
+
+RUN yum update -y
+RUN yum install -y python python-virtualenv
 
 COPY --from=build-env /azure-cli-dev.rpm ./
 RUN rpm -i ./azure-cli-dev.rpm && \

--- a/scripts/release/rpm/Dockerfile.fedora
+++ b/scripts/release/rpm/Dockerfile.fedora
@@ -1,0 +1,21 @@
+ARG tag=29
+
+FROM fedora:${tag} AS build-env
+ARG cli_version=dev
+
+RUN dnf update
+RUN dnf install -y wget rpm-build gcc libffi-devel python3-devel openssl-devel make bash coreutils diffutils patch dos2unix
+
+WORKDIR /azure-cli
+
+COPY . .
+
+RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
+    REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
+    cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.*.x86_64.rpm /azure-cli-dev.rpm
+
+FROM $base_image AS execution-env
+
+COPY --from=build-env /azure-cli-dev.rpm ./
+RUN rpm -i ./azure-cli-dev.rpm && \
+    az --version

--- a/scripts/release/rpm/Dockerfile.fedora
+++ b/scripts/release/rpm/Dockerfile.fedora
@@ -19,5 +19,4 @@ FROM fedora:${tag} AS execution-env
 RUN dnf install -y python3 python3-virtualenv
 
 COPY --from=build-env /azure-cli-dev.rpm ./
-RUN rpm -i ./azure-cli-dev.rpm && \
-    az --version
+RUN rpm -i ./azure-cli-dev.rpm

--- a/scripts/release/rpm/Dockerfile.fedora
+++ b/scripts/release/rpm/Dockerfile.fedora
@@ -3,8 +3,8 @@ ARG tag=29
 FROM fedora:${tag} AS build-env
 ARG cli_version=dev
 
-RUN dnf update
-RUN dnf install -y wget rpm-build gcc libffi-devel python3-devel openssl-devel make bash coreutils diffutils patch dos2unix
+RUN dnf update -y
+RUN dnf install -y wget rpm-build gcc libffi-devel python3-devel python3-virtualenv openssl-devel make bash coreutils diffutils patch dos2unix perl
 
 WORKDIR /azure-cli
 
@@ -14,7 +14,9 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
     REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.*.x86_64.rpm /azure-cli-dev.rpm
 
-FROM $base_image AS execution-env
+FROM fedora:${tag} AS execution-env
+
+RUN dnf install -y python3 python3-virtualenv
 
 COPY --from=build-env /azure-cli-dev.rpm ./
 RUN rpm -i ./azure-cli-dev.rpm && \

--- a/scripts/release/rpm/README.md
+++ b/scripts/release/rpm/README.md
@@ -1,19 +1,31 @@
 # RPM Packaging
 
-## Building the RPM package
+## Building RPM packages
 
 On a machine with Docker, execute the following command from the root directory of this repository:
 
+_Enterprise Linux:_
 ``` bash
-docker build --target build-env -f ./scripts/release/rpm/Dockerfile -t microsoft/azure-cli:centos7-builder .
+docker build --target build-env -f ./scripts/release/rpm/Dockerfile.centos -t mcr.microsoft.com/azure-cli:centos7-builder .
+```
+_Fedora:_
+
+```bash
+docker build --target build-env -f ./scripts/release/rpm/Dockerfile.fedora -t mcr.microsoft.com/azure-cli:fedora29-builder .
 ```
 
 After several minutes, this will have created a Docker image named `microsoft/azure-cli:centos7-builder` containing an
 unsigned `.rpm` built from the current contents of your azure-cli directory. To extract the build product from the image
 you can run the following command:
 
+_Enterprise Linux:_
 ``` bash
-docker run microsoft/azure-cli:centos7-builder cat /root/rpmbuild/RPMS/x86_64/azure-cli-dev-1.el7.x86_64.rpm > ./bin/azure-cli-dev-1.el7.x86_64.rpm
+docker run mcr.microsoft.com/azure-cli:centos7-builder cat /root/rpmbuild/RPMS/x86_64/azure-cli-dev-1.el7.x86_64.rpm > ./bin/azure-cli-dev-1.el7.x86_64.rpm
+```
+
+_Fedora:_
+``` bash
+docker run mcr.microsoft.com/azure-cli:fedora29-builder cat /root/rpmbuild/RPMS/x86_64/azure-cli-dev-1.fc29.x86_64.rpm > ./bin/azure-cli-dev-1.fc29.x86_64.rpm
 ```
 
 This launches a container running from the image built and tagged by the previous command, prints the contents of the
@@ -25,7 +37,7 @@ built package to standard out, and pipes it to a file on your host machine.
 
 This will allow you to name your build. If not specified, the value "dev" is assumed.
 
-`--build-arg base_image={docker image name}`
+`--build-arg tag={centos/fedora version}`
 
 RPMs must be built using a Red Hat distro or derivative. By default, this build uses CentOS7, but one could easily tweak
 it to include slightly different packages for distribution.
@@ -38,7 +50,7 @@ Run the RPM package
 On a machine with Docker, execute the following command from the root directory of this repository:
 
 ``` bash
-docker build -f ./scripts/release/rpm/Dockerfile -t microsoft/azure-cli:centos7 .
+docker build -f ./scripts/release/rpm/Dockerfile.centos -t mcr.microsoft.com/azure-cli:centos7 .
 ``` 
 
 If you had previously followed this instructions above for building an RPM package, this should finish very quickly.

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -6,7 +6,7 @@
   %define dist .el%{?rhel}
 %endif
 
-%if 0%{?rhel} < 8
+%if 0%{?rhel} && 0%{?rhel} < 8
     %define python_cmd python2
 %else
     %define python_cmd python3
@@ -28,7 +28,7 @@ BuildArch:      x86_64
 Requires:       %{python_cmd}, %{python_cmd}-virtualenv
 
 BuildRequires:  gcc, libffi-devel, openssl-devel
-# BuildRequires:  %{python_cmd}-devel
+BuildRequires:  %{python_cmd}-devel
 
 %global _python_bytecompile_errors_terminate_build 0
 

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -27,7 +27,7 @@ Url:            https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 BuildArch:      x86_64
 Requires:       %{python_cmd}, %{python_cmd}-virtualenv
 
-BuildRequires:  gcc, libffi-devel, openssl-devel
+BuildRequires:  gcc, libffi-devel, openssl-devel, perl
 BuildRequires:  %{python_cmd}-devel
 
 %global _python_bytecompile_errors_terminate_build 0
@@ -67,6 +67,8 @@ mkdir -p %{buildroot}%{_sysconfdir}/bash_completion.d/
 cat $source_dir/az.completion > %{buildroot}%{_sysconfdir}/bash_completion.d/azure-cli
 
 %files
+%exclude %{_bindir}/python
+%exclude %{_bindir}/%{python_cmd}
 %attr(-,root,root) %{cli_lib_dir}
 %config(noreplace) %{_sysconfdir}/bash_completion.d/azure-cli
 %attr(0755,root,root) %{_bindir}/az

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -49,7 +49,7 @@ tar -xvzf $tmp_venv_archive -C %{_builddir}
 
 %install
 # Create the venv
-python %{_builddir}/virtualenv-15.0.0/virtualenv.py --python python %{buildroot}%{cli_lib_dir}
+%{python_cmd} %{_builddir}/virtualenv-15.0.0/virtualenv.py --python python %{buildroot}%{cli_lib_dir}
 
 # Build the wheels from the source
 source_dir=%{repo_path}

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -60,15 +60,16 @@ for d in %{buildroot}%{cli_lib_dir}/bin/*; do perl -p -i -e "s#%{buildroot}##g" 
 
 # Create executable
 mkdir -p %{buildroot}%{_bindir}
-printf '#!/usr/bin/env bash\n%{cli_lib_dir}/bin/python -Esm azure.cli "$@"' > %{buildroot}%{_bindir}/az
+python_version=$(ls %{buildroot}%{cli_lib_dir}/lib/ | head -n 1)
+printf "#!/usr/bin/env bash\nPYTHONPATH=%{cli_lib_dir}/lib/${python_version}/site-packages %{python_cmd} -m azure.cli \"\$@\"" > %{buildroot}%{_bindir}/az
+rm %{buildroot}%{cli_lib_dir}/bin/python* %{buildroot}%{cli_lib_dir}/bin/pip*
 
 # Set up tab completion
 mkdir -p %{buildroot}%{_sysconfdir}/bash_completion.d/
 cat $source_dir/az.completion > %{buildroot}%{_sysconfdir}/bash_completion.d/azure-cli
 
 %files
-%exclude %{_bindir}/python
-%exclude %{_bindir}/%{python_cmd}
+%exclude %{cli_lib_dir}/bin/
 %attr(-,root,root) %{cli_lib_dir}
 %config(noreplace) %{_sysconfdir}/bash_completion.d/azure-cli
 %attr(0755,root,root) %{_bindir}/az

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -28,7 +28,7 @@ BuildArch:      x86_64
 Requires:       %{python_cmd}, %{python_cmd}-virtualenv
 
 BuildRequires:  gcc, libffi-devel, openssl-devel
-BuildRequires:  %{python_cmd}-devel
+# BuildRequires:  %{python_cmd}-devel
 
 %global _python_bytecompile_errors_terminate_build 0
 

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -16,8 +16,6 @@
 %define release        1%{?dist}
 %define version        %{getenv:CLI_VERSION}
 %define repo_path      %{getenv:REPO_PATH}
-%define venv_url       https://pypi.python.org/packages/source/v/virtualenv/virtualenv-15.0.0.tar.gz
-%define venv_sha256    70d63fb7e949d07aeb37f6ecc94e8b60671edb15b890aa86dba5dfaf2225dc19
 %define cli_lib_dir    %{_libdir}/az
 
 Summary:        Azure CLI
@@ -27,7 +25,7 @@ Version:        %{version}
 Release:        %{release}
 Url:            https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 BuildArch:      x86_64
-Requires:       %{python_cmd}
+Requires:       %{python_cmd}, %{python_cmd}-virtualenv
 
 BuildRequires:  gcc, libffi-devel, openssl-devel
 BuildRequires:  %{python_cmd}-devel
@@ -39,17 +37,9 @@ A great cloud needs great tools; we're excited to introduce Azure CLI,
  our next generation multi-platform command line experience for Azure.
 
 %prep
-# Create some tmp files
-tmp_venv_archive=$(mktemp)
-
-# Download, Extract Virtualenv
-wget %{venv_url} -qO $tmp_venv_archive
-echo "%{venv_sha256}  $tmp_venv_archive" | sha256sum -c -
-tar -xvzf $tmp_venv_archive -C %{_builddir}
-
 %install
 # Create the venv
-%{python_cmd} %{_builddir}/virtualenv-15.0.0/virtualenv.py --python %{python_cmd} %{buildroot}%{cli_lib_dir}
+%{python_cmd} -m virtualenv --python %{python_cmd} %{buildroot}%{cli_lib_dir}
 
 # Build the wheels from the source
 source_dir=%{repo_path}

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -61,7 +61,7 @@ for d in %{buildroot}%{cli_lib_dir}/bin/*; do perl -p -i -e "s#%{buildroot}##g" 
 # Create executable
 mkdir -p %{buildroot}%{_bindir}
 python_version=$(ls %{buildroot}%{cli_lib_dir}/lib/ | head -n 1)
-printf "#!/usr/bin/env bash\nPYTHONPATH=%{cli_lib_dir}/lib/${python_version}/site-packages %{python_cmd} -m azure.cli \"\$@\"" > %{buildroot}%{_bindir}/az
+printf "#!/usr/bin/env bash\nPYTHONPATH=%{cli_lib_dir}/lib/${python_version}/site-packages %{python_cmd} -sm azure.cli \"\$@\"" > %{buildroot}%{_bindir}/az
 rm %{buildroot}%{cli_lib_dir}/bin/python* %{buildroot}%{cli_lib_dir}/bin/pip*
 
 # Set up tab completion

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -2,14 +2,14 @@
 # Definition of macros used - https://fedoraproject.org/wiki/Packaging:RPMMacros?rd=Packaging/RPMMacros
 
 # .el7.centos -> .el7
-%if 0%{?rhel} == 7
-  %define dist .el7
+%if 0%{?rhel}
+  %define dist .el%{?rhel}
 %endif
 
-%if 0%{?rhel} >= 8
-  %define python_cmd python3
+%if 0%{?rhel} < 8
+    %define python_cmd python2
 %else
-  %define python_cmd python2
+    %define python_cmd python3
 %endif
 
 %define name           azure-cli

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -49,7 +49,7 @@ tar -xvzf $tmp_venv_archive -C %{_builddir}
 
 %install
 # Create the venv
-%{python_cmd} %{_builddir}/virtualenv-15.0.0/virtualenv.py --python python %{buildroot}%{cli_lib_dir}
+%{python_cmd} %{_builddir}/virtualenv-15.0.0/virtualenv.py --python %{python_cmd} %{buildroot}%{cli_lib_dir}
 
 # Build the wheels from the source
 source_dir=%{repo_path}

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -30,7 +30,7 @@ BuildArch:      x86_64
 Requires:       %{python_cmd}
 
 BuildRequires:  gcc, libffi-devel, openssl-devel
-BuildRequires:  %{python_cmd}, %{python_cmd}-devel
+BuildRequires:  %{python_cmd}-devel
 
 %global _python_bytecompile_errors_terminate_build 0
 

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -6,6 +6,12 @@
   %define dist .el7
 %endif
 
+%if 0%{?rhel} >= 8
+  %define python_cmd python3
+%else
+  %define python_cmd python2
+%endif
+
 %define name           azure-cli
 %define release        1%{?dist}
 %define version        %{getenv:CLI_VERSION}
@@ -21,13 +27,10 @@ Version:        %{version}
 Release:        %{release}
 Url:            https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 BuildArch:      x86_64
-Requires:       python
+Requires:       %{python_cmd}
 
-BuildRequires:  gcc
-BuildRequires:  python
-BuildRequires:  libffi-devel
-BuildRequires:  python-devel
-BuildRequires:  openssl-devel
+BuildRequires:  gcc, libffi-devel, openssl-devel
+BuildRequires:  %{python_cmd}, %{python_cmd}-devel
 
 %global _python_bytecompile_errors_terminate_build 0
 


### PR DESCRIPTION
RHEL 8 is changing the way Python is distributed. [See this blog post](https://developers.redhat.com/blog/2018/11/14/python-in-rhel-8/).

This change gives us the flexibility needed to build this RPM in either an EL7 or EL8 environment. To test it, I spun up a RHEL8 VM in Azure and ssh'd in, and ran the centos7 Docker image defined in the repository to make sure there wasn't a regression.

In theory, this change should also let us build and distribute Fedora specific packages that also use Python3 instead of Python2.

Related to #8780 