### PR TITLE
[acr] import warn users if 'acr import' specifies the source registry twice

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -122,6 +122,6 @@ def _handle_result(cmd, result_poller, source_registry, source_image, registry):
         except (ClientException, CLIError) as unexpected_ex:  # raise exception
             logger.debug("Unexpected exception: %s", unexpected_ex)
 
-        logger.debug("Re-raise exception: %s", e)
-        raise e  # regardless reraise the CLIError as this is an error from the service
+        raise e  # regardless re-raise the CLIError as this is an error from the service
+
     return result

--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -124,9 +124,4 @@ def _handle_result(cmd, result_poller, source_registry, source_image, registry):
 
         logger.debug("Re-raise exception: %s", e)
         raise e  # regardless reraise the CLIError as this is an error from the service
-
-    except AttributeError:
-        # in the unlikely event that import_image's api changes and no longer returns a poller, return result
-        return result_poller
-
     return result


### PR DESCRIPTION
Warn users if 'acr import' specifies the source registry twice in --registry and --source.

Expected input
```
(venv) PS C:\Users\oladewal\source\azure-cli\azure-cli> az acr import -n tosinreg2 --source hello-world:v1 -t hello-world:v3 -r "ovatestregistry.azurecr.io" --force
```
Erroneous input with warning added in this pr.
```
(venv) PS C:\Users\oladewal\source\azure-cli\azure-cli> az acr import -n tosinreg2 --source ovatestregistry.azurecr.io/hello-world:v1 -t hello-world:v3 -r "ovatestregistry.azurecr.io"  
Importing image 'ovatestregistry.azurecr.io/ovatestregistry.azurecr.io/hello-world:v1'...
Please ensure that '--source' is a source image and not a fully qualified source, as the source registry was specified via '--registry'
Deployment failed. Correlation ID: fa122d20-baeb-4ad2-a155-3b608659c22b. Operation registries-4254c91c-f47d-11e9-95e8-186024958e56 failed. Resource /subscriptions/00000/resourceGroups/ova-test/providers/Microsoft.ContainerRegistry/registries/tosinreg2 hello-world:v3 Tag hello-world:v3 already exists in target registry.
(venv) PS C:\Users\oladewal\source\azure-cli\azure-cli> az acr import -n tosinreg2 --source ovatestregistry.azurecr.io/hello-world:v1 -t hello-world:v3 -r "/subscriptions/00000/resourceGroups/ova-test/providers/Microsoft.ContainerRegistry/registries/ovaTestRegistry"

Importing image 'ovatestregistry.azurecr.io/ovatestregistry.azurecr.io/hello-world:v1'...
Please ensure that '--source' is a source image and not a fully qualified source, as the source registry was specified via '--registry'
Deployment failed. Correlation ID: 83ac7d3e-5c1c-46a4-8ce4-f19a46acf0f6. Operation registries-526d50c6-f47d-11e9-9d6b-186024958e56 failed. Resource /subscriptions/00000/resourceGroups/ova-test/providers/Microsoft.ContainerRegistry/registries/tosinreg2 hello-world:v3 Tag hello-world:v3 already exists in target registry.
(venv) PS C:\Users\oladewal\source\azure-cli\azure-cli> az acr import -n tosinreg2 --source ovatestregistry.azurecr.io/hello-world:v1 -t hello-world:v3 -r "ovaTestRegistry"

Importing image 'ovatestregistry.azurecr.io/ovatestregistry.azurecr.io/hello-world:v1'...
Please ensure that '--source' is a source image and not a fully qualified source, as the source registry was specified via '--registry'
Deployment failed. Correlation ID: f830b3ff-09d7-4851-8cd3-dc953b98cc54. Operation registries-5fca2e1e-f47d-11e9-82a6-186024958e56 failed. Resource /subscriptions/00000/resourceGroups/ova-test/providers/Microsoft.ContainerRegistry/registries/tosinreg2 hello-world:v3 Tag hello-world:v3 already exists in target registry.
```


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
