### PR TITLE
[Storage] Fix #10228: Remove --auth-mode in az storage remove

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -22,8 +22,8 @@ Release History
 * Expanded `--json-file` capabilities of `az batch pool create` to allow for specifying MountConfigurations for file system mounts(see https://docs.microsoft.com/en-us/rest/api/batchservice/pool/add#request-body for structure)
 * Expanded `--json-file` capabilities of `az batch pool create` with the optional property publicIPs on NetworkConfiguration. This allows specifying publicIPs to be used when deploying pools (see https://docs.microsoft.com/en-us/rest/api/batchservice/pool/add#request-body for structure)
 * Expanded `--image` capabilities to support Shared Image Galleries images. Similar to the commands support for Managed Images, to use a Shared Image Gallery image simply use the ARM ID as the value to the argument.
-* [BREAKING] When not specified, the default value for `--start-task-wait-for-success` on `az batch pool create` is now true (was false).
-* [BREAKING] The default value for Scope on AutoUserSpecification is now always Pool (was Task on Windows nodes, Pool on Linux nodes). This argument is not exposed via the commandline, but can be set in the `--json-file` arguments.
+* [BREAKING CHANGE] When not specified, the default value for `--start-task-wait-for-success` on `az batch pool create` is now true (was false).
+* [BREAKING CHANGE] The default value for Scope on AutoUserSpecification is now always Pool (was Task on Windows nodes, Pool on Linux nodes). This argument is not exposed via the commandline, but can be set in the `--json-file` arguments.
 
 **HDInsight**
 
@@ -34,7 +34,6 @@ Release History
 
 * Fix #10286: Unable to delete subnet from network rules.
 * Fix: Duplicated subnets and IP addresses can be added to network rules.
-
 
 **Network**
 
@@ -48,7 +47,7 @@ Release History
 
 **Storage**
 
-`az storage remove`: remove --auth-mode argument
+* [BREAKING CHANGE] `az storage remove`: remove --auth-mode argument
 
 2.0.72
 ++++++

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -35,6 +35,7 @@ Release History
 * Fix #10286: Unable to delete subnet from network rules.
 * Fix: Duplicated subnets and IP addresses can be added to network rules.
 
+
 **Network**
 
 * az network watcher flow-log: Fix #8132. Support `--interval` to set traffic analysis interval value.
@@ -44,6 +45,10 @@ Release History
 **Policy**
 
 * Support for Policy new API version 2019-01-01
+
+**Storage**
+
+`az storage remove`: remove --auth-mode argument
 
 2.0.72
 ++++++

--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -51,7 +51,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('storage', command_type=block_blob_sdk,
                             custom_command_type=get_custom_sdk('azcopy', blob_data_service_factory)) as g:
-        g.storage_custom_command_oauth('remove', 'storage_remove', is_preview=True)
+        g.storage_custom_command('remove', 'storage_remove', is_preview=True)
 
     with self.command_group('storage', custom_command_type=get_custom_sdk('azcopy', None)) as g:
         g.custom_command('copy', 'storage_copy', is_preview=True)


### PR DESCRIPTION

Fix #10228
---
Because --auth-mode is not supported for file share now, original --auth-mode argument cannot work and will confuse customers. Remove this argument now and add back when service side is ready.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
