### PR TITLE
[functionapp] Add warning to remove functionapp devops-build command

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -465,12 +465,12 @@ examples:
 
 helps['functionapp devops-build'] = """
 type: group
-short-summary: (DEPRECATED) Azure Function specific integration with Azure DevOps.
+short-summary: (DEPRECATED) Azure Function specific integration with Azure DevOps. This command will be removed on 7/2/2019.
 """
 
 helps['functionapp devops-build create'] = """
 type: command
-short-summary: (DEPRECATED) Create an Azure DevOps pipeline for a function app. Please use the devops-pipeline create command.
+short-summary: (DEPRECATED) Create an Azure DevOps pipeline for a function app. Please use the devops-pipeline create command. This command will be removed on 7/2/2019.
 """
 
 helps['functionapp devops-pipeline'] = """

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -465,12 +465,12 @@ examples:
 
 helps['functionapp devops-build'] = """
 type: group
-short-summary: (DEPRECATED) Azure Function specific integration with Azure DevOps. This command will be removed on 7/2/2019.
+short-summary: (DEPRECATED) Azure Function specific integration with Azure DevOps. This command will be removed in 2.0.68
 """
 
 helps['functionapp devops-build create'] = """
 type: command
-short-summary: (DEPRECATED) Create an Azure DevOps pipeline for a function app. Please use the devops-pipeline create command. This command will be removed on 7/2/2019.
+short-summary: (DEPRECATED) Create an Azure DevOps pipeline for a function app. Please use the devops-pipeline create command. This command will be removed in 2.0.68
 """
 
 helps['functionapp devops-pipeline'] = """


### PR DESCRIPTION
We plan to remove the deprecated **az functionapp devops-build** command since it has been renamed to **az functionapp devops-pipeline**.

We are giving a two-week notice to our customers before removal. We will remove the command in the next sprint.

@ahmedelnably 
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
