### PR TITLE
crypto >= 2.5

### DIFF
--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -40,7 +40,7 @@ DEPENDENCIES = [
     'urllib3[secure]>=1.18',
     'xmltodict',
     'fabric>=2.4',
-    'cryptography<2.5',
+    'cryptography',
     'pyOpenSSL',
     'six',
     'vsts-cd-manager<1.1.0',


### PR DESCRIPTION
fixes #9629, fixes #8364

paramiko has been upgraded, we can use cryptography >= 2.5

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
