### PR TITLE
[ACR] Add default value to timeout flag for acr run and acr build

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 **ACR**
 
 * Added a preview parameter `--pack-image-tag` to command `az acr pack build`.
+* Add a default timeout in seconds to `az acr run` and `az acr build`.
 
 **AppConfig**
 

--- a/src/azure-cli/azure/cli/command_modules/acr/build.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/build.py
@@ -19,7 +19,7 @@ from ._archive_utils import upload_source_code, check_remote_source_code
 
 logger = get_logger(__name__)
 
-
+DEFAULT_TIMEOUT_IN_SEC = 60 * 60  # 60 minutes
 BUILD_NOT_SUPPORTED = 'Builds are only supported for managed registries.'
 
 
@@ -29,7 +29,7 @@ def acr_build(cmd,  # pylint: disable=too-many-locals
               source_location,
               image_names=None,
               resource_group_name=None,
-              timeout=None,
+              timeout=DEFAULT_TIMEOUT_IN_SEC,
               arg=None,
               secret_arg=None,
               docker_file_path='',

--- a/src/azure-cli/azure/cli/command_modules/acr/run.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/run.py
@@ -21,6 +21,7 @@ from ._utils import (
 from ._client_factory import cf_acr_registries_tasks
 from ._archive_utils import upload_source_code, check_remote_source_code
 
+DEFAULT_TIMEOUT_IN_SEC = 60 * 60  # 60 minutes
 RUN_NOT_SUPPORTED = 'Run is only available for managed registries.'
 NULL_SOURCE_LOCATION = "/dev/null"
 
@@ -39,7 +40,7 @@ def acr_run(cmd,  # pylint: disable=too-many-locals
             no_format=False,
             no_logs=False,
             no_wait=False,
-            timeout=None,
+            timeout=DEFAULT_TIMEOUT_IN_SEC,
             resource_group_name=None,
             platform=None,
             auth_mode=None):


### PR DESCRIPTION

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
