### PR TITLE
use openssl 1.1 for homebrew formula

### DIFF
--- a/scripts/release/homebrew/docker/formula_template.txt
+++ b/scripts/release/homebrew/docker/formula_template.txt
@@ -10,7 +10,7 @@ class AzureCli < Formula
 
 {{ bottle_hash }}
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "python"
 
 {{ resources }}


### PR DESCRIPTION
As requested by homebrew maintainer [here ](https://github.com/Homebrew/homebrew-core/pull/44128#discussion_r323129572), need to use open ssl 1.1