### PR TITLE
Fixed NoneType iterable error in sql db list-editions --available

### DIFF
--- a/src/command_modules/azure-cli-sql/HISTORY.rst
+++ b/src/command_modules/azure-cli-sql/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 +++++
 * Added commands sql virtual-cluster list/show/delete
 * Upgrade azure-mgmt-storage from 3.1.1 to 3.3.0
+* Fixed "'NoneType' object is not iterable" error for `az sql db list-editions --available`.
 
 2.2.2
 +++++

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
@@ -878,7 +878,8 @@ def db_list_capabilities(
         for e in editions:
             e.supported_service_level_objectives = _filter_available(e.supported_service_level_objectives)
             for slo in e.supported_service_level_objectives:
-                slo.supported_max_sizes = _filter_available(slo.supported_max_sizes)
+                if slo.supported_max_sizes:
+                    slo.supported_max_sizes = _filter_available(slo.supported_max_sizes)
 
     # Remove editions with no service objectives (due to filters)
     editions = [e for e in editions if e.supported_service_level_objectives]
@@ -887,7 +888,8 @@ def db_list_capabilities(
     if DatabaseCapabilitiesAdditionalDetails.max_size.value not in show_details:
         for e in editions:
             for slo in e.supported_service_level_objectives:
-                slo.supported_max_sizes = []
+                if slo.supported_max_sizes:
+                    slo.supported_max_sizes = []
 
     return editions
 

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -1747,6 +1747,21 @@ class SqlServerCapabilityScenarioTest(ScenarioTest):
         # Get all db capabilities
         self.cmd('sql db list-editions -l {}'.format(location),
                  checks=[
+                     # At least system, standard, and premium edition exist
+                     JMESPathCheckExists("[?name == 'System']"),
+                     JMESPathCheckExists("[?name == 'Standard']"),
+                     JMESPathCheckExists("[?name == 'Premium']"),
+                     # At least s0 and p1 service objectives exist
+                     JMESPathCheckExists("[].supportedServiceLevelObjectives[] | [?name == 'S0']"),
+                     JMESPathCheckExists("[].supportedServiceLevelObjectives[] | [?name == 'P1']"),
+                     # Max size data is omitted
+                     JMESPathCheck(db_max_size_length_jmespath, 0)])
+
+        # Get all available db capabilities
+        self.cmd('sql db list-editions -l {} --available'.format(location),
+                 checks=[
+                     # System edition is not available
+                     JMESPathCheck("length([?name == 'System'])", 0),
                      # At least standard and premium edition exist
                      JMESPathCheckExists("[?name == 'Standard']"),
                      JMESPathCheckExists("[?name == 'Premium']"),


### PR DESCRIPTION
The issue is that Hyperscale service objectives have null supportedMaxSizes. This is by design, since Hyperscale has unlimited size. However the CLI command isn't handling this correctly.

Fixes #9411

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
