### PR TITLE
[profile] Polish error when using `az login -u {} -p {}` with Microsoft account

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+**Profile**
+
+* Polish error when using `az login -u {} -p {}` with Microsoft account
+
 2.0.76
 
 
@@ -94,7 +98,6 @@ Release History
 
 * Fix: `az account get-access-token --resource-type ms-graph` not working
 * Remove warning from `az login`
-* Polish error when using `az login -u {} -p {}` with Microsoft account
 
 **RBAC**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -94,6 +94,7 @@ Release History
 
 * Fix: `az account get-access-token --resource-type ms-graph` not working
 * Remove warning from `az login`
+* Polish error when using `az login -u {} -p {}` with Microsoft account
 
 **RBAC**
 

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -154,6 +154,12 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
                 raise CLIError("The user name might be invalid. " + suggestion)
             if 'Server returned error in RSTR - ErrorCode' in msg:
                 raise CLIError("Logging in through command line is not supported. " + suggestion)
+            if 'wstrust' in msg:
+                raise CLIError("Authentication failed due to error of '" + msg + "' "
+                               "This typically happens when attempting a Microsoft account, which requires "
+                               "interactive login. Please invoke 'az login' to cross check. "
+                               # pylint: disable=line-too-long
+                               "More details are available at https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki/Username-Password-Authentication")
         raise CLIError(err)
     except requests.exceptions.ConnectionError as err:
         raise CLIError('Please ensure you have network connection. Error detail: ' + str(err))


### PR DESCRIPTION
Polish error when using `az login -u {} -p {}` with Microsoft account, raised in #10979.

The original error message is not clear: 

> Unsupported wstrust endpoint version. Current support version is wstrust2005 or wstrust13.

Incorporate [error message from MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/af5d63820a29786263b22f7ee7702077dccae2e4/msal/application.py#L633-L636).

Current error message:

> Authentication failed due to error of 'Unsupported wstrust endpoint version. Current support version is wstrust2005 or wstrust13.' This typically happens when attempting a Microsoft account, which requires interactive login. Please invoke 'az login' to cross check. More details are available at https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki/Username-Password-Authentication

To test, use `az login -u {} -p {}` with a personal Microsoft account, such as xxx@outlook.com.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
