### PR TITLE
Az CLI: monitor help: fix references (typo)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_help.py
@@ -815,7 +815,7 @@ parameters:
 
         Dimensions can be queried by adding the 'where' keyword and multiple dimensions can be queried by combining them with the 'and' keyword.
 
-        Values for METRIC, DIMENSION and appropriate THRESHOLD values can be obtained from `az monitor metrics list-definition` command.
+        Values for METRIC, DIMENSION and appropriate THRESHOLD values can be obtained from `az monitor metrics list-definitions` command.
 
         Multiple conditons can be specified by using more than one `--condition` argument.
 examples:
@@ -875,7 +875,7 @@ parameters:
 
         Dimensions can be queried by adding the 'where' keyword and multiple dimensions can be queried by combining them with the 'and' keyword.
 
-        Values for METRIC, DIMENSION and appropriate THRESHOLD values can be obtained from `az monitor metrics list-definition` command.
+        Values for METRIC, DIMENSION and appropriate THRESHOLD values can be obtained from `az monitor metrics list-definitions` command.
 
         Multiple conditons can be specified by using more than one `--condition` argument.
   - name: --remove-conditions


### PR DESCRIPTION
Fix small inconsistency in the help of the cli I encountered in `az monitor metrics`:

Change `list-definition` (wrong) into `list-definitions` (correct)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
