### PR TITLE
Openshift/azure monitoring cli

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+**Azure Red Hat OpenShift**
+
+* Add `--workspace-resource-id` flag to allow creation of Azure Red Hat Openshift cluster with monitoring
+* Add `monitor_profile` to create Azure Red Hat OpenShift cluster with monitoring
 
 **AKS**
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -896,6 +896,9 @@ parameters:
   - name: --customer-admin-group-id
     type: string
     short-summary: The Object ID of an Azure Active Directory Group that memberships will get synced into the OpenShift group "osa-customer-admins". If not specified, no cluster admin access will be granted.
+  - name: --loganalytics-workspace-resource-id
+    type: string
+    short-summary: The resource ID of an existing Log Analytics Workspace to use for storing monitoring data.
 
 
 examples:
@@ -907,6 +910,8 @@ examples:
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --aad-client-app-id {APP_ID} --aad-client-app-secret {APP_SECRET} --aad-tenant-id {TENANT_ID} --compute-count 5
   - name: Create an Openshift cluster using a custom vnet
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --vnet-peer "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/openshift-vnet/providers/Microsoft.Network/virtualNetworks/test"
+  - name: Create an Openshift cluster with Log Analytics monitoring enabled
+    text: az openshift create -g MyResourceGroup -n MyManagedCluster --loganalytics-workspace-resource-id {LOGANALYTICS_WORKSPACE_RESOURCE_ID}
 """
 
 helps['openshift delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -896,7 +896,7 @@ parameters:
   - name: --customer-admin-group-id
     type: string
     short-summary: The Object ID of an Azure Active Directory Group that memberships will get synced into the OpenShift group "osa-customer-admins". If not specified, no cluster admin access will be granted.
-  - name: --loganalytics-workspace-resource-id
+  - name: --workspace-resource-id
     type: string
     short-summary: The resource ID of an existing Log Analytics Workspace to use for storing monitoring data.
 
@@ -911,7 +911,7 @@ examples:
   - name: Create an Openshift cluster using a custom vnet
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --vnet-peer "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/openshift-vnet/providers/Microsoft.Network/virtualNetworks/test"
   - name: Create an Openshift cluster with Log Analytics monitoring enabled
-    text: az openshift create -g MyResourceGroup -n MyManagedCluster --loganalytics-workspace-resource-id {LOGANALYTICS_WORKSPACE_RESOURCE_ID}
+    text: az openshift create -g MyResourceGroup -n MyManagedCluster --workspace-resource-id {WORKSPACE_RESOURCE_ID}
 """
 
 helps['openshift delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -321,7 +321,7 @@ def load_arguments(self, _):
         c.argument('name', validator=validate_linux_host_name)
         c.argument('compute_vm_size', options_list=['--compute-vm-size', '-s'])
         c.argument('customer_admin_group_id', options_list=['--customer-admin-group-id'])
-        c.argument('loganalytics_workspace_resource_id')
+        c.argument('workspace_resource_id')
 
 
 def _get_default_install_location(exe_name):

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -321,6 +321,7 @@ def load_arguments(self, _):
         c.argument('name', validator=validate_linux_host_name)
         c.argument('compute_vm_size', options_list=['--compute-vm-size', '-s'])
         c.argument('customer_admin_group_id', options_list=['--customer-admin-group-id'])
+        c.argument('loganalytics_workspace_resource_id')
 
 
 def _get_default_install_location(exe_name):

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3126,7 +3126,7 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
                      vnet_peer=None,
                      tags=None,
                      no_wait=False,
-                     loganalytics_workspace_resource_id=None,
+                     workspace_resource_id=None,
                      customer_admin_group_id=None):
 
     if location is None:
@@ -3197,13 +3197,13 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
                 namespace='Microsoft.Network', type='virtualNetwork',
                 name=vnet_peer
             )
-    if loganalytics_workspace_resource_id is not None:
-        loganalytics_workspace_resource_id = loganalytics_workspace_resource_id.strip()
-        if not loganalytics_workspace_resource_id.startswith('/'):
-            loganalytics_workspace_resource_id = '/' + loganalytics_workspace_resource_id
-        if loganalytics_workspace_resource_id.endswith('/'):
-            loganalytics_workspace_resource_id = loganalytics_workspace_resource_id.rstrip('/')
-        monitor_profile = OpenShiftManagedClusterMonitorProfile(enabled=True, loganalytics_workspace_resource_id=loganalytics_workspace_resource_id)  # pylint: disable=line-too-long
+    if workspace_resource_id is not None:
+        workspace_resource_id = workspace_resource_id.strip()
+        if not workspace_resource_id.startswith('/'):
+            workspace_resource_id = '/' + workspace_resource_id
+        if workspace_resource_id.endswith('/'):
+            workspace_resource_id = workspace_resource_id.rstrip('/')
+        monitor_profile = OpenShiftManagedClusterMonitorProfile(enabled=True, workspace_resource_id=workspace_resource_id)  # pylint: disable=line-too-long
     else:
         monitor_profile = None
 

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -81,6 +81,8 @@ from azure.mgmt.containerservice.v2019_04_30.models import OpenShiftManagedClust
 from azure.mgmt.containerservice.v2019_04_30.models import OpenShiftRouterProfile
 from azure.mgmt.containerservice.v2019_04_30.models import OpenShiftManagedClusterAuthProfile
 from azure.mgmt.containerservice.v2019_04_30.models import NetworkProfile
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftManagedCluster as OpenShiftManagedClusterMonitor  # pylint: disable=line-too-long
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftManagedClusterMonitorProfile
 
 from ._client_factory import cf_container_services
 from ._client_factory import cf_resource_groups
@@ -3124,6 +3126,7 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
                      vnet_peer=None,
                      tags=None,
                      no_wait=False,
+                     loganalytics_workspace_resource_id=None,
                      customer_admin_group_id=None):
 
     if location is None:
@@ -3194,17 +3197,37 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
                 namespace='Microsoft.Network', type='virtualNetwork',
                 name=vnet_peer
             )
+    if loganalytics_workspace_resource_id is not None:
+        loganalytics_workspace_resource_id = loganalytics_workspace_resource_id.strip()
+        if not loganalytics_workspace_resource_id.startswith('/'):
+            loganalytics_workspace_resource_id = '/' + loganalytics_workspace_resource_id
+        if loganalytics_workspace_resource_id.endswith('/'):
+            loganalytics_workspace_resource_id = loganalytics_workspace_resource_id.rstrip('/')
+        monitor_profile = OpenShiftManagedClusterMonitorProfile(enabled=True, loganalytics_workspace_resource_id=loganalytics_workspace_resource_id)  # pylint: disable=line-too-long
+    else:
+        monitor_profile = None
 
     network_profile = NetworkProfile(vnet_cidr=vnet_prefix, peer_vnet_id=vnet_peer)
 
-    osamc = OpenShiftManagedCluster(
-        location=location, tags=tags,
-        open_shift_version="v3.11",
-        network_profile=network_profile,
-        auth_profile=auth_profile,
-        agent_pool_profiles=agent_pool_profiles,
-        master_pool_profile=agent_master_pool_profile,
-        router_profiles=[default_router_profile])
+    if monitor_profile is not None:
+        osamc = OpenShiftManagedClusterMonitor(
+            location=location, tags=tags,
+            open_shift_version="v3.11",
+            network_profile=network_profile,
+            auth_profile=auth_profile,
+            agent_pool_profiles=agent_pool_profiles,
+            master_pool_profile=agent_master_pool_profile,
+            router_profiles=[default_router_profile],
+            monitor_profile=monitor_profile)
+    else:
+        osamc = OpenShiftManagedCluster(
+            location=location, tags=tags,
+            open_shift_version="v3.11",
+            network_profile=network_profile,
+            auth_profile=auth_profile,
+            agent_pool_profiles=agent_pool_profiles,
+            master_pool_profile=agent_master_pool_profile,
+            router_profiles=[default_router_profile])
 
     try:
         # long_running_operation_timeout=300


### PR DESCRIPTION
- Import `OpenShiftManagedClusterMonitorProfile` 
- Create help example for `openshift create` to be used with `--workspace_resource_id`
- Add `monitor_profile` to `OpenShiftManagedCluster`
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
