### PR TITLE
Updated Readme for non-root docker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ $ docker run -u $(id -u):$(id -g) -v ${HOME}:/home/az -e HOME=/home/az --rm -it 
 For automated builds triggered by pushes to this repo, see [azuresdk/azure-cli-python](https://hub.docker.com/r/azuresdk/azure-cli-python/tags).
 For example:
 ```bash
-docker run -v ${HOME}:/root -it --rm azuresdk/azure-cli-python:dev
+$ docker run -u $(id -u):$(id -g) -v ${HOME}:/home/az -e HOME=/home/az --rm -it azuresdk/azure-cli-python:dev
 ```
 
 ### Edge Builds

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ We maintain a Docker image preconfigured with the Azure CLI.
 See our [Docker tags](https://hub.docker.com/r/microsoft/azure-cli/tags/) for available versions.
 
 ```bash
-$ docker run -v ${HOME}:/root -it --rm mcr.microsoft.com/azure-cli:<version>
+$ docker run -u $(id -u):$(id -g) -v ${HOME}:/home/az -e HOME=/home/az --rm -it mcr.microsoft.com/azure-cli:<version>
 ```
 
 For automated builds triggered by pushes to this repo, see [azuresdk/azure-cli-python](https://hub.docker.com/r/azuresdk/azure-cli-python/tags).


### PR DESCRIPTION
When mounting the home directory the container should not be running without the current user id and group id.
Otherwise all files that azure-cli writes will be written as root - in the container and on the host.
See also [https://medium.com/redbubble/running-a-docker-container-as-a-non-root-user-7d2e00f8ee15](https://medium.com/redbubble/running-a-docker-container-as-a-non-root-user-7d2e00f8ee15)



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
