### PR TITLE
Fixing Dockerfile name of RPM builder for centos in pipeline definition

### DIFF
--- a/scripts/release/rpm/pipeline.sh
+++ b/scripts/release/rpm/pipeline.sh
@@ -12,14 +12,14 @@ CLI_VERSION=`cat src/azure-cli/azure/cli/__init__.py | grep __version__ | sed s/
 docker build \
     --target build-env \
     --build-arg cli_version=${CLI_VERSION} \
-    -f ./scripts/release/rpm/Dockerfile \
+    -f ./scripts/release/rpm/Dockerfile.centos \
     -t microsoft/azure-cli:centos7-builder \
     .
 
 # Continue the previous build, and create a container that has the current azure-cli build but not the source code.
 docker build \
     --build-arg cli_version=${CLI_VERSION} \
-    -f ./scripts/release/rpm/Dockerfile \
+    -f ./scripts/release/rpm/Dockerfile.centos \
     -t microsoft/azure-cli:centos7 \
     .
 


### PR DESCRIPTION
Looks like the RPM spec build is missing a change.
