### PR TITLE
Bump cli telemetry version bounds

### DIFF
--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -49,14 +49,17 @@ setup(
     zip_safe=False,
     classifiers=CLASSIFIERS,
     install_requires=[
-        'applicationinsights>=0.11.1,<0.11.8',
-        'portalocker==1.2.1',
+        'applicationinsights>=0.11.1,<0.12',
+        'portalocker~=1.2',
     ],
     packages=[
         'azure',
         'azure.cli',
         'azure.cli.telemetry',
         'azure.cli.telemetry.components'
+    ],
+    test_requires=[
+        'mock'
     ],
     cmdclass=cmdclass
 )


### PR DESCRIPTION
Trying to package this for [Nixpkgs](https://github.com/NixOS/nixpkgs). And just wanted to submit bump the dependencies here rather than doing text edits as part of the nixpkg installation.

Tested that azure-cli-telemetry's unit tests worked with applicationinsights at 0.11.9 and portalocker at 1.4

Couldn't run through all the tests with `azdev test` but they also fail spectacularly on dev either due to permissions and too many file handles open. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
