### PR TITLE
acr: warn on using registry name with uppercase

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -144,8 +144,8 @@ def acr_login(cmd,
     # warn casing difference caused by ACR normalizes to lower on login_server
     parts = login_server.split('.')
     if registry_name != parts[0] and registry_name.lower() == parts[0]:
-        logger.warning('Uppercase characters are detected in the registry name. When use its server url in docker'
-                       ' commands, to avoid authentication errors, use all lowercase.')
+        logger.warning('Uppercase characters are detected in the registry name. When using its server url in '
+                       'docker commands, to avoid authentication errors, use all lowercase.')
 
     from subprocess import PIPE, Popen
     p = Popen([docker_command, "login",

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -141,6 +141,12 @@ def acr_login(cmd,
         username=username,
         password=password)
 
+    # warn casing difference caused by ACR normalizes to lower on login_server
+    parts = login_server.split('.')
+    if registry_name != parts[0] and registry_name.lower() == parts[0]:
+        logger.warning('Uppercase characters are detected in the registry name. When use its server url in docker'
+                       ' commands, to avoid authentication errors, use all lowercase.')
+
     from subprocess import PIPE, Popen
     p = Popen([docker_command, "login",
                "--username", username,

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -141,7 +141,7 @@ def acr_login(cmd,
         username=username,
         password=password)
 
-    # warn casing difference caused by ACR normalizes to lower on login_server
+    # warn casing difference caused by ACR normalizing to lower on login_server
     parts = login_server.split('.')
     if registry_name != parts[0] and registry_name.lower() == parts[0]:
         logger.warning('Uppercase characters are detected in the registry name. When using its server url in '


### PR DESCRIPTION
- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
