### PR TITLE
auth: handle unicode in subscription name when under python 2.7

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -242,7 +242,7 @@ class Profile(object):
             try:
                 s.display_name.encode(sys.getdefaultencoding())
             except (UnicodeEncodeError, UnicodeDecodeError):  # mainly for Python 2.7 with ascii as the default encoding
-                display_name = re.sub(r'[^\x00-\x7f]', lambda x:'?', display_name)
+                display_name = re.sub(r'[^\x00-\x7f]', lambda x: '?', display_name)
 
             consolidated.append({
                 _SUBSCRIPTION_ID: s.id.rpartition('/')[2],

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -235,11 +235,18 @@ class Profile(object):
 
     def _normalize_properties(self, user, subscriptions, is_service_principal, cert_sn_issuer_auth=None,
                               user_assigned_identity_id=None):
+        import sys
         consolidated = []
         for s in subscriptions:
+            display_name = s.display_name
+            try:
+                s.display_name.encode(sys.getdefaultencoding())
+            except (UnicodeEncodeError, UnicodeDecodeError):  # mainly for Python 2.7 with ascii as the default encoding
+                display_name = re.sub(r'[^\x00-\x7f]', lambda x:'?', display_name)
+
             consolidated.append({
                 _SUBSCRIPTION_ID: s.id.rpartition('/')[2],
-                _SUBSCRIPTION_NAME: s.display_name,
+                _SUBSCRIPTION_NAME: display_name,
                 _STATE: s.state.value,
                 _USER_ENTITY: {
                     _USER_NAME: user,
@@ -249,6 +256,7 @@ class Profile(object):
                 _TENANT_ID: s.tenant_id,
                 _ENVIRONMENT_NAME: self.cli_ctx.cloud.name
             })
+
             if cert_sn_issuer_auth:
                 consolidated[-1][_USER_ENTITY][_SERVICE_PRINCIPAL_CERT_SN_ISSUER_AUTH] = True
             if user_assigned_identity_id:

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -6,6 +6,7 @@
 # pylint: disable=protected-access
 import json
 import os
+import sys
 import unittest
 import mock
 import re
@@ -105,6 +106,21 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(expected, consolidated[0])
         # verify serialization works
         self.assertIsNotNone(json.dumps(consolidated[0]))
+
+    def test_normalize_with_unicode_in_subscription_name(self):
+        cli = DummyCli()
+        storage_mock = {'subscriptions': None}
+        test_display_name = 'sub' + chr(255)
+        polished_display_name = 'sub?'
+        test_subscription = SubscriptionStub('sub1',
+                                             test_display_name,
+                                             SubscriptionState.enabled,
+                                             'tenant1')
+        profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False, async_persist=False)
+        consolidated = profile._normalize_properties(self.user1,
+                                                     [test_subscription],
+                                                     False)
+        self.assertTrue(consolidated[0]['name'] in [polished_display_name, test_display_name])
 
     def test_update_add_two_different_subscriptions(self):
         cli = DummyCli()


### PR DESCRIPTION
fix #8987 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
