### PR TITLE
Update CLI to use Knack 0.6.2 (preview mechanism)

### DIFF
--- a/scripts/dependency/requirements.Darwin.external.txt
+++ b/scripts/dependency/requirements.Darwin.external.txt
@@ -75,7 +75,7 @@ idna==2.7
 isodate==0.6.0
 jmespath==0.9.3
 keyring==15.1.0
-knack==0.5.1
+knack==0.6.2
 mock==2.0.0
 msrest==0.5.5
 msrestazure==0.4.34

--- a/scripts/dependency/requirements.Linux.external.txt
+++ b/scripts/dependency/requirements.Linux.external.txt
@@ -76,7 +76,7 @@ isodate==0.6.0
 jeepney==0.3.1
 jmespath==0.9.3
 keyring==15.1.0
-knack==0.5.1
+knack==0.6.2
 mock==2.0.0
 msrest==0.5.5
 msrestazure==0.4.34

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -17,6 +17,7 @@ from knack.commands import CLICommandsLoader
 from knack.completion import ARGCOMPLETE_ENV_NAME
 from knack.introspection import extract_args_from_signature, extract_full_summary_from_signature
 from knack.log import get_logger
+from knack.preview import PreviewItem
 from knack.util import CLIError
 from knack.arguments import ArgumentsContext, CaseInsensitiveList  # pylint: disable=unused-import
 
@@ -419,8 +420,11 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
             kwargs['command_type'] = command_type
         if 'deprecate_info' in kwargs:
             kwargs['deprecate_info'].target = group_name
-        if 'preview_info' in kwargs:
-            kwargs['preview_info'].target = group_name
+        if kwargs.get('is_preview', False):
+            kwargs['preview_info'] = PreviewItem(
+                target=group_name,
+                object_type='command group'
+            )
         return self._command_group_cls(self, group_name, **kwargs)
 
     def argument_context(self, scope, **kwargs):

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -419,6 +419,8 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
             kwargs['command_type'] = command_type
         if 'deprecate_info' in kwargs:
             kwargs['deprecate_info'].target = group_name
+        if 'preview_info' in kwargs:
+            kwargs['preview_info'].target = group_name
         return self._command_group_cls(self, group_name, **kwargs)
 
     def argument_context(self, scope, **kwargs):

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -266,6 +266,7 @@ class CliCommandHelpFile(KnackCommandHelpFile, CliHelpFile):
                 param_kwargs = {
                     'name_source': [action.metavar or action.dest],
                     'deprecate_info': getattr(action, 'deprecate_info', None),
+                    'preview_info': getattr(action, 'preview_info', None),
                     'description': action.help,
                     'choices': action.choices,
                     'required': False,

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -33,7 +33,7 @@ from knack.arguments import CLICommandArgument
 from knack.commands import CLICommand, CommandGroup
 from knack.deprecation import ImplicitDeprecated, resolve_deprecate_info
 from knack.invocation import CommandInvoker
-from knack.preview import ImplicitPreviewItem, resolve_preview_info
+from knack.preview import ImplicitPreviewItem, PreviewItem, resolve_preview_info
 from knack.log import get_logger
 from knack.util import CLIError, CommandResultItem, todict
 from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
@@ -1102,8 +1102,11 @@ class AzCommandGroup(CommandGroup):
         merged_kwargs = self._flatten_kwargs(kwargs, get_command_type_kwarg(custom_command))
         # don't inherit deprecation or preview info from command group
         merged_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
-        merged_kwargs['preview_info'] = kwargs.get('preview_info', None)
-
+        if kwargs.get('is_preview', False):
+            merged_kwargs['preview_info'] = PreviewItem(
+                self.command_loader.cli_ctx,
+                object_type='command'
+            )
         operations_tmpl = merged_kwargs['operations_tmpl']
         command_name = '{} {}'.format(self.group_name, name) if self.group_name else name
         self.command_loader._cli_command(command_name,  # pylint: disable=protected-access

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -33,6 +33,7 @@ from knack.arguments import CLICommandArgument
 from knack.commands import CLICommand, CommandGroup
 from knack.deprecation import ImplicitDeprecated, resolve_deprecate_info
 from knack.invocation import CommandInvoker
+from knack.preview import ImplicitPreviewItem, resolve_preview_info
 from knack.log import get_logger
 from knack.util import CLIError, CommandResultItem, todict
 from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
@@ -634,10 +635,12 @@ class AzCliCommandInvoker(CommandInvoker):
         return results, exceptions
 
     def resolve_warnings(self, cmd, parsed_args):
-        self._resolve_deprecation_warnings(cmd, parsed_args)
+        self._resolve_preview_and_deprecation_warnings(cmd, parsed_args)
         self._resolve_extension_override_warning(cmd)
 
-    def _resolve_deprecation_warnings(self, cmd, parsed_args):
+    def _resolve_preview_and_deprecation_warnings(self, cmd, parsed_args):
+        import colorama
+
         deprecations = [] + getattr(parsed_args, '_argument_deprecations', [])
         if cmd.deprecate_info:
             deprecations.append(cmd.deprecate_info)
@@ -656,8 +659,30 @@ class AzCliCommandInvoker(CommandInvoker):
             del deprecate_kwargs['_get_message']
             deprecations.append(ImplicitDeprecated(**deprecate_kwargs))
 
+        previews = [] + getattr(parsed_args, '_argument_previews', [])
+        if cmd.preview_info:
+            previews.append(cmd.preview_info)
+
+        # search for implicit preview
+        path_comps = cmd.name.split()[:-1]
+        implicit_preview_info = None
+        while path_comps and not implicit_preview_info:
+            implicit_preview_info = resolve_preview_info(self.cli_ctx, ' '.join(path_comps))
+            del path_comps[-1]
+
+        if implicit_preview_info:
+            preview_kwargs = implicit_preview_info.__dict__.copy()
+            preview_kwargs['object_type'] = 'command'
+            del preview_kwargs['_get_tag']
+            del preview_kwargs['_get_message']
+            previews.append(ImplicitPreviewItem(**preview_kwargs))
+
+        colorama.init()
         for d in deprecations:
-            logger.warning(d.message)
+            print(d.message, file=sys.stderr)
+        for p in previews:
+            print(p.message, file=sys.stderr)
+        colorama.deinit()
 
     def _resolve_extension_override_warning(self, cmd):  # pylint: disable=no-self-use
         if isinstance(cmd.command_source, ExtensionCommandSource) and cmd.command_source.overrides_command:
@@ -1075,8 +1100,9 @@ class AzCommandGroup(CommandGroup):
     def _command(self, name, method_name, custom_command=False, **kwargs):
         self._check_stale()
         merged_kwargs = self._flatten_kwargs(kwargs, get_command_type_kwarg(custom_command))
-        # don't inherit deprecation info from command group
+        # don't inherit deprecation or preview info from command group
         merged_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
+        merged_kwargs['preview_info'] = kwargs.get('preview_info', None)
 
         operations_tmpl = merged_kwargs['operations_tmpl']
         command_name = '{} {}'.format(self.group_name, name) if self.group_name else name
@@ -1117,8 +1143,9 @@ class AzCommandGroup(CommandGroup):
         self._check_stale()
         merged_kwargs = self._flatten_kwargs(kwargs, get_command_type_kwarg())
         merged_kwargs_custom = self._flatten_kwargs(kwargs, get_command_type_kwarg(custom_command=True))
-        # don't inherit deprecation info from command group
+        # don't inherit deprecation or preview info from command group
         merged_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
+        merged_kwargs['preview_info'] = kwargs.get('preview_info', None)
 
         getter_op = self._resolve_operation(merged_kwargs, getter_name, getter_type)
         setter_op = self._resolve_operation(merged_kwargs, setter_name, setter_type)
@@ -1149,8 +1176,9 @@ class AzCommandGroup(CommandGroup):
         from azure.cli.core.commands.arm import _cli_wait_command
         self._check_stale()
         merged_kwargs = self._flatten_kwargs(kwargs, get_command_type_kwarg(custom_command))
-        # don't inherit deprecation info from command group
+        # don't inherit deprecation or preview info from command group
         merged_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
+        merged_kwargs['preview_info'] = kwargs.get('preview_info', None)
 
         if getter_type:
             merged_kwargs = _merge_kwargs(getter_type.settings, merged_kwargs, CLI_COMMAND_KWARGS)
@@ -1168,8 +1196,9 @@ class AzCommandGroup(CommandGroup):
         from azure.cli.core.commands.arm import _cli_show_command
         self._check_stale()
         merged_kwargs = self._flatten_kwargs(kwargs, get_command_type_kwarg(custom_command))
-        # don't inherit deprecation info from command group
+        # don't inherit deprecation or preview info from command group
         merged_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
+        merged_kwargs['preview_info'] = kwargs.get('preview_info', None)
 
         if getter_type:
             merged_kwargs = _merge_kwargs(getter_type.settings, merged_kwargs, CLI_COMMAND_KWARGS)

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -215,12 +215,14 @@ def register_ids_argument(cli_ctx):
             # retrieve existing `ids` arg if it exists
             id_arg = command.loader.argument_registry.arguments[command.name].get('ids', None)
             deprecate_info = id_arg.settings.get('deprecate_info', None) if id_arg else None
+            preview_info = id_arg.settings.get('preview_info', None) if id_arg else None
             id_kwargs = {
                 'metavar': 'ID',
                 'help': "One or more resource IDs (space-delimited). If provided, "
                         "no other 'Resource Id' arguments should be specified.",
                 'dest': 'ids' if id_arg else '_ids',
                 'deprecate_info': deprecate_info,
+                'preview_info': preview_info,
                 'nargs': '+',
                 'arg_group': group_name
             }

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -215,14 +215,13 @@ def register_ids_argument(cli_ctx):
             # retrieve existing `ids` arg if it exists
             id_arg = command.loader.argument_registry.arguments[command.name].get('ids', None)
             deprecate_info = id_arg.settings.get('deprecate_info', None) if id_arg else None
-            preview_info = id_arg.settings.get('preview_info', None) if id_arg else None
             id_kwargs = {
                 'metavar': 'ID',
                 'help': "One or more resource IDs (space-delimited). If provided, "
                         "no other 'Resource Id' arguments should be specified.",
                 'dest': 'ids' if id_arg else '_ids',
                 'deprecate_info': deprecate_info,
-                'preview_info': preview_info,
+                'is_preview': id_arg.settings.get('is_preview', None) if id_arg else None,
                 'nargs': '+',
                 'arg_group': group_name
             }

--- a/src/azure-cli-core/azure/cli/core/commands/constants.py
+++ b/src/azure-cli-core/azure/cli/core/commands/constants.py
@@ -7,7 +7,7 @@ from knack.parser import ARGPARSE_SUPPORTED_KWARGS
 
 
 CLI_COMMON_KWARGS = ['min_api', 'max_api', 'resource_type', 'operation_group',
-                     'custom_command_type', 'command_type']
+                     'custom_command_type', 'command_type', 'preview_info']
 
 CLI_COMMAND_KWARGS = ['transform', 'table_transformer', 'confirmation', 'exception_handler',
                       'client_factory', 'operations_tmpl', 'no_wait_param', 'supports_no_wait', 'validator',

--- a/src/azure-cli-core/azure/cli/core/commands/constants.py
+++ b/src/azure-cli-core/azure/cli/core/commands/constants.py
@@ -7,7 +7,7 @@ from knack.parser import ARGPARSE_SUPPORTED_KWARGS
 
 
 CLI_COMMON_KWARGS = ['min_api', 'max_api', 'resource_type', 'operation_group',
-                     'custom_command_type', 'command_type', 'preview_info']
+                     'custom_command_type', 'command_type', 'is_preview', 'preview_info']
 
 CLI_COMMAND_KWARGS = ['transform', 'table_transformer', 'confirmation', 'exception_handler',
                       'client_factory', 'operations_tmpl', 'no_wait_param', 'supports_no_wait', 'validator',
@@ -15,7 +15,7 @@ CLI_COMMAND_KWARGS = ['transform', 'table_transformer', 'confirmation', 'excepti
                       'supports_local_cache'] + CLI_COMMON_KWARGS
 CLI_PARAM_KWARGS = \
     ['id_part', 'completer', 'validator', 'options_list', 'configured_default', 'arg_group', 'arg_type',
-     'deprecate_info', 'preview_info'] \
+     'deprecate_info'] \
     + CLI_COMMON_KWARGS + ARGPARSE_SUPPORTED_KWARGS
 
 CLI_POSITIONAL_PARAM_KWARGS = \

--- a/src/azure-cli-core/azure/cli/core/commands/constants.py
+++ b/src/azure-cli-core/azure/cli/core/commands/constants.py
@@ -15,7 +15,7 @@ CLI_COMMAND_KWARGS = ['transform', 'table_transformer', 'confirmation', 'excepti
                       'supports_local_cache'] + CLI_COMMON_KWARGS
 CLI_PARAM_KWARGS = \
     ['id_part', 'completer', 'validator', 'options_list', 'configured_default', 'arg_group', 'arg_type',
-     'deprecate_info'] \
+     'deprecate_info', 'preview_info'] \
     + CLI_COMMON_KWARGS + ARGPARSE_SUPPORTED_KWARGS
 
 CLI_POSITIONAL_PARAM_KWARGS = \

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -118,6 +118,7 @@ class AzCliCommandParser(CLICommandParser):
                         command_name, ex.args[0].dest, ex.message))  # pylint: disable=no-member
                 param.completer = arg.completer
                 param.deprecate_info = arg.deprecate_info
+                param.preview_info = arg.preview_info
             command_parser.set_defaults(
                 func=metadata,
                 command=command_name,

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -160,3 +160,32 @@ class AzCliCommandParser(CLICommandParser):
         argcomplete.autocomplete = AzCompletionFinder()
         argcomplete.autocomplete(self, validator=lambda c, p: c.lower().startswith(p.lower()),
                                  default_completer=lambda _: ())
+
+    def _check_value(self, action, value):
+        # Override to customize the error message when a argument is not among the available choices
+        # converted value must be one of the choices (if specified)
+        if action.choices is not None and value not in action.choices:
+            if not self.command_source:
+                # parser has no `command_source`, value is part of command itself
+                error_msg = "{prog}: '{value}' is not in the '{prog}' command group. See '{prog} --help'.".format(
+                    prog=self.prog, value=value)
+            else:
+                # `command_source` indicates command values have been parsed, value is an argument
+                parameter = action.option_strings[0] if action.option_strings else action.dest
+                error_msg = "{prog}: '{value}' is not a valid value for '{param}'. See '{prog} --help'.".format(
+                    prog=self.prog, value=value, param=parameter)
+            telemetry.set_user_fault(error_msg)
+            with CommandLoggerContext(logger):
+                logger.error(error_msg)
+            candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
+            if candidates:
+                print_args = {
+                    's': 's' if len(candidates) > 1 else '',
+                    'verb': 'are' if len(candidates) > 1 else 'is',
+                    'value': value
+                }
+                suggestion_msg = "\nThe most similar choice{s} to '{value}' {verb}:\n".format(**print_args)
+                suggestion_msg += '\n'.join(['\t' + candidate for candidate in candidates])
+                print(suggestion_msg, file=sys.stderr)
+
+            self.exit(2)

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -160,32 +160,3 @@ class AzCliCommandParser(CLICommandParser):
         argcomplete.autocomplete = AzCompletionFinder()
         argcomplete.autocomplete(self, validator=lambda c, p: c.lower().startswith(p.lower()),
                                  default_completer=lambda _: ())
-
-    def _check_value(self, action, value):
-        # Override to customize the error message when a argument is not among the available choices
-        # converted value must be one of the choices (if specified)
-        if action.choices is not None and value not in action.choices:
-            if not self.command_source:
-                # parser has no `command_source`, value is part of command itself
-                error_msg = "{prog}: '{value}' is not in the '{prog}' command group. See '{prog} --help'.".format(
-                    prog=self.prog, value=value)
-            else:
-                # `command_source` indicates command values have been parsed, value is an argument
-                parameter = action.option_strings[0] if action.option_strings else action.dest
-                error_msg = "{prog}: '{value}' is not a valid value for '{param}'. See '{prog} --help'.".format(
-                    prog=self.prog, value=value, param=parameter)
-            telemetry.set_user_fault(error_msg)
-            with CommandLoggerContext(logger):
-                logger.error(error_msg)
-            candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
-            if candidates:
-                print_args = {
-                    's': 's' if len(candidates) > 1 else '',
-                    'verb': 'are' if len(candidates) > 1 else 'is',
-                    'value': value
-                }
-                suggestion_msg = "\nThe most similar choice{s} to '{value}' {verb}:\n".format(**print_args)
-                suggestion_msg += '\n'.join(['\t' + candidate for candidate in candidates])
-                print(suggestion_msg, file=sys.stderr)
-
-            self.exit(2)

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -59,7 +59,7 @@ DEPENDENCIES = [
     'colorama>=0.3.9',
     'humanfriendly>=4.7',
     'jmespath',
-    'knack~=0.6.1',
+    'knack~=0.6.2',
     'msrest>=0.4.4',
     'msrestazure>=0.4.25',
     'paramiko>=2.0.8',

--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+
+* Deprecated ACS commands are now hidden from help view.
+
 2.4.3
 ++++++
 * Allow enabling/disabling AKS kube-dashboard addon

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -380,7 +380,7 @@ short-summary: Download and install kubectl, the Kubernetes command-line tool.
 
 helps['aks install-connector'] = """
 type: command
-short-summary: (PREVIEW) Install the ACI Connector on a managed Kubernetes cluster.
+short-summary: Install the ACI Connector on a managed Kubernetes cluster.
 parameters:
   - name: --chart-url
     type: string
@@ -437,7 +437,7 @@ short-summary: List managed Kubernetes clusters.
 
 helps['aks remove-connector'] = """
 type: command
-short-summary: (PREVIEW) Remove the ACI Connector from a managed Kubernetes cluster.
+short-summary: Remove the ACI Connector from a managed Kubernetes cluster.
 parameters:
   - name: --connector-name
     type: string
@@ -543,7 +543,7 @@ examples:
 
 helps['aks upgrade-connector'] = """
 type: command
-short-summary: (PREVIEW) Upgrade the ACI Connector on a managed Kubernetes cluster.
+short-summary: Upgrade the ACI Connector on a managed Kubernetes cluster.
 parameters:
   - name: --chart-url
     type: string

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -74,16 +74,16 @@ def load_command_table(self, _):
         g.custom_command('get-credentials', 'aks_get_credentials')
         g.command('get-upgrades', 'get_upgrade_profile', table_transformer=aks_upgrades_table_format)
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
-        g.custom_command('install-connector', 'k8s_install_connector')
+        g.custom_command('install-connector', 'k8s_install_connector', preview_info=g.preview())
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
-        g.custom_command('remove-connector', 'k8s_uninstall_connector')
+        g.custom_command('remove-connector', 'k8s_uninstall_connector', preview_info=g.preview())
         g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces')
         g.custom_command('scale', 'aks_scale', supports_no_wait=True)
         g.custom_show_command('show', 'aks_show', table_transformer=aks_show_table_format)
         g.custom_command('upgrade', 'aks_upgrade', supports_no_wait=True,
                          confirmation='Kubernetes may be unavailable during cluster upgrades.\n' +
                          'Are you sure you want to perform this operation?')
-        g.custom_command('upgrade-connector', 'k8s_upgrade_connector')
+        g.custom_command('upgrade-connector', 'k8s_upgrade_connector', preview_info=g.preview())
         g.custom_command('use-dev-spaces', 'aks_use_dev_spaces')
         g.wait_command('wait')
 

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -39,7 +39,7 @@ def load_command_table(self, _):
     # ACS base commands
     # TODO: When the first azure-cli release after January 31, 2020 is planned, add
     # `expiration=<CLI core version>` to the `self.deprecate()` args below.
-    deprecate_info = self.deprecate(redirect='aks')
+    deprecate_info = self.deprecate(redirect='aks', hide=True)
     with self.command_group('acs', container_services_sdk, deprecate_info=deprecate_info,
                             client_factory=cf_container_services) as g:
         g.custom_command('browse', 'acs_browse')

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -74,16 +74,16 @@ def load_command_table(self, _):
         g.custom_command('get-credentials', 'aks_get_credentials')
         g.command('get-upgrades', 'get_upgrade_profile', table_transformer=aks_upgrades_table_format)
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
-        g.custom_command('install-connector', 'k8s_install_connector', preview_info=g.preview())
+        g.custom_command('install-connector', 'k8s_install_connector', is_preview=True)
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
-        g.custom_command('remove-connector', 'k8s_uninstall_connector', preview_info=g.preview())
+        g.custom_command('remove-connector', 'k8s_uninstall_connector', is_preview=True)
         g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces')
         g.custom_command('scale', 'aks_scale', supports_no_wait=True)
         g.custom_show_command('show', 'aks_show', table_transformer=aks_show_table_format)
         g.custom_command('upgrade', 'aks_upgrade', supports_no_wait=True,
                          confirmation='Kubernetes may be unavailable during cluster upgrades.\n' +
                          'Are you sure you want to perform this operation?')
-        g.custom_command('upgrade-connector', 'k8s_upgrade_connector', preview_info=g.preview())
+        g.custom_command('upgrade-connector', 'k8s_upgrade_connector', is_preview=True)
         g.custom_command('use-dev-spaces', 'aks_use_dev_spaces')
         g.wait_command('wait')
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -1328,7 +1328,7 @@ examples:
 
 helps['webapp ssh'] = """
 type: command
-short-summary: (Preview) SSH command establishes a ssh session to the web container and developer would get a shell terminal remotely.
+short-summary: SSH command establishes a ssh session to the web container and developer would get a shell terminal remotely.
 examples:
   - name: ssh into a web app
     text: >

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -76,7 +76,7 @@ def load_arguments(self, _):
         c.argument('name', options_list=['--name', '-n'], help="Name of the new app service plan", completer=None)
         c.argument('sku', arg_type=sku_arg_type)
         c.argument('is_linux', action='store_true', required=False, help='host web app on Linux worker')
-        c.argument('hyper_v', action='store_true', required=False, help='Host web app on Windows container', preview_info=c.preview(target='--hyper-v'))
+        c.argument('hyper_v', action='store_true', required=False, help='Host web app on Windows container', is_preview=True)
         c.argument('tags', arg_type=tags_type)
 
     with self.argument_context('appservice plan update') as c:
@@ -203,7 +203,7 @@ def load_arguments(self, _):
             c.argument('python_version', help='The version used to run your web app if using Python, e.g., 2.7, 3.4')
             c.argument('net_framework_version', help="The version used to run your web app if using .NET Framework, e.g., 'v4.0' for .NET 4.6 and 'v3.0' for .NET 3.5")
             c.argument('linux_fx_version', help="The runtime stack used for your linux-based webapp, e.g., \"RUBY|2.3\", \"NODE|6.6\", \"PHP|5.6\", \"DOTNETCORE|1.1.0\". See https://aka.ms/linux-stacks for more info.")
-            c.argument('windows_fx_version', help="A docker image name used for your windows container web app, e.g., microsoft/nanoserver:ltsc2016", preview_info=c.preview(target='--windows-fx-version'))
+            c.argument('windows_fx_version', help="A docker image name used for your windows container web app, e.g., microsoft/nanoserver:ltsc2016", is_preview=True)
             if scope == 'functionapp':
                 c.ignore('windows_fx_version')
             c.argument('reserved_instance_count', options_list=['--prewarmed-instance-count'], help="Number of pre-warmed instances a function app has")

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -76,7 +76,7 @@ def load_arguments(self, _):
         c.argument('name', options_list=['--name', '-n'], help="Name of the new app service plan", completer=None)
         c.argument('sku', arg_type=sku_arg_type)
         c.argument('is_linux', action='store_true', required=False, help='host web app on Linux worker')
-        c.argument('hyper_v', action='store_true', required=False, help='(Preview) host web app on Windows container')
+        c.argument('hyper_v', action='store_true', required=False, help='Host web app on Windows container', preview_info=c.preview())
         c.argument('tags', arg_type=tags_type)
 
     with self.argument_context('appservice plan update') as c:
@@ -203,7 +203,7 @@ def load_arguments(self, _):
             c.argument('python_version', help='The version used to run your web app if using Python, e.g., 2.7, 3.4')
             c.argument('net_framework_version', help="The version used to run your web app if using .NET Framework, e.g., 'v4.0' for .NET 4.6 and 'v3.0' for .NET 3.5")
             c.argument('linux_fx_version', help="The runtime stack used for your linux-based webapp, e.g., \"RUBY|2.3\", \"NODE|6.6\", \"PHP|5.6\", \"DOTNETCORE|1.1.0\". See https://aka.ms/linux-stacks for more info.")
-            c.argument('windows_fx_version', help="(Preview) a docker image name used for your windows container web app, e.g., microsoft/nanoserver:ltsc2016")
+            c.argument('windows_fx_version', help="A docker image name used for your windows container web app, e.g., microsoft/nanoserver:ltsc2016", preview_info=c.preview())
             if scope == 'functionapp':
                 c.ignore('windows_fx_version')
             c.argument('reserved_instance_count', options_list=['--prewarmed-instance-count'], help="Number of pre-warmed instances a function app has")

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -76,7 +76,7 @@ def load_arguments(self, _):
         c.argument('name', options_list=['--name', '-n'], help="Name of the new app service plan", completer=None)
         c.argument('sku', arg_type=sku_arg_type)
         c.argument('is_linux', action='store_true', required=False, help='host web app on Linux worker')
-        c.argument('hyper_v', action='store_true', required=False, help='Host web app on Windows container', preview_info=c.preview())
+        c.argument('hyper_v', action='store_true', required=False, help='Host web app on Windows container', preview_info=c.preview(target='--hyper-v'))
         c.argument('tags', arg_type=tags_type)
 
     with self.argument_context('appservice plan update') as c:
@@ -203,7 +203,7 @@ def load_arguments(self, _):
             c.argument('python_version', help='The version used to run your web app if using Python, e.g., 2.7, 3.4')
             c.argument('net_framework_version', help="The version used to run your web app if using .NET Framework, e.g., 'v4.0' for .NET 4.6 and 'v3.0' for .NET 3.5")
             c.argument('linux_fx_version', help="The runtime stack used for your linux-based webapp, e.g., \"RUBY|2.3\", \"NODE|6.6\", \"PHP|5.6\", \"DOTNETCORE|1.1.0\". See https://aka.ms/linux-stacks for more info.")
-            c.argument('windows_fx_version', help="A docker image name used for your windows container web app, e.g., microsoft/nanoserver:ltsc2016", preview_info=c.preview())
+            c.argument('windows_fx_version', help="A docker image name used for your windows container web app, e.g., microsoft/nanoserver:ltsc2016", preview_info=c.preview(target='--windows-fx-version'))
             if scope == 'functionapp':
                 c.ignore('windows_fx_version')
             c.argument('reserved_instance_count', options_list=['--prewarmed-instance-count'], help="Number of pre-warmed instances a function app has")

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -74,7 +74,7 @@ def load_command_table(self, _):
     with self.command_group('webapp', webapp_sdk) as g:
         g.custom_command('create', 'create_webapp', exception_handler=ex_handler_factory())
         g.custom_command('up', 'webapp_up', exception_handler=ex_handler_factory())
-        g.custom_command('ssh', 'ssh_webapp', exception_handler=ex_handler_factory())
+        g.custom_command('ssh', 'ssh_webapp', exception_handler=ex_handler_factory(), preview_info=g.preview())
         g.custom_command('list', 'list_webapp', table_transformer=transform_web_list_output)
         g.custom_show_command('show', 'show_webapp', table_transformer=transform_web_output)
         g.custom_command('delete', 'delete_webapp')

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -74,7 +74,7 @@ def load_command_table(self, _):
     with self.command_group('webapp', webapp_sdk) as g:
         g.custom_command('create', 'create_webapp', exception_handler=ex_handler_factory())
         g.custom_command('up', 'webapp_up', exception_handler=ex_handler_factory())
-        g.custom_command('ssh', 'ssh_webapp', exception_handler=ex_handler_factory(), preview_info=g.preview())
+        g.custom_command('ssh', 'ssh_webapp', exception_handler=ex_handler_factory(), is_preview=True)
         g.custom_command('list', 'list_webapp', table_transformer=transform_web_list_output)
         g.custom_show_command('show', 'show_webapp', table_transformer=transform_web_output)
         g.custom_command('delete', 'delete_webapp')

--- a/src/command_modules/azure-cli-batchai/HISTORY.rst
+++ b/src/command_modules/azure-cli-batchai/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+
+* BatchAI commands are now deprecated and hidden.
+
 0.4.9
 +++++
 * Upgrade azure-mgmt-storage from 3.1.1 to 3.3.0

--- a/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/commands.py
+++ b/src/command_modules/azure-cli-batchai/azure/cli/command_modules/batchai/commands.py
@@ -109,5 +109,5 @@ def load_command_table(self, _):
         g.show_command('show', 'get', table_transformer=file_server_show_table_format)
         g.command('list', 'list_by_workspace', table_transformer=file_server_list_table_format)
 
-    with self.command_group('batchai', batchai_usage_sdk, client_factory=usage_client_factory) as g:
+    with self.command_group('batchai', batchai_usage_sdk, client_factory=usage_client_factory, deprecate_info=self.deprecate(hide=True)) as g:
         g.command('list-usages', 'list', table_transformer=usage_table_format)

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
@@ -9,17 +9,17 @@ from knack.help_files import helps
 
 helps['dla'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics accounts, jobs, and catalogs.
+short-summary: Manage Data Lake Analytics accounts, jobs, and catalogs.
 """
 
 helps['dla account'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics accounts.
+short-summary: Manage Data Lake Analytics accounts.
 """
 
 helps['dla account blob-storage'] = """
 type: group
-short-summary: (PREVIEW) Manage links between Data Lake Analytics accounts and Azure Storage.
+short-summary: Manage links between Data Lake Analytics accounts and Azure Storage.
 """
 
 helps['dla account blob-storage add'] = """
@@ -34,7 +34,7 @@ short-summary: Updates an Azure Storage account linked to the specified Data Lak
 
 helps['dla account compute-policy'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics account compute policies.
+short-summary: Manage Data Lake Analytics account compute policies.
 """
 
 helps['dla account compute-policy create'] = """
@@ -108,7 +108,7 @@ parameters:
 
 helps['dla account data-lake-store'] = """
 type: group
-short-summary: (PREVIEW) Manage links between Data Lake Analytics and Data Lake Store accounts.
+short-summary: Manage links between Data Lake Analytics and Data Lake Store accounts.
 """
 
 helps['dla account delete'] = """
@@ -118,7 +118,7 @@ short-summary: Delete a Data Lake Analytics account.
 
 helps['dla account firewall'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics account firewall rules.
+short-summary: Manage Data Lake Analytics account firewall rules.
 """
 
 helps['dla account firewall create'] = """
@@ -189,17 +189,17 @@ parameters:
 
 helps['dla catalog'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalogs.
+short-summary: Manage Data Lake Analytics catalogs.
 """
 
 helps['dla catalog assembly'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog assemblies.
+short-summary: Manage Data Lake Analytics catalog assemblies.
 """
 
 helps['dla catalog credential'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog credentials.
+short-summary: Manage Data Lake Analytics catalog credentials.
 """
 
 helps['dla catalog credential create'] = """
@@ -249,32 +249,32 @@ parameters:
 
 helps['dla catalog database'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog databases.
+short-summary: Manage Data Lake Analytics catalog databases.
 """
 
 helps['dla catalog external-data-source'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog external data sources.
+short-summary: Manage Data Lake Analytics catalog external data sources.
 """
 
 helps['dla catalog package'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog packages.
+short-summary: Manage Data Lake Analytics catalog packages.
 """
 
 helps['dla catalog procedure'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog stored procedures.
+short-summary: Manage Data Lake Analytics catalog stored procedures.
 """
 
 helps['dla catalog schema'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog schemas.
+short-summary: Manage Data Lake Analytics catalog schemas.
 """
 
 helps['dla catalog table'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog tables.
+short-summary: Manage Data Lake Analytics catalog tables.
 """
 
 helps['dla catalog table list'] = """
@@ -291,12 +291,12 @@ parameters:
 
 helps['dla catalog table-partition'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog table partitions.
+short-summary: Manage Data Lake Analytics catalog table partitions.
 """
 
 helps['dla catalog table-stats'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog table statistics.
+short-summary: Manage Data Lake Analytics catalog table statistics.
 """
 
 helps['dla catalog table-stats list'] = """
@@ -316,12 +316,12 @@ parameters:
 
 helps['dla catalog table-type'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog table types.
+short-summary: Manage Data Lake Analytics catalog table types.
 """
 
 helps['dla catalog tvf'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog table valued functions.
+short-summary: Manage Data Lake Analytics catalog table valued functions.
 """
 
 helps['dla catalog tvf list'] = """
@@ -338,7 +338,7 @@ parameters:
 
 helps['dla catalog view'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics catalog views.
+short-summary: Manage Data Lake Analytics catalog views.
 """
 
 helps['dla catalog view list'] = """
@@ -355,7 +355,7 @@ parameters:
 
 helps['dla job'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics jobs.
+short-summary: Manage Data Lake Analytics jobs.
 """
 
 helps['dla job cancel'] = """
@@ -370,7 +370,7 @@ short-summary: List Data Lake Analytics jobs.
 
 helps['dla job pipeline'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics job pipelines.
+short-summary: Manage Data Lake Analytics job pipelines.
 """
 
 helps['dla job pipeline list'] = """
@@ -385,7 +385,7 @@ short-summary: Retrieve a job pipeline in a Data Lake Analytics account.
 
 helps['dla job recurrence'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Analytics job recurrences.
+short-summary: Manage Data Lake Analytics job recurrences.
 """
 
 helps['dla job recurrence list'] = """

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/commands.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/commands.py
@@ -187,5 +187,5 @@ def load_command_table(self, _):
         g.show_command('show', 'get')
         g.command('delete', 'delete')
 
-    with self.command_group('dla', preview_info=self.preview()):
+    with self.command_group('dla', is_preview=True):
         pass

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/commands.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/commands.py
@@ -186,3 +186,6 @@ def load_command_table(self, _):
         g.command('list', 'list_by_account')
         g.show_command('show', 'get')
         g.command('delete', 'delete')
+
+    with self.command_group('dla', preview_info=self.preview()):
+        pass

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/__init__.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/__init__.py
@@ -17,6 +17,7 @@ class DataLakeStoreCommandsLoader(AzCommandsLoader):
         super(DataLakeStoreCommandsLoader, self).__init__(cli_ctx=cli_ctx,
                                                           min_profile='2017-03-10-profile',
                                                           custom_command_type=dls_custom)
+
     def load_command_table(self, args):
         from azure.cli.command_modules.dls.commands import load_command_table
         load_command_table(self, args)

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/__init__.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/__init__.py
@@ -17,7 +17,6 @@ class DataLakeStoreCommandsLoader(AzCommandsLoader):
         super(DataLakeStoreCommandsLoader, self).__init__(cli_ctx=cli_ctx,
                                                           min_profile='2017-03-10-profile',
                                                           custom_command_type=dls_custom)
-
     def load_command_table(self, args):
         from azure.cli.command_modules.dls.commands import load_command_table
         load_command_table(self, args)

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
@@ -9,12 +9,12 @@ from knack.help_files import helps
 
 helps['dls'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Store accounts and filesystems.
+short-summary: Manage Data Lake Store accounts and filesystems.
 """
 
 helps['dls account'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Store accounts.
+short-summary: Manage Data Lake Store accounts.
 """
 
 helps['dls account create'] = """
@@ -51,7 +51,7 @@ short-summary: Enable the use of Azure Key Vault for encryption of a Data Lake S
 
 helps['dls account firewall'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Store account firewall rules.
+short-summary: Manage Data Lake Store account firewall rules.
 """
 
 helps['dls account firewall create'] = """
@@ -100,7 +100,7 @@ examples:
 
 helps['dls account network-rule'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Store account virtual network rules.
+short-summary: Manage Data Lake Store account virtual network rules.
 """
 
 helps['dls account network-rule create'] = """
@@ -146,7 +146,7 @@ examples:
 
 helps['dls account trusted-provider'] = """
 type: group
-short-summary: (PREVIEW) Manage Data Lake Store account trusted identity providers.
+short-summary: Manage Data Lake Store account trusted identity providers.
 """
 
 helps['dls account update'] = """
@@ -156,7 +156,7 @@ short-summary: Updates a Data Lake Store account.
 
 helps['dls fs'] = """
 type: group
-short-summary: (PREVIEW) Manage a Data Lake Store filesystem.
+short-summary: Manage a Data Lake Store filesystem.
 """
 
 helps['dls fs access'] = """

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/commands.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/commands.py
@@ -103,5 +103,5 @@ def load_command_table(self, _):
         g.command('remove-entry', 'remove_adls_item_acl_entry')
         g.command('remove-all', 'remove_adls_item_acl')
 
-    with self.command_group('dls', preview_info=self.preview()):
+    with self.command_group('dls', is_preview=True):
         pass

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/commands.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/commands.py
@@ -102,3 +102,6 @@ def load_command_table(self, _):
         g.command('set', 'set_adls_item_acl')
         g.command('remove-entry', 'remove_adls_item_acl_entry')
         g.command('remove-all', 'remove_adls_item_acl')
+
+    with self.command_group('dls', preview_info=self.preview()):
+        pass

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -3261,7 +3261,7 @@ examples:
 # region RouteFilters
 helps['network route-filter'] = """
 type: group
-short-summary: (PREVIEW) Manage route filters.
+short-summary: Manage route filters.
 long-summary: >
     To learn more about route filters with Microsoft peering with ExpressRoute, visit https://docs.microsoft.com/en-us/azure/expressroute/how-to-routefilter-cli
 """
@@ -3292,7 +3292,7 @@ examples:
 
 helps['network route-filter rule'] = """
 type: group
-short-summary: (PREVIEW) Manage rules in a route filter.
+short-summary: Manage rules in a route filter.
 long-summary: >
     To learn more about route filters with Microsoft peering with ExpressRoute, visit https://docs.microsoft.com/en-us/azure/expressroute/how-to-routefilter-cli
 """
@@ -4536,7 +4536,7 @@ examples:
 
 helps['network watcher test-connectivity'] = """
 type: command
-short-summary: (PREVIEW) Test if a connection can be established between a Virtual Machine and a given endpoint.
+short-summary: Test if a connection can be established between a Virtual Machine and a given endpoint.
 long-summary: >
     To check connectivity between two VMs in different regions, use the VM ids instead of the VM names for the source and destination resource arguments.
     To register for this feature or see additional examples visit https://docs.microsoft.com/en-us/azure/network-watcher/network-watcher-connectivity-cli

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -708,7 +708,7 @@ def load_command_table(self, _):
         g.custom_command('configure', 'configure_network_watcher')
         g.command('list', 'list_all')
         g.custom_command('test-ip-flow', 'check_nw_ip_flow', client_factory=cf_network_watcher)
-        g.custom_command('test-connectivity', 'check_nw_connectivity', client_factory=cf_network_watcher, validator=process_nw_test_connectivity_namespace, preview_info=g.preview())
+        g.custom_command('test-connectivity', 'check_nw_connectivity', client_factory=cf_network_watcher, validator=process_nw_test_connectivity_namespace, is_preview=True)
         g.custom_command('show-next-hop', 'show_nw_next_hop', client_factory=cf_network_watcher)
         g.custom_command('show-security-group-view', 'show_nw_security_view', client_factory=cf_network_watcher)
         g.custom_command('show-topology', 'show_topology_watcher', validator=process_nw_topology_namespace)
@@ -761,7 +761,7 @@ def load_command_table(self, _):
     # endregion
 
     # region RouteFilters
-    with self.command_group('network route-filter', network_rf_sdk, min_api='2016-12-01', preview_info=self.preview()) as g:
+    with self.command_group('network route-filter', network_rf_sdk, min_api='2016-12-01', is_preview=True) as g:
         g.custom_command('create', 'create_route_filter', client_factory=cf_route_filters)
         g.custom_command('list', 'list_route_filters', client_factory=cf_route_filters)
         g.show_command('show', 'get')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -708,7 +708,7 @@ def load_command_table(self, _):
         g.custom_command('configure', 'configure_network_watcher')
         g.command('list', 'list_all')
         g.custom_command('test-ip-flow', 'check_nw_ip_flow', client_factory=cf_network_watcher)
-        g.custom_command('test-connectivity', 'check_nw_connectivity', client_factory=cf_network_watcher, validator=process_nw_test_connectivity_namespace)
+        g.custom_command('test-connectivity', 'check_nw_connectivity', client_factory=cf_network_watcher, validator=process_nw_test_connectivity_namespace, preview_info=g.preview())
         g.custom_command('show-next-hop', 'show_nw_next_hop', client_factory=cf_network_watcher)
         g.custom_command('show-security-group-view', 'show_nw_security_view', client_factory=cf_network_watcher)
         g.custom_command('show-topology', 'show_topology_watcher', validator=process_nw_topology_namespace)
@@ -761,7 +761,7 @@ def load_command_table(self, _):
     # endregion
 
     # region RouteFilters
-    with self.command_group('network route-filter', network_rf_sdk, min_api='2016-12-01') as g:
+    with self.command_group('network route-filter', network_rf_sdk, min_api='2016-12-01', preview_info=self.preview()) as g:
         g.custom_command('create', 'create_route_filter', client_factory=cf_route_filters)
         g.custom_command('list', 'list_route_filters', client_factory=cf_route_filters)
         g.show_command('show', 'get')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -1727,7 +1727,7 @@ examples:
 
 helps['vmss identity remove'] = """
 type: command
-short-summary: (PREVIEW) Remove user assigned identities from a VM scaleset.
+short-summary: Remove user assigned identities from a VM scaleset.
 examples:
   - name: Remove system assigned identity
     text: az vmss identity remove -g MyResourceGroup -n MyVmss

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -340,7 +340,7 @@ def load_arguments(self, _):
         c.argument('priority', resource_type=ResourceType.MGMT_COMPUTE, min_api='2017-12-01', arg_type=get_enum_type(VMPriorityTypes, default=None),
                    help="Priority. Use 'Low' to run short-lived workloads in a cost-effective way")
         c.argument('eviction_policy', resource_type=ResourceType.MGMT_COMPUTE, min_api='2017-12-01', arg_type=get_enum_type(VirtualMachineEvictionPolicyTypes, default=None),
-                   help="The eviction policy for virtual machines in a low priority scale set.", preview_info=c.preview(target='--eviction-policy'))
+                   help="The eviction policy for virtual machines in a low priority scale set.", is_preview=True)
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_COMPUTE, min_api='2018-06-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
 
     with self.argument_context('vmss create', arg_group='Network Balancer') as c:
@@ -487,9 +487,9 @@ def load_arguments(self, _):
             c.argument('data_caching', options_list=['--data-disk-caching'], nargs='+',
                        help="storage caching type for data disk(s), including 'None', 'ReadOnly', 'ReadWrite', etc. Use a singular value to apply on all disks, or use '<lun>=<vaule1> <lun>=<value2>' to configure individual disk")
             c.argument('ultra_ssd_enabled', arg_type=get_three_state_flag(), min_api='2018-06-01',
-                       help='Enables or disables the capability to have 1 or more managed data disks with UltraSSD_LRS storage account', preview_info=c.preview(target='--ultra-ssd-enabled'))
+                       help='Enables or disables the capability to have 1 or more managed data disks with UltraSSD_LRS storage account', is_preview=True)
             c.argument('ephemeral_os_disk', arg_type=get_three_state_flag(), min_api='2018-06-01',
-                       help='Allows you to create an OS disk directly on the host node, providing local disk performance and faster VM/VMSS reimage time.', preview_info=c.preview(target='--ephemeral-os-disk'))
+                       help='Allows you to create an OS disk directly on the host node, providing local disk performance and faster VM/VMSS reimage time.', is_preview=True)
 
         with self.argument_context(scope, arg_group='Network') as c:
             c.argument('vnet_name', help='Name of the virtual network when creating a new one or referencing an existing one.')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -340,7 +340,7 @@ def load_arguments(self, _):
         c.argument('priority', resource_type=ResourceType.MGMT_COMPUTE, min_api='2017-12-01', arg_type=get_enum_type(VMPriorityTypes, default=None),
                    help="Priority. Use 'Low' to run short-lived workloads in a cost-effective way")
         c.argument('eviction_policy', resource_type=ResourceType.MGMT_COMPUTE, min_api='2017-12-01', arg_type=get_enum_type(VirtualMachineEvictionPolicyTypes, default=None),
-                   help="The eviction policy for virtual machines in a low priority scale set.", preview_info=c.preview())
+                   help="The eviction policy for virtual machines in a low priority scale set.", preview_info=c.preview(target='--eviction-policy'))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_COMPUTE, min_api='2018-06-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
 
     with self.argument_context('vmss create', arg_group='Network Balancer') as c:
@@ -487,9 +487,9 @@ def load_arguments(self, _):
             c.argument('data_caching', options_list=['--data-disk-caching'], nargs='+',
                        help="storage caching type for data disk(s), including 'None', 'ReadOnly', 'ReadWrite', etc. Use a singular value to apply on all disks, or use '<lun>=<vaule1> <lun>=<value2>' to configure individual disk")
             c.argument('ultra_ssd_enabled', arg_type=get_three_state_flag(), min_api='2018-06-01',
-                       help='Enables or disables the capability to have 1 or more managed data disks with UltraSSD_LRS storage account', preview_info=c.preview())
+                       help='Enables or disables the capability to have 1 or more managed data disks with UltraSSD_LRS storage account', preview_info=c.preview(target='--ultra-ssd-enabled'))
             c.argument('ephemeral_os_disk', arg_type=get_three_state_flag(), min_api='2018-06-01',
-                       help='Allows you to create an OS disk directly on the host node, providing local disk performance and faster VM/VMSS reimage time.', preview_info=c.preview())
+                       help='Allows you to create an OS disk directly on the host node, providing local disk performance and faster VM/VMSS reimage time.', preview_info=c.preview(target='--ephemeral-os-disk'))
 
         with self.argument_context(scope, arg_group='Network') as c:
             c.argument('vnet_name', help='Name of the virtual network when creating a new one or referencing an existing one.')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -340,7 +340,7 @@ def load_arguments(self, _):
         c.argument('priority', resource_type=ResourceType.MGMT_COMPUTE, min_api='2017-12-01', arg_type=get_enum_type(VMPriorityTypes, default=None),
                    help="Priority. Use 'Low' to run short-lived workloads in a cost-effective way")
         c.argument('eviction_policy', resource_type=ResourceType.MGMT_COMPUTE, min_api='2017-12-01', arg_type=get_enum_type(VirtualMachineEvictionPolicyTypes, default=None),
-                   help="(PREVIEW) The eviction policy for virtual machines in a low priority scale set.")
+                   help="The eviction policy for virtual machines in a low priority scale set.", preview_info=c.preview())
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_COMPUTE, min_api='2018-06-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
 
     with self.argument_context('vmss create', arg_group='Network Balancer') as c:
@@ -487,9 +487,9 @@ def load_arguments(self, _):
             c.argument('data_caching', options_list=['--data-disk-caching'], nargs='+',
                        help="storage caching type for data disk(s), including 'None', 'ReadOnly', 'ReadWrite', etc. Use a singular value to apply on all disks, or use '<lun>=<vaule1> <lun>=<value2>' to configure individual disk")
             c.argument('ultra_ssd_enabled', arg_type=get_three_state_flag(), min_api='2018-06-01',
-                       help='(PREVIEW) Enables or disables the capability to have 1 or more managed data disks with UltraSSD_LRS storage account')
+                       help='Enables or disables the capability to have 1 or more managed data disks with UltraSSD_LRS storage account', preview_info=c.preview())
             c.argument('ephemeral_os_disk', arg_type=get_three_state_flag(), min_api='2018-06-01',
-                       help='(Preview) Allows you to create an OS disk directly on the host node, providing local disk performance and faster VM/VMSS reimage time.')
+                       help='Allows you to create an OS disk directly on the host node, providing local disk performance and faster VM/VMSS reimage time.', preview_info=c.preview())
 
         with self.argument_context(scope, arg_group='Network') as c:
             c.argument('vnet_name', help='Name of the virtual network when creating a new one or referencing an existing one.')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -270,7 +270,7 @@ def load_command_table(self, _):
 
     with self.command_group('vmss', compute_vmss_sdk, operation_group='virtual_machine_scale_sets') as g:
         g.custom_command('identity assign', 'assign_vmss_identity', validator=process_assign_identity_namespace)
-        g.custom_command('identity remove', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01', preview_info=g.preview())
+        g.custom_command('identity remove', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01', is_preview=True)
         g.custom_show_command('identity show', 'show_vmss_identity')
         g.custom_command('create', 'create_vmss', transform=DeploymentOutputLongRunningOperation(self.cli_ctx, 'Starting vmss create'), supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_vmss_create_namespace, exception_handler=handle_template_based_exception)
         g.custom_command('deallocate', 'deallocate_vmss', supports_no_wait=True)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -270,7 +270,7 @@ def load_command_table(self, _):
 
     with self.command_group('vmss', compute_vmss_sdk, operation_group='virtual_machine_scale_sets') as g:
         g.custom_command('identity assign', 'assign_vmss_identity', validator=process_assign_identity_namespace)
-        g.custom_command('identity remove', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01')
+        g.custom_command('identity remove', 'remove_vmss_identity', validator=process_remove_identity_namespace, min_api='2017-12-01', preview_info=g.preview())
         g.custom_show_command('identity show', 'show_vmss_identity')
         g.custom_command('create', 'create_vmss', transform=DeploymentOutputLongRunningOperation(self.cli_ctx, 'Starting vmss create'), supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_vmss_create_namespace, exception_handler=handle_template_based_exception)
         g.custom_command('deallocate', 'deallocate_vmss', supports_no_wait=True)


### PR DESCRIPTION
Closes #5969.

Updates the CLI to use the latest knack.
- <del>Removes the command suggestion code since it now happens in knack</del> Turns out there is CLI-specific logic in the spellchecker so I have to keep the logic in place. It just means that knack now has a limited implementation of this feature (it doesn't handle values)
- Uses the Preview status tag from the latest knack to annotate commands, groups, and arguments in preview. 
- Deprecates and hides BatchAI commands (service is being retired)
- Hides already deprecated ACS commands.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
