### PR TITLE
Remove warning for Cosmos DB update

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -7,6 +7,10 @@ Release History
 
 * add "cognitiveservices account network-rule" commands.
 
+**Cosmos DB**
+
+* remove warning when updating multiple write locations
+
 **HDInsight**
 
 * BREAKING CHANGE:

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -191,9 +191,6 @@ def cli_cosmosdb_update(client,
 
     if enable_multiple_write_locations is None:
         enable_multiple_write_locations = existing.enable_multiple_write_locations
-    elif enable_multiple_write_locations != existing.enable_multiple_write_locations \
-            and not enable_multiple_write_locations:
-        logger.warning("Updating the account from multi master to single master will take 24 hours to complete.")
 
     params = DatabaseAccountCreateUpdateParameters(
         location=existing.location,


### PR DESCRIPTION
Removing warning that disabling multiple write locations will take 24 hours to complete.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
