### PR TITLE
Python 3.8 support

### DIFF
--- a/src/azure-cli-command_modules-nspkg/setup.py
+++ b/src/azure-cli-command_modules-nspkg/setup.py
@@ -22,6 +22,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -43,12 +43,8 @@ class Session(collections.MutableMapping):
         try:
             if max_age > 0:
                 st = os.stat(self.filename)
-                try:
-                    if st.st_mtime + max_age < time.process_time():
-                        self.save()
-                except AttributeError:  # in Python 2.7
-                    if st.st_mtime + max_age < time.clock():
-                        self.save()
+                if st.st_mtime + max_age < time.time():
+                    self.save()
             with codecs_open(self.filename, 'r', encoding=self._encoding) as f:
                 self.data = json.load(f)
         except (OSError, IOError, t_JSONDecodeError) as load_exception:

--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -43,8 +43,12 @@ class Session(collections.MutableMapping):
         try:
             if max_age > 0:
                 st = os.stat(self.filename)
-                if st.st_mtime + max_age < time.clock():
-                    self.save()
+                try:
+                    if st.st_mtime + max_age < time.process_time():
+                        self.save()
+                except AttributeError:  # in Python 2.7
+                    if st.st_mtime + max_age < time.clock():
+                        self.save()
             with codecs_open(self.filename, 'r', encoding=self._encoding) as f:
                 self.data = json.load(f)
         except (OSError, IOError, t_JSONDecodeError) as load_exception:

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -49,6 +49,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli-nspkg/setup.py
+++ b/src/azure-cli-nspkg/setup.py
@@ -22,6 +22,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -30,6 +30,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -27,6 +27,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -49,6 +49,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'License :: OSI Approved :: MIT License',
 ]
 


### PR DESCRIPTION
time.clock() was deprecated in Python 3.3, and removed in Python 3.8. Python 3.8 will be released on 14th October. See [PEP 596](https://www.python.org/dev/peps/pep-0569/) for more info.

Tested locally against Python 3.8.0rc1.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
