### PR TITLE
Handling comments and linebreaks in JSON / ARM templates

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -232,29 +232,28 @@ def read_file_content(file_path, allow_binary=False):
 
 def preprocess_json(original):
     lines = original.splitlines()
-    for i in range(len(lines)):
-        line = lines[i]
-        if "#" in line or "//" in line:
-            quote = None
-            escape = None
-            for ci in range(len(line)):
-                cc = line[ci]
-                nc = line[ci + 1] if ci < (len(line) - 1) else None
-                if quote is None:
-                    if cc == "\"" or cc == "\'":
-                        quote = cc
-                    elif cc == "#" or (cc == "/" and nc == "/"):
-                        line = line[:ci]
-                        break
-                else:
-                    if escape is None:
-                        escape = None
-                    else:
-                        if cc == "\\":
-                            escape = cc
-                        elif line[ci] == quote:
-                            quote = None
-            lines[i] = line
+    for line_index, line in enumerate(lines):
+        if not ("#" in line or "//" in line):
+            continue
+        quote = None
+        escape = None
+        for i, cc in enumerate(line):
+            if quote is None and (cc == "\"" or cc == "\'"):
+                quote = cc
+                continue
+            
+            if quote is None:
+                nc = line[i + 1] if i < (len(line) - 1) else None
+                if cc == "#" or (cc == "/" and nc == "/"):
+                    line = line[:i]
+                    break
+            elif escape is not None:
+                escape = None
+            elif cc == "\\":
+                escape = cc
+            elif cc == quote:
+                quote = None
+        lines[line_index] = line
     return "".join(lines)
 
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -235,23 +235,25 @@ def preprocess_json(original):
     for i in range(len(lines)):
         line = lines[i]
         if "#" in line or "//" in line:
-            outside = True
-            escape = False
+            quote = None
+            escape = None
             for ci in range(len(line)):
-                if outside:
-                    if line[ci] == "\"":
-                        outside = False
-                    elif line[ci] == "#" or (line[ci] == "/" and ci < (len(line) - 1) and line[ci + 1] == "/"):
+                cc = line[ci]
+                nc = line[ci + 1] if ci < (len(line) - 1) else None
+                if quote is None:
+                    if cc == "\"" or cc == "\'":
+                        quote = cc
+                    elif cc == "#" or (cc == "/" and nc == "/"):
                         line = line[:ci]
                         break
                 else:
-                    if escape:
-                        escape = False
+                    if escape is None:
+                        escape = None
                     else:
-                        if line[ci] == "\\":
-                            escape = True
-                        elif line[ci] == "\"":
-                            outside = True
+                        if cc == "\\":
+                            escape = cc
+                        elif line[ci] == quote:
+                            quote = None
             lines[i] = line
     return "".join(lines)
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -241,7 +241,6 @@ def preprocess_json(original):
             if quote is None and (cc == "\"" or cc == "\'"):
                 quote = cc
                 continue
-            
             if quote is None:
                 nc = line[i + 1] if i < (len(line) - 1) else None
                 if cc == "#" or (cc == "/" and nc == "/"):


### PR DESCRIPTION
This is fix for: https://github.com/Azure/azure-cli/issues/8937

Please check discussion there. Basically I have just written simplest possible solution that will preprocess given json that may contain line breaks and comments.

I have tried to use **jsoncomment** but it has very obvious flaws which caused problems even with sample ARM template given in the issue I am solving. More information can be found in the issue I have created below:
https://github.com/vaidik/commentjson/issues/22

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
