### PR TITLE
POC: redact sensitive storage account info from debug logger

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
@@ -139,6 +139,9 @@ def cf_sa(cli_ctx, _):
 
 
 def cf_sa_for_keys(cli_ctx, _):
+    from knack.log import get_logger
+    logger = get_logger(__name__)
+    logger.debug('Redact HTTP response body to avoid including storage keys in body')
     client = storage_client_factory(cli_ctx)
     client.config.enable_http_logger = False
     return client.storage_accounts

--- a/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import msrest
 from azure.cli.core.commands.client_factory import get_mgmt_service_client, get_data_service_client
 from azure.cli.core.profiles import ResourceType, get_sdk
 
@@ -21,25 +20,6 @@ Missing credentials to access storage service. The following variations are acce
         set AZURE_STORAGE_CONNECTION_STRING environment variable); some shells will require
         quoting to preserve literal character interpretation.
 """
-
-
-def log_response_securely(policy_object, request, response, **kwargs):
-    # logic here was cloned from msrest.pipeline.SansIOHTTPPolicy
-    if kwargs.get("enable_http_logger", policy_object.enable_http_logger):
-        if 'listKeys?' in request.http_request.url and response.http_response.status_code == 200:
-            import logging
-            _LOGGER = logging.getLogger(__name__)
-            if not _LOGGER.isEnabledFor(logging.DEBUG):
-                return
-
-            _LOGGER.debug("Response status: %r", response.http_response.status_code)
-            _LOGGER.debug("Response headers:")
-            for res_header, value in response.http_response.headers.items():
-                _LOGGER.debug("    %r: %r", res_header, value)
-
-            _LOGGER.debug("Response content: *****REDACTED")
-        else:
-            msrest.http_logger.log_response(None, request.http_request, response.http_response, result=response)
 
 
 def get_storage_data_service_client(cli_ctx, service, name=None, key=None, connection_string=None, sas_token=None,
@@ -66,9 +46,7 @@ def generic_data_service_factory(cli_ctx, service, name=None, key=None, connecti
 
 
 def storage_client_factory(cli_ctx, **_):
-    msrest.pipeline.universal.HTTPLogger.on_response = log_response_securely
-    client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_STORAGE)
-    return client
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_STORAGE)
 
 
 def file_data_service_factory(cli_ctx, kwargs):
@@ -158,6 +136,12 @@ def multi_service_properties_factory(cli_ctx, kwargs):
 
 def cf_sa(cli_ctx, _):
     return storage_client_factory(cli_ctx).storage_accounts
+
+
+def cf_sa_for_keys(cli_ctx, _):
+    client = storage_client_factory(cli_ctx)
+    client.config.enable_http_logger = False
+    return client.storage_accounts
 
 
 def cf_mgmt_policy(cli_ctx, _):

--- a/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
@@ -141,7 +141,7 @@ def cf_sa(cli_ctx, _):
 def cf_sa_for_keys(cli_ctx, _):
     from knack.log import get_logger
     logger = get_logger(__name__)
-    logger.debug('Redact HTTP response body to avoid including storage keys in body')
+    logger.debug('Disable HTTP logging to avoid having storage keys in debug logs')
     client = storage_client_factory(cli_ctx)
     client.config.enable_http_logger = False
     return client.storage_accounts

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -33,6 +33,7 @@ def _query_account_key(cli_ctx, account_name):
         cli_ctx, ResourceType.MGMT_STORAGE, 'models.storage_account_keys#StorageAccountKeys')
 
     scf.config.enable_http_logger = False
+    logger.debug('Redact HTTP response body to avoid including storage keys in body')
     if t_storage_account_keys:
         return scf.storage_accounts.list_keys(rg, account_name).key1
     # of type: models.storage_account_list_keys_result#StorageAccountListKeysResult

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -5,13 +5,13 @@
 
 # pylint: disable=protected-access
 
-from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.validators import validate_key_value_pairs
 from azure.cli.core.profiles import ResourceType, get_sdk
 
 from azure.cli.command_modules.storage._client_factory import (get_storage_data_service_client,
                                                                blob_data_service_factory,
-                                                               file_data_service_factory)
+                                                               file_data_service_factory,
+                                                               storage_client_factory)
 from azure.cli.command_modules.storage.util import glob_files_locally, guess_content_type
 from azure.cli.command_modules.storage.sdkutil import get_table_data_type
 from azure.cli.command_modules.storage.url_quote_util import encode_for_url
@@ -40,7 +40,7 @@ def _query_account_key(cli_ctx, account_name):
 
 def _query_account_rg(cli_ctx, account_name):
     """Query the storage account's resource group, which the mgmt sdk requires."""
-    scf = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_STORAGE)
+    scf = storage_client_factory(cli_ctx)
     acc = next((x for x in scf.storage_accounts.list() if x.name == account_name), None)
     if acc:
         from msrestazure.tools import parse_resource_id

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -33,7 +33,7 @@ def _query_account_key(cli_ctx, account_name):
         cli_ctx, ResourceType.MGMT_STORAGE, 'models.storage_account_keys#StorageAccountKeys')
 
     scf.config.enable_http_logger = False
-    logger.debug('Redact HTTP response body to avoid including storage keys in body')
+    logger.debug('Disable HTTP logging to avoid having storage keys in debug logs')
     if t_storage_account_keys:
         return scf.storage_accounts.list_keys(rg, account_name).key1
     # of type: models.storage_account_list_keys_result#StorageAccountListKeysResult

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -32,6 +32,7 @@ def _query_account_key(cli_ctx, account_name):
     t_storage_account_keys = get_sdk(
         cli_ctx, ResourceType.MGMT_STORAGE, 'models.storage_account_keys#StorageAccountKeys')
 
+    scf.config.enable_http_logger = False
     if t_storage_account_keys:
         return scf.storage_accounts.list_keys(rg, account_name).key1
     # of type: models.storage_account_list_keys_result#StorageAccountListKeysResult

--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -9,7 +9,7 @@ from azure.cli.command_modules.storage._client_factory import (cf_sa, cf_blob_co
                                                                cloud_storage_account_service_factory,
                                                                multi_service_properties_factory,
                                                                cf_mgmt_policy,
-                                                               cf_blob_data_gen_update)
+                                                               cf_blob_data_gen_update, cf_sa_for_keys)
 from azure.cli.command_modules.storage.sdkutil import cosmosdb_table_exists
 from azure.cli.command_modules.storage._format import transform_immutability_policy
 from azure.cli.core.commands import CliCommandType
@@ -21,6 +21,12 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
     storage_account_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.storage.operations#StorageAccountsOperations.{}',
         client_factory=cf_sa,
+        resource_type=ResourceType.MGMT_STORAGE
+    )
+
+    storage_account_sdk_keys = CliCommandType(
+        operations_tmpl='azure.mgmt.storage.operations#StorageAccountsOperations.{}',
+        client_factory=cf_sa_for_keys,
         resource_type=ResourceType.MGMT_STORAGE
     )
 
@@ -71,6 +77,8 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                          'show_storage_account_connection_string')
         g.generic_update_command('update', getter_name='get_properties', setter_name='update',
                                  custom_func_name='update_storage_account', min_api='2016-12-01')
+
+    with self.command_group('storage account', storage_account_sdk_keys, resource_type=ResourceType.MGMT_STORAGE) as g:
         g.command('keys renew', 'regenerate_key',
                   transform=lambda x: getattr(x, 'keys', x))
         g.command('keys list', 'list_keys',

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -6,7 +6,7 @@
 """Custom operations for storage account commands"""
 
 import os
-from azure.cli.command_modules.storage._client_factory import storage_client_factory
+from azure.cli.command_modules.storage._client_factory import storage_client_factory, cf_sa_for_keys
 from azure.cli.core.util import get_file_json, shell_safe_json_parse
 
 
@@ -60,8 +60,8 @@ def show_storage_account_connection_string(cmd, resource_group_name, account_nam
     endpoint_suffix = cmd.cli_ctx.cloud.suffixes.storage_endpoint
     connection_string = 'DefaultEndpointsProtocol={};EndpointSuffix={}'.format(protocol, endpoint_suffix)
     if account_name is not None:
-        scf = storage_client_factory(cmd.cli_ctx)
-        obj = scf.storage_accounts.list_keys(resource_group_name, account_name, enable_http_logger=False)  # pylint: disable=no-member
+        scf = cf_sa_for_keys(cmd.cli_ctx, None)
+        obj = scf.list_keys(resource_group_name, account_name)  # pylint: disable=no-member
         try:
             keys = [obj.keys[0].value, obj.keys[1].value]  # pylint: disable=no-member
         except AttributeError:

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -61,7 +61,7 @@ def show_storage_account_connection_string(cmd, resource_group_name, account_nam
     connection_string = 'DefaultEndpointsProtocol={};EndpointSuffix={}'.format(protocol, endpoint_suffix)
     if account_name is not None:
         scf = storage_client_factory(cmd.cli_ctx)
-        obj = scf.storage_accounts.list_keys(resource_group_name, account_name)  # pylint: disable=no-member
+        obj = scf.storage_accounts.list_keys(resource_group_name, account_name, enable_http_logger=False)  # pylint: disable=no-member
         try:
             keys = [obj.keys[0].value, obj.keys[1].value]  # pylint: disable=no-member
         except AttributeError:


### PR DESCRIPTION
@lmazuel, please let me know whether the patch here is sustainable, otherwise, we need to expose a hook from the pipeline for client applications to redact in anyway they prefer; or any other options you would suggest.
 
CC @Juliehzl

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
