### PR TITLE
extension removal: surface io errors as warnings instead of verbose info

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,6 +2,7 @@
 
 Release History
 ===============
+* extension removal: surface io errors as warnings instead of verbose info
 
 2.0.67
 ++++++

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -231,8 +231,8 @@ def add_extension(cmd, source=None, extension_name=None, index_url=None, yes=Non
 
 def remove_extension(extension_name):
     def log_err(func, path, exc_info):
-        logger.debug("Error occurred attempting to delete item from the extension '%s'.", extension_name)
-        logger.debug("%s: %s - %s", func, path, exc_info)
+        logger.warning("Error occurred attempting to delete item from the extension '%s'.", extension_name)
+        logger.warning("%s: %s - %s", func, path, exc_info)
 
     try:
         # Get the extension and it will raise an error if it doesn't exist


### PR DESCRIPTION
Fix #9674. Reported by Machine Learning team. 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
