### PR TITLE
[core] Fix bug where --query cannot be used with --output yaml

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -6,6 +6,8 @@ Release History
 * Fixed issue where the CLI would load extensions that were not compatible with its core version.
 * Fix issue if clouds.config is corrupt
 
+* output: Fix bug where commands fail if `--output yaml` is used with `--query`
+
 2.0.64
 ++++++
 * Upgrade to knack 0.6.1

--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -17,8 +17,13 @@ class AzOutputProducer(knack.output.OutputProducer):
 
     @staticmethod
     def format_yaml(obj):
-        import yaml
-        return yaml.safe_dump(obj.result, default_flow_style=False)
+        from yaml import (safe_dump, representer)
+        import json
+
+        try:
+            return safe_dump(obj.result, default_flow_style=False)
+        except representer.RepresenterError:
+            return safe_dump(json.loads(json.dumps(obj.result)), default_flow_style=False)
 
     @staticmethod
     def format_none(_):

--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -23,6 +23,7 @@ class AzOutputProducer(knack.output.OutputProducer):
         try:
             return safe_dump(obj.result, default_flow_style=False)
         except representer.RepresenterError:
+            # yaml.safe_dump fails when obj.result is an OrderedDict. knack's --query implementation converts the result to an OrderedDict. https://github.com/microsoft/knack/blob/af674bfea793ff42ae31a381a21478bae4b71d7f/knack/query.py#L46. # pylint: disable=line-too-long
             return safe_dump(json.loads(json.dumps(obj.result)), default_flow_style=False)
 
     @staticmethod

--- a/src/azure-cli-core/azure/cli/core/tests/test_output.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_output.py
@@ -16,6 +16,31 @@ class TestCoreCLIOutput(unittest.TestCase):
         self.assertIn('yaml', output_producer._FORMAT_DICT)
         self.assertIn('none', output_producer._FORMAT_DICT)
 
+    # regression test for https://github.com/Azure/azure-cli/issues/9263
+    def test_yaml_output_with_ordered_dict(self):
+        from azure.cli.core._output import AzOutputProducer
+        from azure.cli.core.mock import DummyCli
+        from knack.util import CommandResultItem
+        from collections import OrderedDict
+        import yaml
+
+        account_dict = {
+            "environmentName": "AzureCloud",
+            "id": "000000-000000",
+            "isDefault": True,
+            "name": "test_sub",
+            "state": "Enabled",
+            "tenantId": "000000-000000-000000",
+            "user": {
+                "name": "test@example.com",
+                "type": "user"
+            }
+        }
+
+        output_producer = AzOutputProducer(DummyCli())
+        yaml_output = output_producer.format_yaml(CommandResultItem(result=OrderedDict(account_dict)))
+        self.assertEqual(account_dict, yaml.safe_load(yaml_output))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix bug where --query cannot be used with --output yaml
The yaml formatter fails in this scenario because [knack's `--query` implementation converts the result to an OrderedDict](https://github.com/microsoft/knack/blob/af674bfea793ff42ae31a381a21478bae4b71d7f/knack/query.py#L46). 

closes #9263 


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
