### PR TITLE
Fix alignment in az --version

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -145,8 +145,8 @@ def get_az_version_string():
         local = version_dict['local']
         pypi = version_dict.get('pypi', None)
         if pypi and LooseVersion(pypi) > LooseVersion(local):
-            return name.ljust(20) + local.rjust(20) + ' *'
-        return name.ljust(20) + local.rjust(20)
+            return name.ljust(25) + local.rjust(15) + ' *'
+        return name.ljust(25) + local.rjust(15)
 
     ver_string = _get_version_string(CLI_PACKAGE_NAME, versions.pop(CLI_PACKAGE_NAME))
     if '*' in ver_string:


### PR DESCRIPTION
```
> az --version
azure-cli                         2.0.73

command-modules-nspkg               2.0.3
core                              2.0.73
nspkg                              3.0.4
telemetry                          1.0.3
testsdk                            0.2.4
```
⬇
```
> az --version
azure-cli                         2.0.73

command-modules-nspkg              2.0.3   << Aligned
core                              2.0.73
nspkg                              3.0.4
telemetry                          1.0.3
testsdk                            0.2.4
```