### PR TITLE
update get-version and get-upgrade table formatters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_format.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 from collections import OrderedDict
- # pylint: disable=import-error
+# pylint: disable=import-error
 from jmespath import compile as compile_jmes, Options
 # pylint: disable=import-error
 from jmespath import functions
@@ -55,6 +55,7 @@ def aks_upgrades_table_format(result):
     """Format get-upgrades results as a summary for display with "-o table"."""
 
     preview = {}
+
     def find_preview_versions(versions_bag):
         for upgrade in versions_bag.get('upgrades', []):
             if upgrade.get('isPreview', False):
@@ -78,6 +79,7 @@ def aks_versions_table_format(result):
     """Format get-versions results as a summary for display with "-o table"."""
 
     preview = {}
+
     def find_preview_versions():
         for orchestrator in result.get('orchestrators', []):
             if orchestrator.get('isPreview', False):

--- a/src/azure-cli/azure/cli/command_modules/acs/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_format.py
@@ -4,6 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 from collections import OrderedDict
+ # pylint: disable=import-error
+from jmespath import compile as compile_jmes, Options
+# pylint: disable=import-error
+from jmespath import functions
 
 
 def aks_list_table_format(results):
@@ -22,8 +26,6 @@ def aks_show_table_format(result):
 
 
 def _aks_table_format(result):
-    from jmespath import compile as compile_jmes, Options
-
     parsed = compile_jmes("""{
         name: name,
         location: location,
@@ -37,8 +39,6 @@ def _aks_table_format(result):
 
 
 def _osa_table_format(result):
-    from jmespath import compile as compile_jmes, Options
-
     parsed = compile_jmes("""{
         name: name,
         location: location,
@@ -53,50 +53,83 @@ def _osa_table_format(result):
 
 def aks_upgrades_table_format(result):
     """Format get-upgrades results as a summary for display with "-o table"."""
-    from jmespath import compile as compile_jmes, Options
+
+    preview = {}
+    def find_preview_versions(versions_bag):
+        for upgrade in versions_bag.get('upgrades', []):
+            if upgrade.get('isPreview', False):
+                preview[upgrade['kubernetesVersion']] = True
+    find_preview_versions(result.get('controlPlaneProfile', {}))
+    find_preview_versions(result.get('agentPoolProfiles', [{}])[0])
 
     # This expression assumes there is one node pool, and that the master and nodes upgrade in lockstep.
     parsed = compile_jmes("""{
         name: name,
         resourceGroup: resourceGroup,
         masterVersion: controlPlaneProfile.kubernetesVersion || `unknown`,
-        nodePoolVersion: agentPoolProfiles[0].kubernetesVersion || `unknown`,
-        upgrades: controlPlaneProfile.upgrades || [`None available`] | sort_versions(@) | join(`, `, @)
+        nodePoolVersion: agentPoolProfiles[0].kubernetesVersion || `unknown` | set_preview(@),
+        upgrades: controlPlaneProfile.upgrades[].kubernetesVersion || [`None available`] | sort_versions(@) | set_preview_array(@) | join(`, `, @)
     }""")
     # use ordered dicts so headers are predictable
-    return parsed.search(result, Options(dict_cls=OrderedDict, custom_functions=_custom_functions()))
+    return parsed.search(result, Options(dict_cls=OrderedDict, custom_functions=_custom_functions(preview)))
 
 
 def aks_versions_table_format(result):
     """Format get-versions results as a summary for display with "-o table"."""
-    from jmespath import compile as compile_jmes, Options
+
+    preview = {}
+    def find_preview_versions():
+        for orchestrator in result.get('orchestrators', []):
+            if orchestrator.get('isPreview', False):
+                preview[orchestrator['orchestratorVersion']] = True
+    find_preview_versions()
 
     parsed = compile_jmes("""orchestrators[].{
-        kubernetesVersion: orchestratorVersion,
-        upgrades: upgrades[].orchestratorVersion || [`None available`] | sort_versions(@) | join(`, `, @)
+        kubernetesVersion: orchestratorVersion | set_preview(@),
+        upgrades: upgrades[].orchestratorVersion || [`None available`] | sort_versions(@) | set_preview_array(@) | join(`, `, @)
     }""")
+
     # use ordered dicts so headers are predictable
-    results = parsed.search(result, Options(dict_cls=OrderedDict, custom_functions=_custom_functions()))
+    results = parsed.search(result, Options(dict_cls=OrderedDict, custom_functions=_custom_functions(preview)))
     return sorted(results, key=lambda x: version_to_tuple(x.get('kubernetesVersion')), reverse=True)
 
 
-def version_to_tuple(v):
-    """Quick-and-dirty sort function to handle simple semantic versions like 1.7.12 or 1.8.7."""
-    return tuple(map(int, (v.split('.'))))
+def version_to_tuple(version):
+    """Removes preview suffix"""
+    if version.endswith('(preview)'):
+        version = version[:-len('(preview)')]
+    return tuple(map(int, (version.split('.'))))
 
 
-def _custom_functions():
-
-    from jmespath import functions
-
+def _custom_functions(preview_versions):
     class CustomFunctions(functions.Functions):  # pylint: disable=too-few-public-methods
 
         @functions.signature({'types': ['array']})
-        def _func_sort_versions(self, s):  # pylint: disable=no-self-use
+        def _func_sort_versions(self, versions):  # pylint: disable=no-self-use
             """Custom JMESPath `sort_versions` function that sorts an array of strings as software versions."""
             try:
-                return sorted(s, key=version_to_tuple)
+                return sorted(versions, key=version_to_tuple)
             except (TypeError, ValueError):  # if it wasn't sortable, return the input so the pipeline continues
-                return s
+                return versions
+
+        @functions.signature({'types': ['array']})
+        def _func_set_preview_array(self, versions):
+            """Custom JMESPath `set_preview_array` function that suffixes preview version"""
+            try:
+                for i, _ in enumerate(versions):
+                    versions[i] = self._func_set_preview(versions[i])
+                return versions
+            except(TypeError, ValueError):
+                return versions
+
+        @functions.signature({'types': ['string']})
+        def _func_set_preview(self, version):  # pylint: disable=no-self-use
+            """Custom JMESPath `set_preview` function that suffixes preview version"""
+            try:
+                if preview_versions.get(version, False):
+                    return version + '(preview)'
+                return version
+            except(TypeError, ValueError):
+                return version
 
     return CustomFunctions()


### PR DESCRIPTION
Small PR that updates:

1. Get-versions adds the required preview suffix in the `-o table` mode as seen on the cli-extension
2. Get-upgrades fix allows it to run properly in `-o table` mode

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
