### PR TITLE
Support for disabling TTL on Cosmos DB Container

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -10,6 +10,10 @@ Release History
 
 * functionapp: `az functionapp create` enables application insights by default
 
+**Cosmos DB**
+
+* Added support for disabling TTL
+
 **DLS**
 
 * Update ADLS version (0.0.45).

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/_params.py
@@ -71,7 +71,7 @@ def load_arguments(self, _):
         c.argument('throughput', type=int, help='Offer Throughput (RU/s)')
         c.argument('partition_key_path', help='Partition Key Path, e.g., \'/properties/name\'')
         c.argument('indexing_policy', type=shell_safe_json_parse, completer=FilesCompleter(), help='Indexing Policy, you can enter it as a string or as a file, e.g., --indexing-policy @policy-file.json)')
-        c.argument('default_ttl', type=int, help='Default TTL')
+        c.argument('default_ttl', type=int, help='Default TTL. Provide 0 to disable.')
 
     with self.argument_context('cosmosdb database') as c:
         c.argument('throughput', type=int, help='Offer Throughput (RU/s)')

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -430,7 +430,10 @@ def _populate_collection_definition(collection,
         collection['partitionKey'] = {'paths': [partition_key_path], 'kind': 'Hash'}
 
     if default_ttl is not None:
-        collection['defaultTtl'] = default_ttl
+        if default_ttl == 0 and "defaultTtl" in collection:
+            del collection['defaultTtl']
+        elif default_ttl != 0:
+            collection['defaultTtl'] = default_ttl
 
     if indexing_policy is not None:
         collection['indexingPolicy'] = indexing_policy

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_collection.yaml
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_collection.yaml
@@ -1,2331 +1,4541 @@
 interactions:
 - request:
     body: '{"location": "westus", "tags": {"product": "azurecli", "cause": "automation",
-      "date": "2019-06-13T04:45:04Z"}}'
+      "date": "2019-06-21T17:20:24Z"}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [group create]
-      Connection: [keep-alive]
-      Content-Length: ['110']
-      Content-Type: [application/json; charset=utf-8]
-      ParameterSetName: [--location --name --tag]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 resourcemanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --location --name --tag
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 resourcemanagementclient/2.2.0
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_collection000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001","name":"cli_test_cosmosdb_collection000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-06-13T04:45:04Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001","name":"cli_test_cosmosdb_collection000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-06-21T17:20:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['384']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 13 Jun 2019 04:45:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 201, message: Created}
+      cache-control:
+      - no-cache
+      content-length:
+      - '384'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 21 Jun 2019 17:20:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 resourcemanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 resourcemanagementclient/2.2.0
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_collection000001?api-version=2018-05-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001","name":"cli_test_cosmosdb_collection000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-06-13T04:45:04Z"},"properties":{"provisioningState":"Succeeded"}}'}
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001","name":"cli_test_cosmosdb_collection000001","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2019-06-21T17:20:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
-      cache-control: [no-cache]
-      content-length: ['384']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 13 Jun 2019 04:45:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
+      cache-control:
+      - no-cache
+      content-length:
+      - '384'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 21 Jun 2019 17:20:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0}], "databaseAccountOfferType":
       "Standard"}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      Content-Length: ['172']
-      Content-Type: [application/json; charset=utf-8]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Initializing","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Initializing","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Initializing","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Initializing","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      cache-control: ['no-store, no-cache']
-      content-length: ['1332']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:45:10 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: Ok}
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1332'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:20:31 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:45:41 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:21:01 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:46:11 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:21:32 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:46:41 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:22:02 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:47:12 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:22:33 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:47:42 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:23:03 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:48:13 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:23:34 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:48:44 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:24:04 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:49:14 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:24:35 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:49:45 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:25:06 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:50:15 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:25:37 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:50:46 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:26:08 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:51:16 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:26:37 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:51:47 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:27:08 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Dequeued","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['32']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:17 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:27:38 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
   response:
-    body: {string: '{"status":"Succeeded","error":{}}'}
+    body:
+      string: '{"status":"Dequeued","error":{}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['33']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e7af109c-ed13-413e-b08c-5764cad85c5a?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:48 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '32'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:10 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+  response:
+    body:
+      string: '{"status":"Succeeded","error":{}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '33'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e6ba6994-c29a-4b9a-afbb-906e7c960f60?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:40 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:48 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:40 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb create]
-      Connection: [keep-alive]
-      ParameterSetName: [-n -g]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:49 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:41 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb database create]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [-g -n -d]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb database create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -d
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:50 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:42 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb database create]
-      Connection: [keep-alive]
-      ParameterSetName: [-g -n -d]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb database create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -d
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:50 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:43 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:51 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:43 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:51 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:43 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: b'{"id":"cli000004"}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['24']
-      Content-Type: [application/json]
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:51 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:44 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: POST
     uri: https://cli000003-westus.documents.azure.com/dbs
   response:
-    body: {string: '{"id":"cli000004","_rid":"3cJOAA==","_self":"dbs\/3cJOAA==\/","_etag":"\"00009b00-0000-0700-0000-5d01d6a30000\"","_colls":"colls\/","_users":"users\/","_ts":1560401571}'}
+    body:
+      string: '{"id":"cli000004","_rid":"mJhCAA==","_self":"dbs\/mJhCAA==\/","_etag":"\"00001300-0000-0700-0000-5d0d13cc0000\"","_colls":"colls\/","_users":"users\/","_ts":1561138124}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:51 GMT']
-      etag: ['"00009b00-0000-0700-0000-5d01d6a30000"']
-      lsn: ['4']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [8740cf16-8c1c-487b-bfaa-d7857f872808]
-      x-ms-cosmos-llsn: ['4']
-      x-ms-cosmos-quorum-acked-llsn: ['3']
-      x-ms-current-replica-set-size: ['4']
-      x-ms-current-write-quorum: ['3']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['3']
-      x-ms-last-state-change-utc: ['Tue, 11 Jun 2019 20:52:42.733 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-quorum-acked-lsn: ['3']
-      x-ms-request-charge: ['4.95']
-      x-ms-resource-quota: [databases=1000;]
-      x-ms-resource-usage: [databases=1;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#4']
-      x-ms-transport-request-id: ['175812']
-      x-ms-xp-role: ['1']
-    status: {code: 201, message: Created}
+      cache-control:
+      - no-store, no-cache
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:44 GMT
+      etag:
+      - '"00001300-0000-0700-0000-5d0d13cc0000"'
+      lsn:
+      - '4'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 5af9dfde-6b70-490a-94e5-e9babf79eec3
+      x-ms-cosmos-llsn:
+      - '4'
+      x-ms-cosmos-quorum-acked-llsn:
+      - '3'
+      x-ms-current-replica-set-size:
+      - '4'
+      x-ms-current-write-quorum:
+      - '3'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '3'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:13.070 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-quorum-acked-lsn:
+      - '3'
+      x-ms-request-charge:
+      - '4.95'
+      x-ms-resource-quota:
+      - databases=1000;
+      x-ms-resource-usage:
+      - databases=1;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#4
+      x-ms-transport-request-id:
+      - '19438'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection create]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -d -c --default-ttl
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:52 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:45 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection create]
-      Connection: [keep-alive]
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -d -c --default-ttl
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:53 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:45 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:53 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:46 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:53 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:46 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: b'{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*","indexes":[{"kind":"Range","dataType":"String","precision":-1},{"kind":"Range","dataType":"Number","precision":-1}]}]}}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['236']
-      Content-Type: [application/json]
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:53 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '236'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:46 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: POST
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/
   response:
-    body: {string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"3cJOANPHI04=","_ts":1560401574,"_self":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","_etag":"\"00009d00-0000-0700-0000-5d01d6a60000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'}
+    body:
+      string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138127,"_self":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","_etag":"\"00001500-0000-0700-0000-5d0d13cf0000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      collection-partition-index: ['0']
-      collection-service-index: ['0']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:53 GMT']
-      etag: ['"00009d00-0000-0700-0000-5d01d6a60000"']
-      lsn: ['1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [7a67ecf0-a9c2-41e0-8834-2bc8bf9bc0c8]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-cosmos-item-llsn: ['1']
-      x-ms-cosmos-llsn: ['1']
-      x-ms-cosmos-quorum-acked-llsn: ['1']
-      x-ms-current-replica-set-size: ['4']
-      x-ms-current-write-quorum: ['3']
-      x-ms-documentdb-collection-index-transformation-progress: ['100']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['1']
-      x-ms-item-lsn: ['1']
-      x-ms-last-state-change-utc: ['Wed, 12 Jun 2019 20:55:04.512 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-quorum-acked-lsn: ['1']
-      x-ms-request-charge: ['1']
-      x-ms-resource-quota: [functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;]
-      x-ms-resource-usage: [functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#1']
-      x-ms-transport-request-id: ['2']
-      x-ms-xp-role: ['1']
-    status: {code: 201, message: Created}
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:47 GMT
+      etag:
+      - '"00001500-0000-0700-0000-5d0d13cf0000"'
+      lsn:
+      - '1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 9c4ed998-fb4a-4d15-a28d-fb2db333649f
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-cosmos-item-llsn:
+      - '1'
+      x-ms-cosmos-llsn:
+      - '1'
+      x-ms-cosmos-quorum-acked-llsn:
+      - '1'
+      x-ms-current-replica-set-size:
+      - '4'
+      x-ms-current-write-quorum:
+      - '3'
+      x-ms-documentdb-collection-index-transformation-progress:
+      - '100'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '1'
+      x-ms-item-lsn:
+      - '1'
+      x-ms-last-state-change-utc:
+      - Thu, 20 Jun 2019 21:55:12.286 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-quorum-acked-lsn:
+      - '1'
+      x-ms-request-charge:
+      - '1'
+      x-ms-resource-quota:
+      - functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;
+      x-ms-resource-usage:
+      - functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#1
+      x-ms-transport-request-id:
+      - '8029'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:54 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:47 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003-westus.documents.azure.com/offers
   response:
-    body: {string: '{"_rid":"","Offers":[{"resource":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","offerType":"Invalid","offerResourceId":"3cJOANPHI04=","offerVersion":"V2","content":{"offerThroughput":400,"offerIsRUPerMinuteThroughputEnabled":false},"id":"qjdJ","_rid":"qjdJ","_self":"offers\/qjdJ\/","_etag":"\"00009e00-0000-0700-0000-5d01d6a60000\"","_ts":1560401574}],"_count":1}'}
+    body:
+      string: '{"_rid":"","Offers":[{"resource":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","offerType":"Invalid","offerResourceId":"mJhCAK9SZos=","offerVersion":"V2","content":{"offerThroughput":400,"offerIsRUPerMinuteThroughputEnabled":false},"id":"5ZSd","_rid":"5ZSd","_self":"offers\/5ZSd\/","_etag":"\"00001600-0000-0700-0000-5d0d13cf0000\"","_ts":1561138127}],"_count":1}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/offers']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:54 GMT']
-      lsn: ['5']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [5ca3585a-9ccb-46ad-8067-31e7924fdb28]
-      x-ms-cosmos-llsn: ['5']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['5']
-      x-ms-item-count: ['1']
-      x-ms-last-state-change-utc: ['Tue, 11 Jun 2019 20:52:58.916 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-request-charge: ['2']
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#5']
-      x-ms-transport-request-id: ['92112']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/offers
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:47 GMT
+      lsn:
+      - '5'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 47e9a691-044a-4136-8fda-54e23ebb4b44
+      x-ms-cosmos-llsn:
+      - '5'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '5'
+      x-ms-item-count:
+      - '1'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:25.888 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-request-charge:
+      - '2'
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#5
+      x-ms-transport-request-id:
+      - '24756'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection show]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection show
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:54 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:48 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection show]
-      Connection: [keep-alive]
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:55 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:49 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:55 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:49 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:55 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:49 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:56 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:50 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/cli000002/
   response:
-    body: {string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"3cJOANPHI04=","_ts":1560401574,"_self":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","_etag":"\"00009d00-0000-0700-0000-5d01d6a60000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'}
+    body:
+      string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138127,"_self":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","_etag":"\"00001500-0000-0700-0000-5d0d13cf0000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      collection-partition-index: ['0']
-      collection-service-index: ['0']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/dbs/cliuiqh5wpxn3eq/colls/climlb2xhx5phon/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:56 GMT']
-      etag: ['"00009d00-0000-0700-0000-5d01d6a60000"']
-      lsn: ['1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [74e622d8-6516-41a0-b25d-1504d2e943c2]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-content-path: [3cJOAA==]
-      x-ms-cosmos-item-llsn: ['1']
-      x-ms-cosmos-llsn: ['1']
-      x-ms-cosmos-quorum-acked-llsn: ['1']
-      x-ms-current-replica-set-size: ['4']
-      x-ms-current-write-quorum: ['3']
-      x-ms-documentdb-collection-index-transformation-progress: ['100']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['1']
-      x-ms-item-lsn: ['1']
-      x-ms-last-state-change-utc: ['Wed, 12 Jun 2019 20:55:04.512 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-quorum-acked-lsn: ['1']
-      x-ms-request-charge: ['1']
-      x-ms-resource-quota: [functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;]
-      x-ms-resource-usage: [functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#1']
-      x-ms-transport-request-id: ['1']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/dbs/climemymw3s6kh5/colls/clieivnkclrgpms/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:49 GMT
+      etag:
+      - '"00001500-0000-0700-0000-5d0d13cf0000"'
+      lsn:
+      - '1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 6b3c01c9-f8fb-4261-962a-3e87fec42af3
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-content-path:
+      - mJhCAA==
+      x-ms-cosmos-item-llsn:
+      - '1'
+      x-ms-cosmos-llsn:
+      - '1'
+      x-ms-documentdb-collection-index-transformation-progress:
+      - '100'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '1'
+      x-ms-item-lsn:
+      - '1'
+      x-ms-last-state-change-utc:
+      - Thu, 20 Jun 2019 21:55:43.098 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-request-charge:
+      - '1'
+      x-ms-resource-quota:
+      - functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;
+      x-ms-resource-usage:
+      - functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#1
+      x-ms-transport-request-id:
+      - '6104'
+      x-ms-xp-role:
+      - '2'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:56 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:50 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003-westus.documents.azure.com/offers
   response:
-    body: {string: '{"_rid":"","Offers":[{"resource":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","offerType":"Invalid","offerResourceId":"3cJOANPHI04=","offerVersion":"V2","content":{"offerThroughput":400,"offerIsRUPerMinuteThroughputEnabled":false},"id":"qjdJ","_rid":"qjdJ","_self":"offers\/qjdJ\/","_etag":"\"00009e00-0000-0700-0000-5d01d6a60000\"","_ts":1560401574}],"_count":1}'}
+    body:
+      string: '{"_rid":"","Offers":[{"resource":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","offerType":"Invalid","offerResourceId":"mJhCAK9SZos=","offerVersion":"V2","content":{"offerThroughput":400,"offerIsRUPerMinuteThroughputEnabled":false},"id":"5ZSd","_rid":"5ZSd","_self":"offers\/5ZSd\/","_etag":"\"00001600-0000-0700-0000-5d0d13cf0000\"","_ts":1561138127}],"_count":1}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/offers']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:56 GMT']
-      lsn: ['5']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [f838669b-eec0-4ad3-8db1-3a5877d55be3]
-      x-ms-cosmos-llsn: ['5']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['5']
-      x-ms-item-count: ['1']
-      x-ms-last-state-change-utc: ['Wed, 12 Jun 2019 00:29:48.199 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-request-charge: ['2']
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#5']
-      x-ms-transport-request-id: ['99936']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/offers
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:49 GMT
+      lsn:
+      - '5'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 86eccc85-8c10-4efc-b130-4eefdbe27e7c
+      x-ms-cosmos-llsn:
+      - '5'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '5'
+      x-ms-item-count:
+      - '1'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:23.796 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-request-charge:
+      - '2'
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#5
+      x-ms-transport-request-id:
+      - '8821'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection exists]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection exists
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:56 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:50 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection exists]
-      Connection: [keep-alive]
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection exists
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:56 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:51 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:57 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:51 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:56 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:51 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
-    body: '{"query":"SELECT * FROM root r WHERE r.id=@id","parameters":[{"name":"@id","value":"climlb2xhx5phon"}]}'
+    body: '{"query":"SELECT * FROM root r WHERE r.id=@id","parameters":[{"name":"@id","value":"clieivnkclrgpms"}]}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['103']
-      Content-Type: [application/query+json]
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:57 GMT']
-      x-ms-documentdb-isquery: ['true']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/query+json
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:52 GMT
+      x-ms-documentdb-isquery:
+      - 'true'
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: POST
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/
   response:
-    body: {string: '{"_rid":"3cJOAA==","DocumentCollections":[{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"3cJOANPHI04=","_ts":1560401574,"_self":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","_etag":"\"00009d00-0000-0700-0000-5d01d6a60000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}],"_count":1}'}
+    body:
+      string: '{"_rid":"mJhCAA==","DocumentCollections":[{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138127,"_self":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","_etag":"\"00001500-0000-0700-0000-5d0d13cf0000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}],"_count":1}'
     headers:
-      cache-control: ['no-store, no-cache']
-      collection-partition-index: ['0']
-      collection-service-index: ['0']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:56 GMT']
-      lsn: ['5']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [8f454b20-fb63-430d-9d04-a10e407a9c3c]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-content-path: [3cJOAA==]
-      x-ms-cosmos-llsn: ['5']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['5']
-      x-ms-item-count: ['1']
-      x-ms-last-state-change-utc: ['Tue, 11 Jun 2019 20:52:58.916 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-request-charge: ['5.68']
-      x-ms-resource-quota: [collections=5000;]
-      x-ms-resource-usage: [collections=1;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#5']
-      x-ms-transport-request-id: ['125465']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:52 GMT
+      lsn:
+      - '5'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 96439671-838c-42e7-a5d9-39106f14f500
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-content-path:
+      - mJhCAA==
+      x-ms-cosmos-llsn:
+      - '5'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '5'
+      x-ms-item-count:
+      - '1'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:23.800 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-request-charge:
+      - '5.68'
+      x-ms-resource-quota:
+      - collections=5000;
+      x-ms-resource-usage:
+      - collections=1;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#5
+      x-ms-transport-request-id:
+      - '37614'
+      x-ms-xp-role:
+      - '2'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection exists]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection exists
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:57 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:52 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection exists]
-      Connection: [keep-alive]
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection exists
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:58 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:53 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:59 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:54 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:58 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:54 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: '{"query":"SELECT * FROM root r WHERE r.id=@id","parameters":[{"name":"@id","value":"invalid"}]}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['95']
-      Content-Type: [application/query+json]
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:52:59 GMT']
-      x-ms-documentdb-isquery: ['true']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '95'
+      Content-Type:
+      - application/query+json
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:54 GMT
+      x-ms-documentdb-isquery:
+      - 'true'
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: POST
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/
   response:
-    body: {string: '{"_rid":"3cJOAA==","DocumentCollections":[],"_count":0}'}
+    body:
+      string: '{"_rid":"mJhCAA==","DocumentCollections":[],"_count":0}'
     headers:
-      cache-control: ['no-store, no-cache']
-      collection-partition-index: ['0']
-      collection-service-index: ['0']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:58 GMT']
-      lsn: ['5']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [88ff4028-40f1-4757-a216-a660f7eded20]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-content-path: [3cJOAA==]
-      x-ms-cosmos-llsn: ['5']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['5']
-      x-ms-item-count: ['0']
-      x-ms-last-state-change-utc: ['Tue, 11 Jun 2019 20:52:58.916 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-request-charge: ['5.58']
-      x-ms-resource-quota: [collections=5000;]
-      x-ms-resource-usage: [collections=1;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#5']
-      x-ms-transport-request-id: ['85925']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:54 GMT
+      lsn:
+      - '5'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - dd12727d-5b24-49aa-aa36-ffd379d6bd41
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-content-path:
+      - mJhCAA==
+      x-ms-cosmos-llsn:
+      - '5'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '5'
+      x-ms-item-count:
+      - '0'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:23.800 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-request-charge:
+      - '5.58'
+      x-ms-resource-quota:
+      - collections=5000;
+      x-ms-resource-usage:
+      - collections=1;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#5
+      x-ms-transport-request-id:
+      - '41729'
+      x-ms-xp-role:
+      - '2'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection list]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [-g -n -d]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -d
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:52:59 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:55 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection list]
-      Connection: [keep-alive]
-      ParameterSetName: [-g -n -d]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -d
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:00 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:56 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:00 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:56 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:00 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:55 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:01 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:56 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/
   response:
-    body: {string: '{"_rid":"3cJOAA==","DocumentCollections":[{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"3cJOANPHI04=","_ts":1560401574,"_self":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","_etag":"\"00009d00-0000-0700-0000-5d01d6a60000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}],"_count":1}'}
+    body:
+      string: '{"_rid":"mJhCAA==","DocumentCollections":[{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138127,"_self":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","_etag":"\"00001500-0000-0700-0000-5d0d13cf0000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}],"_count":1}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/dbs/cliuiqh5wpxn3eq/colls/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:00 GMT']
-      lsn: ['5']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [2f025fb1-63b2-4290-b62a-0f727ba44a2c]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-content-path: [3cJOAA==]
-      x-ms-cosmos-llsn: ['5']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['5']
-      x-ms-item-count: ['1']
-      x-ms-last-state-change-utc: ['Tue, 11 Jun 2019 20:52:58.916 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-request-charge: ['2']
-      x-ms-resource-quota: [collections=5000;]
-      x-ms-resource-usage: [collections=1;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#5']
-      x-ms-transport-request-id: ['80674']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/dbs/climemymw3s6kh5/colls/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:55 GMT
+      lsn:
+      - '5'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 6bf08540-4d8c-42ed-b5b7-964702b65d90
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-content-path:
+      - mJhCAA==
+      x-ms-cosmos-llsn:
+      - '5'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '5'
+      x-ms-item-count:
+      - '1'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:23.796 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-request-charge:
+      - '2'
+      x-ms-resource-quota:
+      - collections=5000;
+      x-ms-resource-usage:
+      - collections=1;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#5
+      x-ms-transport-request-id:
+      - '9273'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection update]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [--throughput -g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --throughput -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:01 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:57 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection update]
-      Connection: [keep-alive]
-      ParameterSetName: [--throughput -g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --throughput -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:02 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:57 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:02 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:58 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:02 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:57 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:03 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:58 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/cli000002/
   response:
-    body: {string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"3cJOANPHI04=","_ts":1560401574,"_self":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","_etag":"\"00009d00-0000-0700-0000-5d01d6a60000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'}
+    body:
+      string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138127,"_self":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","_etag":"\"00001500-0000-0700-0000-5d0d13cf0000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      collection-partition-index: ['0']
-      collection-service-index: ['0']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/dbs/cliuiqh5wpxn3eq/colls/climlb2xhx5phon/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:02 GMT']
-      etag: ['"00009d00-0000-0700-0000-5d01d6a60000"']
-      lsn: ['1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [1f215f06-e1f9-40e0-88db-004db35fa90d]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-content-path: [3cJOAA==]
-      x-ms-cosmos-item-llsn: ['1']
-      x-ms-cosmos-llsn: ['1']
-      x-ms-documentdb-collection-index-transformation-progress: ['100']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['1']
-      x-ms-item-lsn: ['1']
-      x-ms-last-state-change-utc: ['Wed, 12 Jun 2019 20:55:15.618 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-request-charge: ['1']
-      x-ms-resource-quota: [functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;]
-      x-ms-resource-usage: [functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#1']
-      x-ms-transport-request-id: ['53888']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/dbs/climemymw3s6kh5/colls/clieivnkclrgpms/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:57 GMT
+      etag:
+      - '"00001500-0000-0700-0000-5d0d13cf0000"'
+      lsn:
+      - '1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 0088c98e-1b1e-41c3-8d50-acb443377f84
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-content-path:
+      - mJhCAA==
+      x-ms-cosmos-item-llsn:
+      - '1'
+      x-ms-cosmos-llsn:
+      - '1'
+      x-ms-documentdb-collection-index-transformation-progress:
+      - '100'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '1'
+      x-ms-item-lsn:
+      - '1'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 01:37:13.908 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-request-charge:
+      - '1'
+      x-ms-resource-quota:
+      - functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;
+      x-ms-resource-usage:
+      - functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#1
+      x-ms-transport-request-id:
+      - '1'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:03 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:58 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003-westus.documents.azure.com/offers
   response:
-    body: {string: '{"_rid":"","Offers":[{"resource":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","offerType":"Invalid","offerResourceId":"3cJOANPHI04=","offerVersion":"V2","content":{"offerThroughput":400,"offerIsRUPerMinuteThroughputEnabled":false},"id":"qjdJ","_rid":"qjdJ","_self":"offers\/qjdJ\/","_etag":"\"00009e00-0000-0700-0000-5d01d6a60000\"","_ts":1560401574}],"_count":1}'}
+    body:
+      string: '{"_rid":"","Offers":[{"resource":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","offerType":"Invalid","offerResourceId":"mJhCAK9SZos=","offerVersion":"V2","content":{"offerThroughput":400,"offerIsRUPerMinuteThroughputEnabled":false},"id":"5ZSd","_rid":"5ZSd","_self":"offers\/5ZSd\/","_etag":"\"00001600-0000-0700-0000-5d0d13cf0000\"","_ts":1561138127}],"_count":1}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/offers']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:02 GMT']
-      lsn: ['5']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [62e51e29-166f-4282-87e2-f571aed4e2ff]
-      x-ms-cosmos-llsn: ['5']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['5']
-      x-ms-item-count: ['1']
-      x-ms-last-state-change-utc: ['Tue, 11 Jun 2019 20:52:58.916 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-request-charge: ['2']
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#5']
-      x-ms-transport-request-id: ['106662']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/offers
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:57 GMT
+      lsn:
+      - '5'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - c888acfc-2e30-47ca-bc60-88b4ad9a4666
+      x-ms-cosmos-llsn:
+      - '5'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '5'
+      x-ms-item-count:
+      - '1'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:23.800 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-request-charge:
+      - '2'
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#5
+      x-ms-transport-request-id:
+      - '71056'
+      x-ms-xp-role:
+      - '2'
+    status:
+      code: 200
+      message: Ok
 - request:
-    body: '{"resource":"dbs/3cJOAA==/colls/3cJOANPHI04=/","offerType":"Invalid","offerResourceId":"3cJOANPHI04=","offerVersion":"V2","content":{"offerThroughput":500,"offerIsRUPerMinuteThroughputEnabled":false},"id":"qjdJ","_rid":"qjdJ","_self":"offers/qjdJ/","_etag":"\"00009e00-0000-0700-0000-5d01d6a60000\"","_ts":1560401574}'
+    body: '{"resource":"dbs/mJhCAA==/colls/mJhCAK9SZos=/","offerType":"Invalid","offerResourceId":"mJhCAK9SZos=","offerVersion":"V2","content":{"offerThroughput":500,"offerIsRUPerMinuteThroughputEnabled":false},"id":"5ZSd","_rid":"5ZSd","_self":"offers/5ZSd/","_etag":"\"00001600-0000-0700-0000-5d0d13cf0000\"","_ts":1561138127}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['317']
-      Content-Type: [application/json]
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:03 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '317'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:28:58 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: PUT
-    uri: https://cli000003-westus.documents.azure.com/offers/qjdJ/
+    uri: https://cli000003-westus.documents.azure.com/offers/5ZSd/
   response:
-    body: {string: '{"resource":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","offerType":"Invalid","offerResourceId":"3cJOANPHI04=","offerVersion":"V2","content":{"offerThroughput":500,"offerIsRUPerMinuteThroughputEnabled":false,"offerMinimumThroughputParameters":{"maxCountOfSharedThroughputCollectionsEverCreated":0,"maxThroughputEverProvisioned":0,"maxConsumedStorageEverInKB":0},"offerLastReplaceTimestamp":1560401583},"id":"qjdJ","_rid":"qjdJ","_self":"offers\/qjdJ\/","_etag":"\"0000a100-0000-0700-0000-5d01d6af0000\"","_ts":1560401583}'}
+    body:
+      string: '{"resource":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","offerType":"Invalid","offerResourceId":"mJhCAK9SZos=","offerVersion":"V2","content":{"offerThroughput":500,"offerIsRUPerMinuteThroughputEnabled":false,"offerMinimumThroughputParameters":{"maxCountOfSharedThroughputCollectionsEverCreated":0,"maxThroughputEverProvisioned":0,"maxConsumedStorageEverInKB":0},"offerLastReplaceTimestamp":1561138139},"id":"5ZSd","_rid":"5ZSd","_self":"offers\/5ZSd\/","_etag":"\"00001900-0000-0700-0000-5d0d13db0000\"","_ts":1561138139}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/offers/qjdJ/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:02 GMT']
-      etag: ['"0000a100-0000-0700-0000-5d01d6af0000"']
-      lsn: ['6']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [e644ac67-1276-4b8b-8b85-11d9793a160c]
-      x-ms-cosmos-llsn: ['6']
-      x-ms-cosmos-quorum-acked-llsn: ['5']
-      x-ms-current-replica-set-size: ['4']
-      x-ms-current-write-quorum: ['3']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['5']
-      x-ms-last-state-change-utc: ['Tue, 11 Jun 2019 20:52:42.733 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-quorum-acked-lsn: ['5']
-      x-ms-request-charge: ['9.9']
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#6']
-      x-ms-transport-request-id: ['171701']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/offers/5ZSd/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:58 GMT
+      etag:
+      - '"00001900-0000-0700-0000-5d0d13db0000"'
+      lsn:
+      - '6'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - aff538cd-4558-40c1-a723-124386ce9a6e
+      x-ms-cosmos-llsn:
+      - '6'
+      x-ms-cosmos-quorum-acked-llsn:
+      - '5'
+      x-ms-current-replica-set-size:
+      - '4'
+      x-ms-current-write-quorum:
+      - '3'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '5'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:13.070 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-quorum-acked-lsn:
+      - '5'
+      x-ms-request-charge:
+      - '9.9'
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#6
+      x-ms-transport-request-id:
+      - '18360'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection update]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [--default-ttl -g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --default-ttl -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:04 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:28:59 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection update]
-      Connection: [keep-alive]
-      ParameterSetName: [--default-ttl -g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --default-ttl -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:04 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:00 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:04 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:00 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:04 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:00 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:05 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:01 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/cli000002/
   response:
-    body: {string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"3cJOANPHI04=","_ts":1560401574,"_self":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","_etag":"\"00009d00-0000-0700-0000-5d01d6a60000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'}
+    body:
+      string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138127,"_self":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","_etag":"\"00001500-0000-0700-0000-5d0d13cf0000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      collection-partition-index: ['0']
-      collection-service-index: ['0']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/dbs/cliuiqh5wpxn3eq/colls/climlb2xhx5phon/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:05 GMT']
-      etag: ['"00009d00-0000-0700-0000-5d01d6a60000"']
-      lsn: ['2']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [f710e65b-11e0-40de-a140-eb1b72285bfb]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-content-path: [3cJOAA==]
-      x-ms-cosmos-item-llsn: ['1']
-      x-ms-cosmos-llsn: ['2']
-      x-ms-cosmos-quorum-acked-llsn: ['2']
-      x-ms-current-replica-set-size: ['4']
-      x-ms-current-write-quorum: ['3']
-      x-ms-documentdb-collection-index-transformation-progress: ['100']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['2']
-      x-ms-item-lsn: ['1']
-      x-ms-last-state-change-utc: ['Wed, 12 Jun 2019 20:55:04.512 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-quorum-acked-lsn: ['2']
-      x-ms-request-charge: ['1']
-      x-ms-resource-quota: [functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;]
-      x-ms-resource-usage: [functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#2']
-      x-ms-transport-request-id: ['242']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/dbs/climemymw3s6kh5/colls/clieivnkclrgpms/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:00 GMT
+      etag:
+      - '"00001500-0000-0700-0000-5d0d13cf0000"'
+      lsn:
+      - '2'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - b3693414-5140-4a00-a3d9-b38150dee0e6
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-content-path:
+      - mJhCAA==
+      x-ms-cosmos-item-llsn:
+      - '1'
+      x-ms-cosmos-llsn:
+      - '2'
+      x-ms-cosmos-quorum-acked-llsn:
+      - '2'
+      x-ms-current-replica-set-size:
+      - '4'
+      x-ms-current-write-quorum:
+      - '3'
+      x-ms-documentdb-collection-index-transformation-progress:
+      - '100'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '2'
+      x-ms-item-lsn:
+      - '1'
+      x-ms-last-state-change-utc:
+      - Thu, 20 Jun 2019 21:55:12.286 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-quorum-acked-lsn:
+      - '2'
+      x-ms-request-charge:
+      - '1'
+      x-ms-resource-quota:
+      - functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;
+      x-ms-resource-usage:
+      - functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#2
+      x-ms-transport-request-id:
+      - '8913'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
 - request:
-    body: b'{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*","indexes":[]}],"excludedPaths":[{"path":"/\\"_etag\\"/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"3cJOANPHI04=","_ts":1560401574,"_self":"dbs/3cJOAA==/colls/3cJOANPHI04=/","_etag":"\\"00009d00-0000-0700-0000-5d01d6a60000\\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","defaultTtl":1000}'
+    body: b'{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*","indexes":[]}],"excludedPaths":[{"path":"/\\"_etag\\"/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138127,"_self":"dbs/mJhCAA==/colls/mJhCAK9SZos=/","_etag":"\\"00001500-0000-0700-0000-5d0d13cf0000\\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","defaultTtl":1000}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['586']
-      Content-Type: [application/json]
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:05 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '586'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:01 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: PUT
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/cli000002/
   response:
-    body: {string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"defaultTtl":1000,"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"3cJOANPHI04=","_ts":1560401585,"_self":"dbs\/3cJOAA==\/colls\/3cJOANPHI04=\/","_etag":"\"0000a200-0000-0700-0000-5d01d6b10000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'}
+    body:
+      string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"defaultTtl":1000,"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138141,"_self":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","_etag":"\"00001a00-0000-0700-0000-5d0d13dd0000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      collection-partition-index: ['0']
-      collection-service-index: ['0']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/dbs/cliuiqh5wpxn3eq/colls/climlb2xhx5phon/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:05 GMT']
-      etag: ['"0000a200-0000-0700-0000-5d01d6b10000"']
-      lsn: ['3']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [055e5792-b1de-4e33-bcec-e0d142178247]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-cosmos-llsn: ['3']
-      x-ms-cosmos-quorum-acked-llsn: ['2']
-      x-ms-current-replica-set-size: ['4']
-      x-ms-current-write-quorum: ['3']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['2']
-      x-ms-last-state-change-utc: ['Wed, 12 Jun 2019 20:55:04.512 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-quorum-acked-lsn: ['2']
-      x-ms-request-charge: ['9.9']
-      x-ms-resource-quota: [functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;]
-      x-ms-resource-usage: [functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#3']
-      x-ms-transport-request-id: ['243']
-      x-ms-xp-role: ['1']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/dbs/climemymw3s6kh5/colls/clieivnkclrgpms/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:00 GMT
+      etag:
+      - '"00001a00-0000-0700-0000-5d0d13dd0000"'
+      lsn:
+      - '3'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 0f7eb91c-b6a1-486a-a40d-9f2fdbac7ca7
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-cosmos-llsn:
+      - '3'
+      x-ms-cosmos-quorum-acked-llsn:
+      - '2'
+      x-ms-current-replica-set-size:
+      - '4'
+      x-ms-current-write-quorum:
+      - '3'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '2'
+      x-ms-last-state-change-utc:
+      - Thu, 20 Jun 2019 21:55:12.286 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-quorum-acked-lsn:
+      - '2'
+      x-ms-request-charge:
+      - '9.9'
+      x-ms-resource-quota:
+      - functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;
+      x-ms-resource-usage:
+      - functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#3
+      x-ms-transport-request-id:
+      - '8914'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection delete]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --default-ttl -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:05 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:02 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection delete]
-      Connection: [keep-alive]
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --default-ttl -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:06 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:02 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:07 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:03 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:06 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:02 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:07 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:03 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
+    method: GET
+    uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/cli000002/
+  response:
+    body:
+      string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"defaultTtl":1000,"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138141,"_self":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","_etag":"\"00001a00-0000-0700-0000-5d0d13dd0000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/dbs/climemymw3s6kh5/colls/clieivnkclrgpms/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:02 GMT
+      etag:
+      - '"00001a00-0000-0700-0000-5d0d13dd0000"'
+      lsn:
+      - '3'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 5bfc2997-3c6a-4016-a341-9a9b9e841c30
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-content-path:
+      - mJhCAA==
+      x-ms-cosmos-item-llsn:
+      - '3'
+      x-ms-cosmos-llsn:
+      - '3'
+      x-ms-cosmos-quorum-acked-llsn:
+      - '3'
+      x-ms-current-replica-set-size:
+      - '4'
+      x-ms-current-write-quorum:
+      - '3'
+      x-ms-documentdb-collection-index-transformation-progress:
+      - '100'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '3'
+      x-ms-item-lsn:
+      - '3'
+      x-ms-last-state-change-utc:
+      - Thu, 20 Jun 2019 21:55:12.286 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-quorum-acked-lsn:
+      - '3'
+      x-ms-request-charge:
+      - '1'
+      x-ms-resource-quota:
+      - functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;
+      x-ms-resource-usage:
+      - functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#3
+      x-ms-transport-request-id:
+      - '9338'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: b'{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*","indexes":[]}],"excludedPaths":[{"path":"/\\"_etag\\"/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138141,"_self":"dbs/mJhCAA==/colls/mJhCAK9SZos=/","_etag":"\\"00001a00-0000-0700-0000-5d0d13dd0000\\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '568'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:03 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
+    method: PUT
+    uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/cli000002/
+  response:
+    body:
+      string: '{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"\/*","indexes":[]}],"excludedPaths":[{"path":"\/\"_etag\"\/?"}]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"\/_ts","conflictResolutionProcedure":""},"geospatialConfig":{"type":"Geography"},"_rid":"mJhCAK9SZos=","_ts":1561138143,"_self":"dbs\/mJhCAA==\/colls\/mJhCAK9SZos=\/","_etag":"\"00001b00-0000-0700-0000-5d0d13df0000\"","_docs":"docs\/","_sprocs":"sprocs\/","_triggers":"triggers\/","_udfs":"udfs\/","_conflicts":"conflicts\/"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/dbs/climemymw3s6kh5/colls/clieivnkclrgpms/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:02 GMT
+      etag:
+      - '"00001b00-0000-0700-0000-5d0d13df0000"'
+      lsn:
+      - '4'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - 80296ceb-5db5-4561-88f2-0095f60a0c76
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-cosmos-llsn:
+      - '4'
+      x-ms-cosmos-quorum-acked-llsn:
+      - '3'
+      x-ms-current-replica-set-size:
+      - '4'
+      x-ms-current-write-quorum:
+      - '3'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '3'
+      x-ms-last-state-change-utc:
+      - Thu, 20 Jun 2019 21:55:12.286 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-quorum-acked-lsn:
+      - '3'
+      x-ms-request-charge:
+      - '9.9'
+      x-ms-resource-quota:
+      - functions=25;storedProcedures=100;triggers=25;documentSize=10240;documentsSize=10485760;documentsCount=-1;collectionSize=10485760;
+      x-ms-resource-usage:
+      - functions=0;storedProcedures=0;triggers=0;documentSize=0;documentsSize=0;documentsCount=0;collectionSize=0;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#4
+      x-ms-transport-request-id:
+      - '9339'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
+  response:
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:04 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
+        US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
+        US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:05 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:05 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
+    method: GET
+    uri: https://cli000003.documents.azure.com/
+  response:
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:05 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:05 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: DELETE
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/cli000002/
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: ['no-store, no-cache']
-      collection-partition-index: ['0']
-      collection-service-index: ['0']
-      content-length: ['0']
-      content-location: ['https://cli6ozvvesqk3oq-westus.documents.azure.com/dbs/cliuiqh5wpxn3eq/colls/climlb2xhx5phon/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:07 GMT']
-      lsn: ['8']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      x-ms-activity-id: [c6731b81-9fe7-411e-82ad-1de0c697ce37]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-cosmos-llsn: ['8']
-      x-ms-cosmos-quorum-acked-llsn: ['7']
-      x-ms-current-replica-set-size: ['4']
-      x-ms-current-write-quorum: ['3']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['7']
-      x-ms-last-state-change-utc: ['Tue, 11 Jun 2019 20:52:42.733 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-quorum-acked-lsn: ['7']
-      x-ms-request-charge: ['4.95']
-      x-ms-resource-quota: [collections=5000;]
-      x-ms-resource-usage: [collections=1;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#8']
-      x-ms-transport-request-id: ['241020']
-      x-ms-xp-role: ['1']
-    status: {code: 204, message: No Content}
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-length:
+      - '0'
+      content-location:
+      - https://cliyyzynqhq44m7-westus.documents.azure.com/dbs/climemymw3s6kh5/colls/clieivnkclrgpms/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:05 GMT
+      lsn:
+      - '9'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      x-ms-activity-id:
+      - 36ee2751-7782-4a1f-8735-d9da5dbdb03e
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-cosmos-llsn:
+      - '9'
+      x-ms-cosmos-quorum-acked-llsn:
+      - '8'
+      x-ms-current-replica-set-size:
+      - '4'
+      x-ms-current-write-quorum:
+      - '3'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '8'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:13.070 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-quorum-acked-lsn:
+      - '8'
+      x-ms-request-charge:
+      - '4.95'
+      x-ms-resource-quota:
+      - collections=5000;
+      x-ms-resource-usage:
+      - collections=1;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#9
+      x-ms-transport-request-id:
+      - '13373'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 204
+      message: No Content
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection exists]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection exists
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/listKeys?api-version=2015-04-08
   response:
-    body: {string: '{"primaryMasterKey":"qqWufPlpqfdIP9OFd0BZHB3Obt2G33Bf3PpdZM9UCigTfmdyXaP1EPKRbCLvBJq5oG3mw1jlGVJVOmb0EASd9g==","secondaryMasterKey":"v2q3Xm6F5yU5lILCD3Udua0aABLc8Q5eAH5y5c0GmG40j8ATne3YqBf763KNFzc8oplLcYHGXl0EamK7ubZgrw==","primaryReadonlyMasterKey":"58jhZvfXXZrjdm9YSftO7hDdpwbdj6PbZeWSoMXllZ99lmCjf3eOiioRhgmehx1hkUWJoZrh507H07ULzag27A==","secondaryReadonlyMasterKey":"p62WhPYXaOCjKYL8ZxCOGEE5p6XH21Z5QKyR7ry7jCiZAV8rgkVyoiLMywnrp4k2n4VajVz9xKl1Y9Rb7xB45A=="}'}
+    body:
+      string: '{"primaryMasterKey":"yJWeIoUMxlSbbQ7opGDDXXPt2v6DtZgIjpLi751Ouip4c68J2da4TAISdcsFy82KvAgXUjfstPG52eTEupkhYg==","secondaryMasterKey":"hoIgMf9n6fVfgu3JDGapvekdZ3qi5ZCzCUmwHr7b7YwaauiatH1TXDCkSv9pVzQRsXGuVP5ED63mv44G5lvxSw==","primaryReadonlyMasterKey":"ZvkoI8XRKzoHvdusNA3woZ5UwfvKmSdwE0yZL7NwfF3ROZGrtdDGI8I57H49viE6oAT5vf1410Jrww1lphO5FQ==","secondaryReadonlyMasterKey":"ZR4uQ8wLBBMj8BxSuKcP1YikALnfiZ0452kgIPJKORcsodZ9KF2jjXPW6cMFkwMMHUh6zWUq7ES0KKrrgoQwRQ=="}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['461']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:07 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '461'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:06 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [cosmosdb collection exists]
-      Connection: [keep-alive]
-      ParameterSetName: [-g -n -d -c]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 azure-mgmt-cosmosdb/0.5.2 Azure-SDK-For-Python AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb collection exists
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -d -c
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 azure-mgmt-cosmosdb/0.5.2
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2015-04-08
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_collection000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
         US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","ipRangeFilter":"","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'}
+        US","failoverPriority":0}],"cors":[],"capabilities":[]}}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-length: ['1621']
-      content-location: ['https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionzqgpll7x4ctkxknt3igwhcomzdh2qtfypk5hmqyu74khwld/providers/Microsoft.DocumentDB/databaseAccounts/cli6ozvvesqk3oq?api-version=2015-04-08']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:09 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-gatewayversion: [version=2.4.0.0]
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1621'
+      content-location:
+      - https://management.documents.azure.com:450/subscriptions/12053b8f-cab5-4f5c-9c1a-870580142abd/resourceGroups/cli_test_cosmosdb_collectionmydmwyd5v3msrm6hxngagqjyyli7y2hiuygop4fl2jsdbn2/providers/Microsoft.DocumentDB/databaseAccounts/cliyyzynqhq44m7?api-version=2015-04-08
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:06 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:09 GMT']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-session-token: ['']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:07 GMT
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-session-token:
+      - ''
+      x-ms-version:
+      - '2018-09-17'
     method: GET
     uri: https://cli000003.documents.azure.com/
   response:
-    body: {string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
+    body:
+      string: '{"_self":"","id":"cli000003","_rid":"cli000003.documents.azure.com","media":"//media/","addresses":"//addresses/","_dbs":"//dbs/","writableLocations":[{"name":"West
         US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"readableLocations":[{"name":"West
-        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'}
+        US","databaseAccountEndpoint":"https://cli000003-westus.documents.azure.com:443/"}],"enableMultipleWriteLocations":false,"userReplicationPolicy":{"asyncReplication":false,"minReplicaSetSize":3,"maxReplicasetSize":4},"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"systemReplicationPolicy":{"minReplicaSetSize":3,"maxReplicasetSize":4},"readPolicy":{"primaryReadCoefficient":1,"secondaryReadCoefficient":1},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":8000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"}'
     headers:
-      cache-control: ['no-store, no-cache']
-      content-location: ['https://cli6ozvvesqk3oq.documents.azure.com/']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:09 GMT']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-databaseaccount-consumed-mb: ['0']
-      x-ms-databaseaccount-provisioned-mb: ['0']
-      x-ms-databaseaccount-reserved-mb: ['0']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-max-media-storage-usage-mb: ['2048']
-      x-ms-media-storage-usage-mb: ['0']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      content-location:
+      - https://cliyyzynqhq44m7.documents.azure.com/
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:07 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-databaseaccount-consumed-mb:
+      - '0'
+      x-ms-databaseaccount-provisioned-mb:
+      - '0'
+      x-ms-databaseaccount-reserved-mb:
+      - '0'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-max-media-storage-usage-mb:
+      - '2048'
+      x-ms-media-storage-usage-mb:
+      - '0'
+    status:
+      code: 200
+      message: Ok
 - request:
-    body: '{"query":"SELECT * FROM root r WHERE r.id=@id","parameters":[{"name":"@id","value":"climlb2xhx5phon"}]}'
+    body: '{"query":"SELECT * FROM root r WHERE r.id=@id","parameters":[{"name":"@id","value":"clieivnkclrgpms"}]}'
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Cache-Control: [no-cache]
-      Connection: [keep-alive]
-      Content-Length: ['103']
-      Content-Type: [application/query+json]
-      User-Agent: [Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.66]
-      x-ms-consistency-level: [Session]
-      x-ms-date: ['Thu, 13 Jun 2019 04:53:09 GMT']
-      x-ms-documentdb-isquery: ['true']
-      x-ms-documentdb-query-iscontinuationexpected: ['False']
-      x-ms-version: ['2018-09-17']
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/query+json
+      User-Agent:
+      - Windows/10 Python/3.7.0 azure-cosmos/3.1.0 AZURECLI/2.0.67
+      x-ms-consistency-level:
+      - Session
+      x-ms-date:
+      - Fri, 21 Jun 2019 17:29:07 GMT
+      x-ms-documentdb-isquery:
+      - 'true'
+      x-ms-documentdb-query-iscontinuationexpected:
+      - 'False'
+      x-ms-version:
+      - '2018-09-17'
     method: POST
     uri: https://cli000003-westus.documents.azure.com/dbs/cli000004/colls/
   response:
-    body: {string: '{"_rid":"3cJOAA==","DocumentCollections":[],"_count":0}'}
+    body:
+      string: '{"_rid":"mJhCAA==","DocumentCollections":[],"_count":0}'
     headers:
-      cache-control: ['no-store, no-cache']
-      collection-partition-index: ['0']
-      collection-service-index: ['0']
-      content-type: [application/json]
-      date: ['Thu, 13 Jun 2019 04:53:08 GMT']
-      lsn: ['10']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000]
-      transfer-encoding: [chunked]
-      x-ms-activity-id: [72641333-4da0-4ea4-a95d-8bd09d03381b]
-      x-ms-alt-content-path: [dbs/cliuiqh5wpxn3eq]
-      x-ms-content-path: [3cJOAA==]
-      x-ms-cosmos-llsn: ['10']
-      x-ms-gatewayversion: [version=2.4.0.0]
-      x-ms-global-committed-lsn: ['10']
-      x-ms-item-count: ['0']
-      x-ms-last-state-change-utc: ['Tue, 11 Jun 2019 20:52:57.271 GMT']
-      x-ms-number-of-read-regions: ['0']
-      x-ms-request-charge: ['5.58']
-      x-ms-resource-quota: [collections=5000;]
-      x-ms-resource-usage: [collections=0;]
-      x-ms-schemaversion: ['1.8']
-      x-ms-serviceversion: [version=2.4.0.0]
-      x-ms-session-token: ['0:-1#10']
-      x-ms-transport-request-id: ['122800']
-      x-ms-xp-role: ['2']
-    status: {code: 200, message: Ok}
+      cache-control:
+      - no-store, no-cache
+      collection-partition-index:
+      - '0'
+      collection-service-index:
+      - '0'
+      content-type:
+      - application/json
+      date:
+      - Fri, 21 Jun 2019 17:29:08 GMT
+      lsn:
+      - '11'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      x-ms-activity-id:
+      - bd7d016d-79d8-48cc-bdce-7f5377c1cb67
+      x-ms-alt-content-path:
+      - dbs/climemymw3s6kh5
+      x-ms-content-path:
+      - mJhCAA==
+      x-ms-cosmos-llsn:
+      - '11'
+      x-ms-gatewayversion:
+      - version=2.4.0.0
+      x-ms-global-committed-lsn:
+      - '11'
+      x-ms-item-count:
+      - '0'
+      x-ms-last-state-change-utc:
+      - Fri, 21 Jun 2019 08:55:25.888 GMT
+      x-ms-number-of-read-regions:
+      - '0'
+      x-ms-request-charge:
+      - '5.58'
+      x-ms-resource-quota:
+      - collections=5000;
+      x-ms-resource-usage:
+      - collections=0;
+      x-ms-schemaversion:
+      - '1.8'
+      x-ms-serviceversion:
+      - version=2.4.0.0
+      x-ms-session-token:
+      - 0:-1#11
+      x-ms-transport-request-id:
+      - '16110'
+      x-ms-xp-role:
+      - '1'
+    status:
+      code: 200
+      message: Ok
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [group delete]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      ParameterSetName: [--name --yes --no-wait]
-      User-Agent: [python/3.7.0 (Windows-10-10.0.17763-SP0) requests/2.20.1 msrest/0.5.5
-          msrest_azure/0.4.34 resourcemanagementclient/2.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.66]
-      accept-language: [en-US]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - group delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --name --yes --no-wait
+      User-Agent:
+      - python/3.7.0 (Windows-10-10.0.17763-SP0) msrest/0.6.7 msrest_azure/0.6.1 resourcemanagementclient/2.2.0
+        Azure-SDK-For-Python AZURECLI/2.0.67
+      accept-language:
+      - en-US
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_collection000001?api-version=2018-05-01
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Thu, 13 Jun 2019 04:53:10 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQ09TTU9TREI6NUZDT0xMRUNUSU9OWlFHUExMN1g0Q1RLWHwzNDREQ0NBNEVGMjIwQjIwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-deletes: ['14998']
-    status: {code: 202, message: Accepted}
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Fri, 21 Jun 2019 17:29:08 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGQ09TTU9TREI6NUZDT0xMRUNUSU9OTVlETVdZRDVWM01TUnw3RTU4MjkwQUYyQjhBNkY5LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2018-05-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
 version: 1

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
@@ -345,7 +345,7 @@ class CosmosDBTests(ScenarioTest):
 
         self.cmd('az cosmosdb database create -g {rg} -n {acc} -d {db_name}')
 
-        collection = self.cmd('az cosmosdb collection create -g {rg} -n {acc} -d {db_name} -c {col}').get_output_in_json()
+        collection = self.cmd('az cosmosdb collection create -g {rg} -n {acc} -d {db_name} -c {col} --default-ttl 0').get_output_in_json()
         assert collection["collection"]["id"] == col
 
         collection_show = self.cmd('az cosmosdb collection show -g {rg} -n {acc} -d {db_name} -c {col}').get_output_in_json()
@@ -362,8 +362,12 @@ class CosmosDBTests(ScenarioTest):
         assert throughput_update["offer"]["content"]["offerThroughput"] == throughput
 
         # update ttl
-        throughput_update = self.cmd('az cosmosdb collection update --default-ttl {ttl} -g {rg} -n {acc} -d {db_name} -c {col}').get_output_in_json()
-        assert throughput_update["collection"]["defaultTtl"] == default_ttl
+        ttl_update = self.cmd('az cosmosdb collection update --default-ttl {ttl} -g {rg} -n {acc} -d {db_name} -c {col}').get_output_in_json()
+        assert ttl_update["collection"]["defaultTtl"] == default_ttl
+
+        # remove ttl
+        disable_ttl = self.cmd('az cosmosdb collection update --default-ttl 0 -g {rg} -n {acc} -d {db_name} -c {col}').get_output_in_json()
+        assert "defaultTtl" not in disable_ttl["collection"]
 
         self.cmd('az cosmosdb collection delete -g {rg} -n {acc} -d {db_name} -c {col}')
         assert not self.cmd('az cosmosdb collection exists -g {rg} -n {acc} -d {db_name} -c {col}').get_output_in_json()


### PR DESCRIPTION
This change allows users to specify '0' as the `--default-ttl` of a Cosmos DB collection during create or update to disable TTL. This addresses issue: https://github.com/Azure/azure-cli/issues/7508

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
