### PR TITLE
keyvault: fix the bug in secret set command that igores the expires argument

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -7,10 +7,6 @@ Release History
 
 * Fix the bug in secret set command that igores the expires argument
 
-
-2.0.71
-++++++
-
 **AppService**
 
 * az webapp webjob continuous group commands were failing for slots

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ===============
 
+**keyvault**
+
+* Fix the bug in secret set command that igores the expires argument
+
+
+2.0.71
+++++++
+
 **AppService**
 
 * az webapp webjob continuous group commands were failing for slots

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -48,7 +48,7 @@ def process_certificate_cancel_namespace(namespace):
     namespace.cancellation_requested = True
 
 
-def process_secret_set_namespace(namespace):
+def process_secret_set_namespace(cmd, namespace):
     validate_tags(namespace)
 
     content = namespace.value
@@ -60,6 +60,16 @@ def process_secret_set_namespace(namespace):
 
     if (content and file_path) or (not content and not file_path):
         raise use_error
+
+    from azure.cli.core.profiles import ResourceType
+    SecretAttributes = cmd.get_models('SecretAttributes', resource_type=ResourceType.DATA_KEYVAULT)
+    namespace.secret_attributes = SecretAttributes()
+    if namespace.expires:
+        namespace.secret_attributes.expires = namespace.expires
+    if namespace.disabled:
+        namespace.secret_attributes.enabled = not namespace.disabled
+    if namespace.not_before:
+        namespace.secret_attributes.not_before = namespace.not_before
 
     encoding = encoding or 'utf-8'
     if file_path:


### PR DESCRIPTION
Fix #8052

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
