### PR TITLE
Check for cloud shell before calling localhost endpoint to close port

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,8 @@
 Release History
 ===============
 
+**AKS**                                                                                                                                                                                                                                                                         * Fixed an issue where terminating the browse command always tried to call an endpoint that is only available within cloud shell, resulting in a connection failure in other environments
+
 **Appservice**
 
 * az webapp identity commands will return a proper error message if ResourceGroupName or App name are invalid.

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1438,8 +1438,8 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False,
         # Let command processing finish gracefully after the user presses [Ctrl+C]
         pass
     finally:
-        # TODO: Better error handling here.
-        requests.post('http://localhost:8888/closeport/8001')
+        if in_cloud_console():
+            requests.post('http://localhost:8888/closeport/8001')
 
 
 def _trim_nodepoolname(nodepool_name):


### PR DESCRIPTION
Azure/azure-cli#7336 introduced support for az aks browse in cloud shell using a special localhost endpoint to manage opening and closing ports for the underlying port-forward. However, the close was not wrapped in a check of whether the user was actually in cloud shell, causing an ugly (albeit innocuous) error message when users terminated the browse command.

Fixes #7686 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
