### PR TITLE
EventGrid: Fix help text to point to the right endpoint parameter in Event Subscriptions commands

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -13,6 +13,10 @@ Release History
 
 * Fix #8840: When using tenant domain name in `az login -t`, `keyvault create` fails. Tenant domain name is now resolved to GUID if it is not.
 
+**EventGrid**
+
+* Fix the endpoint help text to refer to the right parameter (namely, to point to parameter `--endpoint` rather than `--endpoint-type` in event subscription commands).
+
 **Monitor**
 
 * monitor metrics alert create: Fix #9901. Support special character `:` in `--condition` argument.

--- a/src/azure-cli/azure/cli/command_modules/eventgrid/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/eventgrid/_help.py
@@ -168,7 +168,6 @@ parameters:
         Example: --deadletter-endpoint /subscriptions/{SubID}/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/sa1/blobServices/default/containers/containerName
   - name: --endpoint-type
     short-summary: The type of the destination endpoint.
-    long-summary: The type of the destination endpoint. It is expected that the destination endpoint be created and available for use before executing any Event Grid command.
 examples:
   - name: Create a new event subscription for an Event Grid topic, using default filters.
     text: |

--- a/src/azure-cli/azure/cli/command_modules/eventgrid/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/eventgrid/_params.py
@@ -64,7 +64,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements
         c.argument('endpoint_type', arg_type=get_enum_type(['webhook', 'eventhub', 'storagequeue', 'hybridconnection', 'servicebusqueue'], default='webhook'))
         c.argument('source_resource_id', help="Fully qualified identifier of the source Azure resource.")
         c.argument('resource_id', deprecate_info=c.deprecate(redirect="--source-resource-id", expiration='2.1.0', hide=True), help="Fully qualified identifier of the Azure resource.")
-        c.argument('endpoint', help="Endpoint where EventGrid should deliver events matching this event subscription. For webhook endpoint type, this should be the corresponding webhook URL. For other endpoint types, this should be the Azure resource identifier of the endpoint.")
+        c.argument('endpoint', help="Endpoint where EventGrid should deliver events matching this event subscription. For webhook endpoint type, this should be the corresponding webhook URL. For other endpoint types, this should be the Azure resource identifier of the endpoint. It is expected that the destination endpoint to be already created and available for use before executing any Event Grid command.")
         c.argument('event_subscription_name', help="Name of the event subscription.")
         c.argument('subject_begins_with', help="An optional string to filter events for an event subscription based on a prefix. Wildcard characters are not supported.")
         c.argument('subject_ends_with', help="An optional string to filter events for an event subscription based on a suffix. Wildcard characters are not supported.")


### PR DESCRIPTION
Port #10376 which has the conflicts hard to resolve; hence I am opening a new one.

CC @ahamad-MS 

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
