### PR TITLE
Fix #10630: Add --preserve-s2s-access-tier parameter for az storage copy

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -85,13 +85,14 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
 
 # pylint: disable=too-many-instance-attributes
 class StorageAccountPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
-    def __init__(self, name_prefix='clitest', sku='Standard_LRS', location='westus', parameter_name='storage_account',
+    def __init__(self, name_prefix='clitest', sku='Standard_LRS', location='westus', kind='Storage', parameter_name='storage_account',
                  resource_group_parameter_name='resource_group', skip_delete=True,
                  dev_setting_name='AZURE_CLI_TEST_DEV_STORAGE_ACCOUNT_NAME', key='sa'):
         super(StorageAccountPreparer, self).__init__(name_prefix, 24)
         self.cli_ctx = get_dummy_cli()
         self.location = location
         self.sku = sku
+        self.kind = kind
         self.resource_group_parameter_name = resource_group_parameter_name
         self.skip_delete = skip_delete
         self.parameter_name = parameter_name
@@ -102,8 +103,8 @@ class StorageAccountPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
         group = self._get_resource_group(**kwargs)
 
         if not self.dev_setting_name:
-            template = 'az storage account create -n {} -g {} -l {} --sku {}'
-            self.live_only_execute(self.cli_ctx, template.format(name, group, self.location, self.sku))
+            template = 'az storage account create -n {} -g {} -l {} --sku {} --kind {}'
+            self.live_only_execute(self.cli_ctx, template.format(name, group, self.location, self.sku, self.kind))
         else:
             name = self.dev_setting_name
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -15,6 +15,10 @@ Release History
 
 * az network private-dns link vnet create/update: Fixes #9851. Support cross-tenant virtual network linking.
 
+**Storage**
+
+* az storage copy: Add --s2sPreserveAccessTier parameter to preserve access tier during service to service copy.
+
 2.0.74
 ++++++
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -17,7 +17,7 @@ Release History
 
 **Storage**
 
-* az storage copy: Add --s2sPreserveAccessTier parameter to preserve access tier during service to service copy.
+* az storage copy: Add --preserve-s2s-access-tier parameter to preserve access tier during service to service copy.
 
 2.0.74
 ++++++

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -397,7 +397,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                    help='Preserve access tier during service to service copy. '
                    'Please refer to https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers '
                    'to ensure destination storage account support setting access tier. In the cases that setting '
-                   'access tier is not supported, please use `--s2sPreserveAccessTier false` to bypass copying access '
+                   'access tier is not supported, please use `--preserve-s2s-access-tier false` to bypass copying access '
                    'tier. (Default true)')
 
     with self.argument_context('storage blob copy') as c:

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -397,8 +397,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                    help='Preserve access tier during service to service copy. '
                    'Please refer to https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers '
                    'to ensure destination storage account support setting access tier. In the cases that setting '
-                   'access tier is not supported, please use `--preserve-s2s-access-tier false` to bypass copying access '
-                   'tier. (Default true)')
+                   'access tier is not supported, please use `--preserve-s2s-access-tier false` to bypass copying '
+                   'access tier. (Default true)')
 
     with self.argument_context('storage blob copy') as c:
         for item in ['destination', 'source']:

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -385,12 +385,18 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                        help='File path in file share of copy {} storage account'.format(item))
             c.argument('{}_local_path'.format(item), arg_group='Copy {}'.format(item),
                        help='Local file path')
-        c.argument('recursive', action='store_true', help='Look into sub-directories \
+        c.argument('recursive', arg_group='Additional Flags', action='store_true', help='Look into sub-directories \
                     recursively when uploading from local file system.')
-        c.argument('put_md5', action='store_true', help='Create an MD5 hash of each file, and save the hash \
+        c.argument('put_md5', arg_group='Additional Flags', action='store_true', help='Create an MD5 hash of each file, and save the hash \
                     as the Content-MD5 property of the destination blob/file.Only available when uploading.')
-        c.argument('blob_type', arg_type=get_enum_type(["BlockBlob", "PageBlob", "AppendBlob"]),
+        c.argument('blob_type', arg_group='Additional Flags', arg_type=get_enum_type(["BlockBlob", "PageBlob", "AppendBlob"]),
                    help='The type of blob at the destination.')
+        c.argument('s2s_preserve_access_tier', arg_group='Additional Flags', arg_type=get_three_state_flag(),
+                   help='Preserve access tier during service to service copy. '
+                   'Please refer to https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers '
+                   'to ensure destination storage account support setting access tier. In the cases that setting '
+                   'access tier is not supported, please use --s2sPreserveAccessTier=false to bypass copying access tier.'
+                   ' (Default true)')
 
     with self.argument_context('storage blob copy') as c:
         for item in ['destination', 'source']:

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -387,16 +387,18 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                        help='Local file path')
         c.argument('recursive', arg_group='Additional Flags', action='store_true', help='Look into sub-directories \
                     recursively when uploading from local file system.')
-        c.argument('put_md5', arg_group='Additional Flags', action='store_true', help='Create an MD5 hash of each file, and save the hash \
-                    as the Content-MD5 property of the destination blob/file.Only available when uploading.')
-        c.argument('blob_type', arg_group='Additional Flags', arg_type=get_enum_type(["BlockBlob", "PageBlob", "AppendBlob"]),
+        c.argument('put_md5', arg_group='Additional Flags', action='store_true',
+                   help='Create an MD5 hash of each file, and save the hash as the Content-MD5 property of the '
+                   'destination blob/file.Only available when uploading.')
+        c.argument('blob_type', arg_group='Additional Flags',
+                   arg_type=get_enum_type(["BlockBlob", "PageBlob", "AppendBlob"]),
                    help='The type of blob at the destination.')
         c.argument('s2s_preserve_access_tier', arg_group='Additional Flags', arg_type=get_three_state_flag(),
                    help='Preserve access tier during service to service copy. '
                    'Please refer to https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers '
                    'to ensure destination storage account support setting access tier. In the cases that setting '
-                   'access tier is not supported, please use --s2sPreserveAccessTier=false to bypass copying access tier.'
-                   ' (Default true)')
+                   'access tier is not supported, please use --s2sPreserveAccessTier=false to bypass copying access '
+                   'tier. (Default true)')
 
     with self.argument_context('storage blob copy') as c:
         for item in ['destination', 'source']:

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -393,11 +393,11 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('blob_type', arg_group='Additional Flags',
                    arg_type=get_enum_type(["BlockBlob", "PageBlob", "AppendBlob"]),
                    help='The type of blob at the destination.')
-        c.argument('s2s_preserve_access_tier', arg_group='Additional Flags', arg_type=get_three_state_flag(),
+        c.argument('preserve_s2s_access_tier', arg_group='Additional Flags', arg_type=get_three_state_flag(),
                    help='Preserve access tier during service to service copy. '
                    'Please refer to https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers '
                    'to ensure destination storage account support setting access tier. In the cases that setting '
-                   'access tier is not supported, please use --s2sPreserveAccessTier=false to bypass copying access '
+                   'access tier is not supported, please use `--s2sPreserveAccessTier false` to bypass copying access '
                    'tier. (Default true)')
 
     with self.argument_context('storage blob copy') as c:

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -93,7 +93,7 @@ def storage_copy(cmd, source=None,
     if blob_type is not None:
         flags.append('--blob-type=' + blob_type)
     if s2s_preserve_access_tier is not None:
-        flags.append('--s2s-preserve-access-tier=' + s2s_preserve_access_tier)
+        flags.append('--s2s-preserve-access-tier=' + str(s2s_preserve_access_tier))
 
     azcopy.copy(full_source, full_destination, flags=flags)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -15,7 +15,7 @@ def storage_copy(cmd, source=None,
                  put_md5=None,
                  recursive=None,
                  blob_type=None,
-                 s2s_preserve_access_tier=None,
+                 preserve_s2s_access_tier=None,
                  source_account_name=None,
                  source_container=None,
                  source_blob=None,
@@ -92,8 +92,8 @@ def storage_copy(cmd, source=None,
         flags.append('--put-md5')
     if blob_type is not None:
         flags.append('--blob-type=' + blob_type)
-    if s2s_preserve_access_tier is not None:
-        flags.append('--s2s-preserve-access-tier=' + str(s2s_preserve_access_tier))
+    if preserve_s2s_access_tier is not None:
+        flags.append('--s2s-preserve-access-tier=' + str(preserve_s2s_access_tier))
 
     azcopy.copy(full_source, full_destination, flags=flags)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -15,6 +15,7 @@ def storage_copy(cmd, source=None,
                  put_md5=None,
                  recursive=None,
                  blob_type=None,
+                 s2s_preserve_access_tier=None,
                  source_account_name=None,
                  source_container=None,
                  source_blob=None,
@@ -91,6 +92,8 @@ def storage_copy(cmd, source=None,
         flags.append('--put-md5')
     if blob_type is not None:
         flags.append('--blob-type=' + blob_type)
+    if s2s_preserve_access_tier is not None:
+        flags.append('--s2s-preserve-access-tier=' + s2s_preserve_access_tier)
 
     azcopy.copy(full_source, full_destination, flags=flags)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -245,7 +245,17 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.assertEqual(1, sum(len(d) for r, d, f in os.walk(local_folder)))
         self.assertEqual(21, sum(len(f) for r, d, f in os.walk(local_folder)))
 
+        # Copy a single blob to another single blob
+        self.cmd('storage copy -s "{}" -d "{}" --s2s-preserve-access-tier false'.format(
+            '{}/readme'.format(first_container_url), second_container_url))
+        self.cmd('storage blob list -c {} --account-name {}'
+                 .format(second_container, second_account), checks=JMESPathCheck('length(@)', 1))
 
+        # Copy an entire directory from blob virtual directory to another blob virtual directory
+        self.cmd('storage copy -s "{}" -d "{}" --recursive --s2s-preserve-access-tier false'.format(
+            '{}/apple'.format(first_container_url), second_container_url))
+        self.cmd('storage blob list -c {} --account-name {}'
+                 .format(second_container, second_account), checks=JMESPathCheck('length(@)', 11))
 
         # Copy an entire storage account data to another blob account
         self.cmd('storage copy -s "{}" -d "{}" --recursive --s2s-preserve-access-tier false'.format(

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -192,7 +192,7 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='first_account')
-    @StorageAccountPreparer(parameter_name='second_account', sku='Premium_LRS')
+    @StorageAccountPreparer(parameter_name='second_account', sku='Premium_LRS', kind='BlockBlobStorage')
     @StorageTestFilesPreparer()
     def test_storage_azcopy_blob_url(self, resource_group, first_account, second_account, test_dir):
 
@@ -246,6 +246,10 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.assertEqual(21, sum(len(f) for r, d, f in os.walk(local_folder)))
 
         # Copy a single blob to another single blob
+        self.cmd('storage account show -n {}'.format(second_account), checks=[
+            self.check('kind', 'BlockBlobStorage')
+        ])
+
         self.cmd('storage copy -s "{}" -d "{}" --s2s-preserve-access-tier false'.format(
             '{}/readme'.format(first_container_url), second_container_url))
         self.cmd('storage blob list -c {} --account-name {}'
@@ -278,7 +282,7 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='first_account')
-    @StorageAccountPreparer(parameter_name='second_account')
+    @StorageAccountPreparer(parameter_name='second_account', sku='Premium_LRS', kind='BlockBlobStorage')
     @StorageTestFilesPreparer()
     def test_storage_azcopy_blob_account(self, resource_group, first_account, second_account, test_dir):
 
@@ -327,20 +331,20 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
 
         # Copy a single blob to another single blob
         self.cmd('storage copy --source-account-name {} --source-container {} --source-blob {} \
-                 --destination-account-name {} --destination-container {}'
+                 --destination-account-name {} --destination-container {} --s2s-preserve-access-tier false'
                  .format(first_account, first_container, 'readme', second_account, second_container))
         self.cmd('storage blob list -c {} --account-name {}'
                  .format(second_container, second_account), checks=JMESPathCheck('length(@)', 1))
 
         # Copy an entire directory from blob virtual directory to another blob virtual directory
         self.cmd('storage copy --source-account-name {} --source-container {} --source-blob {} \
-                 --destination-account-name {} --destination-container {} --recursive'
+                 --destination-account-name {} --destination-container {} --recursive --s2s-preserve-access-tier false'
                  .format(first_account, first_container, 'apple', second_account, second_container))
         self.cmd('storage blob list -c {} --account-name {}'
                  .format(second_container, second_account), checks=JMESPathCheck('length(@)', 11))
 
         # Copy an entire storage account data to another blob account
-        self.cmd('storage copy --source-account-name {} --destination-account-name {} --recursive'
+        self.cmd('storage copy --source-account-name {} --destination-account-name {} --recursive --s2s-preserve-access-tier false'
                  .format(first_account, second_account))
         self.cmd('storage container list --account-name {}'
                  .format(second_account), checks=JMESPathCheck('length(@)', 2))

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -250,19 +250,19 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
             self.check('kind', 'BlockBlobStorage')
         ])
 
-        self.cmd('storage copy -s "{}" -d "{}" --s2s-preserve-access-tier false'.format(
+        self.cmd('storage copy -s "{}" -d "{}" --preserve-s2s-access-tier false'.format(
             '{}/readme'.format(first_container_url), second_container_url))
         self.cmd('storage blob list -c {} --account-name {}'
                  .format(second_container, second_account), checks=JMESPathCheck('length(@)', 1))
 
         # Copy an entire directory from blob virtual directory to another blob virtual directory
-        self.cmd('storage copy -s "{}" -d "{}" --recursive --s2s-preserve-access-tier false'.format(
+        self.cmd('storage copy -s "{}" -d "{}" --recursive --preserve-s2s-access-tier false'.format(
             '{}/apple'.format(first_container_url), second_container_url))
         self.cmd('storage blob list -c {} --account-name {}'
                  .format(second_container, second_account), checks=JMESPathCheck('length(@)', 11))
 
         # Copy an entire storage account data to another blob account
-        self.cmd('storage copy -s "{}" -d "{}" --recursive --s2s-preserve-access-tier false'.format(
+        self.cmd('storage copy -s "{}" -d "{}" --recursive --preserve-s2s-access-tier false'.format(
             first_account_url, second_account_url))
         self.cmd('storage container list --account-name {}'
                  .format(second_account), checks=JMESPathCheck('length(@)', 2))
@@ -331,20 +331,20 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
 
         # Copy a single blob to another single blob
         self.cmd('storage copy --source-account-name {} --source-container {} --source-blob {} \
-                 --destination-account-name {} --destination-container {} --s2s-preserve-access-tier false'
+                 --destination-account-name {} --destination-container {} --preserve-s2s-access-tier false'
                  .format(first_account, first_container, 'readme', second_account, second_container))
         self.cmd('storage blob list -c {} --account-name {}'
                  .format(second_container, second_account), checks=JMESPathCheck('length(@)', 1))
 
         # Copy an entire directory from blob virtual directory to another blob virtual directory
         self.cmd('storage copy --source-account-name {} --source-container {} --source-blob {} \
-                 --destination-account-name {} --destination-container {} --recursive --s2s-preserve-access-tier false'
+                 --destination-account-name {} --destination-container {} --recursive --preserve-s2s-access-tier false'
                  .format(first_account, first_container, 'apple', second_account, second_container))
         self.cmd('storage blob list -c {} --account-name {}'
                  .format(second_container, second_account), checks=JMESPathCheck('length(@)', 11))
 
         # Copy an entire storage account data to another blob account
-        self.cmd('storage copy --source-account-name {} --destination-account-name {} --recursive --s2s-preserve-access-tier false'
+        self.cmd('storage copy --source-account-name {} --destination-account-name {} --recursive --preserve-s2s-access-tier false'
                  .format(first_account, second_account))
         self.cmd('storage container list --account-name {}'
                  .format(second_account), checks=JMESPathCheck('length(@)', 2))

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -192,7 +192,7 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='first_account')
-    @StorageAccountPreparer(parameter_name='second_account')
+    @StorageAccountPreparer(parameter_name='second_account', sku='Premium_LRS')
     @StorageTestFilesPreparer()
     def test_storage_azcopy_blob_url(self, resource_group, first_account, second_account, test_dir):
 
@@ -245,20 +245,10 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.assertEqual(1, sum(len(d) for r, d, f in os.walk(local_folder)))
         self.assertEqual(21, sum(len(f) for r, d, f in os.walk(local_folder)))
 
-        # Copy a single blob to another single blob
-        self.cmd('storage copy -s "{}" -d "{}"'.format(
-            '{}/readme'.format(first_container_url), second_container_url))
-        self.cmd('storage blob list -c {} --account-name {}'
-                 .format(second_container, second_account), checks=JMESPathCheck('length(@)', 1))
 
-        # Copy an entire directory from blob virtual directory to another blob virtual directory
-        self.cmd('storage copy -s "{}" -d "{}" --recursive'.format(
-            '{}/apple'.format(first_container_url), second_container_url))
-        self.cmd('storage blob list -c {} --account-name {}'
-                 .format(second_container, second_account), checks=JMESPathCheck('length(@)', 11))
 
         # Copy an entire storage account data to another blob account
-        self.cmd('storage copy -s "{}" -d "{}" --recursive'.format(
+        self.cmd('storage copy -s "{}" -d "{}" --recursive --s2s-preserve-access-tier false'.format(
             first_account_url, second_account_url))
         self.cmd('storage container list --account-name {}'
                  .format(second_account), checks=JMESPathCheck('length(@)', 2))

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -271,8 +271,8 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
 
         # Upload to managed disk
         diskname = self.create_random_name(prefix='disk', length=12)
-        local_file = self.create_temp_file(1024)
-        self.cmd('disk create -n {} -g {} --for-upload -z 1'
+        local_file = self.create_temp_file(20480)
+        self.cmd('disk create -n {} -g {} --for-upload --upload-size-bytes 20972032'
                  .format(diskname, resource_group))
         sasURL = self.cmd(
             'disk grant-access --access-level Write --duration-in-seconds 3600 -n {} -g {} --query accessSas'


### PR DESCRIPTION
Fix #10630
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
