### PR TITLE
[ACR] Scope map actions enum, typo fixes and showing duplicate actions to user

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -954,7 +954,7 @@ examples:
 
 helps['acr token credential generate'] = """
 type: command
-short-summary: Generate or replace one or both passwords of a token for an Azure Container Registry. For using token and password to access a container registry, see http://aka.ms/acr/token.
+short-summary: Generate or replace one or both passwords of a token for an Azure Container Registry. For using token and password to access a container registry, see https://aka.ms/acr/repo-permissions.
 examples:
   - name: Generate password1 for the token 'MyToken', with an expiration of 30 days.
     text: az acr token credential generate -n MyToken -r MyRegistry --password1 --days 30

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -32,6 +32,7 @@ from ._validators import (
     validate_set_secret,
     validate_retention_days
 )
+from .scope_map import ScopeMapActions
 
 image_by_tag_or_digest_type = CLIArgumentType(
     options_list=['--image', '-t'],
@@ -40,7 +41,8 @@ image_by_tag_or_digest_type = CLIArgumentType(
 
 
 def load_arguments(self, _):  # pylint: disable=too-many-statements
-    SkuName, PasswordName, DefaultAction, PolicyStatus, WebhookAction, WebhookStatus, TaskStatus, BaseImageTriggerType, RunStatus, SourceRegistryLoginMode, UpdateTriggerPayloadType = self.get_models('SkuName', 'PasswordName', 'DefaultAction', 'PolicyStatus', 'WebhookAction', 'WebhookStatus', 'TaskStatus', 'BaseImageTriggerType', 'RunStatus', 'SourceRegistryLoginMode', 'UpdateTriggerPayloadType')
+    SkuName, PasswordName, DefaultAction, PolicyStatus, WebhookAction, WebhookStatus, TaskStatus, BaseImageTriggerType, RunStatus, SourceRegistryLoginMode, UpdateTriggerPayloadType, TokenStatus = self.get_models(
+        'SkuName', 'PasswordName', 'DefaultAction', 'PolicyStatus', 'WebhookAction', 'WebhookStatus', 'TaskStatus', 'BaseImageTriggerType', 'RunStatus', 'SourceRegistryLoginMode', 'UpdateTriggerPayloadType', 'TokenStatus')
     with self.argument_context('acr') as c:
         c.argument('tags', arg_type=tags_type)
         c.argument('registry_name', options_list=['--name', '-n'], help='The name of the container registry. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr')
@@ -256,7 +258,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('description', options_list=['--description'], help='Description for the scope map. Maximum 256 characters are allowed.', required=False)
         c.argument('scope_map_name', options_list=['--name', '-n'], help='The name of the scope map.', required=True)
 
-    valid_actions = "Valid actions are metadata/read, metadata/write, content/read, content/write and content/delete"
+    valid_actions = "Valid actions are {}".format({action.value for action in ScopeMapActions})
     with self.argument_context('acr scope-map update') as c:
         c.argument('add_repository', options_list=['--add'], nargs='+', action='append', required=False,
                    help='repository permissions to be added. Use the format "--add REPO [ACTION1 ACTION2 ...]" per flag. ' + valid_actions)
@@ -271,7 +273,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('registry_name', options_list=['--registry', '-r'])
         c.argument('token_name', options_list=['--name', '-n'], help='The name of the token.', required=True)
         c.argument('scope_map_name', options_list=['--scope-map'], help='The name of the scope map associated with the token', required=False)
-        c.argument('status', options_list=['--status'], arg_type=get_enum_type(['enabled', 'disabled']),
+        c.argument('status', options_list=['--status'], arg_type=get_enum_type(TokenStatus),
                    help='The status of the token', required=False, default="enabled")
 
     with self.argument_context('acr token create') as c:

--- a/src/azure-cli/azure/cli/command_modules/acr/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_utils.py
@@ -415,6 +415,8 @@ def get_task_id_from_task_name(cli_ctx, resource_group, registry_name, task_name
 
 
 def parse_actions_from_repositories(allow_or_remove_repository):
+    from .scope_map import ScopeMapActions
+    valid_actions = {action.value for action in ScopeMapActions}
     REPOSITORIES = 'repositories'
     actions = []
     for rule in allow_or_remove_repository:
@@ -422,7 +424,10 @@ def parse_actions_from_repositories(allow_or_remove_repository):
         if len(rule) < 2:
             raise CLIError('At least one action must be specified with the repository {}.'.format(repository))
         for action in rule[1:]:
-            actions.append('{}/{}/{}'.format(REPOSITORIES, repository, action.lower()))
+            action = action.lower()
+            if action not in valid_actions:
+                raise CLIError('Invalid action "{}" provided. \nValid actions are {}.'.format(action, valid_actions))
+            actions.append('{}/{}/{}'.format(REPOSITORIES, repository, action))
 
     return actions
 

--- a/src/azure-cli/azure/cli/command_modules/acr/token.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/token.py
@@ -68,14 +68,14 @@ def _create_default_scope_map(cmd, resource_group_name, registry_name, token_nam
         # for command idempotency, if the actions are the same, we accept it
         if sorted(existing_scope_map.actions) == sorted(actions):
             return existing_scope_map.id
-        raise CLIError('The default scope map was already configured with different respository permissions.'
+        raise CLIError('The default scope map was already configured with different repository permissions.'
                        '\nPlease use "az acr scope-map update -r {} -n {} --add <REPO> --remove <REPO>" to update.'
                        .format(registry_name, scope_map_name))
     except CloudError:
         pass
-    logger.warning('Creating a scope map "%s" for provided respository permissions.', scope_map_name)
+    logger.warning('Creating a scope map "%s" for provided repository permissions.', scope_map_name)
     poller = scope_map_client.create(resource_group_name, registry_name, scope_map_name,
-                                     actions, "Token {}'s scope map".format(token_name))
+                                     actions, "Created by token: {}".format(token_name))
     scope_map = LongRunningOperation(cmd.cli_ctx)(poller)
     return scope_map.id
 


### PR DESCRIPTION
Addressed review comments by @ankurkhemani in this PR: 
https://github.com/Azure/azure-cli/pull/10864/files

1. Using `TokenStatus` model to fetch permissible values for `status` argument

![1](https://user-images.githubusercontent.com/20955088/67535982-db32c200-f689-11e9-95a1-84894319c6e5.PNG)

2. Using `ScopeMapAction` enum instead of hardcoded strings

![2](https://user-images.githubusercontent.com/20955088/67536012-fbfb1780-f689-11e9-99d9-b74400e72054.PNG)

3. Displaying the duplicate actions entered by users for `acr scope-map update`

![4](https://user-images.githubusercontent.com/20955088/67536053-349af100-f68a-11e9-8f06-f595fa095b8a.PNG)

4. Changed description for auto-generated scope map "Created by token: \<tokenName\>"

![3](https://user-images.githubusercontent.com/20955088/67536079-5ac09100-f68a-11e9-9955-166d32416a85.PNG)

5. Changed the shortened URL redirecting to Official Docs 
(The shortened URL https://aka.ms/acr/repo-permissions must be activated by 11/04 - IMPORTANT)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
