### PR TITLE
Update `prompt-toolkit` to 2.0.9

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/interactive/color_styles.py
+++ b/src/azure-cli/azure/cli/command_modules/interactive/color_styles.py
@@ -4,14 +4,14 @@
 # --------------------------------------------------------------------------------------------
 import platform
 
-from prompt_toolkit.styles import style_from_dict  # pylint: disable=import-error
+from prompt_toolkit.styles import Style
 from pygments.token import Token  # pylint: disable=import-error
 
 
 def color_mapping(curr_completion, completion, prompt, command, subcommand,
                   param, text, line, example, toolbar):
 
-    return style_from_dict({
+    return Style.from_dict({
         # Completion colors
         Token.Menu.Completions.Completion.Current: curr_completion,
         Token.Menu.Completions.Completion: completion,

--- a/src/azure-cli/requirements.py2.Darwin.txt
+++ b/src/azure-cli/requirements.py2.Darwin.txt
@@ -111,7 +111,7 @@ paramiko==2.6.0
 pathlib2==2.3.3
 pbr==5.3.1
 portalocker==1.4.0
-prompt-toolkit==1.0.16
+prompt-toolkit==2.0.9
 psutil==5.6.3
 pyasn1==0.4.5
 pycparser==2.19

--- a/src/azure-cli/requirements.py2.Linux.txt
+++ b/src/azure-cli/requirements.py2.Linux.txt
@@ -111,7 +111,7 @@ paramiko==2.6.0
 pathlib2==2.3.3
 pbr==5.3.1
 portalocker==1.4.0
-prompt-toolkit==1.0.16
+prompt-toolkit==2.0.9
 psutil==5.6.3
 pyasn1==0.4.5
 pycparser==2.19

--- a/src/azure-cli/requirements.py2.windows.txt
+++ b/src/azure-cli/requirements.py2.windows.txt
@@ -108,7 +108,7 @@ paramiko==2.6.0
 pathlib2==2.3.3
 pbr==5.3.1
 portalocker==1.2.1
-prompt-toolkit==1.0.16
+prompt-toolkit==2.0.9
 psutil==5.6.3
 pyasn1==0.4.5
 pycparser==2.19

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -103,7 +103,7 @@ oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==1.4.0
-prompt-toolkit==1.0.16
+prompt-toolkit==2.0.9
 psutil==5.6.3
 pycparser==2.19
 pydocumentdb==2.3.3

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -103,7 +103,7 @@ oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==1.4.0
-prompt-toolkit==1.0.16
+prompt-toolkit==2.0.9
 psutil==5.6.3
 pycparser==2.19
 pydocumentdb==2.3.3

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -100,7 +100,7 @@ oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==1.2.1
-prompt-toolkit==1.0.16
+prompt-toolkit==2.0.9
 psutil==5.6.3
 pycparser==2.19
 pydocumentdb==2.3.3

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -132,7 +132,7 @@ DEPENDENCIES = [
     'knack~=0.6,>=0.6.3',
     'mock~=2.0',
     'paramiko>=2.0.8,<3.0.0',
-    'prompt_toolkit~=1.0,>=1.0.15',
+    'prompt_toolkit~=2.0',
     'pydocumentdb>=2.0.1,<3.0.0',
     'pygments~=2.4',
     'pyOpenSSL>=17.1.0',


### PR DESCRIPTION
We ran into a problem when trying to install `azure-cli` on top of a conda environment.  The problem is that `azure-cli` specifies an old version of `prompt-toolkit`, and installing it forces a downgrade and that breaks the jupyter kernel.

This PR updates the version to the one that is current in conda.
