### PR TITLE
[Test] Fix bug where self.moniker crashes when self is a LiveScenarioTest.

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -175,6 +175,7 @@ class LiveScenarioTest(IntegrationTestBase, CheckerMixin, unittest.TestCase):
         super(LiveScenarioTest, self).__init__(method_name)
         self.cli_ctx = get_dummy_cli()
         self.kwargs = {}
+        self.test_resources_count = 0
 
     def cmd(self, command, checks=None, expect_failure=False):
         command = self._apply_kwargs(command)

--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -25,7 +25,9 @@ class NoTrafficRecordingPreparer(AbstractPreparer):
 
     def live_only_execute(self, cli_ctx, command, expect_failure=False):
         # call AbstractPreparer.moniker to make resource counts and self.resource_moniker consistent between live and
-        # play-back. see SingleValueReplacer.process_request and ScenarioTest.create_random_name
+        # play-back. see SingleValueReplacer.process_request, AbstractPreparer.__call__._preparer_wrapper
+        # and ScenarioTest.create_random_name. This is so that when self.create_random_name is called for the
+        # first time during live or playback, it would have the same value.
         _ = self.moniker
 
         try:

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -10,7 +10,6 @@ from ..storage_test_util import StorageScenarioMixin, StorageTestFilesPreparer
 
 
 class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
-    test_resources_count = 0
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer()


### PR DESCRIPTION
New preparer logic was added that forces self.moniker to be called each time a preparer creates a resource. This was so that self.create_random_name which depends on self.resource_count would be consistent during recording and playback for a ScenarioTest when generating random resource names.

However previously, preparers did not have reason to call self.moniker for LiveScenarioTests, so this bug of self.moniker (defined for AbstractPreparers in azure_devtools ) failing due to no test_resource_count, was never detected.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
