### PR TITLE
fixing version of paramiko

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -62,7 +62,7 @@ DEPENDENCIES = [
     'knack~=0.6.2',
     'msrest>=0.4.4',
     'msrestazure>=0.4.25',
-    'paramiko>=2.0.8',
+    'paramiko>=2.0.8,<2.5.0',
     'pip',
     'pygments',
     'PyJWT',

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -35,7 +35,7 @@ DEPENDENCIES = [
     'azure-mgmt-compute==5.0.0',
     'azure-graphrbac==0.60.0',
     'azure-cli-core',
-    'paramiko>=2.0.8',
+    'paramiko>=2.0.8,<2.5.0',
     'pyyaml',
     'six',
     'scp',


### PR DESCRIPTION
A new version of paramiko (2.5.0) was released today (10th of June) and it broke the ci, as it requires:
ERROR: paramiko 2.5.0 has requirement cryptography>=2.5, but you'll have cryptography 2.4.2 which is incompatible.

Cryptography can't be upgraded to 2.5.0 as in appservice we have:

    'cryptography<2.5',

for some reason.