### PR TITLE
Small fix for `is_preview` messages.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -662,20 +662,20 @@ class AzCliCommandInvoker(CommandInvoker):
         previews = [] + getattr(parsed_args, '_argument_previews', [])
         if cmd.preview_info:
             previews.append(cmd.preview_info)
+        else:
+            # search for implicit command preview status
+            path_comps = cmd.name.split()[:-1]
+            implicit_preview_info = None
+            while path_comps and not implicit_preview_info:
+                implicit_preview_info = resolve_preview_info(self.cli_ctx, ' '.join(path_comps))
+                del path_comps[-1]
 
-        # search for implicit preview
-        path_comps = cmd.name.split()[:-1]
-        implicit_preview_info = None
-        while path_comps and not implicit_preview_info:
-            implicit_preview_info = resolve_preview_info(self.cli_ctx, ' '.join(path_comps))
-            del path_comps[-1]
-
-        if implicit_preview_info:
-            preview_kwargs = implicit_preview_info.__dict__.copy()
-            preview_kwargs['object_type'] = 'command'
-            del preview_kwargs['_get_tag']
-            del preview_kwargs['_get_message']
-            previews.append(ImplicitPreviewItem(**preview_kwargs))
+            if implicit_preview_info:
+                preview_kwargs = implicit_preview_info.__dict__.copy()
+                preview_kwargs['object_type'] = 'command'
+                del preview_kwargs['_get_tag']
+                del preview_kwargs['_get_message']
+                previews.append(ImplicitPreviewItem(**preview_kwargs))
 
         colorama.init()
         for d in deprecations:


### PR DESCRIPTION
Fixes reported issue where, when declaring a command group to be in preview, using commands in that group resulted in a double warning.  

Before (not that the `az group` command group is not actually in preview):
```
(env) D:\github>az group list
This command group is in preview. It may be changed/removed in a future release.
Command group 'group' is in preview. It may be changed/removed in a future release.
```

After:
```
(env) D:\github>az group list
This command group is in preview. It may be changed/removed in a future release.
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
