### PR TITLE
acr: support "--repositories" on token creation command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -497,7 +497,7 @@ short-summary: Create a scope map for an Azure Container Registry.
 examples:
   - name: Create a scope map that allows content/write and metadata/read actions for `hello-world` repository, and content/read action for `hello-world-again`.
     text: >
-        az acr scope-map create -n MyScopeMap -r MyRegistry --add hello-world content/write metadata/read --add hello-world-again content/read --description "Sample scope map."
+        az acr scope-map create -n MyScopeMap -r MyRegistry --repository hello-world content/write metadata/read --repository hello-world-again content/read --description "Sample scope map."
 """
 
 helps['acr scope-map delete'] = """
@@ -925,7 +925,16 @@ helps['acr token create'] = """
 type: command
 short-summary: Create a token associated with a scope map for an Azure Container Registry.
 examples:
-  - name: Create a token associated with the scope map 'MyScopeMap' in the 'disabled' status.
+  - name: Create a token with repository permissions defined in the scope map 'MyScopeMap'.
+    text: >
+        az acr token create -n MyToken -r MyRegistry --scope-map MyScopeMap
+  - name: Create a token which has read permissions on hello-world repository.
+    text: >
+        az acr token create -n myToken -r MyRegistry --repository hello-world content/read metadata/read
+  - name: Create a token without credentials.
+    text: >
+        az acr token create -n myToken -r MyRegistry --repository hello-world content/read --no-passwords
+  - name: Create a token in disabled status.
     text: >
         az acr token create -n MyToken -r MyRegistry --scope-map MyScopeMap --status disabled
 """

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -254,21 +254,32 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
     with self.argument_context('acr scope-map') as c:
         c.argument('registry_name', options_list=['--registry', '-r'])
         c.argument('description', options_list=['--description'], help='Description for the scope map. Maximum 256 characters are allowed.', required=False)
-        c.argument('add_repository', options_list=['--add'], nargs='+', help='Actions to be added. Use the format "--add REPO [ACTION1 ACTION2 ...]" per flag. Valid actions are metadata/read, metadata/write, content/read, content/write and content/delete', action='append', required=False)
-        c.argument('remove_repository', options_list=['--remove'], nargs='+', help='Actions to be removed. Use the format "--remove REPO [ACTION1 ACTION2 ...]" per flag. Valid actions are metadata/read, metadata/write, content/read, content/write and content/delete', action='append', required=False)
         c.argument('scope_map_name', options_list=['--name', '-n'], help='The name of the scope map.', required=True)
 
+    valid_actions = "Valid actions are metadata/read, metadata/write, content/read, content/write and content/delete"
+    with self.argument_context('acr scope-map update') as c:
+        c.argument('add_repository', options_list=['--add'], nargs='+', action='append', required=False,
+                   help='repository permissions to be added. Use the format "--add REPO [ACTION1 ACTION2 ...]" per flag. ' + valid_actions)
+        c.argument('remove_repository', options_list=['--remove'], nargs='+', action='append', required=False,
+                   help='respsitory permissions to be removed. Use the format "--remove REPO [ACTION1 ACTION2 ...]" per flag. ' + valid_actions)
+
     with self.argument_context('acr scope-map create') as c:
-        c.argument('add_repository', options_list=['--add'], nargs='+', help='Actions to be added. Use the format "--add REPO [ACTION1 ACTION2 ...]" per flag. Valid actions are metadata/read, metadata/write, content/read, content/write and content/delete', action='append', required=True)
+        c.argument('repository_actions_list', options_list=['--repository'], nargs='+', action='append', required=True,
+                   help='repository permissions. Use the format "--repository REPO [ACTION1 ACTION2 ...]" per flag. ' + valid_actions)
 
     with self.argument_context('acr token') as c:
         c.argument('registry_name', options_list=['--registry', '-r'])
         c.argument('token_name', options_list=['--name', '-n'], help='The name of the token.', required=True)
         c.argument('scope_map_name', options_list=['--scope-map'], help='The name of the scope map associated with the token', required=False)
-        c.argument('status', options_list=['--status'], help='The status of the token. Allowed values are "enabled" or "disabled".', required=False, default="enabled")
+        c.argument('status', options_list=['--status'], arg_type=get_enum_type(['enabled', 'disabled']),
+                   help='The status of the token', required=False, default="enabled")
 
     with self.argument_context('acr token create') as c:
-        c.argument('scope_map_name', options_list=['--scope-map'], help='The name of the scope map associated with the token', required=True)
+        c.argument('scope_map_name', options_list=['--scope-map'],
+                   help='The name of the scope map with pre-configured repository permissions. Use "--repository" if you would like CLI to configure one for you')
+        c.argument('repository_actions_list', options_list=['--repository'], nargs='+', action='append',
+                   help='repository permissions. Use the format "--repository REPO [ACTION1 ACTION2 ...]" per flag. ' + valid_actions)
+        c.argument('no_passwords', arg_type=get_three_state_flag(), help='Do not generate passwords, instead use "az acr token credentials regenerate"')
 
     with self.argument_context('acr token update') as c:
         c.argument('scope_map_name', options_list=['--scope-map'], help='The name of the scope map associated with the token. If not specified, running this command will disassociate the current scope map related to the token.', required=False)

--- a/src/azure-cli/azure/cli/command_modules/acr/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_utils.py
@@ -414,6 +414,19 @@ def get_task_id_from_task_name(cli_ctx, resource_group, registry_name, task_name
     )
 
 
+def parse_actions_from_repositories(allow_or_remove_repository):
+    REPOSITORIES = 'repositories'
+    actions = []
+    for rule in allow_or_remove_repository:
+        repository = rule[0]
+        if len(rule) < 2:
+            raise CLIError('At least one action must be specified with the repository {}.'.format(repository))
+        for action in rule[1:]:
+            actions.append('{}/{}/{}'.format(REPOSITORIES, repository, action))
+
+    return actions
+
+
 class ResourceNotFound(CLIError):
     """For exceptions that a resource couldn't be found in user's subscription
     """

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_token.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_token.py
@@ -1,0 +1,45 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
+
+
+class AcrTokenCommandsTests(ScenarioTest):
+
+    @AllowLargeResponse()
+    @ResourceGroupPreparer()
+    def test_repository_token_create(self):
+        self.kwargs.update({
+            'registry': self.create_random_name('clireg', 20),
+            'scope_map': 'scope-map',
+            'token': 'acr-token',
+            'token2': 'token-2'
+        })
+        self.cmd('acr create -g {rg} -n {registry} --sku premium')
+
+        # quick create
+        # ACR ever verifies the existence of the repository, hence we will feed a fake
+        self.cmd('acr token create -r {registry} -n {token} --repository foo content/read', checks=[
+            self.check('status', 'enabled'),
+            self.check('credentials.passwords[0].name', 'password1'),
+            self.check('credentials.passwords[1].name', 'password2'),
+            self.check('credentials.username', self.kwargs['token'])
+        ])
+        self.cmd('acr scope-map show -r {registry} -n {token}-scope-map', checks=[
+            self.check('actions', ['repositories/foo/content/read'])
+        ])
+
+        # create from an existing scope map
+        self.cmd('acr scope-map create -r {registry} -n {scope_map} --repository foo content/read metadata/read', checks=[
+            self.check('actions', ['repositories/foo/content/read', 'repositories/foo/metadata/read'])
+        ])
+        self.cmd('acr token create -r {registry} --scope-map {scope_map} -n {token2} --no-passwords', checks=[
+            self.check('credentials.passwords', [])
+        ])
+        self.cmd('acr token credential generate -r {registry} -n {token2} --password1 --password2', checks=[
+            self.check('passwords[0].name', 'password1'),
+            self.check('passwords[1].name', 'password2')
+        ])

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_token.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_token.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import unittest
 from azure_devtools.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
 
@@ -11,6 +12,7 @@ class AcrTokenCommandsTests(ScenarioTest):
 
     @AllowLargeResponse()
     @ResourceGroupPreparer()
+    @unittest.skip('blocked till the feature gets deployed to production')
     def test_repository_token_create(self):
         self.kwargs.update({
             'registry': self.create_random_name('clireg', 20),

--- a/src/azure-cli/azure/cli/command_modules/acr/token.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/token.py
@@ -3,33 +3,45 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from msrestazure.azure_exceptions import CloudError
+from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import CLIError
-from ._utils import get_resource_group_name_by_registry_name, validate_premium_registry
+from ._utils import get_resource_group_name_by_registry_name, validate_premium_registry, parse_actions_from_repositories
 
 SCOPE_MAPS = 'scopeMaps'
 TOKENS = 'tokens'
+DEF_SCOPE_MAP_NAME_TEMPLATE = '{}-scope-map'  # append - to minimize incidental collision
 
 
 def acr_token_create(cmd,
                      client,
                      registry_name,
                      token_name,
-                     scope_map_name,
+                     scope_map_name=None,
+                     repository_actions_list=None,
                      status=None,
-                     resource_group_name=None):
-
-    validate_premium_registry(cmd, registry_name, resource_group_name)
-
-    resource_group_name = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
-
+                     resource_group_name=None,
+                     no_passwords=None):
+    from knack.log import get_logger
     from ._utils import get_resource_id_by_registry_name
 
-    arm_resource_id = get_resource_id_by_registry_name(cmd.cli_ctx, registry_name)
-    scope_map_id = '{}/{}/{}'.format(arm_resource_id, SCOPE_MAPS, scope_map_name)
+    if bool(repository_actions_list) == bool(scope_map_name):
+        raise CLIError("usage error: --repository | --scope-map-name")
+
+    validate_premium_registry(cmd, registry_name, resource_group_name)
+    resource_group_name = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
+
+    logger = get_logger(__name__)
+    if repository_actions_list:
+        scope_map_id = _create_default_scope_map(cmd, resource_group_name, registry_name,
+                                                 token_name, repository_actions_list, logger)
+    else:
+        arm_resource_id = get_resource_id_by_registry_name(cmd.cli_ctx, registry_name)
+        scope_map_id = '{}/{}/{}'.format(arm_resource_id, SCOPE_MAPS, scope_map_name)
 
     Token = cmd.get_models('Token')
 
-    return client.create(
+    poller = client.create(
         resource_group_name,
         registry_name,
         token_name,
@@ -38,6 +50,51 @@ def acr_token_create(cmd,
             status=status
         )
     )
+
+    if no_passwords:
+        return poller
+
+    token = LongRunningOperation(cmd.cli_ctx)(poller)
+    _create_default_passwords(cmd, resource_group_name, registry_name, token, logger)
+    return token
+
+
+def _create_default_scope_map(cmd, resource_group_name, registry_name, token_name, repositories, logger):
+    from ._client_factory import cf_acr_scope_maps
+    scope_map_name = DEF_SCOPE_MAP_NAME_TEMPLATE.format(token_name)
+    scope_map_client = cf_acr_scope_maps(cmd.cli_ctx)
+    actions = parse_actions_from_repositories(repositories)
+    try:
+        existing_scope_map = scope_map_client.get(resource_group_name, registry_name, scope_map_name)
+        # for command idempotency, if the actions are the same, we accept it
+        if sorted(existing_scope_map.actions) == sorted(actions):
+            return existing_scope_map.id
+        raise CLIError('The default scope map was already configured with different respository permissions. Please'
+                       ' use "az acr scope-map update -r {} -n {} --add <REPO> --remove <REPO>" to update'.format(
+                           registry_name, scope_map_name))
+    except CloudError:
+        pass
+    logger.warning('Creating a scope map of "%s" for provided respository permissions', scope_map_name)
+    poller = scope_map_client.create(resource_group_name, registry_name, scope_map_name,
+                                     actions, "Token {}'s scope map".format(token_name))
+    scope_map = LongRunningOperation(cmd.cli_ctx)(poller)
+    return scope_map.id
+
+
+def _create_default_passwords(cmd, resource_group_name, registry_name, token, logger):
+    from ._client_factory import cf_acr_token_credentials, cf_acr_registries
+    cred_client = cf_acr_token_credentials(cmd.cli_ctx)
+    poller = acr_token_credential_generate(cmd, cred_client, registry_name, token.name,
+                                           password1=True, password2=True, days=None,
+                                           resource_group_name=resource_group_name)
+    credentials = LongRunningOperation(cmd.cli_ctx)(poller)
+    setattr(token.credentials, 'username', credentials.username)
+    setattr(token.credentials, 'passwords', credentials.passwords)
+    registry_client = cf_acr_registries(cmd.cli_ctx)
+    login_server = registry_client.get(resource_group_name, registry_name).login_server
+    logger.warning('Please store your generated credentials safely. Meanwhile you can use it through'
+                   ' "docker login %s -u %s -p %s"', login_server, token.credentials.username,
+                   token.credentials.passwords[0].value)
 
 
 def acr_token_delete(cmd,


### PR DESCRIPTION
This is to support fast ramp up on repository level of access control. One command will set up all for users. 
Notes:
1. For consistency, I also renamed the `--add` to `--repositories` to be consistent with `az acr token create`, but do let me know if you feel the `--add` is better. 
2. When the existing scope-map is detected, if the actions are the same, CLI will accept it; otherwise it will throw. This is to support command level idempotency that you can run the same command again and again.


- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
