### PR TITLE
[CI] Lock azure-mgmt-appconfiguration to 0.2.0

### DIFF
--- a/src/azure-cli/requirements.py2.Darwin.txt
+++ b/src/azure-cli/requirements.py2.Darwin.txt
@@ -18,6 +18,7 @@ azure-graphrbac==0.60.0
 azure-keyvault==1.1.0
 azure-mgmt-advisor==2.0.1
 azure-mgmt-apimanagement==0.1.0
+azure-mgmt-appconfiguration==0.2.0
 azure-mgmt-applicationinsights==0.1.1
 azure-mgmt-authorization==0.52.0
 azure-mgmt-batch==7.0.0

--- a/src/azure-cli/requirements.py2.Linux.txt
+++ b/src/azure-cli/requirements.py2.Linux.txt
@@ -18,6 +18,7 @@ azure-graphrbac==0.60.0
 azure-keyvault==1.1.0
 azure-mgmt-advisor==2.0.1
 azure-mgmt-apimanagement==0.1.0
+azure-mgmt-appconfiguration==0.2.0
 azure-mgmt-applicationinsights==0.1.1
 azure-mgmt-authorization==0.52.0
 azure-mgmt-batch==7.0.0

--- a/src/azure-cli/requirements.py2.windows.txt
+++ b/src/azure-cli/requirements.py2.windows.txt
@@ -17,6 +17,7 @@ azure-graphrbac==0.60.0
 azure-keyvault==1.1.0
 azure-mgmt-advisor==2.0.1
 azure-mgmt-apimanagement==0.1.0
+azure-mgmt-appconfiguration==0.2.0
 azure-mgmt-applicationinsights==0.1.1
 azure-mgmt-authorization==0.52.0
 azure-mgmt-batch==7.0.0

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -18,6 +18,7 @@ azure-graphrbac==0.60.0
 azure-keyvault==1.1.0
 azure-mgmt-advisor==2.0.1
 azure-mgmt-apimanagement==0.1.0
+azure-mgmt-appconfiguration==0.2.0
 azure-mgmt-applicationinsights==0.1.1
 azure-mgmt-authorization==0.52.0
 azure-mgmt-batch==7.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -18,6 +18,7 @@ azure-graphrbac==0.60.0
 azure-keyvault==1.1.0
 azure-mgmt-advisor==2.0.1
 azure-mgmt-apimanagement==0.1.0
+azure-mgmt-appconfiguration==0.2.0
 azure-mgmt-applicationinsights==0.1.1
 azure-mgmt-authorization==0.52.0
 azure-mgmt-batch==7.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -17,6 +17,7 @@ azure-graphrbac==0.60.0
 azure-keyvault==1.1.0
 azure-mgmt-advisor==2.0.1
 azure-mgmt-apimanagement==0.1.0
+azure-mgmt-appconfiguration==0.2.0
 azure-mgmt-applicationinsights==0.1.1
 azure-mgmt-authorization==0.52.0
 azure-mgmt-batch==7.0.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -66,6 +66,7 @@ DEPENDENCIES = [
     'azure-keyvault~=1.1',
     'azure-mgmt-advisor>=2.0.1,<3.0.0',
     'azure-mgmt-apimanagement>=0.1.0',
+    'azure-mgmt-appconfiguration~=0.2.0',
     'azure-mgmt-applicationinsights~=0.1.1',
     'azure-mgmt-appconfiguration>=0.1.0',
     'azure-mgmt-authorization~=0.52.0',


### PR DESCRIPTION
We didn't lock this package before. 11.08 a new python version 0.3.0 has been released and including the breaking changes. The CI will download the latest version and let our tests fail.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
