### PR TITLE
Update _help.py - Capitalization in CLI

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/security/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_params.py
@@ -19,7 +19,7 @@ location_arg_type = CLIArgumentType(options_list=('--location', '-l'), metavar='
 alert_status_arg_type = CLIArgumentType(options_list=('--status'), metavar='STATUS', help='target status of the alert. possible values are "dismiss" and "activate"')
 
 # Auto Provisioning
-auto_provisioning_auto_provision_arg_type = CLIArgumentType(options_list=('--auto-provision'), metavar='AUTOPROVISION', help='Automatic provisioning toggle. possible values are "on" or "off"')
+auto_provisioning_auto_provision_arg_type = CLIArgumentType(options_list=('--auto-provision'), metavar='AUTOPROVISION', help='Automatic provisioning toggle. possible values are "On" or "Off"')
 
 # Contacts
 contact_email_arg_type = CLIArgumentType(options_list=('--email'), metavar='EMAIL', help='E-mail of the security contact')


### PR DESCRIPTION
Corrected the required parameters documentation for CLI commands for the auto-provisioning-setting to correctly use the --auto-provision values of On/Off rather than on/off (the latter causes an error).



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
