### PR TITLE
Update CI. Increase timeout for Run Automation, Python 2/3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -332,6 +332,7 @@ jobs:
 - job: RunAutomationFullPython2
   displayName: Run Automation, Python 2
   dependsOn: BuildPythonWheel
+  timeoutInMinutes: 90
 
   pool:
     vmImage: 'ubuntu-16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -356,6 +356,7 @@ jobs:
 - job: RunAutomationReducedPython3
   displayName: Run Automation, Python 3
   dependsOn: BuildPythonWheel
+  timeoutInMinutes: 90
 
   pool:
     vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
Update CI. Increase timeout for Run Automation, Python 2/3

I have seen this timeout error more than once. The normal lasting time for this task is 50+ minutes. Sometimes, it’s over 60 minutes. We use a default timeout, which is 60 minutes. It’s not enough. We are adding more and more test cases, so we need a larger timeout.

```
Run Automation, Python 3
2 error(s), 0 warning(s)
The job running on agent Azure Pipelines 47 has exceeded the maximum execution time of 60. For more information, see https://go.microsoft.com/fwlink/?linkid=2077134
The operation was canceled. 
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
