### PR TITLE
 Add reference to az find from help

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -84,6 +84,8 @@ class CLIPrintMixin(CLIHelp):
                 _print_indent(u'{0}'.format(e.long_summary), indent)
             _print_indent(u'{0}'.format(e.command), indent)
             print('')
+        indent = 0
+        _print_indent('For more specific examples, use: az find \'az {}\' \n'.format(help_file.command), indent)
 
     @staticmethod
     def _process_value_sources(p):

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -74,6 +74,7 @@ class CLIPrintMixin(CLIHelp):
 
     @staticmethod
     def _print_examples(help_file):
+        from colorama import Style
         indent = 0
         _print_indent('Examples', indent)
         for e in help_file.examples:
@@ -85,7 +86,8 @@ class CLIPrintMixin(CLIHelp):
             _print_indent(u'{0}'.format(e.command), indent)
             print('')
         indent = 0
-        _print_indent('For more specific examples, use: az find \'az {}\' \n'.format(help_file.command), indent)
+        message = 'For more specific examples, use: az find \'az {}\''.format(help_file.command)
+        _print_indent(Style.BRIGHT + message + Style.RESET_ALL + '\n', indent)
 
     @staticmethod
     def _process_value_sources(p):

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -86,7 +86,7 @@ class CLIPrintMixin(CLIHelp):
             _print_indent(u'{0}'.format(e.command), indent)
             print('')
         indent = 0
-        message = 'For more specific examples, use: az find \'az {}\''.format(help_file.command)
+        message = 'For more specific examples, use: az find "az {}"'.format(help_file.command)
         _print_indent(Style.BRIGHT + message + Style.RESET_ALL + '\n', indent)
 
     @staticmethod


### PR DESCRIPTION
This update informs users about the `az find` command when they use `-h` on a command with examples. The goal is to increase adoption of the command by making more people aware of it. It will print in a format like this:

```
Examples
    Redeploy a VM.
        az vm redeploy -g MyResourceGroup -n MyVm

    Redeploy all VMs in a resource group.
        az vm redeploy --ids $(az vm list -g MyResourceGroup --query "[].id" -o tsv)

For more specific examples, use: az find 'az vm redeploy'
```

As this solely modifies help, I haven't updated the HISTORY.rst file.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
