### PR TITLE
[Storage]: Change help message for --https-only parameter in az storage account create

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -116,6 +116,10 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('account_name', acct_name_type, options_list=['--name', '-n'], completer=None)
         c.argument('kind', help='Indicates the type of storage account.',
                    arg_type=get_enum_type(t_kind, default='storage'))
+        c.argument('https_only', arg_type=get_three_state_flag(), min_api='2019-04-01',
+                   help='Allow https traffic only to storage service if set to true. The default value is true.')
+        c.argument('https_only', arg_type=get_three_state_flag(), max_api='2018-11-01',
+                   help='Allow https traffic only to storage service if set to true. The default value is false.')
         c.argument('tags', tags_type)
         c.argument('custom_domain', help='User domain assigned to the storage account. Name is the CNAME source.')
         c.argument('sku', help='The storage account SKU.', arg_type=get_enum_type(t_sku_name, default='standard_ragrs'))

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -24,13 +24,13 @@ def create_storage_account(cmd, resource_group_name, account_name, sku=None, loc
     scf = storage_client_factory(cmd.cli_ctx)
     logger.warning("The default kind for created storage account will change to 'StorageV2' from 'Storage' in future")
     params = StorageAccountCreateParameters(sku=Sku(name=sku), kind=Kind(kind), location=location, tags=tags)
-    if custom_domain is not None:
+    if custom_domain:
         params.custom_domain = CustomDomain(name=custom_domain, use_sub_domain=None)
-    if encryption_services is not None:
+    if encryption_services:
         params.encryption = Encryption(services=encryption_services)
-    if access_tier is not None:
+    if access_tier:
         params.access_tier = AccessTier(access_tier)
-    if assign_identity is not None:
+    if assign_identity:
         params.identity = Identity()
     if https_only is not None:
         params.enable_https_traffic_only = https_only
@@ -38,7 +38,7 @@ def create_storage_account(cmd, resource_group_name, account_name, sku=None, loc
         AzureFilesIdentityBasedAuthentication = cmd.get_models('AzureFilesIdentityBasedAuthentication')
         params.azure_files_identity_based_authentication = AzureFilesIdentityBasedAuthentication(
             directory_service_options='AADDS' if enable_files_aadds else 'None')
-    if enable_large_file_share is not None:
+    if enable_large_file_share:
         LargeFileSharesState = cmd.get_models('LargeFileSharesState')
         params.large_file_shares_state = LargeFileSharesState("Enabled")
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -24,21 +24,21 @@ def create_storage_account(cmd, resource_group_name, account_name, sku=None, loc
     scf = storage_client_factory(cmd.cli_ctx)
     logger.warning("The default kind for created storage account will change to 'StorageV2' from 'Storage' in future")
     params = StorageAccountCreateParameters(sku=Sku(name=sku), kind=Kind(kind), location=location, tags=tags)
-    if custom_domain:
+    if custom_domain is not None:
         params.custom_domain = CustomDomain(name=custom_domain, use_sub_domain=None)
-    if encryption_services:
+    if encryption_services is not None:
         params.encryption = Encryption(services=encryption_services)
-    if access_tier:
+    if access_tier is not None:
         params.access_tier = AccessTier(access_tier)
-    if assign_identity:
+    if assign_identity is not None:
         params.identity = Identity()
-    if https_only:
+    if https_only is not None:
         params.enable_https_traffic_only = https_only
     if enable_files_aadds is not None:
         AzureFilesIdentityBasedAuthentication = cmd.get_models('AzureFilesIdentityBasedAuthentication')
         params.azure_files_identity_based_authentication = AzureFilesIdentityBasedAuthentication(
             directory_service_options='AADDS' if enable_files_aadds else 'None')
-    if enable_large_file_share:
+    if enable_large_file_share is not None:
         LargeFileSharesState = cmd.get_models('LargeFileSharesState')
         params.large_file_shares_state = LargeFileSharesState("Enabled")
 


### PR DESCRIPTION

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
