### PR TITLE
Fix: azure.cli.core refers to azure.cli.command_modules

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -44,6 +44,7 @@ except AttributeError:  # in Python 2.7
     t_JSONDecodeError = ValueError
 
 logger = get_logger(__name__)
+DEFAULT_CACHE_TTL = '10'
 
 
 def _explode_list_args(args):
@@ -357,7 +358,6 @@ def _is_stale(cli_ctx, cache_obj):
         cls_str = str(ex.__class__)
         if 'NoOptionError' in cls_str or 'NoSectionError' in cls_str:
             # ensure a default value exists even if not previously set
-            from azure.cli.command_modules.configure._consts import DEFAULT_CACHE_TTL
             cli_ctx.config.set_value('core', 'cache_ttl', DEFAULT_CACHE_TTL)
             cache_ttl = DEFAULT_CACHE_TTL
         else:

--- a/src/azure-cli/azure/cli/command_modules/configure/_consts.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/_consts.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from azure.cli.core.commands import DEFAULT_CACHE_TTL
+
 OUTPUT_LIST = [
     {'name': 'json', 'desc': 'JSON formatted output that most closely matches API responses.'},
     {'name': 'jsonc',
@@ -42,5 +44,4 @@ MSG_PROMPT_TELEMETRY = '\nMicrosoft would like to collect anonymous Azure CLI us
                        'again.\nSelect y to enable data collection.'
 MSG_PROMPT_FILE_LOGGING = '\nWould you like to enable logging to file?'
 
-DEFAULT_CACHE_TTL = '10'
 MSG_PROMPT_CACHE_TTL = '\nCLI object cache time-to-live (TTL) in minutes [Default: {}]: '.format(DEFAULT_CACHE_TTL)


### PR DESCRIPTION
Move `DEFAULT_CACHE_TTL` to `src/azure-cli-core/azure/cli/core/commands/__init__.py` to break loop reference between `azure.cli.core` and `azure.cli.command_modules`.