### PR TITLE
Added Error Message when no TTY is available

### DIFF
--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.1.15
+++++++
+* `deployment create`: Improve error message when there is no TTY available
+
 2.1.14
 ++++++
 * `resource link`: Deprecate `--link-id`, `--target-id` and `--filter-string` in favor of

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -224,11 +224,15 @@ def _prompt_for_parameters(missing_parameters, fail_on_no_tty=True):  # pylint: 
 def _get_missing_parameters(parameters, template, prompt_fn):
     missing = _find_missing_parameters(parameters, template)
     if missing:
-        prompt_parameters = prompt_fn(missing)
-        for param_name in prompt_parameters:
-            parameters[param_name] = {
-                "value": prompt_parameters[param_name]
-            }
+        try:
+            prompt_parameters = prompt_fn(missing)
+            for param_name in prompt_parameters:
+                parameters[param_name] = {
+                    "value": prompt_parameters[param_name]
+                }
+        except NoTTYException:
+            raise CLIError("Missing input parameters: {}"
+                           .format(', '.join(sorted(missing.keys()))))
     return parameters
 
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -194,6 +194,33 @@ class TestCustom(unittest.TestCase):
 
         self.assertDictEqual(out_params, expected)
 
+    def test_resource_missing_parameters_no_tty(self):
+        template = {
+            "parameters": {
+                "def": {
+                    "type": "string",
+                    "defaultValue": "default"
+                },
+                "present": {
+                    "type": "string",
+                },
+                "missing": {
+                    "type": "string",
+                }
+            }
+        }
+        parameters = {
+            "present": {
+                "value": "foo"
+            }
+        }
+
+        def prompt_function(x):
+            from knack.prompting import NoTTYException
+            raise NoTTYException
+        with self.assertRaisesRegex(CLIError, "Missing input parameters: missing"):
+            _get_missing_parameters(parameters, template, prompt_function)
+
     def test_deployment_parameters(self):
 
         curr_dir = os.path.dirname(os.path.realpath(__file__))

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -9,6 +9,7 @@ import unittest
 
 from six.moves.urllib.request import pathname2url  # pylint: disable=import-error
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
+from six import assertRaisesRegex
 
 try:
     import unittest.mock as mock
@@ -218,7 +219,7 @@ class TestCustom(unittest.TestCase):
         def prompt_function(x):
             from knack.prompting import NoTTYException
             raise NoTTYException
-        with self.assertRaisesRegex(CLIError, "Missing input parameters: missing"):
+        with assertRaisesRegex(self, CLIError, "Missing input parameters: missing"):
             _get_missing_parameters(parameters, template, prompt_function)
 
     def test_deployment_parameters(self):

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.1.14"
+VERSION = "2.1.15"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fix #3876

When performing a resource group deployment, if no TTY is available,
a CLIError will be raised detailing the parameters that were not
provided.

I took the liberty of bumping to a new version.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
