### PR TITLE
[AKS] Add support of ACR integration

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -10,6 +10,13 @@ Release History
 * [BREAKING] When not specified, the default value for `--start-task-wait-for-success` on `az batch pool create` is now true (was false).
 * [BREAKING] The default value for Scope on AutoUserSpecification is now always Pool (was Task on Windows nodes, Pool on Linux nodes). This argument is not exposed via the commandline, but can be set in the `--json-file` arguments.
 
+**AKS**
+
+* Add support of ACR integration, which includes
+  * Add `--attach-acr <acr-name-or-resource-id>` to `az aks create` command, which allows for attach the ACR to AKS cluster.
+  * Add `--attach-acr <acr-name-or-resource-id>` and `--detach-acr <acr-name-or-resource-id>` to `az aks update` command, which allows to attach or detach the ACR from AKS cluster.
+
+
 2.0.72
 ++++++
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -4,7 +4,9 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
+from azure.cli.core.commands.parameters import get_resources_in_subscription
 from azure.cli.core.profiles import ResourceType
+from knack.util import CLIError
 
 
 def cf_compute_service(cli_ctx, *_):
@@ -31,6 +33,11 @@ def cf_resource_groups(cli_ctx, subscription_id=None):
 def cf_resources(cli_ctx, subscription_id=None):
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,
                                    subscription_id=subscription_id).resources
+
+
+def cf_container_registry_service(cli_ctx, subscription_id=None):
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CONTAINERREGISTRY,
+                                   subscription_id=subscription_id)
 
 
 def get_auth_management_client(cli_ctx, scope=None, **_):
@@ -69,3 +76,34 @@ def get_graph_rbac_management_client(cli_ctx, **_):
         base_url=cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
     configure_common_settings(cli_ctx, client)
     return client
+
+
+def get_resource_by_name(cli_ctx, resource_name, resource_type):
+    """Returns the ARM resource in the current subscription with resource_name.
+    :param str resource_name: The name of resource
+    :param str resource_type: The type of resource
+    """
+    result = get_resources_in_subscription(cli_ctx, resource_type)
+    elements = [item for item in result if item.name.lower() ==
+                resource_name.lower()]
+
+    if not elements:
+        from azure.cli.core._profile import Profile
+        profile = Profile(cli_ctx=cli_ctx)
+        message = "The resource with name '{}' and type '{}' could not be found".format(
+            resource_name, resource_type)
+        try:
+            subscription = profile.get_subscription(
+                cli_ctx.data['subscription_id'])
+            raise CLIError(
+                "{} in subscription '{} ({})'.".format(message, subscription['name'], subscription['id']))
+        except (KeyError, TypeError):
+            raise CLIError(
+                "{} in the current subscription.".format(message))
+
+    elif len(elements) == 1:
+        return elements[0]
+    else:
+        raise CLIError(
+            "More than one resources with type '{}' are found with name '{}'.".format(
+                resource_type, resource_name))

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -280,7 +280,9 @@ parameters:
   - name: --workspace-resource-id
     type: string
     short-summary: The resource ID of an existing Log Analytics Workspace to use for storing monitoring data. If not specified, uses the default Log Analytics Workspace if it exists, otherwise creates one.
-
+  - name: --attach-acr
+    type: string
+    short-summary: Grant the 'acrpull' role assignment to the ACR specified by name or resource ID.
 examples:
   - name: Create a Kubernetes cluster with an existing SSH public key.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --ssh-key-value /path/to/publickey
@@ -614,6 +616,21 @@ examples:
   - name: Use Azure Dev Spaces with a managed Kubernetes cluster, selecting a new or existing dev space \\ 'develop/my-space' without prompting for confirmation.
     text: |-
         az aks use-dev-spaces -g my-aks-group -n my-aks -s develop/my-space -y
+"""
+
+helps['aks update'] = """
+type: command
+short-summary: Update a managed Kubernetes cluster to attach or detach ACR
+parameters:
+  - name: --attach-acr
+    type: string
+    short-summary: Grant the 'acrpull' role assignment to the ACR specified by name or resource ID.
+  - name: --detach-acr
+    type: string
+    short-summary: Disable the 'acrpull' role assignment to the ACR specified by name or resource ID.
+examples:
+  - name: Attach AKS cluster to ACR by name "acrName"
+    text: az aks update -g MyResourceGroup -n MyManagedCluster --attach-acr acrName
 """
 
 helps['aks wait'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -12,6 +12,7 @@ from argcomplete.completers import FilesCompleter
 from azure.cli.core.commands.parameters import (
     file_type, get_enum_type, get_resource_name_completion_list, name_type, tags_type)
 from azure.cli.core.commands.validators import validate_file_or_dict
+from knack.arguments import CLIArgumentType
 
 from ._completers import (
     get_vm_size_completion_list, get_k8s_versions_completion_list, get_k8s_upgrades_completion_list)
@@ -61,6 +62,8 @@ storage_profile_types = ["StorageAccount", "ManagedDisks"]
 
 
 def load_arguments(self, _):
+
+    acr_arg_type = CLIArgumentType(metavar='ACR_NAME_OR_RESOURCE_ID')
 
     # ACS command argument configuration
     with self.argument_context('acs') as c:
@@ -179,6 +182,11 @@ def load_arguments(self, _):
         c.argument('vnet_subnet_id')
         c.argument('workspace_resource_id')
         c.argument('skip_subnet_role_assignment', action='store_true')
+        c.argument('attach_acr', acr_arg_type)
+
+    with self.argument_context('aks update') as c:
+        c.argument('attach_acr', acr_arg_type)
+        c.argument('detach_acr', acr_arg_type)
 
     with self.argument_context('aks disable-addons') as c:
         c.argument('addons', options_list=['--addons', '-a'])

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -16,6 +16,7 @@ from ._format import aks_upgrades_table_format
 from ._format import aks_versions_table_format
 
 
+# pylint: disable=too-many-statements
 def load_command_table(self, _):
 
     container_services_sdk = CliCommandType(
@@ -85,6 +86,7 @@ def load_command_table(self, _):
                          'Are you sure you want to perform this operation?')
         g.custom_command('upgrade-connector', 'k8s_upgrade_connector', is_preview=True)
         g.custom_command('use-dev-spaces', 'aks_use_dev_spaces')
+        g.custom_command('update', 'aks_update', supports_no_wait=True)
         g.wait_command('wait')
 
     with self.command_group('aks', container_services_sdk, client_factory=cf_container_services) as g:


### PR DESCRIPTION
 Add support of ACR integration, which includes

* Add `--attach-acr <acr-name-or-resource-id>` to `az aks create` command, which allows for attach the ACR to AKS cluster.
* Add `--attach-acr <acr-name-or-resource-id>` and `--detach-acr <acr-name-or-resource-id>` to `az aks update` command, which allows to attach or detach the ACR from AKS cluster.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
