### PR TITLE
[BotService]: add deprecation warnings for v3 SDK bot creation

### DIFF
--- a/src/command_modules/azure-cli-botservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-botservice/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 
-* Add discontinue/maintenance mode warning messages for commands that support the v3 SDK
+* Add "discontinued support"/"maintenance mode"-warning messages for commands that support the v3 SDK
 
 0.2.1
 +++++

--- a/src/command_modules/azure-cli-botservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-botservice/HISTORY.rst
@@ -3,6 +3,8 @@
 Release History
 ===============
 
+* Add discontinue/maintenance mode warning messages for commands that support the v3 SDK
+
 0.2.1
 +++++
 * Allow all casing for `--lang` parameters for commands

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
@@ -13,7 +13,7 @@ helps['bot create'] = """
     type: command
     short-summary: Create a new bot.
     long-summary: Create a new bot. Support for creating v3 SDK bots will be deprecated on August 1st, 2019. For more
-                  information please visit this blog post: https://blog.botframework.com/2019/06/07/v3-bot-broadcast-message/
+                  information please visit this blog post, blog.botframework.com/2019/06/07/v3-bot-broadcast-message/
 """
 helps['bot show'] = """
     type: command

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
@@ -12,6 +12,8 @@ helps['bot'] = """
 helps['bot create'] = """
     type: command
     short-summary: Create a new bot.
+    long-summary: Create a new bot. Support for creating v3 SDK bots will be deprecated on August 1st, 2019. For more 
+                  information please visit this blog post: https://blog.botframework.com/2019/06/07/v3-bot-broadcast-message/
 """
 helps['bot show'] = """
     type: command

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
@@ -25,8 +25,8 @@ helps['bot show'] = """
 """
 helps['bot prepare-publish'] = """
     type: command
-    short-summary: Add scripts to your local source code directory to
-                   be able to publish back using `az bot publish`.
+    short-summary: (Maintenance mode) Add scripts to your local source code directory to
+                   be able to publish back using `az bot publish` for v3 SDK bots.
 """
 helps['bot prepare-deploy'] = """
     type: command

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/_help.py
@@ -12,7 +12,7 @@ helps['bot'] = """
 helps['bot create'] = """
     type: command
     short-summary: Create a new bot.
-    long-summary: Create a new bot. Support for creating v3 SDK bots will be deprecated on August 1st, 2019. For more 
+    long-summary: Create a new bot. Support for creating v3 SDK bots will be deprecated on August 1st, 2019. For more
                   information please visit this blog post: https://blog.botframework.com/2019/06/07/v3-bot-broadcast-message/
 """
 helps['bot show'] = """

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
@@ -424,7 +424,8 @@ def prepare_publish(cmd, client, resource_group_name, resource_name, sln_name, p
         raise CLIError('\'az bot prepare-publish\' is only for v3 bots. Please use \'az bot publish\' to prepare and '
                        'publish a v4 bot.')
 
-    logger.warning('WARNING: `az bot prepare-publish` is in maintenance mode for v3 bots. We recommend developers '
+    logger.warning('WARNING: `az bot prepare-publish` is in maintenance mode for v3 bots as support for creating v3 '
+                   'SDK bots via `az bot create` will be discontinued on August 1st, 2019. We encourage developers '
                    'move to creating and deploying v4 bots.\n\nFor more information on creating and deploying v4 bots, '
                    'please visit https://aka.ms/create-and-deploy-v4-bot\n\nFor more information on v3 bot '
                    'creation deprecation, please visit this blog post: '
@@ -578,9 +579,10 @@ def publish_app(cmd, client, resource_group_name, resource_name, code_dir=None, 
                        ' to deploy your bot to Azure. For more information on how to deploy a v4 bot, see '
                        'https://aka.ms/deploy-your-bot.')
     else:
-        logger.warning('WARNING: `az bot publish` is in maintenance mode for v3 bots. We recommend developers move to '
-                       'creating and deploying v4 bots.\n\nFor more information on creating and deploying v4 bots, '
-                       'please visit https://aka.ms/create-and-deploy-v4-bot\n\nFor more information on v3 bot '
+        logger.warning('WARNING: `az bot publish` is in maintenance mode for v3 bots as support for creating v3 '
+                       'SDK bots via `az bot create` will be discontinued on August 1st, 2019. We encourage developers '
+                       'move to creating and deploying v4 bots.\n\nFor more information on creating and deploying v4 '
+                       'bots, please visit https://aka.ms/create-and-deploy-v4-bot\n\nFor more information on v3 bot '
                        'creation deprecation, please visit this blog post: '
                        'https://blog.botframework.com/2019/06/07/v3-bot-broadcast-message/')
 

--- a/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
+++ b/src/command_modules/azure-cli-botservice/azure/cli/command_modules/botservice/custom.py
@@ -88,6 +88,13 @@ def create(cmd, client, resource_group_name, resource_name, kind, msa_app_id, pa
     webapp_kind = 'webapp'
     function_kind = 'function'
 
+    if version == 'v3':
+        logger.warning('WARNING: `az bot create` for v3 bots is being discontinued on August 1st, 2019. We encourage '
+                       'developers to move to creating and deploying v4 bots.\n\nFor more information on creating '
+                       'and deploying v4 bots, please visit https://aka.ms/create-and-deploy-v4-bot\n\nFor more '
+                       'information on v3 bot creation deprecation, please visit this blog post: '
+                       'https://blog.botframework.com/2019/06/07/v3-bot-broadcast-message/')
+
     if resource_name.find(".") > -1:
         logger.warning('"." found in --name parameter ("%s"). "." is an invalid character for Azure Bot resource names '
                        'and will been removed.', resource_name)
@@ -417,6 +424,12 @@ def prepare_publish(cmd, client, resource_group_name, resource_name, sln_name, p
         raise CLIError('\'az bot prepare-publish\' is only for v3 bots. Please use \'az bot publish\' to prepare and '
                        'publish a v4 bot.')
 
+    logger.warning('WARNING: `az bot prepare-publish` is in maintenance mode for v3 bots. We recommend developers '
+                   'move to creating and deploying v4 bots.\n\nFor more information on creating and deploying v4 bots, '
+                   'please visit https://aka.ms/create-and-deploy-v4-bot\n\nFor more information on v3 bot '
+                   'creation deprecation, please visit this blog post: '
+                   'https://blog.botframework.com/2019/06/07/v3-bot-broadcast-message/')
+
     bot = client.bots.get(
         resource_group_name=resource_group_name,
         resource_name=resource_name
@@ -564,6 +577,13 @@ def publish_app(cmd, client, resource_group_name, resource_name, code_dir=None, 
         logger.warning('DEPRECATION WARNING: `az bot publish` is deprecated for v4 bots. We recommend using `az webapp`'
                        ' to deploy your bot to Azure. For more information on how to deploy a v4 bot, see '
                        'https://aka.ms/deploy-your-bot.')
+    else:
+        logger.warning('WARNING: `az bot publish` is in maintenance mode for v3 bots. We recommend developers move to '
+                       'creating and deploying v4 bots.\n\nFor more information on creating and deploying v4 bots, '
+                       'please visit https://aka.ms/create-and-deploy-v4-bot\n\nFor more information on v3 bot '
+                       'creation deprecation, please visit this blog post: '
+                       'https://blog.botframework.com/2019/06/07/v3-bot-broadcast-message/')
+
     # Get the bot information and ensure it's not only a registration bot.
     bot = client.bots.get(
         resource_group_name=resource_group_name,


### PR DESCRIPTION
Add warning message indicating plans to discontinue v3 bot creation support.

_For more information on the discontinued support for creating v3 SDK bots, please read this blog post: **https://blog.botframework.com/2019/06/07/v3-bot-broadcast-message/**_

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
