### PR TITLE
ci: disable 'Integration for profiles'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,11 @@ jobs:
       python: 2.7
       env: TOXENV=py27
       script: ./scripts/ci/unittest.sh
-    - stage: verify
-      script: ./scripts/ci/test_profile_integration.sh
-      env: PURPOSE='Integration for profiles'
-      python: 3.6
+    #  Disable it due to https://github.com/Azure/azure-cli/issues/10721
+    # - stage: verify
+    #  script: ./scripts/ci/test_profile_integration.sh
+    #  env: PURPOSE='Integration for profiles'
+    #  python: 3.6
     - stage: verify
       script: ./scripts/ci/test_profile_integration.sh
       env: PURPOSE='Integration for profiles'


### PR DESCRIPTION
This is to unblock CI. I have opened a tracking issue https://github.com/Azure/azure-cli/issues/10721

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
