### PR TITLE
WIP: Create Dependency List during CI Builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,8 +47,8 @@ jobs:
       pip install --upgrade pip
       python -m venv venv/
       source ./venv/bin/activate
-      find src/ -name setup.py | xargs dirname | sort | uniq | xargs pip3 install
-      pip3 freeze > linux-py3-requirements.txt
+      find src/ -name setup.py | xargs dirname | sort | uniq | xargs pip install
+      pip freeze > linux-py3-requirements.txt
 
     displayName: Install and Lock Requirements
   - task: PublishPipelineArtifact@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       TargetPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: metadata
 
-- job: LockLinuxDependencies
+- job: LockLinux3Dependencies
   displayName: Lock Linux Python3 Dependencies
   condition: succeeded()
   pool:
@@ -42,11 +42,12 @@ jobs:
   - bash: |
       #! /usr/bin/env bash
 
-      set -ev
-
       pip install --upgrade pip
       python -m venv venv/
       source ./venv/bin/activate
+
+      set -ev
+
       find src/ -name setup.py | xargs dirname | sort | uniq | xargs pip install
       pip freeze > linux-py3-requirements.txt
 
@@ -56,6 +57,36 @@ jobs:
     inputs:
       TargetPath: 'linux-py3-requirements.txt'
       ArtifactName: linux-python3-requirements
+
+- job: LockMacOS3Dependencies
+  displayName: Lock macOS Python3 Dependencies
+  condition: succeeded()
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.7'
+    inputs:
+      versionSpec: 3.7
+  - bash: |
+      #! /usr/bin/env bash
+
+      pip install --upgrade pip
+      python -m venv venv/
+      source ./venv/bin/activate
+
+      set -ev
+
+      find src/ -name setup.py | xargs dirname | sort | uniq | xargs pip install
+      pip freeze > macos-py3-requirements.txt
+
+    displayName: Install and Lock Requirements
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Artifact: Linux Python3 Requirements'
+    inputs:
+      TargetPath: 'macos-py3-requirements.txt'
+      ArtifactName: macos-python3-requirements
 
 - job: VerifyVersions
   displayName: Verify Command Module Versions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,35 @@ jobs:
       TargetPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: metadata
 
+- job: LockLinuxDependencies
+  displayName: Lock Linux Python3 Dependencies
+  condition: succeeded()
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.7'
+    inputs:
+      versionSpec: 3.7
+  - bash: |
+      #! /usr/bin/env bash
+
+      set -ev
+
+      pip install --upgrade pip
+      python -m venv venv/
+      source ./venv/bin/activate
+      find src/ -name setup.py | xargs dirname | sort | uniq | xargs pip3 install
+      pip3 freeze > requirements.txt
+
+    displayName: Install and Lock Requirements
+  - task: PublishPipelineArtifact@0
+      displayName: 'Publish Artifact: MSI'
+      inputs:
+        TargetPath: 'requirements.txt'
+        ArtifactName: linux-python3-requirements
+
 - job: VerifyVersions
   displayName: Verify Command Module Versions
   condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/release'), eq(variables['System.PullRequest.TargetBranch'], 'release')))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,13 +48,13 @@ jobs:
       python -m venv venv/
       source ./venv/bin/activate
       find src/ -name setup.py | xargs dirname | sort | uniq | xargs pip3 install
-      pip3 freeze > requirements.txt
+      pip3 freeze > linux-py3-requirements.txt
 
     displayName: Install and Lock Requirements
   - task: PublishPipelineArtifact@0
-    displayName: 'Publish Artifact: MSI'
+    displayName: 'Publish Artifact: Linux Python3 Requirements'
     inputs:
-      TargetPath: 'requirements.txt'
+      TargetPath: 'linux-py3-requirements.txt'
       ArtifactName: linux-python3-requirements
 
 - job: VerifyVersions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
   displayName: Lock macOS Python3 Dependencies
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'macOS-10.13'
 
   steps:
   - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,36 @@ jobs:
       TargetPath: 'linux-py3-requirements.txt'
       ArtifactName: linux-python3-requirements
 
+- job: LockLinux2Dependencies
+  displayName: Lock Linux Python2 Dependencies
+  condition: succeeded()
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 2.7'
+    inputs:
+      versionSpec: 2.7
+  - bash: |
+      #! /usr/bin/env bash
+
+      pip install --upgrade pip
+      python -m venv venv/
+      source ./venv/bin/activate
+
+      set -ev
+
+      find src/ -name setup.py | xargs dirname | sort | uniq | xargs pip install
+      pip freeze > linux-py2-requirements.txt
+
+    displayName: Install and Lock Requirements
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Artifact: Linux Python2 Requirements'
+    inputs:
+      TargetPath: 'linux-py2-requirements.txt'
+      ArtifactName: linux-python2-requirements
+
 - job: LockMacOS3Dependencies
   displayName: Lock macOS Python3 Dependencies
   condition: succeeded()
@@ -87,6 +117,36 @@ jobs:
     inputs:
       TargetPath: 'macos-py3-requirements.txt'
       ArtifactName: macos-python3-requirements
+
+- job: LockMacOS2Dependencies
+  displayName: Lock macOS Python2 Dependencies
+  condition: succeeded()
+  pool:
+    vmImage: 'macOS-10.13'
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 2.7'
+    inputs:
+      versionSpec: 2.7
+  - bash: |
+      #! /usr/bin/env bash
+
+      pip install --upgrade pip
+      python -m virtualenv venv/
+      source ./venv/bin/activate
+
+      set -ev
+
+      find src/ -name setup.py | xargs -I {} dirname {} | sort | uniq | xargs pip install
+      pip freeze > macos-py2-requirements.txt
+
+    displayName: Install and Lock Requirements
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Artifact: macOS Python2 Requirements'
+    inputs:
+      TargetPath: 'macos-py2-requirements.txt'
+      ArtifactName: macos-python2-requirements
 
 - job: VerifyVersions
   displayName: Verify Command Module Versions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,12 +78,12 @@ jobs:
 
       set -ev
 
-      find src/ -name setup.py | xargs dirname | sort | uniq | xargs pip install
+      find src/ -name setup.py | xargs -I {} dirname {} | sort | uniq | xargs pip install
       pip freeze > macos-py3-requirements.txt
 
     displayName: Install and Lock Requirements
   - task: PublishPipelineArtifact@0
-    displayName: 'Publish Artifact: Linux Python3 Requirements'
+    displayName: 'Publish Artifact: macOS Python3 Requirements'
     inputs:
       TargetPath: 'macos-py3-requirements.txt'
       ArtifactName: macos-python3-requirements

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,10 +52,10 @@ jobs:
 
     displayName: Install and Lock Requirements
   - task: PublishPipelineArtifact@0
-      displayName: 'Publish Artifact: MSI'
-      inputs:
-        TargetPath: 'requirements.txt'
-        ArtifactName: linux-python3-requirements
+    displayName: 'Publish Artifact: MSI'
+    inputs:
+      TargetPath: 'requirements.txt'
+      ArtifactName: linux-python3-requirements
 
 - job: VerifyVersions
   displayName: Verify Command Module Versions


### PR DESCRIPTION
This will help us have reproducible builds, including the ability to lock down transitive dependencies.