### PR TITLE
set tabulate version to be exactly 0.8.3

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -70,6 +70,7 @@ DEPENDENCIES = [
     'six',
     'wheel==0.30.0',
     'azure-mgmt-resource~=4.0',
+    'tabulate==0.8.3'
 ]
 
 TESTS_REQUIRE = [

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -149,7 +149,8 @@ DEPENDENCIES = [
     'websocket-client~=0.56.0',
     'xmltodict~=0.12',
     'javaproperties==0.5.1',
-    'jsondiff==1.2.0'
+    'jsondiff==1.2.0',
+    'tabulate==0.8.3'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -32,7 +32,7 @@ DEPENDENCIES = [
     'pyyaml',
     'knack',
     'six>=1.10.0',
-    'tabulate>=0.7.7',
+    'tabulate==0.8.3',
     'colorama>=0.3.7'
 ]
 


### PR DESCRIPTION
Latest 0.8.4 errors when installing. https://bitbucket.org/astanin/python-tabulate/issues/182/tabulate-fails-to-install-on-windows

Locking to 0.8.3.