### PR TITLE
[ACR] Return patch response directly for acr repository update

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/repository.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/repository.py
@@ -343,31 +343,15 @@ def _acr_repository_attributes_helper(cmd,
         path = _get_repository_path(repository)
         result_index = None
 
-    # Non-GET request doesn't return the entity so there is always a GET reqeust
-    if http_method != 'get':
-        try:
-            request_data_from_registry(
-                http_method=http_method,
-                login_server=login_server,
-                path=path,
-                username=username,
-                password=password,
-                result_index=result_index,
-                json_payload=json_payload)
-        except RegistryException as e:
-            # Check for Classic registry
-            if e.status_code == 405:
-                raise CLIError(ATTRIBUTES_NOT_SUPPORTED)
-            raise
-
     try:
         return request_data_from_registry(
-            http_method='get',
+            http_method=http_method,
             login_server=login_server,
             path=path,
             username=username,
             password=password,
-            result_index=result_index)[0]
+            result_index=result_index,
+            json_payload=json_payload)[0]
     except RegistryException as e:
         # Check for Classic registry
         if e.status_code == 405:

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/repository.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/repository.py
@@ -17,12 +17,6 @@ from ._docker_utils import request_data_from_registry, get_access_credentials, R
 logger = get_logger(__name__)
 
 
-UNTAG_NOT_SUPPORTED = 'Untag is only supported for managed registries.'
-DELETE_NOT_SUPPORTED = 'Delete is only supported for managed registries.'
-SHOW_MANIFESTS_NOT_SUPPORTED = 'Show manifests is only supported for managed registries.'
-ATTRIBUTES_NOT_SUPPORTED = 'Attributes are only supported for managed registries.'
-METADATA_NOT_SUPPORTED = 'Metadata is only supported for managed registries.'
-
 ORDERBY_PARAMS = {
     'time_asc': 'timeasc',
     'time_desc': 'timedesc'
@@ -214,20 +208,14 @@ def acr_repository_show_manifests(cmd,
         repository=repository,
         permission='pull')
 
-    try:
-        raw_result = _obtain_data_from_registry(
-            login_server=login_server,
-            path=_get_manifest_path(repository),
-            username=username,
-            password=password,
-            result_index='manifests',
-            top=top,
-            orderby=orderby)
-    except RegistryException as e:
-        # Check for Classic registry
-        if e.status_code == 405:
-            raise CLIError(SHOW_MANIFESTS_NOT_SUPPORTED)
-        raise
+    raw_result = _obtain_data_from_registry(
+        login_server=login_server,
+        path=_get_manifest_path(repository),
+        username=username,
+        password=password,
+        result_index='manifests',
+        top=top,
+        orderby=orderby)
 
     # For backward compatibility, convert the results to the old schema
     if not detail:
@@ -343,20 +331,14 @@ def _acr_repository_attributes_helper(cmd,
         path = _get_repository_path(repository)
         result_index = None
 
-    try:
-        return request_data_from_registry(
-            http_method=http_method,
-            login_server=login_server,
-            path=path,
-            username=username,
-            password=password,
-            result_index=result_index,
-            json_payload=json_payload)[0]
-    except RegistryException as e:
-        # Check for Classic registry
-        if e.status_code == 405:
-            raise CLIError(ATTRIBUTES_NOT_SUPPORTED)
-        raise
+    return request_data_from_registry(
+        http_method=http_method,
+        login_server=login_server,
+        path=path,
+        username=username,
+        password=password,
+        result_index=result_index,
+        json_payload=json_payload)[0]
 
 
 def acr_repository_untag(cmd,
@@ -377,18 +359,12 @@ def acr_repository_untag(cmd,
         repository=repository,
         permission='delete')
 
-    try:
-        return request_data_from_registry(
-            http_method='delete',
-            login_server=login_server,
-            path=_get_tag_path(repository, tag),
-            username=username,
-            password=password)[0]
-    except RegistryException as e:
-        # Check for Classic registry
-        if e.status_code == 405:
-            raise CLIError(UNTAG_NOT_SUPPORTED)
-        raise
+    return request_data_from_registry(
+        http_method='delete',
+        login_server=login_server,
+        path=_get_tag_path(repository, tag),
+        username=username,
+        password=password)[0]
 
 
 def acr_repository_delete(cmd,
@@ -433,18 +409,12 @@ def acr_repository_delete(cmd,
                           "and all images under it?".format(repository), yes)
         path = _get_repository_path(repository)
 
-    try:
-        return request_data_from_registry(
-            http_method='delete',
-            login_server=login_server,
-            path=path,
-            username=username,
-            password=password)[0]
-    except RegistryException as e:
-        # Check for Classic registry
-        if e.status_code == 405:
-            raise CLIError(DELETE_NOT_SUPPORTED)
-        raise
+    return request_data_from_registry(
+        http_method='delete',
+        login_server=login_server,
+        path=path,
+        username=username,
+        password=password)[0]
 
 
 def _validate_parameters(repository, image):
@@ -483,35 +453,22 @@ def _delete_manifest_confirmation(login_server,
                                   manifest,
                                   yes):
     # Always query manifest if it is empty
-    try:
-        manifest = manifest or _get_manifest_digest(
-            login_server=login_server,
-            repository=repository,
-            tag=tag,
-            username=username,
-            password=password)
-    except RegistryException as e:
-        # Check for Classic registry
-        if e.status_code == 405:
-            raise CLIError(DELETE_NOT_SUPPORTED)
-        raise
+    manifest = manifest or _get_manifest_digest(
+        login_server=login_server,
+        repository=repository,
+        tag=tag,
+        username=username,
+        password=password)
 
     if yes:
         return manifest
 
-    try:
-        tags = _obtain_data_from_registry(
-            login_server=login_server,
-            path=_get_tag_path(repository),
-            username=username,
-            password=password,
-            result_index='tags'
-        )
-    except RegistryException as e:
-        # Check for Classic registry
-        if e.status_code == 405:
-            raise CLIError(DELETE_NOT_SUPPORTED)
-        raise
+    tags = _obtain_data_from_registry(
+        login_server=login_server,
+        path=_get_tag_path(repository),
+        username=username,
+        password=password,
+        result_index='tags')
 
     filter_by_manifest = [x['name'] for x in tags if manifest == x['digest']]
     message = "This operation will delete the manifest '{}'".format(manifest)

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -243,7 +243,6 @@ class AcrMockCommandsTests(unittest.TestCase):
             json=None,
             verify=mock.ANY)
 
-
     @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
     @mock.patch('requests.request', autospec=True)
     def test_repository_show(self, mock_requests_get, mock_get_access_credentials):
@@ -304,7 +303,6 @@ class AcrMockCommandsTests(unittest.TestCase):
                 'writeEnabled': 'false'
             },
             verify=mock.ANY)
-
 
     @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
     @mock.patch('azure.cli.command_modules.acr.repository._get_manifest_digest', autospec=True)

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -19,6 +19,7 @@ from azure.cli.command_modules.acr.repository import (
     acr_repository_show_tags,
     acr_repository_show_manifests,
     acr_repository_show,
+    acr_repository_update,
     acr_repository_delete,
     acr_repository_untag
 )
@@ -241,6 +242,69 @@ class AcrMockCommandsTests(unittest.TestCase):
             params=None,
             json=None,
             verify=mock.ANY)
+
+
+    @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
+    @mock.patch('requests.request', autospec=True)
+    def test_repository_show(self, mock_requests_get, mock_get_access_credentials):
+        cmd = self._setup_cmd()
+
+        response = mock.MagicMock()
+        response.headers = {}
+        response.status_code = 200
+        response.content = json.dumps({
+            'registry': 'testregistry.azurecr.io',
+            'imageName': 'testrepository'
+        }).encode()
+        mock_requests_get.return_value = response
+
+        mock_get_access_credentials.return_value = 'testregistry.azurecr.io', 'username', 'password'
+
+        # Update attributes for a repository
+        acr_repository_update(cmd,
+                              registry_name='testregistry',
+                              repository='testrepository',
+                              write_enabled='false')
+        mock_requests_get.assert_called_with(
+            method='patch',
+            url='https://testregistry.azurecr.io/acr/v1/testrepository',
+            headers=get_authorization_header('username', 'password'),
+            params=None,
+            json={
+                'writeEnabled': 'false'
+            },
+            verify=mock.ANY)
+
+        # Update attributes for an image by tag
+        acr_repository_update(cmd,
+                              registry_name='testregistry',
+                              image='testrepository:testtag',
+                              write_enabled='false')
+        mock_requests_get.assert_called_with(
+            method='patch',
+            url='https://testregistry.azurecr.io/acr/v1/testrepository/_tags/testtag',
+            headers=get_authorization_header('username', 'password'),
+            params=None,
+            json={
+                'writeEnabled': 'false'
+            },
+            verify=mock.ANY)
+
+        # Update attributes for an image by manifest digest
+        acr_repository_update(cmd,
+                              registry_name='testregistry',
+                              image='testrepository@sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
+                              write_enabled='false')
+        mock_requests_get.assert_called_with(
+            method='patch',
+            url='https://testregistry.azurecr.io/acr/v1/testrepository/_manifests/sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
+            headers=get_authorization_header('username', 'password'),
+            params=None,
+            json={
+                'writeEnabled': 'false'
+            },
+            verify=mock.ANY)
+
 
     @mock.patch('azure.cli.command_modules.acr.repository.get_access_credentials', autospec=True)
     @mock.patch('azure.cli.command_modules.acr.repository._get_manifest_digest', autospec=True)


### PR DESCRIPTION
Fixes https://github.com/Azure/acr/issues/212

Also remove deprecated classic registry error handling

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
