### PR TITLE
Add docker to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,11 @@ LABEL maintainer="Microsoft" \
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool
 # libintl and icu-libs - required by azure devops artifact (az extension add --name azure-devops)
+# docker - include as a useful tool (with mounted docker socket, docker commands can be executed from a container)
 RUN apk add --no-cache bash openssh ca-certificates jq curl openssl git zip \
  && apk add --no-cache --virtual .build-deps gcc make openssl-dev libffi-dev musl-dev linux-headers \
  && apk add --no-cache libintl icu-libs \
+ && apk add --no-cache docker \
  && update-ca-certificates
 
 ARG JP_VERSION="0.1.3"


### PR DESCRIPTION
Changes:

- Add `docker` to `azure-cli` image

---

It can be really useful to have `docker` command available in `azure-cli` image.

If `docker` command is available in image, you can simply mount docker socket (e.g. `-v /var/run/docker.sock:/var/run/docker.sock`) and the run docker commands from container.

For example, it will allow you to push images from `azure-cli` container and there is no need to have `azure-cli` installed locally, you just pull the image.

Real world usage, CI platform:

- `docker build -t my-image .`
- `docker pull mcr.microsoft.com/azure-cli`
- `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock mcr.microsoft.com/azure-cli sh -c 'az login ... && az acr login ... && docker push ...'` (dots mean there are more arguments in mentioned commands)

