### PR TITLE
Added installation of libintl and icu-libs in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,10 @@ LABEL maintainer="Microsoft" \
 # jq - we include jq as a useful tool
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool
+# libintl and icu-libs - required by azure devops artifact (az extension add --name azure-devops)
 RUN apk add --no-cache bash openssh ca-certificates jq curl openssl git zip \
  && apk add --no-cache --virtual .build-deps gcc make openssl-dev libffi-dev musl-dev linux-headers \
+ && apk add --no-cache libintl icu-libs \
  && update-ca-certificates
 
 ARG JP_VERSION="0.1.3"


### PR DESCRIPTION
In order to run the 'azure-devops' extension from the docker
container, these libraries must installed: libintl and icu-libs.

Without these library using `az artifacts universal publish ...`
would display these error lines:

Universal Packages is currently in preview.
Failed to parse structured output from Universal Packages tooling (ArtifactTool)
Exception: Expecting value: line 1 column 1 (char 0)
Log line: Failed to load @6U, error: Error loading shared library libintl.so.8: No such file or directory
(needed by /root/.azure/azuredevops/cli/tools/artifacttool/ArtifactTool_alpine-x64_0.2.99/libcoreclr.so)

Failed to parse structured output from Universal Packages tooling (ArtifactTool)
Exception: Expecting value: line 1 column 1 (char 0)
Log line: Failed to bind to CoreCLR at
'/root/.azure/azuredevops/cli/tools/artifacttool/ArtifactTool_alpine-x64_0.2.99/libcoreclr.so'



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
