### PR TITLE
Ensure transfer is complete before execution

### DIFF
--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -36,6 +36,8 @@ function assert_consent {
 
 global_consent=0 # Artificially giving global consent after review-feedback. Remove this line to enable interactive mode
 
+setup() {
+
 assert_consent "Add packages necessary to modify your apt-package sources?" ${global_consent}
 set -v
 apt-get update
@@ -57,3 +59,7 @@ set +v
 
 assert_consent "Install the Azure CLI?" ${global_consent}
 apt-get install -y azure-cli
+
+}
+
+setup


### PR DESCRIPTION
This script is being published via https://aka.ms/InstallAzureCLIDeb and being used in a `curl | bash` way. In order to avoid partial execution in case of incomplete transfers, wrap the whole setup in a bash function which is called when the transfer is completed.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
