### PR TITLE
Rename `regenerate-key` to `renew-key`

### DIFF
--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -487,12 +487,12 @@ examples:
     crafted: true
 """
 
-helps['iot hub policy regenerate-key'] = """
+helps['iot hub policy renew-key'] = """
 type: command
 short-summary: Regenerate keys of a shared access policy of an IoT hub.
 examples:
   - name: Regenerate primary key of a shared access policy of an IoT hub.
-    text: az iot hub policy regenerate-key --hub-name MyHub --name MySharedAccessPolicy --rk Primary
+    text: az iot hub policy renew-key --hub-name MyHub --name MySharedAccessPolicy --rk Primary
     crafted: true
 """
 

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -156,8 +156,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    help='Permissions of shared access policy. Use space-separated list for multiple permissions. '
                         'Possible values: {}'.format(permission_values))
 
-    with self.argument_context('iot hub policy regenerate-key') as c:
-        c.argument('regenerate_key', options_list=['--regenerate-key', '--rk'], arg_type=get_enum_type(RenewKeyType),
+    with self.argument_context('iot hub policy renew-key') as c:
+        c.argument('regenerate_key', options_list=['--renew-key', '--rk'], arg_type=get_enum_type(RenewKeyType),
                    help='Regenerate keys')
 
     with self.argument_context('iot hub job') as c:

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/commands.py
@@ -116,7 +116,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.custom_command('show', 'iot_hub_policy_get')
         g.custom_command('create', 'iot_hub_policy_create', transform=PolicyUpdateResultTransform(self.cli_ctx))
         g.custom_command('delete', 'iot_hub_policy_delete', transform=PolicyUpdateResultTransform(self.cli_ctx))
-        g.custom_command('regenerate-key', 'iot_hub_policy_key_renew', supports_no_wait=True)
+        g.custom_command('renew-key', 'iot_hub_policy_key_renew', supports_no_wait=True)
 
     # iot hub job commands
     with self.command_group('iot hub job', client_factory=iot_hub_service_factory) as g:

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -99,8 +99,8 @@ class IoTHubTest(ScenarioTest):
             self.check('rights', 'RegistryWrite, ServiceConnect, DeviceConnect')
         ])
 
-        # Test 'az iot hub policy regenerate-key'
-        policy = self.cmd('iot hub policy regenerate-key --hub-name {0} -n {1} --regenerate-key Primary'.format(hub, policy_name),
+        # Test 'az iot hub policy renew-key'
+        policy = self.cmd('iot hub policy renew-key --hub-name {0} -n {1} --renew-key Primary'.format(hub, policy_name),
                           checks=[self.check('keyName', policy_name)]).get_output_in_json()
 
         policy_name_conn_str_pattern = r'^HostName={0}.azure-devices.net;SharedAccessKeyName={1};SharedAccessKey={2}'.format(
@@ -111,8 +111,8 @@ class IoTHubTest(ScenarioTest):
             self.check_pattern('connectionString', policy_name_conn_str_pattern)
         ])
 
-        # Test swap keys 'az iot hub policy regenerate-key'
-        self.cmd('iot hub policy regenerate-key --hub-name {0} -n {1} --regenerate-key Swap'.format(hub, policy_name),
+        # Test swap keys 'az iot hub policy renew-key'
+        self.cmd('iot hub policy renew-key --hub-name {0} -n {1} --renew-key Swap'.format(hub, policy_name),
                  checks=[self.check('primaryKey', policy['secondaryKey']),
                          self.check('secondaryKey', policy['primaryKey'])])
 


### PR DESCRIPTION
Gave bad guidance during the review of #9586. While "renew" and "regenerate" are both used in the CLI, the most common usage is "renew". This PR adopts the more consistent name.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [N/A] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
