### PR TITLE
Fix app package validator to conform with data plane naming

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -19,7 +19,7 @@ Release History
 * [Breaking] Replaced az batch pool node-agent-skus list with az batch pool supported-images list. The new command contains all of the same information originally available, but in a clearer format. New non-verified images are also now returned. Additional information about capabilities and batchSupportEndOfLife is accessible on the imageInformation object returned.
 * When using --json-file option of az batch pool create network security rules blocking network access to a pool based on the source port of the traffic is now supported. This is done via the SourcePortRanges property on NetworkSecurityGroupRule.
 * When using --json-file option of az batch task create and running a container, Batch now supports executing the task in the container working directory or in the Batch task working directory. This is controlled by the WorkingDirectory property on TaskContainerSettings.
-
+* Fix error in --application-package-references option of `az batch pool create` where it would only work with defaults. Now it will properly accept specific versions as well.
 
 **RDBMS**
 

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -62,7 +62,7 @@ def application_package_reference_format(value):
     app_reference = value.split('#', 1)
     package = {'application_id': app_reference[0]}
     try:
-        package['version_name'] = app_reference[1]
+        package['version'] = app_reference[1]
     except IndexError:  # No specified version - ignore
         pass
     return package

--- a/src/azure-cli/azure/cli/command_modules/batch/tests/latest/test_batch_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/tests/latest/test_batch_commands.py
@@ -65,10 +65,10 @@ class TestBatchValidators(unittest.TestCase):
         self.assertEqual(ref, {'application_id': 'app_1'})
 
         ref = _validators.application_package_reference_format("app#1")
-        self.assertEqual(ref, {'application_id': 'app', 'version_name': '1'})
+        self.assertEqual(ref, {'application_id': 'app', 'version': '1'})
 
         ref = _validators.application_package_reference_format("app#1#RC")
-        self.assertEqual(ref, {'application_id': 'app', 'version_name': '1#RC'})
+        self.assertEqual(ref, {'application_id': 'app', 'version': '1#RC'})
 
     def test_batch_certificate_reference_format(self):
         cert = _validators.certificate_reference_format("thumbprint_lkjsahakjg")


### PR DESCRIPTION
Fixes #9426
![image](https://user-images.githubusercontent.com/18502617/60983377-ae32ed00-a2ee-11e9-9125-0a87e995df99.png)
![image](https://user-images.githubusercontent.com/18502617/60983320-978c9600-a2ee-11e9-8bb5-9f55d52eeee8.png)

Caused by confusion in difference between create app package parameters https://docs.microsoft.com/en-us/rest/api/batchmanagement/applicationpackage/create and values used when creating the app package reference https://docs.microsoft.com/en-us/rest/api/batchservice/pool/add#applicationpackagereference
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
