### PR TITLE
Updated Dockerfile to use Alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-ARG PYTHON_VERSION="3.6.4"
+ARG PYTHON_VERSION="3.6.9"
 
-FROM python:${PYTHON_VERSION}-alpine3.7
+FROM python:${PYTHON_VERSION}-alpine3.10
 
 ARG CLI_VERSION
 


### PR DESCRIPTION
Updated dockerfile to use Alpine 3.10, involves also upgrading python to version 3.6.9 which is the release of python in 3.6 release that has an available docker image.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
