### PR TITLE
aks: remove outdated comment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1399,7 +1399,6 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False,
                        'by running "az aks enable-addons --addons kube-dashboard".')
 
     _, browse_path = tempfile.mkstemp()
-    # TODO: need to add an --admin option?
     aks_get_credentials(cmd, client, resource_group_name, name, admin=False, path=browse_path)
 
     # find the dashboard pod's name


### PR DESCRIPTION
Removes an old comment that could be distracting to readers of the code. (The answer to its question was "no": we shouldn't ever use the admin version of the kubeconfig for accessing the dashboard.)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
