### PR TITLE
[RBAC] Fix #10807: `az ad app update --id {} --display-name {}` doesn't work

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -26,6 +26,10 @@ Release History
 * Fix: `az account get-access-token --resource-type ms-graph` not working
 * Remove warning from `az login`
 
+**RBAC**
+
+* Fix #10807: `az ad app update --id {} --display-name {}` doesn't work
+
 2.0.75
 ++++++
 

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -972,6 +972,8 @@ def update_application(instance, display_name=None, homepage=None,  # pylint: di
         app_patch_param.oauth2_allow_implicit_flow = oauth2_allow_implicit_flow
     if identifier_uris is not None:
         app_patch_param.identifier_uris = identifier_uris
+    if display_name is not None:
+        app_patch_param.display_name = display_name
     if reply_urls is not None:
         app_patch_param.reply_urls = reply_urls
     if homepage is not None:

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_application_set_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_application_set_scenario.yaml
@@ -13,8 +13,8 @@ interactions:
       ParameterSetName:
       - --display-name --homepage --identifier-uris
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
@@ -34,19 +34,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:01 GMT
+      - Wed, 16 Oct 2019 08:06:43 GMT
       duration:
-      - '493997'
+      - '2497853'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - FYbVpC3JeFowFri8itMBzmKvIAPYr8LlBbuqXkPHMlA=
+      - ioV00GD0iCnKAf4rbBF9BaSdqytXkAsz7MJFOipZ4QY=
       ocp-aad-session-key:
-      - P7YMeeP8RxgtCpOykXVGtpZMkwiC5UcD87SD0AKhE8Sn3lySlF7IcyILe4hMtJPPctQgi1T3qJ1N7DQP4TCVUkMHBM93BZFWbiRqWl00Lte6wvZfyERfFuCl9hBWTrV_SBVRRdP-Tx9gIZW1JIcb_g.EeT2BobhmnAx8eqPXajzp7EBKLGYICZdLNkYxT2ilKY
+      - Szje4lXthlEr9kpK4emlZrE6q2LIy0o9_8kQqcivgS_Q228UxeZGr8fp28YOZ6KQC5YlhU_IF2k3CtlImNOQaoMC1iWhzZIlhaZqUgOlBemLRyYEOHmZrcM4wLpElpdHZOZscODkUhaiXs5PkqdNyg.aTgat_rRdiPTZhfktVu29PhWw6kza2ntI7qNd-Kloys
       pragma:
       - no-cache
       request-id:
-      - be3707d6-c61a-4731-b9a0-c96d9bfc7d5f
+      - bdfc902f-6ff8-4962-962c-d23e3d1fd933
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -77,8 +77,8 @@ interactions:
       ParameterSetName:
       - --display-name --homepage --identifier-uris
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: POST
@@ -87,21 +87,21 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "42169648-56c7-4fdc-bd12-da49f52db75f", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "b3e278fe-5210-432f-aa3e-050eb5355ed4",
+        "objectId": "68ede549-1321-42c5-bdeb-c9d527851bce", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "1fcda07c-3b39-4056-a70f-a5f0361c0fcd",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
         false, "displayName": "cli-graph000001", "errorUrl": null, "groupMembershipClaims":
         null, "homepage": "http://cli-graph000001", "identifierUris": ["http://cli-graph000001"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
         "Allow the application to access cli-graph000001 on behalf of the signed-in
-        user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "bc8d4954-af91-42a9-be13-71ecf45ad652",
+        user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "01a223f0-3f2c-4f36-a5c4-e970b8f15157",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
         to access cli-graph000001 on your behalf.", "userConsentDisplayName": "Access
         cli-graph000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
@@ -123,21 +123,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:02 GMT
+      - Wed, 16 Oct 2019 08:06:44 GMT
       duration:
-      - '2869652'
+      - '6846194'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - ZYFC41TC1iFeHL1BF0h1sw/ZuGXV+Jwa2aQ8ZB7QXAw=
+      - Z1oxbFGVWWSVUNgUJQwzH6MA8tfaPhwW0mAej+ZjmRA=
       ocp-aad-session-key:
-      - ABXq5iQ79-XOWu_eBmE5YqMJkAfbeSitGZ6dqYmcUZdjKS4F7vW28pMeDtFl5BCq6TsbdekBJnSOXn0oSYS8gpcqae3tDtvh81FOt6BO5GoxSaTyHiweZtgbDzLuGbm4Oia1YdLm7DU2C_tT6CXXmQ.ZXVoGhPA-uYu6Mawt7H60kfvisfMksurqwiUSJAalaI
+      - 0Mdw2JoTK1EBZf6U9VpLx0XEgCyMXjjqSVW-sK8g0nYNvI3nZWzfloMQNn4ZGxJrTRuFAivk4HJ9Bb8t4a0-lif5IsiCRSPdILpQRDza5UcnXwMHhzdnZHWrc7hSKq3zeQFoxLGlP9Y2IccvjA4E1g.kJRRtYVzJvg5jFakZ5SHgU5PPN4MvFEee_UWMMriScE
       pragma:
       - no-cache
       request-id:
-      - 4c01440e-07d1-4204-a8e8-76fa4fa2432e
+      - bcfc6b36-cd77-40e7-a6ef-87cae562ff56
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -163,8 +163,8 @@ interactions:
       ParameterSetName:
       - --id --append --password --years
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
@@ -184,19 +184,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:02 GMT
+      - Wed, 16 Oct 2019 08:06:44 GMT
       duration:
-      - '500323'
+      - '2389827'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - H9an+qrvBeT3NN3b3xSppbQhDiR9CXe5UeASTHq/18Y=
+      - 7Tp4SeZmHVWpitsft4pblwtoFkhCl6ghSATSpneLCJI=
       ocp-aad-session-key:
-      - okllI_9bjSQMgwRiGugH0I4Z_3E1KbbJqFqMytOfciUJfDf02GwI-MZqc_VV3tDY-XV40bmDMc1P5SuV-ZqSTU7_9X5vlZKqROjujYOv1L4PBXMh7n03iVxzq7gOUtBQ-qyCRKT3O5nkN9TYXqAVLA.NRBoe-EyDZYmLLgOcC7ZlkMuzdQRRHa_om5ByBNelug
+      - 98SRiHsF_lVDmqcRBCcfhOP4IB0blafN_zE4xHGWm5_olWQG5f2L-3oOd8ylXviAOLqxpRlHBJAbOT4JvDhiaDW5M_lf_1V0YfCx3Jl7JHwiiUvkiZ7EiPd0mBooxCKevD00rvN6YKOkrDMIVyWwow.mzAhyOJXMawaErWJY56X76-Xt4tPC7Y6mGgP1C4ggls
       pragma:
       - no-cache
       request-id:
-      - 3fa1fb1b-ec75-4f74-bd62-57ae527ae1b2
+      - 3afeee60-5696-444f-9d37-95316e3b0508
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -222,17 +222,17 @@ interactions:
       ParameterSetName:
       - --id --append --password --years
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
         cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
@@ -247,19 +247,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:03 GMT
+      - Wed, 16 Oct 2019 08:06:44 GMT
       duration:
-      - '555028'
+      - '2415945'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 2Gv1gQSfiKJpA3rt4Mi13yQYs8l/cSGK1elzeDUE/p8=
+      - 1HvD8lAPaWsbC2Joke2OmWSHZYhlf6+j+tmR6MNGsas=
       ocp-aad-session-key:
-      - Ry9tEj4bvhkVncie3WIOiDcS0qX4hK7VC5D58ULV5FtyiMx-YXMNqSlRBAdYQlG6bTuhfNEgZYlMPskTyGDhrPVxqxou07PHazLp2E-Giq_zvwcMJJf_nan8Iw_C1I0DQv8K48FZSuMpDfsWvJmn6A.NM-N2s2hNmrw3UdjJ81IHUsdLts9yb0FYg9PjrUWGJo
+      - _wTUgQ0v6clcDT0N6Oj5No1aGiWj8xlDld8p6TMV7tx3ZwIJRtEErs9-79j40ORch8ovFaudMWB0eC67insLRTmNrDMHPtGuKgmU7OFWHeMPyftOfLgWke4v5CkrV5PmUSxejSNURRx60TMPvqOmUA.HqEwuU_UO5nfvoTstu6wtFlQb9cluUs5J3f4khRKJw8
       pragma:
       - no-cache
       request-id:
-      - 4ecc81b7-1d22-41b8-97b3-caed291c0799
+      - 812dbbd5-b88e-449d-88f0-d8d99a9d8a48
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -285,17 +285,17 @@ interactions:
       ParameterSetName:
       - --id --append --password --years
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
         cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
@@ -310,19 +310,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:02 GMT
+      - Wed, 16 Oct 2019 08:06:45 GMT
       duration:
-      - '571853'
+      - '2420839'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - pMP8f8RT8BuYgTu1dfMWey3W85KBh0EioUNuKG1c8Zw=
+      - 9WXYjtljUni6R4x3ceMCi6jN8lbj4nyUqEgooMOCvq8=
       ocp-aad-session-key:
-      - dn4L1PgoAfPyYsimecvFLXayyY9P9xYXoZ1Rv5dkEzavAUWAXFtmpHQeLHGS4w2hZutXtJf4t8QzVwtilXKlbqC-UMi47CLmQ8I282kcKBfr5udsqeLMff987QdMa53Gj8Fiu28ARZOGjKi4vccMgg.1J9EL1v2FuEwKdNUCNKrOzzTKY649JJ0Afm4aVPzwpk
+      - gyBbrSgGwyJMkQIhL4PgRM1TugVHD52L2-Viqu6K3rtSThA389zOSdoWydivp3FBmFqIALsstoUmp1_kXUkyPzTkKXbHHct3sAQYf-DiH_wLQ2nRuX9VZ4ueml0Hkku2BJuxOY5GqQjh52ECFcX5hw.6uYI6Yo6CIwVmL6oEZS6L-3Ipo6lf49wj3TCt1u26ts
       pragma:
       - no-cache
       request-id:
-      - a5a0864a-ca05-4f70-bbc3-e59ccf682aab
+      - c0929f25-070a-4cde-9042-9fb34aa3c77a
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -348,12 +348,12 @@ interactions:
       ParameterSetName:
       - --id --append --password --years
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f/passwordCredentials?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce/passwordCredentials?api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)","value":[]}'
@@ -369,19 +369,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:02 GMT
+      - Wed, 16 Oct 2019 08:06:46 GMT
       duration:
-      - '547308'
+      - '2422695'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - B9hYoi04n3STjygYV8RwAIIPiCMo0VjVNVt/bvTUKGU=
+      - TDZAGBecobGZ+vWQ2KTi3URBXNSatGDNYjgtJnpnCpg=
       ocp-aad-session-key:
-      - Rs9N6mqxGt6Ky9qsRqjIRg38Aq-fJrIyKspGZRGMoQNlXp8Q7iEn9st5RZZfXL9p3HE2x-Flm3tRL7lDLVskcuhB6PI5F7Q13cCBPb5jZYMwaL9y7CnbWAT4syHlqFQm7l9p3-rWOpKAxaxaOvMfmA.kQFQz-pPcaptCYf4VkCSNVczzXME1ZOpafww3f2sC6A
+      - -tspvByid53N1qw9-WyxroKa2kD6tu1DLYPokl178eYA7x-vlKMzJP2jcc0vwX1gtL6diSxogS0xUPi-crFtJpDI1TW-bYii7NKLypkTC9reWoozfmdNhN7jz5Uitfzh6znjkUAE87jxYcflcBG4pw._4fGvyPFRUn_x0NBEic9IZ7NnCOfNaJab8jC0FkmMbg
       pragma:
       - no-cache
       request-id:
-      - e72e0bbf-e9ea-4c23-b350-9fba5ec25216
+      - b62c1094-59ec-49c0-a2d5-f6a7c78f7442
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -394,8 +394,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"passwordCredentials": [{"startDate": "2019-07-20T19:08:03.25109Z", "endDate":
-      "2021-07-20T19:08:03.25109Z", "keyId": "d62da830-67d8-40b5-91e6-d492b63526ef",
+    body: '{"passwordCredentials": [{"startDate": "2019-10-16T08:06:44.733518Z", "endDate":
+      "2021-10-16T08:06:44.733518Z", "keyId": "cfc0afdb-5307-41e2-b636-2f131c8793c4",
       "value": "test"}]}'
     headers:
       Accept:
@@ -407,18 +407,18 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '177'
+      - '179'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --id --append --password --years
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
       string: ''
@@ -428,19 +428,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Sat, 20 Jul 2019 19:08:03 GMT
+      - Wed, 16 Oct 2019 08:06:47 GMT
       duration:
-      - '2231717'
+      - '6138617'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - H0ECu2C3fj445zUSyWW2cfK9qFomYi0t8wudfuiYe+I=
+      - Xggm2lV7GH3yEUVfEvzm26S1umz7EprHWD9kDtATl70=
       ocp-aad-session-key:
-      - 8I8XGrWYAYFEOdCc_D5QRXcv1Asj0Rd8DnRmiAgNG7bBNXGU3kyPV6v1M2AcCTbOJuCs10CC6b4JHE06956OIYUc1YCmBS2ZgaigQuw386cCPfaRxWECoEmWbcyg9sre1R6Y8ma1RXkwYIBmNuVCmQ.cSgkaL2zzvvTEbPK8lbUG6To7pFRp5KesZLFAqkiUf8
+      - EvS6GE7dFS06S_FNpOcwszjvTFk5Jaujb8bv_oGCCRev4zgfGKVIw9LeinwmkX7rWuuvdUDRuQhJKo5gWrM5VdMO1HkMniL1CY5TBF-yF3LfEPLJEoRFV5I7pnvE9i-g6HbSlGFQZCypKaLizQ9QCg.tZvi0afDmH4qX5y4cimbexr-XSvW4loxmd2RwhAuq2A
       pragma:
       - no-cache
       request-id:
-      - cbc779d7-1934-4226-ba97-a8852f2f15ac
+      - 99bc6e01-8b59-4f73-9cb8-50047741a1ec
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -466,44 +466,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2175'
+      - '2177'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:04 GMT
+      - Wed, 16 Oct 2019 08:06:48 GMT
       duration:
-      - '730508'
+      - '2435778'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - zZhyt14zl0OhjZk/+0wTMqtIww9oR8AMqmXQ2MnPyJw=
+      - zvWoFjuE2ehmMVgbV3Cg2Jr+3wQYeCjyzG9gzD1iIS8=
       ocp-aad-session-key:
-      - Qcpa0r4RKB-N_327Q_NpgA_gm_D2mcbpVlBn6CCJieGT5I9WJkCDpxXvgzkpL0jkVN54vQCYspe_0pBSqpYASBZENcSR_64SYklgLxlZHzPb1YpRXhMWc_nPuQLw1fEpOS9YTa2Gv8FovDat_d5Zpw.yNACl3omWvj7IAiD5eSTA6n81J06_jE-N3HMA4XZgxo
+      - 5uWuJpPCva-6Ku8VlVob6zS6XLN7V_UBSXHRPR2HLMECNxQYLIwIM4PkUr5eWnHqv3Pc-2I2_zoxzObL2IhWDGzbU1dHIb4k6xQOLajOeR8pUC3FhHqL4U7xeJd7s2YWhK-HKQ9p1HGN0r1VykSU4Q.vp1uTxfQW17_fYXljMHRt_Cj2D2Bhfi5jn7B5gZkO2A
       pragma:
       - no-cache
       request-id:
-      - 32f2a906-8a4f-4577-b07a-b45cc9657f93
+      - 4fcc809d-c64b-409f-b44f-29fde17a6fe6
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -529,44 +529,229 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2172'
+      - '2174'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:04 GMT
+      - Wed, 16 Oct 2019 08:06:48 GMT
       duration:
-      - '547866'
+      - '2445319'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - ugNwVUhy/uil8Pg9hUjbVUCmwvlEB5WBlRSXf9K7vo0=
+      - QE46OP7QH9b9YEig+PQuzvbDRWQ4hRBhkwALGVrMwDo=
       ocp-aad-session-key:
-      - mD-Gf4041DPhMSJqxHK6Cqo1kPvbSX-EhMtCPLc6gpgqNv0EJBleQSXwuz1WRVtxWpOVR4cRlMFLs3rHZY4fPWnHNyRRiXn-CVODISKedJHGig6W6ZU6J1Hkqs1AFAly-rr14rfiuOxT8yayAV4Kuw.VgWmfYVCgG7AIdRcrc29GkWOl6Btpxta4P4bE4Juxgc
+      - zDXvULmMLwkmw1lbiJZ1Yq2LiFS1e1LvgjCAXacJlB7rzXIzs4pdKZk9cth5z72M-JkHwgqjxIIHqFcs-tVGZo8oLfE6pJU5Pf3inNUfFTumgpz2tDDGgH2IdOTDv8jkZe4VJnL_eJ8JQPF9f-4GQQ.QuHHP7ebJSGrbPmGSozEeE8AGpXzUhJjn4l-F7vHrOI
       pragma:
       - no-cache
       request-id:
-      - 8ec6e274-7360-45e5-8f55-24dbdc094a50
+      - ae40d758-3025-4725-b892-5a6443b43af0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%271fcda07c-3b39-4056-a70f-a5f0361c0fcd%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:06:49 GMT
+      duration:
+      - '2356571'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - TDZAGBecobGZ+vWQ2KTi3URBXNSatGDNYjgtJnpnCpg=
+      ocp-aad-session-key:
+      - tIeS7bXDUR06DSIHjATLPU4QI5K-36MztKNA5nh9bCcQX26KByE3r8iukmpHu4TgnA2Bm_7PjsP0l8J2-vJTqvfogG3NgvH7HGdIcv3tR8Wd1b3evkQjDK-uVWD4LZyktu6-ZTFfASsvW6UDNGNEqg.adLrOKA4imNN-vMI9DVuZf_K4ezT4JFUS12z_xfkJ-M
+      pragma:
+      - no-cache
+      request-id:
+      - d166b68a-7e38-409c-80d3-9aeef58f7b42
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%271fcda07c-3b39-4056-a70f-a5f0361c0fcd%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2177'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:06:49 GMT
+      duration:
+      - '2373470'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - rZtW4/HU4ECAMb71twjC/joa5Sdtj/ze6WKfVz2tkEM=
+      ocp-aad-session-key:
+      - YnBKOCkuI3q6vy6QeA5r8Gg6UZPCJJVNfNkUHZ4_GC0qXYJN4ejcv8SaFGbKsnzHicvn1R_HaRjJPbbIPUwxMDRzehjD3MKSD2j2__fTakYkijxZIFhvXeXS14q9a_emlfVIihiR6DDScHWP1jxwtw.4ahqjhTkq4cxlcmEanILJL6G5oF2-PgwtEDmcb_CmnY
+      pragma:
+      - no-cache
+      request-id:
+      - 18f035ac-13c4-4e44-a751-89efb48c15f5
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2174'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:06:50 GMT
+      duration:
+      - '2655976'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - Uxtl/q3xvktlehA8tlzo2bGqMFDKE9tmB0AkTQgg97U=
+      ocp-aad-session-key:
+      - tsVPi2Ba1kARHfqp1bnZhLhNEQa8-FJ4n214NZiX0QjDdF6i6qBgVF48-gbi4i1wrM3kbfkGAwACrok4Jb5mXARtGQSD9Afw993-XvqmRSlCDim2RvVAuOFWV4UMdLG5VbY4CX-nM4Bm_uJjtrqrNQ.IOF1THMrcEPBbOr8q3lEdy8yM_6XDo2A6WtJDfmPek8
+      pragma:
+      - no-cache
+      request-id:
+      - a38d9b93-807f-4777-9342-fcd45e592bf6
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -592,44 +777,44 @@ interactions:
       ParameterSetName:
       - --display-name
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=startswith%28displayName%2C%27cli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2175'
+      - '2177'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:04 GMT
+      - Wed, 16 Oct 2019 08:06:51 GMT
       duration:
-      - '744695'
+      - '2389925'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - NcWqSj/sn1Gs7WS77zsDP0PBWjCCvVzN+zmvny+nkzI=
+      - Xggm2lV7GH3yEUVfEvzm26S1umz7EprHWD9kDtATl70=
       ocp-aad-session-key:
-      - 1B_kQAl63uU32bjGHHvuy8u64eVQHhQsoJ25MINqfLZfUBxecoHUtjN1dFJvOAb3nBbniCuyi9_dYlX8IbTVwK6ypWVw0SWuqHl9kXMQ2N54OpXwFNy7Cx4qqdveNIo6DCwKRVMHZ93ymElXGg653g.fuwux0fC_kz4djVFtEf2GVSgJTo99TtweigFC4j3LNM
+      - myoy7uOF1-LuHh_MfLfvRURDRaNblPhqXsIxlFB-GtExqlzM3UE7E3yI1RjDTtURJ-0-yXEQpWt4Gf7YU44G5PWHSfbIT0LZvT91WzhEqM18sf3t-P4J_dCeQ3RAjIStRi_ROWxu5D0qxtcPUl6gKQ.pPJyEZSzszIeMhfOIuBL0sWjC-stW0m_ievObioeuhg
       pragma:
       - no-cache
       request-id:
-      - dfd4e68f-be43-44a7-a6dc-c934f13506bc
+      - d90e4929-a313-4ea0-9cf5-bcf854be935e
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -655,44 +840,44 @@ interactions:
       ParameterSetName:
       - --id --reply-urls
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2175'
+      - '2177'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:05 GMT
+      - Wed, 16 Oct 2019 08:06:52 GMT
       duration:
-      - '536711'
+      - '2641684'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - NSNh3Nj4zOpZv/7BPIpALY9v8UlGuldFvmsP41oD7q8=
+      - mNC6ykkADf+DbDHASLExRba6la3ciPirVXXtzNtDj14=
       ocp-aad-session-key:
-      - zQqtsOj-xpWCdH4bNe554j7bjk-tkTe_D3aN5QcJOLwWFBsDlHk0wYH3MkaWCiTHIEvb-teUO2rNCV-2ebie0hSZi9kWv17ogVGqZWLBXN6GKHw-Duz9qm6w6kfUDp4wL5dHttnrmRXAV5WyZEHCVA.mRJowIkPY4NAG9xiBR_AU5W7hvmiUU6rKVJlJpvZLWk
+      - i_p6N6AOV8p2dzn6ygGvo4QmQrZkH9FvqOI_Y62CKfQl5N4FXnlFtAvpd59KeUjAjja66NJG5UO-a7v2T-R6GhwAtC9az8Bx7J-ZXtw6dD_Kh67GRjCOS5MZUG9y7RB3vZ1ERunMFo0d2jASmzdPQw.R2F2vXzjWQ8kbmdxDojzkoORf1jXmnhWk9OoyKZKjr0
       pragma:
       - no-cache
       request-id:
-      - e4b43a77-913c-4a15-b1f4-ab809eead56a
+      - 25b926ac-8b0e-4bb4-9d11-eb24e3b043e7
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -718,44 +903,44 @@ interactions:
       ParameterSetName:
       - --id --reply-urls
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2172'
+      - '2174'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:05 GMT
+      - Wed, 16 Oct 2019 08:06:52 GMT
       duration:
-      - '576085'
+      - '2390118'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 79iHEFv08Z5eYiqEE8bs8QssJ8Mw1GK/njyBHhNtDbo=
+      - Ape/spQCG0XP19Hk8iE/ATS2tS1w3fT1+xqIKJSVb1M=
       ocp-aad-session-key:
-      - _RPl7CN6HPATxf22UIAHgSENjx6Jrh2IKtvrtB_dUO49G7jnld2xSbCRVxJWDUWvsr4A46qQ_yMWDw9Gq8YuE1PraQ6u1jlPC2PI3R97PknH_ewvK0W6auL63QtPmB1ljtK6CzM_GLzOpx63AnEc7Q.F5cyBsZcE9XgAyhUHDvpRJ-nKKjd0hOjGx-xTURfioE
+      - caCv8GVmFkWbLciu__S7J5yhGhGQC7Rlb2tFB81AgKbsgxtWDCK7hjwDNJ9Fn0uynxlAU-tu_tRI-2Z31efzDb_WF4hDeiVOeO3VvP3oAXsNslDe36_WqO8itzmldDxAHQbGEksY5waa5fbTzip5RA.vTW9QOXqizqilO0znuQk6WokLWf-TXIeFIRdioC9PC0
       pragma:
       - no-cache
       request-id:
-      - b163b967-4c0c-4fb4-b061-3972e9cc3fe8
+      - af93822e-83af-4e3a-86fe-651c02d46b5a
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -781,44 +966,44 @@ interactions:
       ParameterSetName:
       - --id --reply-urls
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2175'
+      - '2177'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:05 GMT
+      - Wed, 16 Oct 2019 08:06:53 GMT
       duration:
-      - '692394'
+      - '2447213'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - WzhaGtBqxSLZ0hrAkiIQJ9kgl/P+rn9FQMPcJn/2zBI=
+      - cQ8uB4IS1LgZ4Oy2RjJLTdo0AEOIgVfVV0c2RuOHYvQ=
       ocp-aad-session-key:
-      - qAA8-FeO2uzSA42_Ma8Sjb9jipGD6tSOdIzpmG0-ff_mLnmQazo8EccKul-nKH48uo7d2dDp2GNwSI--VNpbGqZKp0VtAAphV47_yFBSCOEmDegcRvCeNsUomc4bqVfoNZE7uvRLz6OvtlZxAtcRoQ.rPKzwAUobMCa77uM_LBjGM1l29Qent0wxkMrvFi5W_w
+      - KSYWyskBFYDoaosnm6KUs2Lq51jWGFud17z9xQ86Elvn60bQd1vMurP23vcpaWH5SDo_5Swyd4uHeCsLhaDWvz2L939RbOggIEwSrGxg_Xepxrilhtoyl0z5adIZ7TI0fYqRld_A9ohPiN_dQKptwQ.U3rWM94L1cSnwNzECxPv7ji8Taux4cd2zetzbihyu5Y
       pragma:
       - no-cache
       request-id:
-      - 84368526-afb6-4162-8a37-4eab6019229a
+      - 927ecc52-4a98-4c6a-9626-bd3e4502ea06
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -835,7 +1020,7 @@ interactions:
       "informationalUrls": {}, "knownClientApplications": [], "oauth2AllowImplicitFlow":
       false, "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
       "Allow the application to access cli-graph000001 on behalf of the signed-in
-      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "bc8d4954-af91-42a9-be13-71ecf45ad652",
+      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "01a223f0-3f2c-4f36-a5c4-e970b8f15157",
       "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
       to access cli-graph000001 on your behalf.", "userConsentDisplayName": "Access
       cli-graph000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
@@ -859,12 +1044,12 @@ interactions:
       ParameterSetName:
       - --id --reply-urls
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
       string: ''
@@ -874,19 +1059,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Sat, 20 Jul 2019 19:08:05 GMT
+      - Wed, 16 Oct 2019 08:06:54 GMT
       duration:
-      - '2097404'
+      - '5450109'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - FbAahKj+CAgBE9nDxnX/a9xy4bKzwpDul27qCyangJw=
+      - TQODFBO79eHT34Qk5647Ew5MUFYqECRDq+7SetrUnAQ=
       ocp-aad-session-key:
-      - ODE6QPhAU4TrsFDh8uk4_qczLQ1Az7iu91GIblXuITOcAHSTImU8QNqObgySTQ5V3T9-pwNHRsUGbL7ZZNxXQwYQ637VQBjXafM-wkniy7Hs41eEw7ORXETXqy1ib-CkVYUb0u7hoOzq_r1KsGFVMg.-KTBHmnL-akPDxRfXFIHfmt5NqLNxdwxGMo5LtQ49qs
+      - P8auRQ4qf5k2dqWgKs_s5OlNxrKiyqneYCnxKDGt91xvyWVnKrUoECMnd_qJUwICa6mIuBaM1oCFsMnzVMC49GRVDUgNCEUWuCCnSzuZTvKAi_FbLYWfT0mAn_rUK3yU7uFvNrxSrXTJ5iWiXnyoRg.lnMaf0cIqpxWIsJ4PEFygk_e8z1dBU_VIjxxKuFbMkI
       pragma:
       - no-cache
       request-id:
-      - 8d3a6c54-2813-4777-8215-c1f940767aa4
+      - 1d29790f-bb4d-4793-a5ab-d873723b7a99
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -912,44 +1097,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2205'
+      - '2207'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:05 GMT
+      - Wed, 16 Oct 2019 08:06:55 GMT
       duration:
-      - '537390'
+      - '2440132'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - L8oCGyE5q2mQ7HUDVIEpKVut/pMOnbaFrVMe6zpPzuo=
+      - xsDuxg+DnSkPNi77Rg8RaRUuQ9cvtYMMdi27ynpDZuA=
       ocp-aad-session-key:
-      - PsXHeWOpq51xvUFrpcKByER57iKK38ASaGH74P0OQIN9AUsq1To4G465OvR_yiTZsmSkGdvVdcE451KsWgyDwYvYDg1k3PgNvSPLvh25h5KRZABQI9WTxNl04AY4hOxd1Zn-t7nhyXf9XwhwPE7Tuw.fejIK92RWFg9q6ClYBp0svwEnB1WuXDMfY9y2eKR0Bo
+      - nbkK9iey3I3KSaP1O9BMDH_xHFoxYbWXxSVsc84ElaMM8K7NQwwQcvjcnFyFvSKU2meaMYfop1jhDi7CKlEj-w4vDfkDslwUflmtdVH6-Ntt2k4qOVGINKGZgpJe5NurLtlKaNxzPQwiD0hRu7Swlg.Ef27n0O1gfxEiz7FaFSkfYrTm1pqwh60EdinCsEL6vM
       pragma:
       - no-cache
       request-id:
-      - 3ba53e0f-ebd7-419f-b99e-ab0cae1c63d3
+      - c0fefa6c-0257-45b5-b343-b7b5eda2dcd2
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -975,44 +1160,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2202'
+      - '2204'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:06 GMT
+      - Wed, 16 Oct 2019 08:06:56 GMT
       duration:
-      - '689001'
+      - '2463131'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - beDiFJigAIn0DsweUo9b0LUsK5GXPcxyO2/EYM1RVJ0=
+      - MsR8dNtw/2nXn4ZEvTFyfkw61QFDCp+xMP8KxEby8jA=
       ocp-aad-session-key:
-      - cPzv1fzBjM1Qi5MhXzNN0GPrfwdSTNzvAe8lufrFpDRjepb4wde0ZPhwViclNkhlbjdinU99USpYFQ90rm_RpKTC1X0HqhsBxsxOpXCau6iXwpS2xLxPA0rKIPMxuNUckSG_q6S7_0JbH4XlmKV6Eg.3W_QSdTfSOffJrEWhpE93KXV-VLzFMWTumZojebFBhA
+      - Z3sjUtgLNZTyhZDyCGG8GkBM81EJWmbRkiuM0aCt5fPdEAeEfmkP_vZxUPxgHhRGzH700KTqGGl27NritveNEZY3mU_JeWVvqpmA4UaqHjbv749ZFP8oB1t1ttQ21rS57flN7IklVOBCe1Z-EXsrbg.efWU7sXSON5cs78zL0Ws_X3rOLDJwurWVHyUhDQKfe0
       pragma:
       - no-cache
       request-id:
-      - 2ef84908-00a5-4fd9-87ee-158ff76bac6c
+      - 5cb738c3-dd89-4f2c-a832-64c70ddaa10e
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1038,44 +1223,44 @@ interactions:
       ParameterSetName:
       - --id --add
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2205'
+      - '2207'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:07 GMT
+      - Wed, 16 Oct 2019 08:06:56 GMT
       duration:
-      - '552642'
+      - '2421371'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - zeEKft775yziUv/M3yxCcMpC6+8oLdRKdYxEjthog6s=
+      - Drw2XA9KyQgsrpvmmqtwgHiZqOOXvdLCC08yhhod2oI=
       ocp-aad-session-key:
-      - DLV6iwKiNEzoZEW0mEpJQ4NiAh_rRGP3uLOz-IR1lyYvlr_VJ67z22iNAXTK_uZVSLWQ9XKkUN-6HOIph0D0Od2XlMXzjrCKLbNFM1H-qnRIWtE-L-yjy5UjL5WnYx4YII7o7k6zJzHKEWZiEupUhQ.klCF8jrHrvzz_nEIvneuQQDakWtOmCJXcP85xl7TEAU
+      - PqZlZ1p6YbcebaqQNBJmzwrlKHWAH37b-gdT7odezoKTwwLdsaxSZLl2pLLYlrlRDE32lLJWI9KDswobqhwmgX4paGsDXXs-YscbNvAvMnHz6s0pfglI3pbgziNvKuU7-U3TvXmxCZcIGOlcc0IEjQ.V7qYFciZgfzqmR-S2oNW1OSrXmKPWROfalSbYixBBOU
       pragma:
       - no-cache
       request-id:
-      - 52462240-e041-47d0-99f3-356df5265821
+      - a1ba62c8-9e1a-4c92-939b-d26af83f8c35
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1101,44 +1286,44 @@ interactions:
       ParameterSetName:
       - --id --add
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2202'
+      - '2204'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:06 GMT
+      - Wed, 16 Oct 2019 08:06:57 GMT
       duration:
-      - '547190'
+      - '2435385'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - k6fa1kSiMnUZJuknHiO9y0+zpxRd0b2xW6UyOlqu9kw=
+      - +ZQCeST5sqkh8PfRlmTpQsH/+32BWqALmUNV8T7ZW80=
       ocp-aad-session-key:
-      - NdaKrXaAYbHHQltqxULbth2uq-TacmTYnVWLbcAGvn9LlbsMJ_MLLIs2kBqHJDM7JB2RnDYF9SyJDdJaZZeqVunAMWGUKu-oS7UPWjMCs-2GJB2SrE_renMwDabOauU2F9dNyjExy0Wxoay_KgZOgw.dBSfexK2VFo2qTGxXe85ZZaokkbODSeQsPVkXFIFwZE
+      - 0ttlWzwgnugYn4xw9t9A6iqzhjytwxxciJETxJ6Oalhw9Fg6rMB2Vs1LwY4NClMI9v4Hf61o_9BIYIMpEVz35EypPsFDkoQyIuJ02fhXGNtS58Qbcx0SZw63hGhFU9O6g-ZhZNzrDp5ICMF1Feclwg.U0MgM3j-H84FIM2ti10UaU4FFctiJa7Wk7qKZvLe1so
       pragma:
       - no-cache
       request-id:
-      - e88454fc-88ac-437f-ab1c-db12f19fd7fd
+      - fb681bed-797c-4c41-9f18-de3b1c5ccc88
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1164,44 +1349,44 @@ interactions:
       ParameterSetName:
       - --id --add
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2205'
+      - '2207'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:06 GMT
+      - Wed, 16 Oct 2019 08:06:58 GMT
       duration:
-      - '686336'
+      - '2477695'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 9GQqI6S1ECS4j4T2qnjxLorVEkd1sq21GP7tQfmsPNE=
+      - wS2v50cTZUT4bz/2CRgi1A0/5ITLqXZZTz8+URT4w64=
       ocp-aad-session-key:
-      - 1Lh6T2sp6icukcmReBZ3l_UQ151-zE4Fh8jOHFnhpLaErQPOgQJ4_sGkZxGqCy1Lr8OntZ-WE4O8h8p0s4xYFHjFX4cAHt0gpe-C8f1UBF2aVa1F-eDdNfvTK9gOPDMj934x4b8S0aQ6hjto1C67xg.YspgUQLU9myZyq3AhwQZG46rUUT7cphOD6ezx-_L3Do
+      - VHggwLn8UiLL6cSq1fyveaWa8GLyz5qldVgB3Dhewt-JzWl8t3uPJ6rJ6lNSe7zQ0OGvUN7wQD2L6wn7J3lwbR_iVl6sqTSR5M8ARwp-YDxrjGaf6OXaC4FN3VQk8tULAdRrUEf4CAswmNvgwvJWZw.Y7q9nNN_os9ZELe50lSLuCL7EaHo23PuW4JQKm6YfFM
       pragma:
       - no-cache
       request-id:
-      - 71a698f6-4bba-476a-b806-49d88ea3bb25
+      - 3bbd219e-0409-4c0f-bace-1abadf32467c
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1218,7 +1403,7 @@ interactions:
       "informationalUrls": {}, "knownClientApplications": [], "oauth2AllowImplicitFlow":
       false, "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
       "Allow the application to access cli-graph000001 on behalf of the signed-in
-      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "bc8d4954-af91-42a9-be13-71ecf45ad652",
+      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "01a223f0-3f2c-4f36-a5c4-e970b8f15157",
       "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
       to access cli-graph000001 on your behalf.", "userConsentDisplayName": "Access
       cli-graph000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
@@ -1242,12 +1427,12 @@ interactions:
       ParameterSetName:
       - --id --add
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
       string: ''
@@ -1257,19 +1442,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Sat, 20 Jul 2019 19:08:07 GMT
+      - Wed, 16 Oct 2019 08:06:58 GMT
       duration:
-      - '1656257'
+      - '5389561'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - r0o8Zfv+/EsfSzvffV1oL1MCccQ68EumyGGwG7/SNv8=
+      - TDZAGBecobGZ+vWQ2KTi3URBXNSatGDNYjgtJnpnCpg=
       ocp-aad-session-key:
-      - iC7bJKx6t9tRRokaXs9Slqqw11CoxAaJLkXBmpNkx9ZGcx3a1jyDXViPtGU2KnEfdXyOO0QLtWErgN1JZ15XMpV1UHnZVs2ZOifrsU8zfN7sDbV7UkKXggx1iHmDY8DhbZdggCL6rEw8f-VmRfICyQ.2BmAD3NbnoQdXDBSxDsBcS84DRSUd8dnCyHK6Po1Fe4
+      - 9pZv70HifSlDf0fLJBkcP0eXOuH0CvF4ci6QA94rTiV7XRFY01BS6kNK9TdzUt-Z5kjFh6qaFa7Dx--q7Gx8oPlulWJRrCUXZdfqiizEsKIjCwJPjcGxBst8CN5D_VqPt0ElNhk3gI2Ctvfn0WD4SA.iTvE7AmARbD_eN-x1ZcaaOl7UucLGjbrB-2EYQNZZ7c
       pragma:
       - no-cache
       request-id:
-      - 7ab28457-367f-40a8-8cb2-0fc037bdb18b
+      - 394d4e7c-6868-4a0b-92ba-ade4f084524e
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1295,44 +1480,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2237'
+      - '2239'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:07 GMT
+      - Wed, 16 Oct 2019 08:07:00 GMT
       duration:
-      - '554807'
+      - '2418782'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - pMP8f8RT8BuYgTu1dfMWey3W85KBh0EioUNuKG1c8Zw=
+      - QF+2Kom5kdqiaMnyIX2qvy7RneHOkkB0ozKS2e4Q0lc=
       ocp-aad-session-key:
-      - g6DbDFvegdPEQI0BwAWE8miLT2zkvFEWVgwPwaBoZWgPqcpZ0hq9Hs5wBziajdmpusrlSM6RBscyaul8UIrx5-H0Tq9Ts6V4NkdkJ-4eNWpyNPkOffKi3Z0M02x7FPhYDyXMsmV9olkQ2-1EwFBo8Q.czHKulH9udjZAHUye4f8khx0i8YLxZW--3i3sraBNX4
+      - P9iShybD8OKpU-2_mRk4DN5s_gBtxBjenjt4nJN_6arB8rUGHitqnxs8naeiMY4NvLNhqL_HqmIOWUC3ih3yn67cxaN3YR3P2nvtBmNhHWSH1T-FwQoyM4-npSbbP4dBiGGDWksA-47JDEUutYIc8w.5AZv3rwwwRj4xtSXXkksy9q86SipxY37N92HXTFn1r4
       pragma:
       - no-cache
       request-id:
-      - 2ee85038-b18c-4bf5-9b17-e569eec7d3c4
+      - 1bbfe6b8-e6c0-4849-bc4c-02a65319c23b
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1358,44 +1543,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2234'
+      - '2236'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:08 GMT
+      - Wed, 16 Oct 2019 08:07:00 GMT
       duration:
-      - '799895'
+      - '2401483'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 7dMU+33Cz+68qE5sK7ANGlhWJX2RrZSFfal152ZxuSk=
+      - DywEMvMXgmzBKuxC2RUbHTI5GoseRFuCk5fYnmzpiIE=
       ocp-aad-session-key:
-      - J_i1-xdH9VPYpipEB_Az7DCpd0q-exQYvtsKxlFDDfnYix3mfuB-FNi6-ORLuBpbzWWO04cXXX3u5Oa6nq3Mcej5l_AYIaxSgzRsAqOIEhqX9bRPqSpuq9IUv24Mo4aKM9XEciGb8IN4aLT_CJnrzA.qE0N9ntv81mwqxZNmKcm4y-swQqrV89_votwAUtovLo
+      - 13G0DgReoWHfHwWZd3IlIWSN-SfgP-2ouPgc1WrLnry2GiPnVww2E_tYPCFNzPIqPTGwoTJ5JqF0d231srGfqayeQbJ9lbL-lHwpideD3GGIBoY0eTBn8Yafd6s0G75hY4BHU5kuM-_w_M-Yv8EnTg.5e8-BUuMZwbUKSTA0yJZebwO9Me4nNoCheQ5dLrI-GA
       pragma:
       - no-cache
       request-id:
-      - d989648d-21b7-4b1d-b278-6a195b454695
+      - e2f2ccb9-710f-4848-8f0a-e1ae210e06b0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1421,44 +1606,44 @@ interactions:
       ParameterSetName:
       - --id --remove
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2237'
+      - '2239'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:08 GMT
+      - Wed, 16 Oct 2019 08:07:01 GMT
       duration:
-      - '551159'
+      - '2423122'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - NSNh3Nj4zOpZv/7BPIpALY9v8UlGuldFvmsP41oD7q8=
+      - ON3EEhW/20kp2jdRuzcrIB6ISFqSfwR4xZWK1GBfKTM=
       ocp-aad-session-key:
-      - EcPViZEZ3Frc-vFQowBXzxsz9US5ROpy3lAEod2lZu2568OAXfilLjB1vMLM8uzVajBjtoDDiM-rV4N_gEH4YHSgINz5oRc94tPS_B2rfsOC_eva55Nv-QX1a--C8FehnjtRwI4P9h2it1zIzWv3tA.n5W957A9WruRrDYOx_j0IVZG2slU2_S2gVdk5n6Ye7I
+      - NMmfE1dU0tPgZNPhE0guoh7yd00bWcn358_aTey_KcXMMMr30EfKuqca8N75Saq8ubEE0yBi_t5RiP2zndnEXyHnLb_zlG7O4MPfYtqiyIM3lcuGbrHa7JBX0-o1FiwqLZQXeAw3LjcWDDj9A_m1UQ.HHIYrIwAMLoFJmlwaa289ZRWZ4fLdIY7IF9TWSuWfH0
       pragma:
       - no-cache
       request-id:
-      - 2e570f9d-996e-4453-9075-e7a9d4030135
+      - f9b140f7-b7c6-4b31-8cc5-2c06d9c21aaf
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1484,44 +1669,44 @@ interactions:
       ParameterSetName:
       - --id --remove
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2234'
+      - '2236'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:08 GMT
+      - Wed, 16 Oct 2019 08:07:02 GMT
       duration:
-      - '690499'
+      - '2822697'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - Jyamh40I/riKJflXwk3LHmaI3Lsq6osSe+/rd7Qerq0=
+      - 9ZHp9DWrFOJDdtIudkw3WViQ6HjfSWNkT6r5darksVU=
       ocp-aad-session-key:
-      - 4SSA1I-FXbl9V7g2ius3jCmqaI9B8ujCkU15UXTmrYd6JakuXi0csXHW_-4GiXsTyeWUglo1KZa_0vp-IiizseHm8yvq0Dzv_KSIe2LiHV3a-7KQ-2ewwWjLLoNV1SUNiizEp5ks54kQQmSmWz9aVw.Ahum7JHAseA3SgHOaHs4t173NdqnYSNJ6CtF8u9GIqg
+      - s_bCDYvQaSjptEPWfo5ho55rdEBQF-k6n16988FkSnkzkZSYfonjPBAlaQcjr4uTqVPRC8S9w4PceXE6kCzYhFOzPWGlw7hc--uyevlZXxcTtc6YS1yyDNJNPt4cN5ppOzqBDxJyPLvqbULDbPfrMw.vlxAxA3FEkJle3LhczecGjXmsfLAmACAUeimOX6XmoU
       pragma:
       - no-cache
       request-id:
-      - 60d9ebdb-917d-45ab-8afe-b48fd64a624c
+      - 3f17a8db-051e-4089-844c-d5f80a5e103e
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1547,44 +1732,44 @@ interactions:
       ParameterSetName:
       - --id --remove
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2","http://azureclitest-replyuri"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2237'
+      - '2239'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:08 GMT
+      - Wed, 16 Oct 2019 08:07:03 GMT
       duration:
-      - '574308'
+      - '2600986'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - hpfDxhPDvpsezzM4Rl1qV9P5qcNnaUPXm6yGHqCYKyw=
+      - kBih7fSyN4KBVbbQbefvyTLr/UFDpjbEhYoFfqqwsMs=
       ocp-aad-session-key:
-      - DHWrxNN_--qGyOcipoX7JdWQg4fmgjoMlyV21oiCqbOtsZPGs8yBCD3p22ReXMuCjstBs56G6ncw6ZtVad_yqxGZoQxQDXKvYyzW9mgBv97z0EN3AGPMTiZnCp5yPskOEIq_Ahc-1QlgNupdLp1J2Q.E-PLvp0ivbeZBHPSaWmwWu6bDAublqqF7BXkSvjniDg
+      - fIzcQMoNn81BbX0B-YPR9SFO_dXsxdMCBZRyCRjF-g2_fGOIXVl3HYo4uMBwWna4wRynzTE0rPYsbk2MqFK8IU2uKKvEqKMyqffR3ghlKkikcmz-lNfBKDl0Lf9DsSQBxcZvndIRa727_8w4mU1a4g.xO0ZpOQTR8sM38oILJhtu4wqdUf_9lwBV9zAPVQIVJI
       pragma:
       - no-cache
       request-id:
-      - d11806c4-6e80-44a1-a4ff-74ad1d29b9b1
+      - 520c0e10-63ae-4715-80b1-cbcb06ea2447
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1601,7 +1786,7 @@ interactions:
       "informationalUrls": {}, "knownClientApplications": [], "oauth2AllowImplicitFlow":
       false, "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
       "Allow the application to access cli-graph000001 on behalf of the signed-in
-      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "bc8d4954-af91-42a9-be13-71ecf45ad652",
+      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "01a223f0-3f2c-4f36-a5c4-e970b8f15157",
       "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
       to access cli-graph000001 on your behalf.", "userConsentDisplayName": "Access
       cli-graph000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
@@ -1625,12 +1810,12 @@ interactions:
       ParameterSetName:
       - --id --remove
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
       string: ''
@@ -1640,19 +1825,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Sat, 20 Jul 2019 19:08:09 GMT
+      - Wed, 16 Oct 2019 08:07:03 GMT
       duration:
-      - '1764195'
+      - '5542201'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - h+gNQTLppZriD7Bi3QhCZ7WfmMUeEJkUmLK1DkwYnjU=
+      - nnwm1rHUXNOC2HCdDk0/PkC/19HDnlsfx+Y5YAxupsE=
       ocp-aad-session-key:
-      - pXmS3MhrqBVs89WLV1pXFZG6zeb6uxXRzd1fpWk64LAbvGXxyfLUC5YUf_v8Lmvd1-LBSETyMHX9Q1HnMiHW6vc6HziNP4VxwDkiqzXX_ua1WAhTWV3_WHU6InTu3_BWZf6dT1piuozeWl256ThMuw.LalOac4Nih89qy0LzltSVFA8iuKDQYYplmqqW6UWF-0
+      - Of0HLh8Lx5Nl5pNb80wRsJ0V1YeY4KxvxY0AqoE1b1bKh7YA0kAGeiCjvpyh3viz5cP82JfXvwhsdhuAT-Sh0wvgpn5uvIsva647g-mpOMW5EOzToyPfJmSSJ8kDQ9Y-UmEoIbSbUe_f8E-iRDfsVA.MQt2jwOH2dYS-LXyMBAxk8K4YODw5InUsWXRcoBpj40
       pragma:
       - no-cache
       request-id:
-      - 4d729f2c-6574-4896-a31e-9366e68c63c0
+      - 2b636a3b-d04f-444f-ab18-c1652b7945b1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1678,44 +1863,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2206'
+      - '2208'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:08 GMT
+      - Wed, 16 Oct 2019 08:07:06 GMT
       duration:
-      - '566274'
+      - '12675641'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - YPCVOwAR3XOdfRvDdWZX3yHf1fnOOll9dsEetoCYv9Y=
+      - sc2HGlAzCMS1VY7X5hfVhAS42eedMCDVczjCHW+dA+w=
       ocp-aad-session-key:
-      - 68YKaaPxV4Qib0rosPvgQvHItGf304eyTpsyHjZN8kdFFWpp0YOvD6SteC03_P15w7ArqIH7IQKoTXTcfOw8JI2qol040zKMwzuMuiEdNSCeony6ZkBJBQvFT1tQeExV1Ni_GXuVzteLyLL1Ry0eJQ.BCCS93fBnxCeFfn3IT5DVyPZvLfOImTXKAw2tHRqvOM
+      - 2_5Es2k_olF6BDLuyi8TdkOf387V-kv9AeJW1i5-9jIsZ0bneKhWMP5zmjp5_sfhW3cdY8ebkHGJi88EyqbVQRIi2x7SsZG9yx18DwtSDsNVvQ3m6Z_w9MgbR2T3jZhgW8GMrHYvIASdsXe5rrg7oQ.yA3SbNtHJ2G09602OUecm5qOk1bwIwL8vVtmGN30xTg
       pragma:
       - no-cache
       request-id:
-      - 59a67b41-2ffa-44f4-8566-38a9327a7c7a
+      - 8a593f5a-8818-480b-a64c-dd05199eb950
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1741,44 +1926,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2203'
+      - '2205'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:09 GMT
+      - Wed, 16 Oct 2019 08:07:06 GMT
       duration:
-      - '685543'
+      - '2397952'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - beDiFJigAIn0DsweUo9b0LUsK5GXPcxyO2/EYM1RVJ0=
+      - fP4NK2gNaIdDNhBv8pKeGATgIpn16XzVoGGpzH0I8Co=
       ocp-aad-session-key:
-      - LcQVrjoAVniXUwfp914bcTbOHR7mqJA1fF77RFSgCU-OX1V-WB6Wo5pqTfXtK4dhVWtkNNwJFKM4mcr9VVsaGi4wrhaPU88DDG-LsZvsME6cgqgvgulbXJ5zUkdIAa9eGwm98tOUD36z8wUpFz28Pg._8lMeFf_Un5HD-s3Sz0qTBkfkaWFQuukkpAZWI2XdxI
+      - DyINNBHkc93dkAlphIOsZ6oAICW9ccLqSRFpfJg3kypooAj0aAvCKisrORauyS_PO4PqKe8cbPq4Du1sDon5x22ey-ronnls3Bj1RJ5i1m-MymYUvO8h7BPkggU1sqyPuzO_UQFg-1owow7ygvE_tA.IhNeZ6ZexB4QyQfMglwViAYoQCjET52TD4I9AyhdRA8
       pragma:
       - no-cache
       request-id:
-      - eabe56a9-9e32-4045-82fb-450d36f65163
+      - 3bdf3b33-ed91-44d0-b645-3198a63f769e
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1802,46 +1987,46 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --set
+      - --id --display-name
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2206'
+      - '2208'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:10 GMT
+      - Wed, 16 Oct 2019 08:07:07 GMT
       duration:
-      - '578333'
+      - '2404698'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - h7UB8YGKOzmHmjp1ZIS89QpqUVjy/3RInQUF7SgT0jk=
+      - +ZQCeST5sqkh8PfRlmTpQsH/+32BWqALmUNV8T7ZW80=
       ocp-aad-session-key:
-      - 5Tpinvmix2uQNTr3Rzg1IBvJXa-DCWojr87RjfOhcC7WgU4--w2GMDKgmbhzLZTR0q3vH473QB75T1kKALfbNtc3FzVMfRN7mdMpgFABt4tjrSzY8DyilLDK5NiFMdmv1Ml76Hd_eGpDv2-sZkKuiQ.97_m74GmKJw3wXK9K3V31zucPZbniHjtpH2jOnhsZrc
+      - 3-Hz4Ha26gmu0vu-hlYBzqpgpvwaVC4QnxexbZS9gzkTb08Bl3HlFiYlpRQq5j-GYc14Fv8c8trHwh9pU3I-MIR7Ev4hY8CvGa45Fei2OT66e6q5rjqL2Hv-o0j-T5l52nfFZ_i5gmmZ5S_OmQkEWw.5wewiFcSW6R4uBGhaYacR08fCwN4rmx42EkMvMEizds
       pragma:
       - no-cache
       request-id:
-      - d75a9433-cb61-4412-acaa-1951fa2f1cc7
+      - 2e6ffe8c-a1c0-4003-8e16-cb437fb53d16
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1865,46 +2050,46 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --set
+      - --id --display-name
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2203'
+      - '2205'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:10 GMT
+      - Wed, 16 Oct 2019 08:07:07 GMT
       duration:
-      - '691058'
+      - '2664612'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - KYF7EAD5GdFo5pErauKR0U3XtkJ5NfeKZzns2dm1Woo=
+      - Uxtl/q3xvktlehA8tlzo2bGqMFDKE9tmB0AkTQgg97U=
       ocp-aad-session-key:
-      - k4erjGRG-T9Gev6IzWfopxY1tRYjbMXmex1NreVWD5zSkbmkhVZLpP-FoazmhpLieWrscjjgNBlIQrDPfvHraDu59607VTzYera0OEQJVASii4VfAZ4f2OfQ9QaW7QtmJ2MhHo5j1dkgDGxLcE1k8Q.khEVVvaIfyoJ1F_SQt84BuDLUlgaDGF5fMrBulZQpHo
+      - CFOPNEJ4h7ZcMYn6yWlsbZHQEqSGwj2WnEyAKW2g9-hsEmDfs-yGgQ3G2J10qsOFbcGxypf1Pot_eiG0cXEbdkqAnafT4vMyXtQ7aY3XxwT3csTSetO1g5vQnS5IVZ8Leg0utHw4AIA3TmWESV_HwQ.OdsHrLhAlLbAYinIqFHUPhjueLE6kQOM9Ya-xUIQImY
       pragma:
       - no-cache
       request-id:
-      - dd17efeb-b915-497a-99d2-d1cb7ec8495a
+      - 6631761a-2f06-4455-b6c4-d572f0f04cbb
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1928,46 +2113,46 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --set
+      - --id --display-name
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2206'
+      - '2208'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:10 GMT
+      - Wed, 16 Oct 2019 08:07:08 GMT
       duration:
-      - '546054'
+      - '2399030'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - qDFIdgBNQXp6GxWR09voGLIwUqYx4S5KlXg1xhMFfPg=
+      - sc2HGlAzCMS1VY7X5hfVhAS42eedMCDVczjCHW+dA+w=
       ocp-aad-session-key:
-      - 7pOpcnT_p0RkcSUEu3vyBACiwsOg2R7qItpxlj2_ru8LSQbj6KYD5zRfuGZwPA3VuGl9uxRYy7GnKBgQl-pz-mTHxbfLiYrmAUl2kvx-L65vXqY5yf7CYyxt1LfE53twINN9pRHUXXAoUuFeq4YGCg.2NDEX9R7leJI5_7mCvAecRLcT_oz8qhZVWXIs5wkvzk
+      - R3SKWWOgEDG_9KD3oC6BgzXktRcoKzpZfDf6RIVXTmGYsKU8rKscu_Cel0jS_AfOdMS_zm02oQtqMypOsjBz2EDqsqzQID4BaCWKYHPwb_2cZ0lpOhLJouul651FXem56NNSq0ic5c-IjqHSomf2vQ.DFA-llpC8AMSqx9ZBReu00GCH6eQXovW4meJtDSIVXw
       pragma:
       - no-cache
       request-id:
-      - 8abb82eb-5a98-4cdc-b860-68653e203a18
+      - e49d84f9-2a09-4b92-937d-286e38ff9d27
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1982,15 +2167,781 @@ interactions:
 - request:
     body: '{"appRoles": [], "availableToOtherTenants": false, "homepage": "http://cli-graph000001",
       "informationalUrls": {}, "knownClientApplications": [], "oauth2AllowImplicitFlow":
-      false, "oauth2AllowUrlPathMatching": true, "oauth2Permissions": [{"adminConsentDescription":
+      false, "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
       "Allow the application to access cli-graph000001 on behalf of the signed-in
-      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "bc8d4954-af91-42a9-be13-71ecf45ad652",
+      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "01a223f0-3f2c-4f36-a5c4-e970b8f15157",
       "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
       to access cli-graph000001 on your behalf.", "userConsentDisplayName": "Access
       cli-graph000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
       false, "orgRestrictions": [], "publisherDomain": "AzureSDKTeam.onmicrosoft.com",
       "replyUrls": ["http://azureclitest-replyuri2"], "requiredResourceAccess": [],
-      "signInAudience": "AzureADMyOrg", "displayName": "cli-graph000001", "identifierUris":
+      "signInAudience": "AzureADMyOrg", "displayName": "cli-graph000002", "identifierUris":
+      ["http://cli-graph000001"]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '956'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --id --display-name
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
+  response:
+    body:
+      string: ''
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 16 Oct 2019 08:07:09 GMT
+      duration:
+      - '5433832'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - 3CMafgu+LVf53IqS2V5xA1VtIqsHUIzo8C7eaZ65J3U=
+      ocp-aad-session-key:
+      - 5mMpsGw2bqBW-NCYOvFUoK-pFqGpWd8b071s77T8sS3nw4vck5BN7p3CNs9rYfNhVJ5weH5MZ_x3hhKkwgNV935wG9DrIxB7LkPgzyFbXBl1_pr4uHIUUT_f4wkh1VC_UePzKgH-aPFiCA0dLEjBbA.kOdAyLgsCcUr1T5LE0SLPqXnHyzHj0tBStoKzAhyKLM
+      pragma:
+      - no-cache
+      request-id:
+      - 6866244d-4bad-4aa1-8a7d-4dd67260c48e
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2208'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:10 GMT
+      duration:
+      - '3713384'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - Xue2xIv4aVyJ+cQtv/X6CuUDT74+HqRXcHt4rB3UTr0=
+      ocp-aad-session-key:
+      - HpAS8g0H9DUq6VrW2du52JCFbT16aZsmJMdJvJ9SxWxsUdPC_fd_kq3aw0oM0PkKvKa04Jy_nuoxLsNuu3BvAdfq_O-GC-yN2CgMU3G09ca7krMEcEFcmQAINljOZiL5dsO6piBpBpjNEw3wBZqAgQ.kf-8XLUIW25o3XqpCgrOSpz3q45jbDxu98212i3iErc
+      pragma:
+      - no-cache
+      request-id:
+      - 020c290c-4c90-4b32-8bb9-7ed9782d88cf
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2205'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:11 GMT
+      duration:
+      - '2418015'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - 2dwL4zmGotV02lDmIuML9wD2xi2nJgoszFrjUl3LYBw=
+      ocp-aad-session-key:
+      - FkQSTiDZJyCuATkbfLpz8K7JmsWD6x7oYdnrqZQGjJ9ogucTXBRgfsal_O_CHfY1ifQuJboYdFSTQFeXrr98VMf-qRffSU49bMpswviCHZeAQIDsqErpJoGITi3KmEFhU4KxhU6phrc09egpY8rfQg.nCEAK7GA7Rl62FqAs5uTOFB9fRdIohnzb6PqTaWQzJ0
+      pragma:
+      - no-cache
+      request-id:
+      - 82a745ee-f5e1-4869-91f2-3d9ba67de651
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --homepage
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2208'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:11 GMT
+      duration:
+      - '2474113'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - 4gwQrBtXks5dVi0aRt0zGhLTOtYc/KnLaBj5AQs9ou4=
+      ocp-aad-session-key:
+      - 0YtgMRHFpqxXHvYlFtq6l7PmKGyueEAV6Ocq6d_lia_Znv8Iv1vHUHVzSwamZKwuapIyy6iA9QzClkScm3t8G8OzSiWV27Y_mUDpAwo5OQP84BwzUzixJ7XBqU9O5U0tRdx_9s_uH7am5X3M_7tq5g.8HD-vD53PXniXw29s1-byb-F5TNEhYEdqHbS9BQ8d0E
+      pragma:
+      - no-cache
+      request-id:
+      - 4176fadb-c41c-4677-9dd8-9f0d13420d27
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --homepage
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2205'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:12 GMT
+      duration:
+      - '2409106'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - ESVIy1e+JXVUVgmV7VeKLAjLSG2HRo/cFw4RCtyyqhQ=
+      ocp-aad-session-key:
+      - WpwJlXEJSHrLuePzxs2txujm1VUFA22fbiCMrzf-o3Pm38RGE9Wc-dJvw11UOQykJdmEaOvNsuBxxLpAxysx7msHNd32_yp1tARNzsGM-f2QyRFI8vZctO8R2eVa7kxuuTs1RyEpCbWvbhePCGv6RQ.H98KLpS7E2WTgYmKwhhp2S-gvsK6dZy5XfuK7CvRstU
+      pragma:
+      - no-cache
+      request-id:
+      - b1eddf4e-ae23-4715-87aa-363241c0b947
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --homepage
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2208'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:13 GMT
+      duration:
+      - '2448495'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - TDZAGBecobGZ+vWQ2KTi3URBXNSatGDNYjgtJnpnCpg=
+      ocp-aad-session-key:
+      - 665wy2RCPks3SsALpuq0riOW7Jz5rHTIfjxtmURZ6XRceKKRwr1zMttQ-ODMrHzGOGJGoR-WLEqLYbvTd1WKbOboTtR8BN3XqQd007GSTETawH9yJlyRLxRVDzjb1bULtRRjQJwi3GpW7g1YqfoM0A.CZlD3Vj2Svf-NR-D-PeQ9g4kWZLGsTKQAuKQ_BnnUWg
+      pragma:
+      - no-cache
+      request-id:
+      - a6762f24-69e1-4da5-a512-9dc559047d3d
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"appRoles": [], "availableToOtherTenants": false, "homepage": "http://cli-graph000002",
+      "informationalUrls": {}, "knownClientApplications": [], "oauth2AllowImplicitFlow":
+      false, "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
+      "Allow the application to access cli-graph000001 on behalf of the signed-in
+      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "01a223f0-3f2c-4f36-a5c4-e970b8f15157",
+      "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
+      to access cli-graph000001 on your behalf.", "userConsentDisplayName": "Access
+      cli-graph000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+      false, "orgRestrictions": [], "publisherDomain": "AzureSDKTeam.onmicrosoft.com",
+      "replyUrls": ["http://azureclitest-replyuri2"], "requiredResourceAccess": [],
+      "signInAudience": "AzureADMyOrg", "displayName": "cli-graph000002", "identifierUris":
+      ["http://cli-graph000001"]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '956'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --id --homepage
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
+  response:
+    body:
+      string: ''
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 16 Oct 2019 08:07:13 GMT
+      duration:
+      - '5479422'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - QF+2Kom5kdqiaMnyIX2qvy7RneHOkkB0ozKS2e4Q0lc=
+      ocp-aad-session-key:
+      - 4lipx58-5rt7UKHBYcqYASHyLeNDE393zPOSnlAnmSZTF2iFfB7DzTpe_1gzPEQzoExw8xOp3R8rIPkqUmAd-3RmPtaxf4wn3d41t9jvRUSfTxMZ0r617K4m_Cs2s_rinoK8iyPFBvHJoR9LCOon7g.oNs6iU_thQw2fIdSOdH1Aii63TKNR9Rf3zFyJe-IDBg
+      pragma:
+      - no-cache
+      request-id:
+      - e92299a8-7021-491d-8bbe-62cd10226f78
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2208'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:14 GMT
+      duration:
+      - '2652011'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - Uxtl/q3xvktlehA8tlzo2bGqMFDKE9tmB0AkTQgg97U=
+      ocp-aad-session-key:
+      - rW4xX0Tq6WIUWKvkP2l0r9-Np3NnU0-uP3EriB0cjk6vatw3MVMrh_PyWPVhAJmvWIVapl_p8mMlltKrl9qlBvI4Cn8N4Wo4taaaCeFGZQSWpscVKJwix5lktQ6HNLeotFniHm7TXQMAF-JtbHStcw.QOAJDdpTtil4se62ZOMuBfTcjYAEamuwYhFmFkmdOA4
+      pragma:
+      - no-cache
+      request-id:
+      - f99c2508-47ff-43dc-8a64-d23f174ae1fd
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2205'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:15 GMT
+      duration:
+      - '2382955'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - As0gHGadq5h2LTxl2ZFYNVFv2OujPh15mwcM8SjOsH0=
+      ocp-aad-session-key:
+      - tNOazSyKbH7zL92xTmfzlIcIdnjos0limvq0gnsATEHXpAEoc5tAQq653gZHYXqtirBkmfM0C4QBnxewZZNRWlA7wz5clIIb-Gk28v2gfWpnv4TZ6yHvJfUsAXHHvrdJ9b99oBV7aHWodefkyyOKUg.rmvUK7XfMAEXXbEHNZsBhtzWa0UL1IU2MJF7wcqIsro
+      pragma:
+      - no-cache
+      request-id:
+      - 7c417c2d-13e3-4134-9d12-96ad6314a986
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --set
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2208'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:16 GMT
+      duration:
+      - '2471464'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - P6XHi15PiD96nTMoJDvb6zXRHSAmPtZhG5f+3+NCpS4=
+      ocp-aad-session-key:
+      - gNIm33yihji5yy4ydkrnwPSxuW2WKTmNK92rkRhDLa155CGELPKGDv8z5_9K7tDBKlZa3nJMybx7ILP7TB2lwgHHe54-fs6PFW33UuoMq35KrQdhgpMBBGKhzU9EvTgVI0pYcvgJtrtpo0GN0CJTwQ.7HsVpdhdeedN_XYglWa-iol_P-MdSd6L3kA1KQc7dT4
+      pragma:
+      - no-cache
+      request-id:
+      - df87e3c7-0743-410c-80aa-8786556801fc
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --set
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2205'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:16 GMT
+      duration:
+      - '2383222'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - +ZQCeST5sqkh8PfRlmTpQsH/+32BWqALmUNV8T7ZW80=
+      ocp-aad-session-key:
+      - UFFbKpovpa3jpDsnmjUXMSNGnDoLSyrhPUJ_FVU4N6JRd9M9gb5t8faMDyTTWRP1JMCXCjRbTEbyvAmaVmFJh_CH8CInxEGCg-oPSk7Ey4gfxn4keZoPGgIVzbSXZ-HNeMDcja0f3VVLh3R5Qta1yA._SSqG-X0Wp3b4PGO9mR_6GvEN-LZtqwJ-l0SqJxoa2o
+      pragma:
+      - no-cache
+      request-id:
+      - 99c6558a-1b1d-4a7f-bddf-06d8b0b8c906
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --set
+      User-Agent:
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2208'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 16 Oct 2019 08:07:17 GMT
+      duration:
+      - '2403383'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - LYzAcq7V3eLxMoJD8VBflwEorAlQCAHjPijhfeZyV1w=
+      ocp-aad-session-key:
+      - rWAuGf35MvZeshtos48OMniuRU1-E9BgcA6SPnn5CWu9_ZA2UsA-kgQNt3G3vL6Q6SLJ6rY1EakqFPpq9M8vi_J3X3XZ-WGAph4bkksOKBESxbgK6zQavxhArS2-SJ-NiYuvfcOcvRdKxCbh2d969w.WiNyr-3DLo_t4CfjA-ngNhvKAQyGImPdFb9n2UkYYa0
+      pragma:
+      - no-cache
+      request-id:
+      - 0dff6891-4297-4fae-ba53-d65669e5136b
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"appRoles": [], "availableToOtherTenants": false, "homepage": "http://cli-graph000002",
+      "informationalUrls": {}, "knownClientApplications": [], "oauth2AllowImplicitFlow":
+      false, "oauth2AllowUrlPathMatching": true, "oauth2Permissions": [{"adminConsentDescription":
+      "Allow the application to access cli-graph000001 on behalf of the signed-in
+      user.", "adminConsentDisplayName": "Access cli-graph000001", "id": "01a223f0-3f2c-4f36-a5c4-e970b8f15157",
+      "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
+      to access cli-graph000001 on your behalf.", "userConsentDisplayName": "Access
+      cli-graph000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+      false, "orgRestrictions": [], "publisherDomain": "AzureSDKTeam.onmicrosoft.com",
+      "replyUrls": ["http://azureclitest-replyuri2"], "requiredResourceAccess": [],
+      "signInAudience": "AzureADMyOrg", "displayName": "cli-graph000002", "identifierUris":
       ["http://cli-graph000001"]}'
     headers:
       Accept:
@@ -2008,12 +2959,12 @@ interactions:
       ParameterSetName:
       - --id --set
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
       string: ''
@@ -2023,19 +2974,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Sat, 20 Jul 2019 19:08:10 GMT
+      - Wed, 16 Oct 2019 08:07:19 GMT
       duration:
-      - '1774514'
+      - '7329118'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - WuWPPeV7dv5/89XBwAEVlawMeyvMAtJ8EugXI+UUkGg=
+      - B2B0JGJdLwMkyIJk2CVbVPrGBozgMZvNfItsKCGgg7U=
       ocp-aad-session-key:
-      - Waeb8jIv4jY2iDETw_HE1FSczIhV4HnC9mU27VQUB2I3DQ-sR6hEp0Ch8aO_ro7iFRZbZQ30h6G04LcotwtrmMqh1N6qSCRKtxTwMa8pnJQxxngoVlOn1_dT-bqCJQ3mZ3vnHctJt5cUJLyGKeNB7g.yf1Vp71kmiP7sG_wPZKJrLA954DH-__OlpFPIraSRPM
+      - 6pt0NB9nA-_-JGiSsKP_nDC1xnrvhJk4cmenIPzJPE4IqjPPLjcjru7syMwyNwdzLAdpRzzMEF7kivJtUDxCFPPpsfAWmQY0fp4xtB3Kyb3ijMGCz0Hg65Nd_l1T0n9VcBNC7Qh1E2208WswnSQg8Q.i-kq7Faj8ldIOAIguaPXBtG6uWNGQA8ldP1WiQUAEG0
       pragma:
       - no-cache
       request-id:
-      - 602db69a-1737-4475-8f94-fccdb7961203
+      - c1cb77b9-63bd-4aaf-893f-2f5f398f4dc1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2061,44 +3012,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2205'
+      - '2207'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:11 GMT
+      - Wed, 16 Oct 2019 08:07:19 GMT
       duration:
-      - '633158'
+      - '2573934'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - wyZ2chLc7keUKHMJZ5WTQztb1eGl2liBganf3B36Fuk=
+      - hhJdfLW66JLi2nEcbTnUgI+AxnSecUxb4zj7RAMm+V0=
       ocp-aad-session-key:
-      - gY7BOoPF1iz4hF4F9gBw0dGI0bSrBgBR0m-JyV0c4SEvSDF0PO5HlEe74SiZhsYeA_zxhek5IzsvkJFztXeBrMFeEonjXMvqPYL0kKIlhk0J5eQ_1qZXtBYnx57ofcIbMG9eCOiNPMIB95uWx1ne6Q.mEBwW-ol7WYd4owmajlTL-QHFEBppuFDQSHSQ-Yjg1s
+      - fr0IIiRBBCUBm0qklRIxtdfMYSsfS1YopgZzgXiMhFJMf4m5L84O8D5knQo1Za5saJy8dje_I5TTmPT8prg_5qdEcblIOJrAuXBe2hfd2pATCrpyKPo7bckJajDEWnSePlccfgvqSAOEo0HIshw-ug.DRja3JL_ylSZktT0yI1GEonsVNAtoTgm7AeiE5HFJAI
       pragma:
       - no-cache
       request-id:
-      - ea3ca563-110c-4ff5-8989-773beb0e082e
+      - 091aae7c-fa4b-463c-b7e6-a43135941c47
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2124,44 +3075,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2202'
+      - '2204'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:10 GMT
+      - Wed, 16 Oct 2019 08:07:20 GMT
       duration:
-      - '541916'
+      - '2424307'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - s2UwUVi+htM/n2YkhPwXRPeUZqg0DtftoAt5dzpH0b8=
+      - hoeUnLk/HRIDactdqallGve/v3aEoFMSVRd79jp6uBg=
       ocp-aad-session-key:
-      - jSNlcC-Lo9Dz--H_VMwxv8MeIzFq_zp8udUO9Ugrny3wpagcG7dm-DLzgoinL6B2JxbSaudWL6istDAoGPApka08PXBv9Krypd_L_WVswrYI7MIOoPglUbbgKymOJg196DDEwG7EiLuVpA5MLg8p7Q.JQKxPWKM7uRRrr0OclceZ7lfjBLFPzouluUm0z5v_P4
+      - uRaYByPrTExwmCYeJyFSspP52pWyItem7zdPgVKaq2FZ4EvZ0vCOEec2z1uYOZ0Pl8vXiINlSCcmPK9BnDTgsw9_5Pm9fJvLESip9UqR-v6M7g51YL19W8lrz8OAFk7VfNVLLwSNq43pySHb4UQ87w.y2tdpr7jiuntfyLyH39eQVDIZtqWpMBz9C4JpNouTEY
       pragma:
       - no-cache
       request-id:
-      - d9b9b921-94a9-4141-a968-b0951c9ed3c1
+      - 77fadac3-4d45-4d2e-8fcd-e24e52031540
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2187,44 +3138,44 @@ interactions:
       ParameterSetName:
       - --id --app-roles
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2205'
+      - '2207'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:11 GMT
+      - Wed, 16 Oct 2019 08:07:21 GMT
       duration:
-      - '570044'
+      - '2410169'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - /NtEgZUZd+wP7jWSrDYgeIT+rUlfDWAtBVfze/ynjcQ=
+      - xvWJHMWAHzosjXNMZ9eWLFLy/hDOFxHPaxgG2NiJKnA=
       ocp-aad-session-key:
-      - _gr_lBLG-8mZng4bhsYQ6gr56Nb8uRybiok_JsrJf3LZdTedCbXSW-27T9EkXlSraU-S26igDAE5aT_T-INIsW-pGEcqx1oOQT1N5UjeM-jAslCMcfbaqYBbGo3RjzQo0vt5J1wy3ekqQxYFrhGsAA.UlwiKC0qq7acLvqjf-1F255KgYz90qgFFKL5b6Abq_o
+      - dMIS960xTy9Xw3JTLNUAn1k3CNt0n9bBliHlwCeG647gEkbexX0FN3mJ-se2UrrVH0NwPCSWPBhGwy2EQxZoX9FEiNH17dPaM-EMNCVMaunH891MWe13G9L6JNkf32ef0T2K2eTZnHp6UqthVBFZFw.LacUfII7n1uWZyqAjO0YJM8wJkKxbCnINw_ILRV5CJw
       pragma:
       - no-cache
       request-id:
-      - 5c446036-e689-4f29-b5a5-709ef3dd5f5b
+      - c2d394af-7f0a-42f7-b12c-d339bdbc3895
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2250,44 +3201,44 @@ interactions:
       ParameterSetName:
       - --id --app-roles
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2202'
+      - '2204'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:12 GMT
+      - Wed, 16 Oct 2019 08:07:21 GMT
       duration:
-      - '560549'
+      - '2397926'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - ZGx5BTxWx3rJ0qV6fN7KouGYhLhktis4+Etrku5CN4A=
+      - Z1oxbFGVWWSVUNgUJQwzH6MA8tfaPhwW0mAej+ZjmRA=
       ocp-aad-session-key:
-      - 9jcx5GbagUrtgyprY3Ob1auDppa7qQdeQzlnWcEEb4DFLH6dd8eATB-FVc-OiA1S53H-J9NVp3YENOugUW2JlUSMVI8QBJkB7xKugCtL-yfxO_fPOQ7F_qMweq8ZlHZY7gdkuinLkX2dyK2C3ifx9w.DhkveJxYTvxftjJu8PXVhg98WamT23a_OY8zmFyJcoM
+      - OjrgMuq_VRTJOJs_WDY8_mIA8UnTIkqUtKoAIkd8lN6BqdibgwE7CqAMTIfm6xjPFnscq78jtPDol-W_2BZcO017T3J74Hq2-Omc_quXotrRDvMUKyFenfiEhorg_BpLg7ioeEOg-DjrGmgsoohFzg.CU1DV_7gOvuBAvFbktu9JslnrznloW1iGlzWBGimvvU
       pragma:
       - no-cache
       request-id:
-      - ba3e12fa-e810-46a3-ab65-17ddcdbf3344
+      - 37e89a45-832d-4619-bf76-a9d0d80524a8
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2313,44 +3264,44 @@ interactions:
       ParameterSetName:
       - --id --app-roles
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2205'
+      - '2207'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:11 GMT
+      - Wed, 16 Oct 2019 08:07:22 GMT
       duration:
-      - '595095'
+      - '2374605'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - TJe6MFynSFyAmJNhaN8aNaZ14HLvl6p1KI20CCDX1+8=
+      - As0gHGadq5h2LTxl2ZFYNVFv2OujPh15mwcM8SjOsH0=
       ocp-aad-session-key:
-      - yrfeV6sWMXrrllOoujhSkjsKtkoD5JdZm38XipuGH_TU8vLOgFv0e10GM8JI3FJEq1qP6jEYcUIDZfV3NMxRJeYGJX9U3e_q0k1T26bc2rku35g2LXUv060YpewKP5goptV7-Y4hStb4IIieWP9gIw.tVjFLOH4RsFa2tMB3T-njv6JyuAiA-TIWGabbt5LsrM
+      - PgcKjlsnk0X6dP_N0RFJEXMzD3TMieZD11wDxa1QAiIJoyurDdgYik8Th4w0YYS_NDFT-T-ZfOsR2Trd8sJyOjIM-Cj49W7lCBaQI91_9ugaRNSfDZbZsZN_BEWWZGksh7HtK5gEh2REyIRQN78_IQ.MrR4ECpJQWoy6FwcnFYqois-WOIZNkqHtOfn2tBIv6k
       pragma:
       - no-cache
       request-id:
-      - 1325f79c-9518-434b-82eb-420992aba4e2
+      - 5be604c3-5a34-4706-8cc4-37363de12e24
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2363,20 +3314,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appRoles": [{"id": "79e1c228-a66f-439f-b389-df8fbed1e073", "allowedMemberTypes":
+    body: '{"appRoles": [{"id": "2d7ce059-1baa-493c-95ab-85d8ab0f440e", "allowedMemberTypes":
       ["User"], "description": "Approvers can mark documents as approved", "displayName":
       "Approver", "isEnabled": true, "value": "approver"}], "availableToOtherTenants":
-      false, "homepage": "http://cli-graph000001", "informationalUrls": {}, "knownClientApplications":
+      false, "homepage": "http://cli-graph000002", "informationalUrls": {}, "knownClientApplications":
       [], "oauth2AllowImplicitFlow": false, "oauth2AllowUrlPathMatching": true, "oauth2Permissions":
       [{"adminConsentDescription": "Allow the application to access cli-graph000001
       on behalf of the signed-in user.", "adminConsentDisplayName": "Access cli-graph000001",
-      "id": "bc8d4954-af91-42a9-be13-71ecf45ad652", "isEnabled": true, "type": "User",
+      "id": "01a223f0-3f2c-4f36-a5c4-e970b8f15157", "isEnabled": true, "type": "User",
       "userConsentDescription": "Allow the application to access cli-graph000001 on
       your behalf.", "userConsentDisplayName": "Access cli-graph000001", "value":
       "user_impersonation"}], "oauth2RequirePostResponse": false, "orgRestrictions":
       [], "publisherDomain": "AzureSDKTeam.onmicrosoft.com", "replyUrls": ["http://azureclitest-replyuri2"],
       "requiredResourceAccess": [], "signInAudience": "AzureADMyOrg", "displayName":
-      "cli-graph000001", "identifierUris": ["http://cli-graph000001"]}'
+      "cli-graph000002", "identifierUris": ["http://cli-graph000001"]}'
     headers:
       Accept:
       - application/json
@@ -2393,12 +3344,12 @@ interactions:
       ParameterSetName:
       - --id --app-roles
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
       string: ''
@@ -2408,19 +3359,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Sat, 20 Jul 2019 19:08:12 GMT
+      - Wed, 16 Oct 2019 08:07:23 GMT
       duration:
-      - '1991581'
+      - '5659400'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - OT1pBwZPRNgbUkGRpqPoxk5bHm4AmYoeYhjvz4y1ZHs=
+      - QF+2Kom5kdqiaMnyIX2qvy7RneHOkkB0ozKS2e4Q0lc=
       ocp-aad-session-key:
-      - Jjrve3dLmN1SPa74O01O73J3dfO-7UfP1_y9TR_jsOUdLqC4A0Pmf72yFseJpTnxI6fDpMvU-EBMeRCwGWEGIKAuwQ3u-KYzEjbi3nHrKIlEmOUzSvhwL-bmK7usAsjFpadhK1z-MehW_hz3nz6xFw.Ysn1dlnvgwgGMObOtVx_8zLVEi6o4CcKbZ37NMbsV_Y
+      - tKGYYrBpuiKRUQCB-wsx5tjXr7onoHYdWzjjBt0RrxrA0VhyG_u81pNeyUgKH8pTwJ16l1kU4ImHyRrYMxlr3Kl0l_7jq-RZiDj2hI-4zMH3kw4NwU5WLR0y1TWQwixHwkF9azHUgyWY7ZxyI5aNSA.v_eYGm0lb6lN05OOzNYyuiEgsL5NW4zsxk0oIVFkwrw
       pragma:
       - no-cache
       request-id:
-      - 7e69276c-4ae3-40d9-a4cb-20fa7ef69747
+      - eafcf008-4cd2-4474-837c-db3f15ddc0f9
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2446,45 +3397,45 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
-        can mark documents as approved","displayName":"Approver","id":"79e1c228-a66f-439f-b389-df8fbed1e073","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
+        can mark documents as approved","displayName":"Approver","id":"2d7ce059-1baa-493c-95ab-85d8ab0f440e","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2398'
+      - '2400'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:12 GMT
+      - Wed, 16 Oct 2019 08:07:24 GMT
       duration:
-      - '575777'
+      - '2742945'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - kJb7eEk4kMicgDbqn/N9c4r/6jAICP58uRw4QuTpBa0=
+      - 9ZHp9DWrFOJDdtIudkw3WViQ6HjfSWNkT6r5darksVU=
       ocp-aad-session-key:
-      - 5CPp3he94Hbl6j71SPAhxO5ZXmYOGnrmLWoXsbGQMBce4zYv4EoSMjEh-Cu6-kxstysD3bSvBpVj3HXa4go0UwYNB44FGZ75oPwG82j4oShu4hAgCfKhrsB__VvrV0irk2qHuBKfKvk58MOUfGu6Mw.BBoZ0qLMJhPFuYiINYEDNOUGkg-81Sqs63v6eUrTfgs
+      - OrD1_fgZ-i1Ohq9hiQHy5UNOjohz2a4L3ZMZabj4Voh23B61aTIvU-00H7NDpiIpC8pzTSYJu55SOSzlVNmbYH35nz9KvurW7Qrqof8LrcPBlejGSMAIMyDZX3TQFgnJrLVx5kqMXzgSWe66GmxgGA.0cqNGwisoRl_5zKutROX9I4yArYoqScDzNfCpIYw4LU
       pragma:
       - no-cache
       request-id:
-      - f5123b98-9df2-4676-91d9-aef9998709e9
+      - 4c549814-88f4-47b9-97d4-07f4e81a0378
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2510,45 +3461,45 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
-        can mark documents as approved","displayName":"Approver","id":"79e1c228-a66f-439f-b389-df8fbed1e073","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
+        can mark documents as approved","displayName":"Approver","id":"2d7ce059-1baa-493c-95ab-85d8ab0f440e","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2395'
+      - '2397'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:12 GMT
+      - Wed, 16 Oct 2019 08:07:25 GMT
       duration:
-      - '566179'
+      - '2417257'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 8cABrxGeuUtXZIb4tLTbZKP7GAyp5Rz3TMI9wedexHQ=
+      - 7aPIIBM9F67f67B178yBUSx82WhjIC+frQ+bJ4Jdp/A=
       ocp-aad-session-key:
-      - IVmg4bU_daOlF8Bg6SiozmvtfWZTzPrvNhKw-HLR4zV8ct18mN9WVmJLavMjVFnaZkkvKkS_YjNRdsH0HkUsPjumDYpcFqX6CAIKf4gaj-ZOx0Aw_G8kqq124j0QyhNYuLwoF9Azo4qXgnqCGZ0Z6Q.FZDuD4mZ1CjQbA6IFIIC6mAqsWtE-FGaWxuy-eR6o88
+      - nUNKYN5ECQON8wjPPTQZW_lmCzjIYWc1IckBFUa1oBq50yZ5pVbuWCI3Hcrt-z8CwCCmreWIywlzWJoSG55szqmpsbmxIF3pOG855IO7VtXFf8pe-28jJ4y_0Ik-3xgHlmVE0AoMzP2c_GpcUrLxtQ.lWkIr2cMkWdykf0l-ZcA493lhbK-9SFSC39thdPfazU
       pragma:
       - no-cache
       request-id:
-      - 35ed8912-2c14-400c-8076-51adc2912413
+      - aa488697-fc6a-4e13-a455-26545b852d57
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2574,45 +3525,45 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli-graph000001%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"42169648-56c7-4fdc-bd12-da49f52db75f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"b3e278fe-5210-432f-aa3e-050eb5355ed4","applicationTemplateId":null,"appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
-        can mark documents as approved","displayName":"Approver","id":"79e1c228-a66f-439f-b389-df8fbed1e073","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000001","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/42169648-56c7-4fdc-bd12-da49f52db75f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"68ede549-1321-42c5-bdeb-c9d527851bce","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1fcda07c-3b39-4056-a70f-a5f0361c0fcd","applicationTemplateId":null,"appRoles":[{"allowedMemberTypes":["User"],"description":"Approvers
+        can mark documents as approved","displayName":"Approver","id":"2d7ce059-1baa-493c-95ab-85d8ab0f440e","isEnabled":true,"value":"approver"}],"availableToOtherTenants":false,"displayName":"cli-graph000002","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://cli-graph000002","identifierUris":["http://cli-graph000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/68ede549-1321-42c5-bdeb-c9d527851bce/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":true,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-graph000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-graph000001","id":"bc8d4954-af91-42a9-be13-71ecf45ad652","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-graph000001","id":"01a223f0-3f2c-4f36-a5c4-e970b8f15157","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-graph000001 on your behalf.","userConsentDisplayName":"Access
-        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-07-20T19:08:03.25109Z","keyId":"d62da830-67d8-40b5-91e6-d492b63526ef","startDate":"2019-07-20T19:08:03.25109Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-graph000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2021-10-16T08:06:44.733518Z","keyId":"cfc0afdb-5307-41e2-b636-2f131c8793c4","startDate":"2019-10-16T08:06:44.733518Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":["http://azureclitest-replyuri2"],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2398'
+      - '2400'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:13 GMT
+      - Wed, 16 Oct 2019 08:07:25 GMT
       duration:
-      - '701770'
+      - '2398397'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - itPlsAoHbG6osDHbVzYs2a+9kGEe205TaLepJuLRQYY=
+      - xvWJHMWAHzosjXNMZ9eWLFLy/hDOFxHPaxgG2NiJKnA=
       ocp-aad-session-key:
-      - fmktM5NsP7qBQby7-XvaqWRKrBb610DnsphwFG6i4HiFNrvT3bbmhoTmFwYUOVGJduRVrNStYyCfUMjkjOqTuxy9gbLfj5tPgedSS3b9GYuTYQUxMqXysI4jpwoxwMAcHHn2th39fNdVbu-3UgsT3A.5pOeZvNt_O1a9d-GZhzBRkABE9wt3sJitIPgx7iuiSQ
+      - JZSKUNuMnceumMIUULKYzQP5JPxr2dhnCa5jS3Rvy6ojy5vNllXGcxFskyfEQpVEnSsm8ZwZcNO1WirttttjOQwkV6tFtPG1SPEXZg61T3VXfeCPXMzraGUNj7-aCAVxBN0pza4Y_sY1ktT1TC5lNg.OA6pHJYjC1400ROMPGgE5pQQ20d9HOqgMnfOk2TpY-c
       pragma:
       - no-cache
       request-id:
-      - 40d6ae03-6d4a-47d5-b0f0-fe3d64ba17ec
+      - 574f6d27-f65c-4f64-962a-827b7ce08919
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2640,12 +3591,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/42169648-56c7-4fdc-bd12-da49f52db75f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/68ede549-1321-42c5-bdeb-c9d527851bce?api-version=1.6
   response:
     body:
       string: ''
@@ -2655,19 +3606,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Sat, 20 Jul 2019 19:08:18 GMT
+      - Wed, 16 Oct 2019 08:07:32 GMT
       duration:
-      - '47204121'
+      - '57577751'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - PVnULe5dALNq/bbvE8F58gBDcMNb9mqLWPzuEA7CxHI=
+      - m44jz5vCS9u4O5sSSVss6CKrthWLHfOPU5++FHDbfV8=
       ocp-aad-session-key:
-      - AAPRfpYARYF0f1PsYjAsckEEtFA4HWpgwhwYct93-3ZClgzTnM17Ns9e9uAfV2bU3fFIcvNcXv35OPy-0HGWkNwskFYAlIptLinK4-GMXI6rYxR0G0MZfZbzJCTvDOcjayxHr9Ax6A4QlI__xEpD3A.G7W6sr7q0EnR0XSj2A8EN4YDdvPXfoirvJ1JhNCFqBw
+      - tvYix3X15wenWA353T08v6hLIpi1Gcb6MRHJ1aGj_8FS27njTSTlaeyeGGFmK9ZVhsVmFd--ZwNtLn9Ktute3oUcHcKid_rPD0KVyrUhk4yZzv6-2vPmdVqe-alCR7KAxNPZoQHhWDpSFBjNBVAowQ.Pb0eG4CARB2UynQC1w4UZHA-opEW7AiklCPAqowiWMM
       pragma:
       - no-cache
       request-id:
-      - 087a9287-b111-4bda-8499-44c6d18148ae
+      - 81a401be-f1ad-4f34-ab86-5d32acc9feef
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2693,8 +3644,8 @@ interactions:
       ParameterSetName:
       - --identifier-uri
       User-Agent:
-      - python/3.6.6 (Windows-10-10.0.18362-SP0) msrest/0.6.8 msrest_azure/0.6.1 azure-graphrbac/0.60.0
-        Azure-SDK-For-Python AZURECLI/2.0.69
+      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-graphrbac/0.60.0
+        Azure-SDK-For-Python AZURECLI/2.0.75
       accept-language:
       - en-US
     method: GET
@@ -2714,19 +3665,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sat, 20 Jul 2019 19:08:19 GMT
+      - Wed, 16 Oct 2019 08:07:33 GMT
       duration:
-      - '495377'
+      - '2337346'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 8cABrxGeuUtXZIb4tLTbZKP7GAyp5Rz3TMI9wedexHQ=
+      - jAY6tweZL71h4Zs/fSXIbbKUblkE4vI7Xhf6+Ag18Ok=
       ocp-aad-session-key:
-      - tU6RmEECYrgbI-RDrPJNa7R_Or5wTFIw6Ero90Fwh3q1ROjkgMefgfGLPJMzxs2wZBwNyMMrVBcX6YGbVEgLBYyMXYnAX_dBFez9xhFLvTkFtadjajKpl6OMd2NS9sFnYq4sKu-W_JvtOFl8Sj-vnA.pkD_wCgHU4JL81HvMBABaxOhWHgRJFIo44_MLmlishY
+      - uWy7uZ1vTeLUNxrArELkiyyZ84q98FLTZI0V-YxVF1ZI_Wh3HPC0nefEtsV_qY3uXzrrWomCkHp-cMmuWSBBZWBP7LHDFufcnixy7wXZPKwD3xINMUWYje0dzncTx2lKfc24pvApNfamIvHvWR6kAA.CukLayJYx-fp4UzvqVn5Nh-E_ofL-3LvIW6yQo2lFgU
       pragma:
       - no-cache
       request-id:
-      - 50702759-a12e-43f1-8d37-90b7cdb10dc7
+      - f400d857-6007-48f7-830d-8f25f7bffca3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:


### PR DESCRIPTION
Fix #10807: `az ad app update --id {} --display-name {}` doesn't work

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
