### PR TITLE
Add Identity configurability to ExpressRoute Port and MACsec configurability to ExpressRoute Link

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -259,6 +259,8 @@ Release History
 * az network application-gateway ssl-cert: Fix #8244. Add support for setting key vault id in application-gateway ssl-cert.
 * az network express-route peering peer-connection: Fix #9404. Onboard `show` and `list` command for Azure express route peering peer connection resource.
 * az network vnet-gateway create/update: Fix #9327. Support `--custom-routes` argument to set custom routes address space for VNet gateway and VPN client.
+* az network express-route port identity: Fix #10747. Support to configure identity.
+* az network express-route port link update: Fix #10747. Support to configure MACsec and enable/disable admin state.
 
 **Policy**
 

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -2351,6 +2351,29 @@ type: command
 short-summary: Get the details of an ExpressRoute link.
 """
 
+
+helps['network express-route port link update'] = """
+type: command
+short-summary: Manage MACsec configuration of an ExpressRoute Link.
+examples:
+  - name: Enable MACsec on ExpressRoute Direct Ports once at a time.
+    text: |-
+        az network express-route port link update \\
+        --resource-group MyResourceGroup \\
+        --port-name MyExpressRoutePort \\
+        --name MyExpressRouteLink \\
+        --ckn-secret-identifier MacSecCKNSecretID \\
+        --cak-secret-identifier MacSecCAKSecretID \\
+        --cipher gcm-aes-128
+  - name: Enable administrative state of an ExpressRoute Link.
+    text: |-
+        az network express-route port link update \\
+        --resource-group MyResourceGroup \\
+        --port-name MyExpressRoutePort \\
+        --name MyExpressRouteLink \\
+        --admin-state Enabled
+"""
+
 helps['network express-route port list'] = """
 type: command
 short-summary: List ExpressRoute ports.

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -2395,7 +2395,8 @@ type: command
 short-summary: Assign a managed service identity to an ExpressRoute Port
 examples:
   - name: Assign an identity to the ExpressRoute Port
-    text: az network express-route identity assign -g MyResourceGroup --name MyExpressRoutePortName \\ --identity /subscriptions/*-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1
+    text: az network express-route port identity assign --resource-group MyResourceGroup --name MyExpressRoutePort
+            --identity MyUserAssignedManagedServiceIdentity
 """
 
 helps['network express-route port identity remove'] = """
@@ -2403,7 +2404,7 @@ type: command
 short-summary: Remove the managed service identity of an ExpressRoute Port
 examples:
   - name: Remove an identity of the ExpressRoute Port
-    text: az network application-gateway identity remove -g MyResourceGroup --name MyExpressRoutePortName
+    text: az network express-route port identity remove -g MyResourceGroup --name MyExpressRoutePort
 """
 
 helps['network express-route port identity show'] = """
@@ -2411,7 +2412,7 @@ type: command
 short-summary: Show the managed service identity of an ExpressRoute Port
 examples:
   - name: Show an identity of the ExpressRoute Port
-    text: az network application-gateway identity show -g MyResourceGroup --name MyExpressRoutePortName
+    text: az network express-route port identity show -g MyResourceGroup --name MyExpressRoutePort
 """
 
 helps['network express-route show'] = """

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -2362,9 +2362,9 @@ examples:
         --resource-group MyResourceGroup \\
         --port-name MyExpressRoutePort \\
         --name MyExpressRouteLink \\
-        --ckn-secret-identifier MacSecCKNSecretID \\
-        --cak-secret-identifier MacSecCAKSecretID \\
-        --cipher gcm-aes-128
+        --macsec-ckn-secret-identifier MacSecCKNSecretID \\
+        --macsec-cak-secret-identifier MacSecCAKSecretID \\
+        --macsec-cipher gcm-aes-128
   - name: Enable administrative state of an ExpressRoute Link.
     text: |-
         az network express-route port link update \\

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -2361,7 +2361,7 @@ examples:
         az network express-route port link update \\
         --resource-group MyResourceGroup \\
         --port-name MyExpressRoutePort \\
-        --name MyExpressRouteLink \\
+        --name link1 \\
         --macsec-ckn-secret-identifier MacSecCKNSecretID \\
         --macsec-cak-secret-identifier MacSecCAKSecretID \\
         --macsec-cipher gcm-aes-128
@@ -2370,7 +2370,7 @@ examples:
         az network express-route port link update \\
         --resource-group MyResourceGroup \\
         --port-name MyExpressRoutePort \\
-        --name MyExpressRouteLink \\
+        --name link2 \\
         --admin-state Enabled
 """
 

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -2385,6 +2385,35 @@ type: command
 short-summary: Update settings of an ExpressRoute port.
 """
 
+helps['network express-route port identity'] = """
+type: group
+short-summary: Manage the managed service identity of an ExpressRoute Port
+"""
+
+helps['network express-route port identity assign'] = """
+type: command
+short-summary: Assign a managed service identity to an ExpressRoute Port
+examples:
+  - name: Assign an identity to the ExpressRoute Port
+    text: az network express-route identity assign -g MyResourceGroup --name MyExpressRoutePortName \\ --identity /subscriptions/*-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1
+"""
+
+helps['network express-route port identity remove'] = """
+type: command
+short-summary: Remove the managed service identity of an ExpressRoute Port
+examples:
+  - name: Remove an identity of the ExpressRoute Port
+    text: az network application-gateway identity remove -g MyResourceGroup --name MyExpressRoutePortName
+"""
+
+helps['network express-route port identity show'] = """
+type: command
+short-summary: Show the managed service identity of an ExpressRoute Port
+examples:
+  - name: Show an identity of the ExpressRoute Port
+    text: az network application-gateway identity show -g MyResourceGroup --name MyExpressRoutePortName
+"""
+
 helps['network express-route show'] = """
 type: command
 short-summary: Get the details of an ExpressRoute circuit.

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -2395,8 +2395,11 @@ type: command
 short-summary: Assign a managed service identity to an ExpressRoute Port
 examples:
   - name: Assign an identity to the ExpressRoute Port
-    text: az network express-route port identity assign --resource-group MyResourceGroup --name MyExpressRoutePort
-            --identity MyUserAssignedManagedServiceIdentity
+    text: |-
+        az network express-route port identity assign \\
+        --resource-group MyResourceGroupg \\
+        --name MyExpressRoutePort \\
+        --identity MyUserAssignedManagedServiceIdentity
 """
 
 helps['network express-route port identity remove'] = """

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -52,7 +52,8 @@ def load_arguments(self, _):
      FlowLogFormatType, HTTPMethod, IPAllocationMethod,
      IPVersion, LoadBalancerSkuName, LoadDistribution, ProbeProtocol, ProcessorArchitecture, Protocol, PublicIPAddressSkuName,
      RouteNextHopType, SecurityRuleAccess, SecurityRuleProtocol, SecurityRuleDirection, TransportProtocol,
-     VirtualNetworkGatewaySkuName, VirtualNetworkGatewayType, VpnClientProtocol, VpnType, ZoneType) = self.get_models(
+     VirtualNetworkGatewaySkuName, VirtualNetworkGatewayType, VpnClientProtocol, VpnType, ZoneType,
+     ExpressRouteLinkMacSecCipher, ExpressRouteLinkAdminState) = self.get_models(
          'Access', 'ApplicationGatewayFirewallMode', 'ApplicationGatewayProtocol', 'ApplicationGatewayRedirectType',
          'ApplicationGatewayRequestRoutingRuleType', 'ApplicationGatewaySkuName', 'ApplicationGatewaySslProtocol', 'AuthenticationMethod',
          'Direction',
@@ -60,7 +61,8 @@ def load_arguments(self, _):
          'FlowLogFormatType', 'HTTPMethod', 'IPAllocationMethod',
          'IPVersion', 'LoadBalancerSkuName', 'LoadDistribution', 'ProbeProtocol', 'ProcessorArchitecture', 'Protocol', 'PublicIPAddressSkuName',
          'RouteNextHopType', 'SecurityRuleAccess', 'SecurityRuleProtocol', 'SecurityRuleDirection', 'TransportProtocol',
-         'VirtualNetworkGatewaySkuName', 'VirtualNetworkGatewayType', 'VpnClientProtocol', 'VpnType', 'ZoneType')
+         'VirtualNetworkGatewaySkuName', 'VirtualNetworkGatewayType', 'VpnClientProtocol', 'VpnType', 'ZoneType',
+         'ExpressRouteLinkMacSecCipher', 'ExpressRouteLinkAdminState')
 
     if self.supported_api_version(min_api='2018-02-01'):
         ExpressRoutePeeringType = self.get_models('ExpressRoutePeeringType')
@@ -85,6 +87,8 @@ def load_arguments(self, _):
     http_protocol_type = CLIArgumentType(get_enum_type(ApplicationGatewayProtocol))
     ag_servers_type = CLIArgumentType(nargs='+', help='Space-separated list of IP addresses or DNS names corresponding to backend servers.', validator=get_servers_validator())
     app_gateway_name_type = CLIArgumentType(help='Name of the application gateway.', options_list='--gateway-name', completer=get_resource_name_completion_list('Microsoft.Network/applicationGateways'), id_part='name')
+    express_route_link_macsec_cipher_type = CLIArgumentType(get_enum_type(ExpressRouteLinkMacSecCipher))
+    express_route_link_admin_state_type = CLIArgumentType(get_enum_type(ExpressRouteLinkAdminState))
 
     # region NetworkRoot
     with self.argument_context('network') as c:
@@ -615,6 +619,18 @@ def load_arguments(self, _):
 
     with self.argument_context('network express-route port link list', min_api='2018-08-01') as c:
         c.argument('express_route_port_name', er_port_name_type, id_part=None)
+
+    with self.argument_context('network express-route port link update', min_api='2019-08-01') as c:
+        c.argument('admin_state',
+                   arg_type=express_route_link_admin_state_type,
+                   help='Enable/Disable administrative state of an ExpressRoute Link')
+
+    with self.argument_context('network express-route port link update', arg_group='MACsec', min_api='2019-08-01') as c:
+        c.argument('macsec_cak_secret_identifier',
+                   help='The connectivity association key (CAK) ID that stored in the KeyVault.')
+        c.argument('macsec_ckn_secret_identifier',
+                   help='The connectivity key name (CKN) that stored in the KeyVault.')
+        c.argument('macsec_cipher', arg_type=express_route_link_macsec_cipher_type, help='Cipher Method')
 
     with self.argument_context('network express-route port location', min_api='2018-08-01') as c:
         c.argument('location_name', options_list=['--location', '-l'])

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -615,7 +615,8 @@ def load_arguments(self, _):
 
     with self.argument_context('network express-route port link', min_api='2018-08-01') as c:
         c.argument('express_route_port_name', er_port_name_type)
-        c.argument('link_name', options_list=['--name', '-n'], id_part='child_name_1')
+        c.argument('link_name', options_list=['--name', '-n'], id_part='child_name_1',
+                   help='The link name of the ExpressRoute Port')
 
     with self.argument_context('network express-route port link list', min_api='2018-08-01') as c:
         c.argument('express_route_port_name', er_port_name_type, id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -618,6 +618,10 @@ def load_arguments(self, _):
 
     with self.argument_context('network express-route port location', min_api='2018-08-01') as c:
         c.argument('location_name', options_list=['--location', '-l'])
+
+    with self.argument_context('network express-route port identity assign', arg_group='Identity', min_api='2019-08-01') as c:
+        c.argument('user_assigned_identity', options_list='--identity',
+                   help="Name or ID of the ManagedIdentity Resource", validator=validate_application_gateway_identity)
     # endregion
 
     # region PrivateEndpoint

--- a/src/azure-cli/azure/cli/command_modules/network/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/commands.py
@@ -596,6 +596,12 @@ def load_command_table(self, _):
         g.command('list', 'list')
         g.show_command('show')
 
+    with self.command_group('network express-route port link', network_er_ports_sdk) as g:
+        g.generic_update_command('update',
+                                 custom_func_name='update_express_route_port_link',
+                                 supports_no_wait=True,
+                                 min_api='2019-08-01')
+
     with self.command_group('network express-route port location', network_er_port_locations_sdk) as g:
         g.command('list', 'list')
         g.show_command('show')

--- a/src/azure-cli/azure/cli/command_modules/network/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/commands.py
@@ -587,6 +587,11 @@ def load_command_table(self, _):
         g.show_command('show')
         g.generic_update_command('update', custom_func_name='update_express_route_port')
 
+    with self.command_group('network express-route port identity', min_api='2019-08-01') as g:
+        g.custom_command('assign', 'assign_express_route_port_identity', supports_no_wait=True)
+        g.custom_command('remove', 'remove_express_route_port_identity', supports_no_wait=True)
+        g.custom_show_command('show', 'show_express_route_port_identity')
+
     with self.command_group('network express-route port link', network_er_links_sdk) as g:
         g.command('list', 'list')
         g.show_command('show')

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2104,6 +2104,44 @@ def list_express_route_ports(cmd, resource_group_name=None):
     if resource_group_name:
         return client.list_by_resource_group(resource_group_name)
     return client.list()
+
+
+def assign_express_route_port_identity(cmd, resource_group_name, express_route_port_name,
+                                       user_assigned_identity, no_wait=False):
+    client = network_client_factory(cmd.cli_ctx).express_route_ports
+    ports = client.get(resource_group_name, express_route_port_name)
+
+    ManagedServiceIdentity, ManagedServiceIdentityUserAssignedIdentitiesValue = \
+        cmd.get_models('ManagedServiceIdentity', 'ManagedServiceIdentityUserAssignedIdentitiesValue')
+
+    user_assigned_identity_instance = ManagedServiceIdentityUserAssignedIdentitiesValue()
+    user_assigned_identities_instance = dict()
+    user_assigned_identities_instance[user_assigned_identity] = user_assigned_identity_instance
+
+    identity_instance = ManagedServiceIdentity(type="UserAssigned",
+                                               user_assigned_identities=user_assigned_identities_instance)
+    ports.identity = identity_instance
+
+    return sdk_no_wait(no_wait, client.create_or_update, resource_group_name, express_route_port_name, ports)
+
+
+def remove_express_route_port_identity(cmd, resource_group_name, express_route_port_name, no_wait=False):
+    client = network_client_factory(cmd.cli_ctx).express_route_ports
+    ports = client.get(resource_group_name, express_route_port_name)
+
+    if ports.identity is None:
+        logger.warning("The identity of the ExpressRoute Port doesn't exist.")
+        return ports
+
+    ports.identity = None
+
+    return sdk_no_wait(no_wait, client.create_or_update, resource_group_name, express_route_port_name, ports)
+
+
+def show_express_route_port_identity(cmd, resource_group_name, express_route_port_name):
+    client = network_client_factory(cmd.cli_ctx).express_route_ports
+    ports = client.get(resource_group_name, express_route_port_name)
+    return ports.identity
 # endregion
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2150,8 +2150,8 @@ def update_express_route_port_link(cmd, instance, express_route_port_name, link_
     """
     :param cmd:
     :param instance: an instance of ExpressRoutePort
-    :param express_route_port_name
-    :param link_name
+    :param express_route_port_name:
+    :param link_name:
     :param macsec_cak_secret_identifier:
     :param macsec_ckn_secret_identifier:
     :param macsec_cipher:

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2142,6 +2142,46 @@ def show_express_route_port_identity(cmd, resource_group_name, express_route_por
     client = network_client_factory(cmd.cli_ctx).express_route_ports
     ports = client.get(resource_group_name, express_route_port_name)
     return ports.identity
+
+
+def update_express_route_port_link(cmd, instance, express_route_port_name, link_name,
+                                   macsec_cak_secret_identifier=None, macsec_ckn_secret_identifier=None,
+                                   macsec_cipher=None, admin_state=None):
+    """
+    :param cmd:
+    :param instance: an instance of ExpressRoutePort
+    :param express_route_port_name
+    :param link_name
+    :param macsec_cak_secret_identifier:
+    :param macsec_ckn_secret_identifier:
+    :param macsec_cipher:
+    :param admin_state:
+    :return:
+    """
+    if len(instance.links) != 2:
+        raise CLIError("The number of ExpressRoute Links should be 2. "
+                       "Code may not perform as expected. Please contact us to update CLI.")
+
+    try:
+        link_index = [index for index, link in enumerate(instance.links) if link.name == link_name][0]
+    except Exception:
+        raise CLIError('ExpressRoute Link "{}" not found'.format(link_name))
+
+    if any([macsec_cak_secret_identifier, macsec_ckn_secret_identifier, macsec_cipher]):
+        instance.links[link_index].mac_sec_config.cak_secret_identifier = macsec_cak_secret_identifier
+        instance.links[link_index].mac_sec_config.ckn_secret_identifier = macsec_ckn_secret_identifier
+
+        # TODO https://github.com/Azure/azure-rest-api-specs/issues/7569
+        # need to remove this conversion when the issue is fixed.
+        if macsec_cipher is not None:
+            macsec_ciphers_tmp = {'gcm-aes-128': 'GcmAes128', 'gcm-aes-256': 'GcmAes256'}
+            macsec_cipher = macsec_ciphers_tmp[macsec_cipher]
+        instance.links[link_index].mac_sec_config.cipher = macsec_cipher
+
+    if admin_state is not None:
+        instance.links[link_index].admin_state = admin_state
+
+    return instance
 # endregion
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -1219,6 +1219,12 @@ class NetworkExpressRouteScenarioTest(ScenarioTest):
         self.cmd('network express-route list --resource-group {rg}', checks=self.is_empty())
 
 
+class NetworkExpressRoutePortScenarioTest(ScenarioTest):
+
+    def test_network_express_route_identity(self):
+        pass
+
+
 class NetworkExpressRouteIPv6PeeringScenarioTest(ScenarioTest):
 
     @ResourceGroupPreparer(name_prefix='cli_test_express_route_ipv6_peering')

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -1224,7 +1224,7 @@ class NetworkExpressRoutePortScenarioTest(ScenarioTest):
     def test_network_express_route_port_identity(self):
         """
         Since the resource ExpressRoute Port is rare currently, it's very expensive to write test.
-        We test it manually by cooperating with Service team for now.
+        We run test manually for now. Any changes related to this command, please contract to Service team for help.
         For ussage, run `az network express-route port identity --help` to get help.
         """
         pass
@@ -1232,7 +1232,7 @@ class NetworkExpressRoutePortScenarioTest(ScenarioTest):
     def test_network_express_route_port_config_macsec(self):
         """
         Since the resource ExpressRoute Port is rare currently, it's very expensive to write test.
-        We test it manually by cooperating with Service team for now.
+        We run test manually for now. Any changes related to this command, please contract to Service team for help.
         For ussage, run `az network express-route port link update --help` to get help.
         """
         pass
@@ -1240,7 +1240,7 @@ class NetworkExpressRoutePortScenarioTest(ScenarioTest):
     def test_network_express_route_port_config_adminstate(self):
         """
         Since the resource ExpressRoute Port is rare currently, it's very expensive to write test.
-        We test it manually by cooperating with Service team for now.
+        We run test manually for now. Any changes related to this command, please contract to Service team for help.
         For ussage, run `az network express-route port link update --help` to get help.
         """
         pass

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -1221,7 +1221,28 @@ class NetworkExpressRouteScenarioTest(ScenarioTest):
 
 class NetworkExpressRoutePortScenarioTest(ScenarioTest):
 
-    def test_network_express_route_identity(self):
+    def test_network_express_route_port_identity(self):
+        """
+        Since the resource ExpressRoute Port is rare currently, it's very expensive to write test.
+        We test it manually by cooperating with Service team for now.
+        For ussage, run `az network express-route port identity --help` to get help.
+        """
+        pass
+
+    def test_network_express_route_port_config_macsec(self):
+        """
+        Since the resource ExpressRoute Port is rare currently, it's very expensive to write test.
+        We test it manually by cooperating with Service team for now.
+        For ussage, run `az network express-route port link update --help` to get help.
+        """
+        pass
+
+    def test_network_express_route_port_config_adminstate(self):
+        """
+        Since the resource ExpressRoute Port is rare currently, it's very expensive to write test.
+        We test it manually by cooperating with Service team for now.
+        For ussage, run `az network express-route port link update --help` to get help.
+        """
         pass
 
 


### PR DESCRIPTION
Add features requested in #10747

- Support to configure identity in `az network express-route port identity`
- Support to configure MACsec in `az network express-route port link`
- Support enable/disable admin state in `az network express-route port link`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
