### PR TITLE
Add --resource-type to az account get-access-token

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,11 +2,12 @@
 
 Release History
 ===============
+* Added ossrdbmsResourceId to cloud.py.
+
 2.0.70
 ++++++
 * no changes
 
-**ACR**
 2.0.69
 ++++++
 * Fixed issue where `--subscription` would appear despite being suppressed on certain commands.

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -63,7 +63,8 @@ class CloudEndpoints(object):  # pylint: disable=too-few-public-methods,too-many
                  microsoft_graph_resource_id=None,
                  active_directory_data_lake_resource_id=None,
                  vm_image_alias_doc=None,
-                 media_resource_id=None):
+                 media_resource_id=None,
+                 ossrdbms_resource_id=None):
         # Attribute names are significant. They are used when storing/retrieving clouds from config
         self.management = management
         self.resource_manager = resource_manager
@@ -77,6 +78,7 @@ class CloudEndpoints(object):  # pylint: disable=too-few-public-methods,too-many
         self.active_directory_data_lake_resource_id = active_directory_data_lake_resource_id
         self.vm_image_alias_doc = vm_image_alias_doc
         self.media_resource_id = media_resource_id
+        self.ossrdbms_resource_id = ossrdbms_resource_id
 
     def has_endpoint_set(self, endpoint_name):
         try:
@@ -165,7 +167,8 @@ AZURE_PUBLIC_CLOUD = Cloud(
         microsoft_graph_resource_id='https://graph.microsoft.com/',
         active_directory_data_lake_resource_id='https://datalake.azure.net/',
         vm_image_alias_doc='https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json',  # pylint: disable=line-too-long
-        media_resource_id='https://rest.media.azure.net'),
+        media_resource_id='https://rest.media.azure.net',
+        ossrdbms_resource_id='https://ossrdbms-aad.database.windows.net'),
     suffixes=CloudSuffixes(
         storage_endpoint='core.windows.net',
         keyvault_dns='.vault.azure.net',
@@ -187,7 +190,8 @@ AZURE_CHINA_CLOUD = Cloud(
         active_directory_graph_resource_id='https://graph.chinacloudapi.cn/',
         microsoft_graph_resource_id='https://microsoftgraph.chinacloudapi.cn',
         vm_image_alias_doc='https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json',  # pylint: disable=line-too-long
-        media_resource_id='https://rest.media.chinacloudapi.cn'),
+        media_resource_id='https://rest.media.chinacloudapi.cn',
+        ossrdbms_resource_id='https://ossrdbms-aad.database.chinacloudapi.cn'),
     suffixes=CloudSuffixes(
         storage_endpoint='core.chinacloudapi.cn',
         keyvault_dns='.vault.azure.cn',
@@ -207,7 +211,8 @@ AZURE_US_GOV_CLOUD = Cloud(
         active_directory_graph_resource_id='https://graph.windows.net/',
         microsoft_graph_resource_id='https://graph.microsoft.us/',
         vm_image_alias_doc='https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json',  # pylint: disable=line-too-long
-        media_resource_id='https://rest.media.usgovcloudapi.net'),
+        media_resource_id='https://rest.media.usgovcloudapi.net',
+        ossrdbms_resource_id='https://ossrdbms-aad.database.usgovcloudapi.net'),
     suffixes=CloudSuffixes(
         storage_endpoint='core.usgovcloudapi.net',
         keyvault_dns='.vault.usgovcloudapi.net',
@@ -227,7 +232,8 @@ AZURE_GERMAN_CLOUD = Cloud(
         active_directory_graph_resource_id='https://graph.cloudapi.de/',
         microsoft_graph_resource_id='https://graph.microsoft.de',
         vm_image_alias_doc='https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json',  # pylint: disable=line-too-long
-        media_resource_id='https://rest.media.cloudapi.de'),
+        media_resource_id='https://rest.media.cloudapi.de',
+        ossrdbms_resource_id='https://ossrdbms-aad.database.cloudapi.de'),
     suffixes=CloudSuffixes(
         storage_endpoint='core.cloudapi.de',
         keyvault_dns='.vault.microsoftazure.de',

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+**Profile**
+
+* Add get-access-token --resource-type enum for convenience of getting access tokens for well-known resources.
+
 2.0.70
 ++++++
 
@@ -57,6 +62,7 @@ Release History
 **Core**
 
 * Fixed issue where `--subscription` would appear despite being not applicable.
+* Added ossrdbmsResourceId to cloud.py.
 
 **BATCH**
 

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -5,9 +5,12 @@
 
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import CliCommandType
+from azure.cli.core.commands.parameters import get_enum_type
 
 from azure.cli.command_modules.profile._format import transform_account_list
 import azure.cli.command_modules.profile._help  # pylint: disable=unused-import
+
+cloud_resource_types = ["oss-rdbms", "arm", "aad-graph", "ms-graph", "batch", "media", "data-lake"]
 
 
 class ProfileCommandsLoader(AzCommandsLoader):
@@ -68,6 +71,9 @@ class ProfileCommandsLoader(AzCommandsLoader):
 
         with self.argument_context('account show') as c:
             c.argument('show_auth_for_sdk', options_list=['--sdk-auth'], action='store_true', help='Output result to a file compatible with Azure SDK auth. Only applicable when authenticating with a Service Principal.')
+
+        with self.argument_context('account get-access-token') as c:
+            c.argument('resource_type', get_enum_type(cloud_resource_types), options_list=['--resource-type'], arg_group='', help='Type of well-known resource.')
 
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader


### PR DESCRIPTION
Because OSS RDBMS clients such as psql are community-supported, direct integration of AAD authentication into such clients is not possible. As a convenient workaround, customers can generate access tokens using the `az account get-access-token` command for use with these clients. 

Although the existing command `az account get-access-token` with the `--resource` parameter set to the ossrdbmsResourceId from `az cloud show` would work, it requires the user to type multiple commands and copy/paste the correct resourceId value.

The solution here is to add a new parameter `--resource-type` to `az account get-access-token`. The new parameter takes one of an enumerated set of well-known resource types. These types are then mapped to a resourceId field in cloud_endpoints.

For example, instead of typing:

`az account get-access-token --resource https://ossrdbms-aad.database.windows.net` 

while logged into the public cloud, the user would instead type:

`az account get-access-token --resource-type oss-rdbms`

This new parameter provides a convenient way to specify well-known resources, including for the ossrdbmsResourceId, without having to lookup and copy the entire resource URL.

This PR supersedes https://github.com/Azure/azure-cli/pull/10091 and is an attempt to cleanup what should be a pretty minor change.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
