### PR TITLE
Clarifying language for az network lb create

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -2386,7 +2386,7 @@ examples:
   - name: Create a basic load balancer.
     text: >
         az network lb create -g MyResourceGroup -n MyLb --sku Basic
-  - name: Create a basic internal load balancer, and a new virtual network and subnet.
+  - name: Create a basic load balancer on a specific virtual network and subnet. If a virtual network with the same name is found in the same resource group, the load balancer will utilize this virtual network.  If one is not found a new one will be created.
     text: >
         az network lb create -g MyResourceGroup -n MyLb --sku Basic --vnet-name MyVnet --subnet MySubnet
   - name: Create a basic load balancer on a subnet of a pre-existing virtual network.

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -2386,7 +2386,7 @@ examples:
   - name: Create a basic load balancer.
     text: >
         az network lb create -g MyResourceGroup -n MyLb --sku Basic
-  - name: Create a basic internal load balancer on a specific virtual network and subnet.
+  - name: Create a basic internal load balancer, and a new virtual network and subnet.
     text: >
         az network lb create -g MyResourceGroup -n MyLb --sku Basic --vnet-name MyVnet --subnet MySubnet
   - name: Create a basic load balancer on a subnet of a pre-existing virtual network.


### PR DESCRIPTION
Adjusted the language for the second example of the az network lb create to specifically highlight that the command will create a new lb on a NEW vnet and subnet, and not create a new lb on a specific vnet and subnet that already exists.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
