### PR TITLE
Lock six version to ~=1.12 temporarily to let Travis CI pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - libssl-dev
       - libffi-dev
       - python-dev
-install: pip install --upgrade pip tox six
+install: pip install --upgrade pip tox six~=1.12.0
 cache: pip
 jobs:
   include:

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -68,7 +68,7 @@ DEPENDENCIES = [
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'pyyaml',
     'requests~=2.20',
-    'six',
+    'six~=1.12',
     'wheel==0.30.0',
     'azure-mgmt-resource~=4.0',
 ]

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -31,7 +31,7 @@ DEPENDENCIES = [
     'requests',
     'pyyaml',
     'knack',
-    'six~=1.12.0',
+    'six>=1.10.0',
     'tabulate>=0.7.7',
     'colorama>=0.3.7'
 ]

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -31,7 +31,7 @@ DEPENDENCIES = [
     'requests',
     'pyyaml',
     'knack',
-    'six>=1.10.0',
+    'six~=1.12.0',
     'tabulate>=0.7.7',
     'colorama>=0.3.7'
 ]


### PR DESCRIPTION
**Temporarily** lock six version to ~=1.12 until next Sprint due to [upgrade of package six from ~1.12.0 to 1.13.0](https://pypi.org/project/six/#history) in Nov 6, 2019 breaks dependency, which failed Travis CI

Related PR:  #11051

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
