### PR TITLE
default task to v1.1.0 on run cmd

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_utils.py
@@ -245,13 +245,13 @@ def get_validate_platform(cmd, platform):
 
 def get_yaml_template(cmd_value, timeout, file):
     """Generates yaml template
-    :param str cmd_value: The command to execute in each step
+    :param str cmd_value: The command to execute in each step. Task version defaults to v1.1.0
     :param str timeout: The timeout for each step
     :param str file: The task definition
     """
-    yaml_template = ""
+    yaml_template = "version: v1.1.0\n"
     if cmd_value:
-        yaml_template = "steps: \n  - cmd: {0}\n".format(cmd_value)
+        yaml_template += "steps: \n  - cmd: {0}\n".format(cmd_value)
         if timeout:
             yaml_template += "    timeout: {0}\n".format(timeout)
     else:


### PR DESCRIPTION
This will enable task to be run on v1.1.0 (which makes use of Aliases)

So instead of, 
```
az acr run -r MyRegistry --cmd "{{.Run.Registry}}/MyImage" /dev/null
```
You can do
```
az acr run -r MyRegistry --cmd "\$Registry/MyImage" /dev/null
```



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
