### PR TITLE
Make "find" examples work on Windows

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/find/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/find/_help.py
@@ -12,11 +12,11 @@ helps['find'] = """
     examples:
         - name: Give me any Azure CLI group and I’ll show the most popular commands within the group.
           text: |
-            az find 'az storage'
+            az find "az storage"
         - name: Give me any Azure CLI command and I’ll show the most popular parameters and subcommands.
           text: |
-            az find 'az monitor activity-log list'
+            az find "az monitor activity-log list"
         - name: You can also enter a search term, and I'll try to help find the best commands.
           text: |
-            az find 'arm template'
+            az find "arm template"
 """


### PR DESCRIPTION
The examples originally use single quotes, but that doesn't work on Windows cmd.exe:

C:\Users\mikebaz>az find 'arm template'
az: error: unrecognized arguments: template'

Double quotes works correctly.  This may be a lingering issue throughout the commands - this is fixing one that just caught me.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
