### PR TITLE
Continue parsing image argument if aliases doc unreachable

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -254,7 +254,7 @@ def _parse_image_argument(cmd, namespace):
 
     # 4 - attempt to match an URN alias (most likely)
     from azure.cli.command_modules.vm._actions import load_images_from_aliases_doc
-    from requests.exceptions import ConnectionError
+    import requests
     try:
         images = load_images_from_aliases_doc(cmd.cli_ctx)
         matched = next((x for x in images if x['urnAlias'].lower() == namespace.image.lower()), None)
@@ -264,7 +264,7 @@ def _parse_image_argument(cmd, namespace):
             namespace.os_sku = matched['sku']
             namespace.os_version = matched['version']
             return 'urn'
-    except ConnectionError:
+    except requests.exceptions.ConnectionError:
         pass
 
     # 5 - check if an existing managed disk image resource

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -254,14 +254,17 @@ def _parse_image_argument(cmd, namespace):
 
     # 4 - attempt to match an URN alias (most likely)
     from azure.cli.command_modules.vm._actions import load_images_from_aliases_doc
-    images = load_images_from_aliases_doc(cmd.cli_ctx)
-    matched = next((x for x in images if x['urnAlias'].lower() == namespace.image.lower()), None)
-    if matched:
-        namespace.os_publisher = matched['publisher']
-        namespace.os_offer = matched['offer']
-        namespace.os_sku = matched['sku']
-        namespace.os_version = matched['version']
-        return 'urn'
+    try:
+        images = load_images_from_aliases_doc(cmd.cli_ctx)
+        matched = next((x for x in images if x['urnAlias'].lower() == namespace.image.lower()), None)
+        if matched:
+            namespace.os_publisher = matched['publisher']
+            namespace.os_offer = matched['offer']
+            namespace.os_sku = matched['sku']
+            namespace.os_version = matched['version']
+            return 'urn'
+    except requests.exceptions.ConnectionError:
+        pass
 
     # 5 - check if an existing managed disk image resource
     compute_client = _compute_client_factory(cmd.cli_ctx)
@@ -271,9 +274,14 @@ def _parse_image_argument(cmd, namespace):
                                            'images', 'Microsoft.Compute')
         return 'image_id'
     except CloudError:
-        err = 'Invalid image "{}". Use a valid image URN, custom image name, custom image id, VHD blob URI, or ' \
-              'pick an image from {}.\nSee vm create -h for more information on specifying an image.'
-        raise CLIError(err.format(namespace.image, [x['urnAlias'] for x in images]))
+        if images != None:
+            err = 'Invalid image "{}". Use a valid image URN, custom image name, custom image id, VHD blob URI, or ' \
+                  'pick an image from {}.\nSee vm create -h for more information on specifying an image.'.format(namespace.image, [x['urnAlias'] for x in images])
+        else:
+            err = 'Failed to connect to remote source of image aliases. Invalid image "{}". Use a valid image URN, ' \
+                  'custom image name, custom image id, or VHD blob URI.\nSee vm create -h for more information on ' \
+                  'specifying an image.'.format(namespace.image)
+        raise CLIError(err)
 
 
 def _get_image_plan_info_if_exists(cmd, namespace):


### PR DESCRIPTION
Currently the Azure CLI does not work in environments without public internet access when trying to use the managed disk image in `#5` of the _parse_image_argument function. 

This fix ignores the ConnectionError in `#4` when trying to lookup the aliases doc from `githubusercontent.com` and proceeds to `#5`. If `#5` does not match then it will return the error message:
```
Failed to connect to remote source of image aliases. Invalid image "{}". Use a valid image URN, customer image name, customer image id, or VHD blob URI.
See vm create -h for more information on specifying an image.
```



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
