### PR TITLE
Polish SSLError

### DIFF
--- a/doc/use_cli_effectively.md
+++ b/doc/use_cli_effectively.md
@@ -105,7 +105,7 @@ For clarity, Bash scripts are used inline. Windows batch or PowerScript examples
 ## Working behind a proxy
 Proxy is common behind corporate network or introduced by tracing tools like Fiddler, mitmproxy, etc. If the proxy uses self-signed certificates, the Python [requests library](https://github.com/kennethreitz/requests) which CLI depends on will throw `SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)`. There are 2 ways to handle this error:
 
-1. Set environment variable `REQUESTS_CA_BUNDLE` to the CA bundle certificate file in PEM format. This is recommended if you use CLI frequently behind a corporate proxy. The default CA bundle which CLI uses is located at `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem` on Windows and ` /opt/az/lib/python3.6/site-packages/certifi/cacert.pem` on Linux. You may append the proxy server's certificate to this file or copy the contents to another certificate file, then set `REQUESTS_CA_BUNDLE` to it. For example:
+1. Set environment variable `REQUESTS_CA_BUNDLE` to the path of CA bundle certificate file in PEM format. This is recommended if you use CLI frequently behind a corporate proxy. The default CA bundle which CLI uses is located at `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem` on Windows and ` /opt/az/lib/python3.6/site-packages/certifi/cacert.pem` on Linux. You may append the proxy server's certificate to this file or copy the contents to another certificate file, then set `REQUESTS_CA_BUNDLE` to it. For example:
   
     ```
     <Original cacert.pem>
@@ -115,7 +115,7 @@ Proxy is common behind corporate network or introduced by tracing tools like Fid
     -----END CERTIFICATE-----
     ```
 
-   A frequent ask is whether or not `HTTP_PROXY` or `HTTPS_PROXY` environment variables should be set, the answer is it depends. For Fiddler on Windows, by default it acts as system proxy on start, you don't need to set anything. If the option is off or using other tools which don't work as system proxy, you should set them. Since almost all traffics from CLI are SSL based, only `HTTPS_PROXY` should be set. If you are not sure, just set them, but do remember to unset it after the proxy is shut down. For fiddler, the default value is `http://localhost:8888`.
+   A frequent ask is whether or not `HTTP_PROXY` or `HTTPS_PROXY` environment variables should be set, the answer is it depends. For Fiddler on Windows, by default it acts as system proxy on start, you don't need to set anything. If the option is off or using other tools which don't work as system proxy, you should set them. Since almost all traffic from CLI is SSL-based, only `HTTPS_PROXY` should be set. If you are not sure, just set them, but do remember to unset it after the proxy is shut down. For fiddler, the default value is `http://localhost:8888`.
 
    For other details, check out [Stefan's blog](https://blog.jhnr.ch/2018/05/16/working-with-azure-cli-behind-ssl-intercepting-proxy-server/).
   

--- a/doc/use_cli_effectively.md
+++ b/doc/use_cli_effectively.md
@@ -103,7 +103,7 @@ For clarity, Bash scripts are used inline. Windows batch or PowerScript examples
   2. Check out the Rest API reference for the request payload, URL and API version. As an examplee, check out the community's comments on [how to create AppInsights](https://github.com/Azure/azure-cli/issues/5543).
 
 ## Working behind a proxy
-Proxy is common behind corporate network or introduced by tracing tools like Fiddler, mitmproxy, etc. If the proxy uses self-signed certificates, the Python [requests library](https://github.com/kennethreitz/requests) which CLI depends on will throw `SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)`. There are 2 ways to handle this error:
+Proxy is common behind corporate network or introduced by tracing tools like Fiddler, mitmproxy, etc. If the proxy uses self-signed certificates, the Python [Requests](https://github.com/kennethreitz/requests) library which CLI uses will throw `SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)`. There are 2 ways to handle this error:
 
 1. Set environment variable `REQUESTS_CA_BUNDLE` to the path of CA bundle certificate file in PEM format. This is recommended if you use CLI frequently behind a corporate proxy. The default CA bundle which CLI uses is located at `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem` on Windows and ` /opt/az/lib/python3.6/site-packages/certifi/cacert.pem` on Linux. You may append the proxy server's certificate to this file or copy the contents to another certificate file, then set `REQUESTS_CA_BUNDLE` to it. For example:
   
@@ -119,7 +119,7 @@ Proxy is common behind corporate network or introduced by tracing tools like Fid
 
    For other details, check out [Stefan's blog](https://blog.jhnr.ch/2018/05/16/working-with-azure-cli-behind-ssl-intercepting-proxy-server/).
   
-2. Disable the certificate check across Azure CLI by setting environment variable `AZURE_CLI_DISABLE_CONNECTION_VERIFICATION` to 1. This is not safe, but good for a short period like capturing a network trace for a specific command and promptly turning it off when finished. This may not work for some data-plane commands due to underlying SDK limitations.
+2. Disable the certificate check across Azure CLI by setting environment variable `AZURE_CLI_DISABLE_CONNECTION_VERIFICATION=1`. This is not safe, but good for a short period like capturing a network trace for a specific command and promptly turning it off when finished. This may not work for some data-plane commands due to underlying SDK limitations.
 
 ## Concurrent builds
 

--- a/doc/use_cli_effectively.md
+++ b/doc/use_cli_effectively.md
@@ -103,21 +103,23 @@ For clarity, Bash scripts are used inline. Windows batch or PowerScript examples
   2. Check out the Rest API reference for the request payload, URL and API version. As an examplee, check out the community's comments on [how to create AppInsights](https://github.com/Azure/azure-cli/issues/5543).
 
 ## Working behind a proxy
-  Proxy is common behind corporate network or introduced by tracing tools like Fiddler, mitmproxy, etc. If the proxy uses self-signed certificates, the Python [requests library](https://github.com/kennethreitz/requests) which CLI depends on will throw `SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)`.  There are 2 ways to handle this error:
-  1. Disable the certificate check across the CLI by setting the env var of `AZURE_CLI_DISABLE_CONNECTION_VERIFICATION` to any value. This is not safe, but good for a short period like you want to capture a trace for a specific command and promptly turn it off after done.
-  2. Set env var of `REQUESTS_CA_BUNDLE` to the CA bundle certificate in PEM format. This is recommended if you use CLI frequently behind a corporate proxy. The default CA bundle which CLI uses is located at `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem` on Windows and ` /opt/az/lib/python3.6/site-packages/certifi/cacert.pem` on Linux. You may append the proxy server's certificate to this file or copy the contents to another certificate file, then set `REQUESTS_CA_BUNDLE` to it. For example:
+Proxy is common behind corporate network or introduced by tracing tools like Fiddler, mitmproxy, etc. If the proxy uses self-signed certificates, the Python [requests library](https://github.com/kennethreitz/requests) which CLI depends on will throw `SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)`. There are 2 ways to handle this error:
+
+1. Set environment variable `REQUESTS_CA_BUNDLE` to the CA bundle certificate file in PEM format. This is recommended if you use CLI frequently behind a corporate proxy. The default CA bundle which CLI uses is located at `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem` on Windows and ` /opt/az/lib/python3.6/site-packages/certifi/cacert.pem` on Linux. You may append the proxy server's certificate to this file or copy the contents to another certificate file, then set `REQUESTS_CA_BUNDLE` to it. For example:
   
-```
-<Original cacert.pem>
+    ```
+    <Original cacert.pem>
+    
+    -----BEGIN CERTIFICATE-----
+    <Your proxy's certificate here> 
+    -----END CERTIFICATE-----
+    ```
 
------BEGIN CERTIFICATE-----
-<Your proxy's certificate here> 
------END CERTIFICATE-----
-```
+   A frequent ask is whether or not `HTTP_PROXY` or `HTTPS_PROXY` environment variables should be set, the answer is it depends. For Fiddler on Windows, by default it acts as system proxy on start, you don't need to set anything. If the option is off or using other tools which don't work as system proxy, you should set them. Since almost all traffics from CLI are SSL based, only `HTTPS_PROXY` should be set. If you are not sure, just set them, but do remember to unset it after the proxy is shut down. For fiddler, the default value is `http://localhost:8888`.
 
-  A frequent ask is whether or not `HTTP_PROXY` or `HTTPS_PROXY` envionment variables should be set, the answer is it depends. For fiddler on Windows, by default it acts as system proxy on start, you don't need to set anything. If the option is off or using other tools which don't work as system proxy, you should set them. Since almost all traffics from CLI are SSL based, so only `HTTPS_PROXY` should be set. If you are not sure, just set them, but do remember to unset it after the proxy is shut down. For fiddler, the default value is `http://localhost:8888`.
-
-  For other details, check out [Stefan's blog](https://blog.jhnr.ch/2018/05/16/working-with-azure-cli-behind-ssl-intercepting-proxy-server/).
+   For other details, check out [Stefan's blog](https://blog.jhnr.ch/2018/05/16/working-with-azure-cli-behind-ssl-intercepting-proxy-server/).
+  
+2. Disable the certificate check across Azure CLI by setting environment variable `AZURE_CLI_DISABLE_CONNECTION_VERIFICATION` to 1. This is not safe, but good for a short period like capturing a network trace for a specific command and promptly turning it off when finished. This may not work for some data-plane commands due to underlying SDK limitations.
 
 ## Concurrent builds
 

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -49,6 +49,9 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
                                    if not in_cloud_console() else ''))
 
             raise CLIError(err)
+        except requests.exceptions.SSLError as err:
+            from .util import SSLERROR_TEMPLATE
+            raise CLIError(SSLERROR_TEMPLATE.format(str(err)))
         except requests.exceptions.ConnectionError as err:
             raise CLIError('Please ensure you have network connection. Error detail: ' + str(err))
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -9,7 +9,8 @@ Release History
 
 **Profile**
 
-* Polish error when using `az login -u {} -p {}` with Microsoft account
+* Polish error when running `az login -u {} -p {}` with Microsoft account
+* Polish `SSLError` when running `az login` behind a proxy with custom root certificate
 
 **RBAC**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -10,7 +10,7 @@ Release History
 **Profile**
 
 * Polish error when running `az login -u {} -p {}` with Microsoft account
-* Polish `SSLError` when running `az login` behind a proxy with custom root certificate
+* Polish `SSLError` when running `az login` behind a proxy with self-signed root certificate
 
 **RBAC**
 

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -161,6 +161,12 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
                                # pylint: disable=line-too-long
                                "More details are available at https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki/Username-Password-Authentication")
         raise CLIError(err)
+    except requests.exceptions.SSLError as err:
+        raise CLIError('Certificate verification failed. Please typically happens when using Azure CLI behind a proxy '
+                       'that intercepts traffic with a root certificate. '
+                       # pylint: disable=line-too-long
+                       'Please add this certificate to the trusted CA bundle: https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#working-behind-a-proxy. '
+                       'Error detail: ' + str(err))
     except requests.exceptions.ConnectionError as err:
         raise CLIError('Please ensure you have network connection. Error detail: ' + str(err))
     all_subscriptions = list(subscriptions)

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -162,11 +162,8 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
                                "More details are available at https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki/Username-Password-Authentication")
         raise CLIError(err)
     except requests.exceptions.SSLError as err:
-        raise CLIError('Certificate verification failed. Please typically happens when using Azure CLI behind a proxy '
-                       'that intercepts traffic with a self-signed certificate. '
-                       # pylint: disable=line-too-long
-                       'Please add this certificate to the trusted CA bundle: https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#working-behind-a-proxy. '
-                       'Error detail: ' + str(err))
+        from azure.cli.core.util import SSLERROR_TEMPLATE
+        raise CLIError(SSLERROR_TEMPLATE.format(str(err)))
     except requests.exceptions.ConnectionError as err:
         raise CLIError('Please ensure you have network connection. Error detail: ' + str(err))
     all_subscriptions = list(subscriptions)

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -163,7 +163,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
         raise CLIError(err)
     except requests.exceptions.SSLError as err:
         raise CLIError('Certificate verification failed. Please typically happens when using Azure CLI behind a proxy '
-                       'that intercepts traffic with a root certificate. '
+                       'that intercepts traffic with a self-signed certificate. '
                        # pylint: disable=line-too-long
                        'Please add this certificate to the trusted CA bundle: https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#working-behind-a-proxy. '
                        'Error detail: ' + str(err))


### PR DESCRIPTION
Polish `SSLError` reported in issues #11069, #11068, #10921, #10860, #10272 ...

Changed 3 places:

- `src/azure-cli/azure/cli/command_modules/profile/custom.py` when logging in
- `src/azure-cli-core/azure/cli/core/adal_authentication.py` when retrieving tokens
- `src/azure-cli-core/azure/cli/core/util.py` when making REST requests

To test, replace `<virtual env>\Lib\site-packages\certifi\cacert.pem` with some self-signed certificate like Fiddler's:

```
-----BEGIN CERTIFICATE-----
MIIDsjCCApqgAwIBAgIQP8ptgN302YBPYVf50e6xfDANBgkqhkiG9w0BAQsFADBn
MSswKQYDVQQLDCJDcmVhdGVkIGJ5IGh0dHA6Ly93d3cuZmlkZGxlcjIuY29tMRUw
EwYDVQQKDAxET19OT1RfVFJVU1QxITAfBgNVBAMMGERPX05PVF9UUlVTVF9GaWRk
bGVyUm9vdDAeFw0xODA3MzAxMjQ4MzFaFw0yMTEwMjgxMjQ4MzFaMGcxKzApBgNV
BAsMIkNyZWF0ZWQgYnkgaHR0cDovL3d3dy5maWRkbGVyMi5jb20xFTATBgNVBAoM
DERPX05PVF9UUlVTVDEhMB8GA1UEAwwYRE9fTk9UX1RSVVNUX0ZpZGRsZXJSb290
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm4kCm94NDkJ91DMcTBjq
z/u1LPkiXlBbcknTEp4CBkEtVr8rfGmm058M01QikoLigh8OISeU+MbCao/8fvCg
+TFYHQFFZONKw6sad4IHN6iHwVpPXgfCtP52ZnCGfntrlNJdikQeycPjDSJNDLpy
XGuNkIwk2jREts+u61EF0459CPtyGn9bpxfDQ5LNP5YJ/1dXnslUJAXTLvP4xBKT
u2QP+5OmOjKTHXP53lqqW0rOioijj6PsvPNf+517SoFJrMR5Q9P+FT6BSYav83kU
F/NvIWNRQLrGgx5BXjc4WXDhnC9mM8pUghj4lEfAEBXn/qmntedp4IZoIWbSbANL
lQIDAQABo1owWDATBgNVHSUEDDAKBggrBgEFBQcDATASBgNVHRMBAf8ECDAGAQH/
AgEAMB0GA1UdDgQWBBS18ByP6P35iRo34tV/nbc8FZ0X9DAOBgNVHQ8BAf8EBAMC
AQYwDQYJKoZIhvcNAQELBQADggEBAGa9svmawn4LYELUrotMQVeZF57hPSExWzpr
7UbHMOtoIfGGu1AMosJFfvTZIEhPePLQuZqIQwdSm9m7kmFegqLqoBYjTJRq9mur
KvJvGDXyyTNN2rQV0qf0JL7LFp5XdiltTABtfRKHKZ5vGZPi6lanQwsvBUryShHe
erNP1JIg0ZXS0yFJUdtLYnhFOUqp/ZutWYJjsBB/GMqpHp8rYl6vJSE0pzhRITjP
xk586Tj0RBCby4DJw35AwQeuk9lBqNCVjtNZkKKhEUmAAut6cnLsHWTbV136OcP1
y5useyKJgGCR9p7TWOW2PVz968WH8U/tq3orip3CaTsstGoyt+c=
-----END CERTIFICATE-----
```

`az login` now fails with

> Certificate verification failed. This typically happens when using Azure CLI behind a proxy that intercepts traffic with a self-signed certificate. Please add this certificate to the trusted CA bundle: https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#working-behind-a-proxy. Error detail: HTTPSConnectionPool(host='login.microsoftonline.com', port=443): Max retries exceeded with url: /common/oauth2/token (Caused by SSLError(SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')])")))

If logged in, `az vm list` fails with similar message.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
