### PR TITLE
[Core]support more kwargs for `--defer`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -132,13 +132,11 @@ class CacheObject(object):
 
         if len(args) > 2:
             raise CLIError('expected 2 args, got {}: {}'.format(len(args), args))
-        if len(copy_kwargs) > 1:
-            raise CLIError('expected 1 kwarg, got {}: {}'.format(len(copy_kwargs), copy_kwargs))
 
         try:
             resource_name = args[-1]
         except IndexError:
-            resource_name = list(copy_kwargs.values())[0]
+            resource_name = '_'.join(list(copy_kwargs.values()))
 
         self._resource_group = resource_group
         self._resource_name = resource_name

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -136,7 +136,7 @@ class CacheObject(object):
         try:
             resource_name = args[-1]
         except IndexError:
-            resource_name = '_'.join(list(copy_kwargs.values()))
+            resource_name = list(copy_kwargs.values())[-1]
 
         self._resource_group = resource_group
         self._resource_name = resource_name

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -133,10 +133,13 @@ class CacheObject(object):
         if len(args) > 2:
             raise CLIError('expected 2 args, got {}: {}'.format(len(args), args))
 
+        directory_appendix = None
         try:
             resource_name = args[-1]
         except IndexError:
-            resource_name = list(copy_kwargs.values())[-1]
+            resource_list = list(copy_kwargs.values())
+            resource_name = resource_list.pop()
+            directory_appendix = resource_list
 
         self._resource_group = resource_group
         self._resource_name = resource_name
@@ -149,6 +152,10 @@ class CacheObject(object):
             self._resource_group,
             self._model_name
         )
+
+        if directory_appendix:
+            directory = os.path.join(directory, *directory_appendix)
+
         filename = '{}.json'.format(resource_name)
         return directory, filename
 


### PR DESCRIPTION
---
to support 
```
cached_put(cmd, client.create_or_update, rule_group, resource_group_name=resource_group_name, firewall_policy_name=firewall_policy_name, rule_group_name=rule_group_name)
```
This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
