### PR TITLE
fix create and update bugs

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
@@ -8,15 +8,17 @@ from distutils.version import StrictVersion  # pylint: disable=no-name-in-module
 from azure.mgmt.containerservice.v2019_08_01.models import ManagedClusterAPIServerAccessProfile
 
 
-def _populate_api_server_access_profile(api_server_authorized_ip_ranges):
+def _populate_api_server_access_profile(api_server_authorized_ip_ranges, instance=None):
+    if instance is None or instance.api_server_access_profile:
+        profile = ManagedClusterAPIServerAccessProfile()
+
     if api_server_authorized_ip_ranges == "":
         authorized_ip_ranges = []
     else:
         authorized_ip_ranges = [ip.strip() for ip in api_server_authorized_ip_ranges.split(",")]
 
-    return ManagedClusterAPIServerAccessProfile(
-        authorized_ip_ranges=authorized_ip_ranges
-    )
+    profile.authorized_ip_ranges = authorized_ip_ranges
+    return profile
 
 
 def _set_load_balancer_sku(load_balancer_sku, kubernetes_version):

--- a/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
@@ -9,8 +9,13 @@ from azure.mgmt.containerservice.v2019_08_01.models import ManagedClusterAPIServ
 
 
 def _populate_api_server_access_profile(api_server_authorized_ip_ranges):
+    if api_server_authorized_ip_ranges == "":
+        authorized_ip_ranges = []
+    else:
+        authorized_ip_ranges = [ip.strip() for ip in api_server_authorized_ip_ranges.split(",")]
+
     return ManagedClusterAPIServerAccessProfile(
-        authorized_ip_ranges=[ip.strip() for ip in api_server_authorized_ip_ranges.split(",")]
+        authorized_ip_ranges=authorized_ip_ranges
     )
 
 
@@ -31,6 +36,14 @@ def _set_vm_set_type(vm_set_type, kubernetes_version):
             not specified and kubernetes version(%s) less than 1.12.9 only supports \
             availabilityset\n' % (kubernetes_version))
             vm_set_type = "AvailabilitySet"
-        else:
-            vm_set_type = "VirtualMachineScaleSets"
-    return vm_set_type.capitalize()
+
+    if not vm_set_type:
+        vm_set_type = "VirtualMachineScaleSets"
+
+    # normalize as server validation is case-sensitive
+    if vm_set_type.lower() == "AvailabilitySet".lower():
+        vm_set_type = "AvailabilitySet"
+
+    if vm_set_type.lower() == "VirtualMachineScaleSets".lower():
+        vm_set_type = "VirtualMachineScaleSets"
+    return vm_set_type

--- a/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
@@ -9,8 +9,10 @@ from azure.mgmt.containerservice.v2019_08_01.models import ManagedClusterAPIServ
 
 
 def _populate_api_server_access_profile(api_server_authorized_ip_ranges, instance=None):
-    if instance is None or instance.api_server_access_profile:
+    if instance is None or instance.api_server_access_profile is None:
         profile = ManagedClusterAPIServerAccessProfile()
+    else:
+        profile = instance.api_server_access_profile
 
     if api_server_authorized_ip_ranges == "":
         authorized_ip_ranges = []

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1969,6 +1969,7 @@ def aks_update(cmd, client, resource_group_name, name,
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
     instance = client.get(resource_group_name, name)
+
     client_id = instance.service_principal_profile.client_id
     if not client_id:
         raise CLIError('Cannot get the AKS cluster\'s service principal.')
@@ -1996,7 +1997,8 @@ def aks_update(cmd, client, resource_group_name, name,
 
     # empty string is valid as it disables ip whitelisting
     if api_server_authorized_ip_ranges is not None:
-        instance.api_server_access_profile = _populate_api_server_access_profile(api_server_authorized_ip_ranges)
+        instance.api_server_access_profile = \
+            _populate_api_server_access_profile(api_server_authorized_ip_ranges, instance)
 
     return sdk_no_wait(no_wait, client.create_or_update, resource_group_name, name, instance)
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_helpers.py
@@ -17,3 +17,30 @@ class TestPopulateApiServerAccessProfile(unittest.TestCase):
         api_server_authorized_ip_ranges = " 0.0.0.0/32 , 129.1.1.1/32"
         profile = helpers._populate_api_server_access_profile(api_server_authorized_ip_ranges)
         self.assertListEqual(profile.authorized_ip_ranges, ["0.0.0.0/32", "129.1.1.1/32"])
+
+
+class TestSetVmSetType(unittest.TestCase):
+    def test_archaic_k8_version(self):
+        version = "1.11.9"
+        vm_type = helpers._set_vm_set_type("", version)
+        self.assertEqual(vm_type, "AvailabilitySet")
+
+    def test_archaic_k8_version_with_vm_set(self):
+        version = "1.11.9"
+        vm_type = helpers._set_vm_set_type("AvailabilitySet", version)
+        self.assertEqual(vm_type, "AvailabilitySet")
+
+    def test_no_vm_set(self):
+        version = "1.15.0"
+        vm_type = helpers._set_vm_set_type("", version)
+        self.assertEqual(vm_type, "VirtualMachineScaleSets")
+
+    def test_casing_vmss(self):
+        version = "1.15.0"
+        vm_type = helpers._set_vm_set_type("virtualmachineScaleSets", version)
+        self.assertEqual(vm_type, "VirtualMachineScaleSets")
+
+    def test_casing_as(self):
+        version = "1.15.0"
+        vm_type = helpers._set_vm_set_type("Availabilityset", version)
+        self.assertEqual(vm_type, "AvailabilitySet")


### PR DESCRIPTION
Fixes two bugs:
1. On `az aks update  --api-server-authorized-ip-ranges ""` which is used to disable the resulting input to RP should be [] not ['']

2. On `az aks create` there is a bug on vm sku type naming that prevents clusters from being created 
Both bugs were introduced in a previous (non-released) PR: https://github.com/Azure/azure-cli/pull/10865
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
