### PR TITLE
Annotate packages as supporting Python 3.7.

### DIFF
--- a/src/azure-cli-command_modules-nspkg/setup.py
+++ b/src/azure-cli-command_modules-nspkg/setup.py
@@ -21,6 +21,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -48,6 +48,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli-nspkg/setup.py
+++ b/src/azure-cli-nspkg/setup.py
@@ -21,6 +21,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -29,6 +29,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -26,6 +26,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -48,6 +48,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'License :: OSI Approved :: MIT License',
 ]
 


### PR DESCRIPTION
They've been distributed on MacOS using Python 3.7 for quite some time. It's good empirical evidence that we have the capacity to work with Python 3.7.

Note: Because this is targeting the `flatten` branch, we have many fewer places where this notation needs to be added.