### PR TITLE
[HDInsight] Update hdinsight version related to support ssh-public-key parameter

### DIFF
--- a/src/command_modules/azure-cli-hdinsight/HISTORY.rst
+++ b/src/command_modules/azure-cli-hdinsight/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+0.3.5
++++++
+* Support for using `--ssh-public-key` parameter in `hdinsight create` command.
 
 0.3.4
 +++++

--- a/src/command_modules/azure-cli-hdinsight/setup.py
+++ b/src/command_modules/azure-cli-hdinsight/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.3.4"
+VERSION = "0.3.5"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
This PR is in order to update azure-hdinsight version which is related to previsous PR[ [HDInsight] support ssh_public_key ](https://github.com/Azure/azure-cli/pull/9512)
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
