### PR TITLE
[Testsdk] Add resource group name prefix validator in resource group preparer

### DIFF
--- a/src/azure-cli-testsdk/HISTORY.rst
+++ b/src/azure-cli-testsdk/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+
+* Add resource group name prefix validator in resource group preparer
+
 0.2.4
 +++++
 * Add ManagedApplicationPreparer

--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -50,6 +50,8 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
                  dev_setting_name='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME',
                  dev_setting_location='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION',
                  random_name_length=75, key='rg'):
+        if ' ' in name_prefix:
+            raise CliTestError('Error: Space character in resource group name prefix \'%s\'' % name_prefix)
         super(ResourceGroupPreparer, self).__init__(name_prefix, random_name_length)
         self.cli_ctx = get_dummy_cli()
         self.location = location


### PR DESCRIPTION
```
class VMCreateSpecialName(ScenarioTest):

    @ResourceGroupPreparer(name_prefix='cli_test_vm create_special_name_')
    def test_vm_create_special_name(self, resource_group):
```
Once a time, I miss a '_' in name_prefix, then the following error occurs, which is confusing. It cost me many minutes to find cause. 
```
ERROR: az: error: unrecognized arguments: create_special_name_2xlzojtmqjmvlv4ukdmwj3r7q5oawd5jpz67lvmmrei
usage: az [-h] [--verbose] [--debug]
          [--output {json,jsonc,table,tsv,yaml,none}] [--query JMESPATH]
          {group} ...
```
Now the error message becomes:
```
azure.cli.testsdk.exceptions.CliTestError: An error caused by the CLI test harness failed the test: Error: Space character in resource group name prefix 'cli_test_vm create_special_name_'
```
, which is more understandable.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
