### PR TITLE
Put azure_bdist_wheel.py in MANIFEST.in file.

### DIFF
--- a/src/azure-cli-core/MANIFEST.in
+++ b/src/azure-cli-core/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst
+include azure_bdist_wheel.py

--- a/src/azure-cli-telemetry/MANIFEST.in
+++ b/src/azure-cli-telemetry/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst
+include azure_bdist_wheel.py

--- a/src/azure-cli-testsdk/MANIFEST.in
+++ b/src/azure-cli-testsdk/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst
+include azure_bdist_wheel.py

--- a/src/azure-cli/MANIFEST.in
+++ b/src/azure-cli/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE.txt
 include HISTORY.rst
 include README.rst
+include azure_bdist_wheel.py


### PR DESCRIPTION
`pip wheel SDIST_SOURCE` may throw "command 'bdist_wheel' has no
such option 'azure_namespace_package'". We need to include
azure_bdist_wheel.py in MANIFEST.in to avoid such errors.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
