### PR TITLE
fix: per issue #5627 on botframework-sdk repo, change user redirect l…

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/botservice/_exception_handler.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/_exception_handler.py
@@ -20,10 +20,10 @@ def bot_exception_handler(ex):
         return None
     if isinstance(ex, ClientRequestError):
         message = 'Error occurred in sending request. Please file an issue on {0}'.format(
-            'https://github.com/Microsoft/botbuilder-tools/issues'
+            'https://github.com/microsoft/botframework-sdk'
         )
         raise CLIError(message)
     message = 'Unknown error during execution. Please file an issue on {0}'.format(
-        'https://github.com/Microsoft/botbuilder-tools/issues'
+        'https://github.com/microsoft/botframework-sdk'
     )
     raise CLIError(message)

--- a/src/azure-cli/azure/cli/command_modules/botservice/bot_template_deployer.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/bot_template_deployer.py
@@ -147,7 +147,7 @@ class BotTemplateDeployer:
         response = requests.get('https://dev.botframework.com/api/misc/bottemplateroot')
         if response.status_code != 200:
             raise CLIError('Unable to get bot code template from CDN. Please file an issue on {0}'.format(
-                'https://github.com/Microsoft/botbuilder-tools/issues'
+                'https://github.com/microsoft/botframework-sdk'
             ))
         cdn_link = response.text.strip('"')
 


### PR DESCRIPTION
…ink to point to botframework-sdk repo instead of soon-to-be deprecated botbuilder-tools repo

This fixes related [issue #5627](https://github.com/microsoft/botframework-sdk/issues/5627) in the microsoft/botframework-sdk repo. 

Users are currently redirected to a soon-to-be deprecated repo, so I fixed them to point to the current and appropriate repo.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
