### PR TITLE
[HDInsight] support ssh_public_key

### DIFF
--- a/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/custom.py
+++ b/src/command_modules/azure-cli-hdinsight/azure/cli/command_modules/hdinsight/custom.py
@@ -36,7 +36,7 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
     from azure.mgmt.hdinsight.models import ClusterCreateParametersExtended, ClusterCreateProperties, OSType, \
         ClusterDefinition, ComputeProfile, HardwareProfile, Role, OsProfile, LinuxOperatingSystemProfile, \
         StorageProfile, StorageAccount, DataDisksGroups, SecurityProfile, \
-        DirectoryType, DiskEncryptionProperties, Tier
+        DirectoryType, DiskEncryptionProperties, Tier, SshProfile, SshPublicKey
 
     validate_esp_cluster_create_params(esp, cluster_name, resource_group_name, cluster_type,
                                        subnet, domain, cluster_admin_account, assign_identity,
@@ -157,7 +157,11 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
         linux_operating_system_profile=LinuxOperatingSystemProfile(
             username=ssh_username,
             password=ssh_password,
-            ssh_public_key=ssh_public_key
+            ssh_profile=ssh_public_key and SshProfile(
+                public_keys=[SshPublicKey(
+                    certificate_data=ssh_public_key
+                )]
+            )
         )
     )
 


### PR DESCRIPTION
HDInsight Fix can not support --ssh-public-key when create cluster
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
