### PR TITLE
rest: simplifications on uri and add telemetry

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -13,7 +13,7 @@ import json
 
 from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
-     open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter)
+     open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter, send_raw_request)
 
 
 class TestUtils(unittest.TestCase):
@@ -317,6 +317,38 @@ class TestHandleException(unittest.TestCase):
         with ConfiguredDefaultSetter(config, False):
             self.assertEqual(config.use_local_config, False)
         self.assertTrue(config.use_local_config)
+
+    @mock.patch('requests.request', autospec=True)
+    def test_send_raw_requests(self, request_mock):
+        from azure.cli.core.commands.client_factory import UA_AGENT
+        return_val = mock.MagicMock()
+        return_val.is_ok = True
+        request_mock.return_value = return_val
+
+        cli_ctx = mock.MagicMock()
+        cli_ctx.data = {
+            'command': 'rest',
+            'safe_params': ['method', 'uri']
+        }
+        test_arm_endpoint = 'https://arm.com/'
+        test_url = 'subscription/1234/good'
+        tets_uri_parameters = ['p1=v1', "{'p2': 'v2'}"]
+        test_body = '{"b1": "v1"}'
+        cli_ctx.cloud.endpoints.resource_manager = test_arm_endpoint
+
+        expected_header = {
+            'User-Agent': UA_AGENT,
+            'Content-Type': 'application/json',
+            'CommandName': 'rest',
+            'ParameterSetName': 'method uri'
+        }
+
+        send_raw_request(cli_ctx, 'PUT', test_url, uri_parameters=tets_uri_parameters, body=test_body,
+                         skip_authorization_header=True, generated_client_request_id_name=None)
+
+        request_mock.assert_called_with('PUT', test_arm_endpoint + test_url,
+                                        params={'p1': 'v1', 'p2': 'v2'}, data=test_body,
+                                        headers=expected_header, verify=True)
 
     @staticmethod
     def _get_mock_HttpOperationError(response_text):

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -13,7 +13,8 @@ import json
 
 from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
-     open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter, send_raw_request)
+     open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter, send_raw_request,
+     should_disable_connection_verify)
 
 
 class TestUtils(unittest.TestCase):
@@ -348,7 +349,7 @@ class TestHandleException(unittest.TestCase):
 
         request_mock.assert_called_with('PUT', test_arm_endpoint + test_url,
                                         params={'p1': 'v1', 'p2': 'v2'}, data=test_body,
-                                        headers=expected_header, verify=True)
+                                        headers=expected_header, verify=(not should_disable_connection_verify()))
 
     @staticmethod
     def _get_mock_HttpOperationError(response_text):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -491,7 +491,7 @@ def check_connectivity(url='https://example.org', max_retries=5, timeout=1):
     return success
 
 
-def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  # pylint: disable=too-many-locals
+def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
                      body=None, skip_authorization_header=False, resource=None, output_file=None,
                      generated_client_request_id_name='x-ms-client-request-id'):
     import uuid

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -491,8 +491,9 @@ def check_connectivity(url='https://example.org', max_retries=5, timeout=1):
     return success
 
 
-def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  # pylint: disable=too-many-locals
-                     body=None, skip_authorization_header=False, resource=None, output_file=None):
+def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  # pylint: disable=too-many-locals
+                     body=None, skip_authorization_header=False, resource=None, output_file=None,
+                     generated_client_request_id_name='x-ms-client-request-id'):
     import uuid
     import requests
     from azure.cli.core.commands.client_factory import UA_AGENT
@@ -508,8 +509,23 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
     headers = result
     headers.update({
         'User-Agent': UA_AGENT,
-        'x-ms-client-request-id': str(uuid.uuid4()),
     })
+    if generated_client_request_id_name:
+        headers[generated_client_request_id_name] = str(uuid.uuid4())
+
+    # try to figure out the correct content type
+    if body:
+        try:
+            _ = shell_safe_json_parse(body)
+            if 'Content-Type' not in headers:
+                headers['Content-Type'] = 'application/json'
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    # add telemetry
+    headers['CommandName'] = cli_ctx.data['command']
+    if cli_ctx.data.get('safe_params'):
+        headers['ParameterSetName'] = ' '.join(cli_ctx.data['safe_params'])
 
     result = {}
     for s in uri_parameters or []:
@@ -521,16 +537,23 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
             result[key] = value
     uri_parameters = result or None
 
-    if not skip_authorization_header and url.lower().startswith('https://'):
-        from azure.cli.core._profile import Profile
+    if '://' not in uri:
+        uri = cli_ctx.cloud.endpoints.resource_manager + uri.lstrip('/')
+    # Replace common tokens with real values. It is for smooth experience if users copy and paste the url from
+    # Azure Rest API doc
+    from azure.cli.core._profile import Profile
+    profile = Profile()
+    if '{subscriptionId}' in uri:
+        uri = uri.replace('{subscriptionId}', profile.get_subscription_id())
+
+    if not skip_authorization_header and uri.lower().startswith('https://'):
         if not resource:
             endpoints = cli_ctx.cloud.endpoints
             for p in [x for x in dir(endpoints) if not x.startswith('_')]:
                 value = getattr(endpoints, p)
-                if isinstance(value, six.string_types) and url.lower().startswith(value.lower()):
+                if isinstance(value, six.string_types) and uri.lower().startswith(value.lower()):
                     resource = value
                     break
-        profile = Profile()
         if resource:
             token_info, _, _ = profile.get_raw_token(resource)
             logger.debug('Retrievd AAD token for resource: %s', resource or 'ARM')
@@ -541,7 +564,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
             logger.warning("Can't derive appropriate Azure AD resource from --url to acquire an access token. "
                            "If access token is required, use --resource to specify the resource")
     try:
-        r = requests.request(method, url, params=uri_parameters, data=body, headers=headers,
+        r = requests.request(method, uri, params=uri_parameters, data=body, headers=headers,
                              verify=not should_disable_connection_verify())
     except Exception as ex:  # pylint: disable=broad-except
         raise CLIError(ex)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -1200,8 +1200,8 @@ helps['rest'] = """
     examples:
        - name: Get Audit log through Microsoft Graph
          text: >
-             az rest --method get --url https://graph.microsoft.com/beta/auditLogs/directoryAudits
-       - name: Update a Azure Active Directory Graph User's display name
+             az rest --method get --uri https://graph.microsoft.com/beta/auditLogs/directoryAudits
+       - name: Update a Azure Active Directory Graph User's display name in BASH
          text: >
-             az rest --method patch --headers "{\"Content-Type\": \"application/json\"}" --url "https://graph.microsoft.com/v1.0/users/johndoe@azuresdkteam.onmicrosoft.com" --body "{\"displayName\":\"jondoe2\"}"
+             az rest --method patch --uri "https://graph.microsoft.com/v1.0/users/johndoe@azuresdkteam.onmicrosoft.com" --body '{"displayName": "jondoe2"}'
 """

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -1203,5 +1203,5 @@ helps['rest'] = """
              az rest --method get --uri https://graph.microsoft.com/beta/auditLogs/directoryAudits
        - name: Update a Azure Active Directory Graph User's display name in BASH
          text: >
-             az rest --method patch --uri "https://graph.microsoft.com/v1.0/users/johndoe@azuresdkteam.onmicrosoft.com" --body '{"displayName": "jondoe2"}'
+             az rest --method patch --uri "https://graph.microsoft.com/v1.0/users/johndoe@azuresdkteam.onmicrosoft.com" --body "{\\"displayName\\": \\"jondoe2\\"}"
 """

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -1201,7 +1201,7 @@ helps['rest'] = """
        - name: Get Audit log through Microsoft Graph
          text: >
              az rest --method get --uri https://graph.microsoft.com/beta/auditLogs/directoryAudits
-       - name: Update a Azure Active Directory Graph User's display name in BASH
+       - name: Update a Azure Active Directory Graph User's display name
          text: >
              az rest --method patch --uri "https://graph.microsoft.com/v1.0/users/johndoe@azuresdkteam.onmicrosoft.com" --body "{\\"displayName\\": \\"jondoe2\\"}"
 """

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -278,13 +278,14 @@ def load_arguments(self, _):
         c.argument('parent_id', options_list=['--parent', '-p'])
 
     with self.argument_context('rest') as c:
-        c.argument('method', arg_type=get_enum_type(['head', 'get', 'put', 'post', 'delete', 'options', 'patch'], default='get'),
+        c.argument('method', options_list=['--method', '-m'], arg_type=get_enum_type(['head', 'get', 'put', 'post', 'delete', 'options', 'patch'], default='get'),
                    help='HTTP request method')
-        c.argument('url', help="request url")
+        c.argument('uri', options_list=['--uri', '-u'], help='request uri. For uri without host, CLI will assume "https://management.azure.com/".'
+                   ' Common tokens will also be replaced with real values including "{subscriptionId}"')
         c.argument('headers', nargs='+', help="Space-separated headers in KEY=VALUE format or JSON string. Use @{file} to load from a file")
         c.argument('uri_parameters', nargs='+', help='Space-separated queries in KEY=VALUE format or JSON string. Use @{file} to load from a file')
         c.argument('skip_authorization_header', action='store_true', help='do not auto append "Authorization" header')
-        c.argument('body', help='request body')
+        c.argument('body', options_list=['--body', '-b'], help='request body')
         c.argument('output_file', help='save response payload to a file')
         c.argument('resource', help='Resource url for which CLI should acquire a token in order to access '
                    'the service. The token will be placed in the "Authorization" header. By default, '

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -315,4 +315,4 @@ def load_command_table(self, _):
         g.custom_command('remove', 'cli_managementgroups_subscription_remove')
 
     with self.command_group('') as g:
-        g.custom_command('rest', 'rest_call')
+        g.custom_command('rest', 'rest_call', is_preview=True)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -1769,10 +1769,10 @@ def list_resource_links(cmd, scope=None, filter_string=None):
 # endregion
 
 
-def rest_call(cmd, method, url, headers=None, uri_parameters=None,
+def rest_call(cmd, method, uri, headers=None, uri_parameters=None,
               body=None, skip_authorization_header=False, resource=None, output_file=None):
     from azure.cli.core.util import send_raw_request
-    r = send_raw_request(cmd.cli_ctx, method, url, headers, uri_parameters, body,
+    r = send_raw_request(cmd.cli_ctx, method, uri, headers, uri_parameters, body,
                          skip_authorization_header, resource, output_file)
     if not output_file and r.content:
         try:


### PR DESCRIPTION
Add a few optimizations towards the e2e experience by starting with referencing ARM rest API doc:
1. A full uri is not required. If host is missing, assume ARM endpoint
2. Replace the  `{subscriptionId}` token with real id

Also add telemetry data.

//CC: @achandmsft  
Related issue: #7618

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
