### PR TITLE
Fix #10578: `az login` hangs

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -367,9 +367,9 @@ def sdk_no_wait(no_wait, func, *args, **kwargs):
 def open_page_in_browser(url):
     import subprocess
     import webbrowser
-    platform_name, release = _get_platform_info()
+    platform_name, _ = _get_platform_info()
 
-    if _is_wsl(platform_name, release):   # windows 10 linux subsystem
+    if is_wsl():   # windows 10 linux subsystem
         try:
             return subprocess.call(['cmd.exe', '/c', "start {}".format(url.replace('&', '^&'))])
         except OSError:  # WSL might be too old  # FileNotFoundError introduced in Python 3
@@ -395,16 +395,21 @@ def _get_platform_info():
     return platform_name.lower(), release.lower()
 
 
-def _is_wsl(platform_name, release):
+def is_wsl():
     platform_name, release = _get_platform_info()
     return platform_name == 'linux' and release.split('-')[-1] == 'microsoft'
+
+
+def is_windows():
+    platform_name, _ = _get_platform_info()
+    return platform_name == 'windows'
 
 
 def can_launch_browser():
     import os
     import webbrowser
-    platform_name, release = _get_platform_info()
-    if _is_wsl(platform_name, release) or platform_name != 'linux':
+    platform_name, _ = _get_platform_info()
+    if is_wsl() or platform_name != 'linux':
         return True
     # per https://unix.stackexchange.com/questions/46305/is-there-a-way-to-retrieve-the-name-of-the-desktop-environment
     # and https://unix.stackexchange.com/questions/193827/what-is-display-0

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -112,6 +112,7 @@ Release History
 
 * Fix: `az account get-access-token --resource-type ms-graph` not working
 * Remove warning from `az login`
+* Fix #10578: `az login` hangs when more than one instances are launched at the same time on Windows or WSL
 
 **RBAC**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -113,7 +113,6 @@ Release History
 
 * Fix: `az account get-access-token --resource-type ms-graph` not working
 * Remove warning from `az login`
-* Fix #10578: `az login` hangs when more than one instances are launched at the same time on Windows or WSL
 
 **RBAC**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -15,6 +15,7 @@ Release History
 
 * Polish error when running `az login -u {} -p {}` with Microsoft account
 * Polish `SSLError` when running `az login` behind a proxy with self-signed root certificate
+* Fix #10578: `az login` hangs when more than one instances are launched at the same time on Windows or WSL
 
 **RBAC**
 


### PR DESCRIPTION
Fix #10578: `az login` hangs when more than one instances of `az login` are launched at the same time on Windows or WSL

The root cause is that `HTTPServer` can't detect port is in-use on Windows. 

To repro, launch `az login` but do not continue in the browser. Then run `az login` from another terminal and continue with the login. One of the `az` instance will get stuck. 

This PR disables `HTTPServer.allow_reuse_address` so that the correct routine is resumed. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
