### PR TITLE
adding devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,23 @@
 
-FROM ubuntu
+# start from Ubuntu 16.04
+FROM ubuntu:xenial
 
+# install python 3.6, pip, venv and git
 RUN apt-get update
-RUN apt-get -y install python3.7
-RUN apt-get -y install python3-pip
-RUN apt-get -y install git
-RUN git clone https://github.com/zikalino/azure-cli.git
-RUN apt-get -y install python3-venv
-RUN cd /azure-cli; python3 -m venv env; chmod 777 /azure-cli/env/bin/activate
-RUN /bin/bash -c "source /azure-cli/env/bin/activate; pip3 install azdev; azdev setup --cli /azure-cli" 
+RUN apt-get -y install software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update
+RUN apt-get -y install python3.6 python3-pip python3-venv git
+
+# clone azure cli into /workspaces/azure-cli
+RUN mkdir /workspaces; cd /workspaces; git clone https://github.com/Azure/azure-cli.git
+
+# create environment in /env and set up 
+RUN python3 -m venv env
+RUN /bin/bash -c "source /env/bin/activate; pip3 install azdev; azdev setup --cli /workspaces/azure-cli" 
+
+# remove azure-cli as it will be used 
+RUN rm -rf ./workspaces/azure-cli
+
+# add environment activation to .bashrc
+RUN echo "source /env/bin/activate" >> ~/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+
+FROM ubuntu
+
+RUN apt-get update
+RUN apt-get -y install python3.7
+RUN apt-get -y install python3-pip
+RUN apt-get -y install git
+RUN git clone https://github.com/zikalino/azure-cli.git
+RUN apt-get -y install python3-venv
+RUN cd /azure-cli; python3 -m venv env; chmod 777 /azure-cli/env/bin/activate
+RUN /bin/bash -c "source /azure-cli/env/bin/activate; pip3 install azdev; azdev setup --cli /azure-cli" 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"name": "Azure CLI Dev",
+	"image": "zikalino/azure-cli-dev",
+	"extensions": [
+		"ms-python.python"
+	],
+	"settings": {
+		"python.pythonPath": "/azure-cli/env/bin/"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,12 @@
 {
 	"name": "Azure CLI Dev",
-	"image": "zikalino/azure-cli-dev",
+	"dockerFile": "Dockerfile",
+	"context": ".",
 	"extensions": [
 		"ms-python.python"
 	],
 	"settings": {
-		"python.pythonPath": "/azure-cli/env/bin/"
-	}
+		"python.pythonPath": "/env/bin/python3"
+	},
+	"postCreateCommand": "bash"
 }


### PR DESCRIPTION
Adding devcontainer setup, it requires Visual Studio Code Insiders Edition.

For more details please read note here:

https://zikalino.github.io/blog/2019/06/10/setting-azure-cli-development-environment-using-visual-studio-code-remote-development-with-containers/

When this PR is merged I could also move the note (or parts of it) to become official documentation.

When the project is opened from VSC Insiders:
- VSC will automatically build development container (after confirmation)
- Developers will be able to start debugging (set a breakpoint, etc.) immediately after the container is ready. No additional steps are required

This provides very consistent development environment.
I think this PR is ready to be merged, I would like to use it in my daily work and continue testing.
Perhaps some things will change, for instance we may discover that the environment could be setup in more convenient way.
We could also refer ready-made image instead of Dockerfile, if we decide to have any prebuilt public dev image for VSC.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
