### PR TITLE
Change flag workspace-resource-id to workspace-resource

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -38,7 +38,7 @@ Release History
 
 **Azure Red Hat OpenShift**
 
-* Add `--workspace-resource-id` flag to allow creation of Azure Red Hat Openshift cluster with monitoring
+* Add `--workspace-resource` flag to allow creation of Azure Red Hat Openshift cluster with monitoring
 * Add `monitor_profile` to create Azure Red Hat OpenShift cluster with monitoring
 
 **AKS**

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -38,7 +38,7 @@ Release History
 
 **Azure Red Hat OpenShift**
 
-* Add `--workspace-resource` flag to allow creation of Azure Red Hat Openshift cluster with monitoring
+* Add `--workspace-id` flag to allow creation of Azure Red Hat Openshift cluster with monitoring
 * Add `monitor_profile` to create Azure Red Hat OpenShift cluster with monitoring
 
 **AKS**

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -7,6 +7,10 @@ Release History
 
 * Support Local context in acr task run
 
+**ACS**
+
+* [BREAKING CHANGE]az openshift create: rename `--workspace-resource-id` to `--workspace-id`.
+
 **Compute**
 
 * vmss create/update: Add --scale-in-policy, which decides which virtual machines are chosen for removal when a VMSS is scaled-in
@@ -38,7 +42,7 @@ Release History
 
 **Azure Red Hat OpenShift**
 
-* Add `--workspace-id` flag to allow creation of Azure Red Hat Openshift cluster with monitoring
+* Add `--workspace-resource-id` flag to allow creation of Azure Red Hat Openshift cluster with monitoring
 * Add `monitor_profile` to create Azure Red Hat OpenShift cluster with monitoring
 
 **AKS**

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -7,10 +7,6 @@ Release History
 
 * Support Local context in acr task run
 
-**ACS**
-
-* [BREAKING CHANGE]az openshift create: rename `--workspace-resource-id` to `--workspace-id`.
-
 **Compute**
 
 * vmss create/update: Add --scale-in-policy, which decides which virtual machines are chosen for removal when a VMSS is scaled-in

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -896,7 +896,7 @@ parameters:
   - name: --customer-admin-group-id
     type: string
     short-summary: The Object ID of an Azure Active Directory Group that memberships will get synced into the OpenShift group "osa-customer-admins". If not specified, no cluster admin access will be granted.
-  - name: --workspace-resource
+  - name: --workspace-id
     type: string
     short-summary: The resource id of an existing Log Analytics Workspace to use for storing monitoring data.
 
@@ -911,7 +911,7 @@ examples:
   - name: Create an Openshift cluster using a custom vnet
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --vnet-peer "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/openshift-vnet/providers/Microsoft.Network/virtualNetworks/test"
   - name: Create an Openshift cluster with Log Analytics monitoring enabled
-    text: az openshift create -g MyResourceGroup -n MyManagedCluster --workspace-resource "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/<resourcegroup>/providers/Microsoft.OperationalInsights/workspaces/<workspace-resource-id>"
+    text: az openshift create -g MyResourceGroup -n MyManagedCluster --workspace-id "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/<resourcegroup>/providers/Microsoft.OperationalInsights/workspaces/<workspace-resource-id>"
 """
 
 helps['openshift delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -911,7 +911,7 @@ examples:
   - name: Create an Openshift cluster using a custom vnet
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --vnet-peer "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/openshift-vnet/providers/Microsoft.Network/virtualNetworks/test"
   - name: Create an Openshift cluster with Log Analytics monitoring enabled
-    text: az openshift create -g MyResourceGroup -n MyManagedCluster --workspace-id "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/<resourcegroup>/providers/Microsoft.OperationalInsights/workspaces/<workspace-resource-id>"
+    text: az openshift create -g MyResourceGroup -n MyManagedCluster --workspace-id "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.OperationalInsights/workspaces/{workspace-id}"
 """
 
 helps['openshift delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -896,9 +896,9 @@ parameters:
   - name: --customer-admin-group-id
     type: string
     short-summary: The Object ID of an Azure Active Directory Group that memberships will get synced into the OpenShift group "osa-customer-admins". If not specified, no cluster admin access will be granted.
-  - name: --workspace-resource-id
+  - name: --workspace-resource
     type: string
-    short-summary: The resource ID of an existing Log Analytics Workspace to use for storing monitoring data.
+    short-summary: The resource id of an existing Log Analytics Workspace to use for storing monitoring data.
 
 
 examples:
@@ -911,7 +911,7 @@ examples:
   - name: Create an Openshift cluster using a custom vnet
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --vnet-peer "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/openshift-vnet/providers/Microsoft.Network/virtualNetworks/test"
   - name: Create an Openshift cluster with Log Analytics monitoring enabled
-    text: az openshift create -g MyResourceGroup -n MyManagedCluster --workspace-resource-id {WORKSPACE_RESOURCE_ID}
+    text: az openshift create -g MyResourceGroup -n MyManagedCluster --workspace-resource "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/<resourcegroup>/providers/Microsoft.OperationalInsights/workspaces/<workspace-resource-id>"
 """
 
 helps['openshift delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -321,7 +321,7 @@ def load_arguments(self, _):
         c.argument('name', validator=validate_linux_host_name)
         c.argument('compute_vm_size', options_list=['--compute-vm-size', '-s'])
         c.argument('customer_admin_group_id', options_list=['--customer-admin-group-id'])
-        c.argument('workspace_resource_id')
+        c.argument('workspace_resource')
 
 
 def _get_default_install_location(exe_name):

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -321,7 +321,7 @@ def load_arguments(self, _):
         c.argument('name', validator=validate_linux_host_name)
         c.argument('compute_vm_size', options_list=['--compute-vm-size', '-s'])
         c.argument('customer_admin_group_id', options_list=['--customer-admin-group-id'])
-        c.argument('workspace_resource')
+        c.argument('workspace_id')
 
 
 def _get_default_install_location(exe_name):

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3125,7 +3125,7 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
                      vnet_peer=None,
                      tags=None,
                      no_wait=False,
-                     workspace_resource=None,
+                     workspace_id=None,
                      customer_admin_group_id=None):
 
     if location is None:
@@ -3196,13 +3196,13 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
                 namespace='Microsoft.Network', type='virtualNetwork',
                 name=vnet_peer
             )
-    if workspace_resource is not None:
-        workspace_resource = workspace_resource.strip()
-        if not workspace_resource.startswith('/'):
-            workspace_resource = '/' + workspace_resource
-        if workspace_resource.endswith('/'):
-            workspace_resource = workspace_resource.rstrip('/')
-        monitor_profile = OpenShiftManagedClusterMonitorProfile(enabled=True, workspace_resource=workspace_resource)  # pylint: disable=line-too-long
+    if workspace_id is not None:
+        workspace_id = workspace_id.strip()
+        if not workspace_id.startswith('/'):
+            workspace_id = '/' + workspace_id
+        if workspace_id.endswith('/'):
+            workspace_id = workspace_id.rstrip('/')
+        monitor_profile = OpenShiftManagedClusterMonitorProfile(enabled=True, workspace_id=workspace_id)  # pylint: disable=line-too-long
     else:
         monitor_profile = None
 

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3125,7 +3125,7 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
                      vnet_peer=None,
                      tags=None,
                      no_wait=False,
-                     workspace_resource_id=None,
+                     workspace_resource=None,
                      customer_admin_group_id=None):
 
     if location is None:
@@ -3196,13 +3196,13 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
                 namespace='Microsoft.Network', type='virtualNetwork',
                 name=vnet_peer
             )
-    if workspace_resource_id is not None:
-        workspace_resource_id = workspace_resource_id.strip()
-        if not workspace_resource_id.startswith('/'):
-            workspace_resource_id = '/' + workspace_resource_id
-        if workspace_resource_id.endswith('/'):
-            workspace_resource_id = workspace_resource_id.rstrip('/')
-        monitor_profile = OpenShiftManagedClusterMonitorProfile(enabled=True, workspace_resource_id=workspace_resource_id)  # pylint: disable=line-too-long
+    if workspace_resource is not None:
+        workspace_resource = workspace_resource.strip()
+        if not workspace_resource.startswith('/'):
+            workspace_resource = '/' + workspace_resource
+        if workspace_resource.endswith('/'):
+            workspace_resource = workspace_resource.rstrip('/')
+        monitor_profile = OpenShiftManagedClusterMonitorProfile(enabled=True, workspace_resource=workspace_resource)  # pylint: disable=line-too-long
     else:
         monitor_profile = None
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_osa_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_osa_commands.py
@@ -18,7 +18,7 @@ from azure.cli.testsdk.checkers import (StringContainCheck, StringContainCheckIg
 
 
 class AzureOpenShiftServiceScenarioTest(ScenarioTest):
-    
+
     # It works in --live mode but fails in replay mode.get rid off @live_only attribute once this resolved
     @live_only()
     @ResourceGroupPreparer(random_name_length=17, name_prefix='clitestosa', location='eastus')
@@ -67,7 +67,7 @@ class AzureOpenShiftServiceScenarioTest(ScenarioTest):
 
         # delete
         self.cmd('openshift delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
-    
+
     # It works in --live mode but fails in replay mode.get rid off @live_only attribute once this resolved
     @live_only()
     @ResourceGroupPreparer(random_name_length=17, name_prefix='clitestosa', location='eastus')
@@ -108,7 +108,7 @@ class AzureOpenShiftServiceScenarioTest(ScenarioTest):
 
         # show again and expect failure
         self.cmd('openshift show -g {resource_group} -n {name}', expect_failure=True)
-    
+
     # It works in --live mode but fails in replay mode.get rid off @live_only attribute once this resolved
     @live_only()
     @ResourceGroupPreparer(random_name_length=17, name_prefix='clitestosa', location='eastus')
@@ -153,3 +153,37 @@ class AzureOpenShiftServiceScenarioTest(ScenarioTest):
 
         # delete
         self.cmd('openshift delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
+    # It works in --live mode but fails in replay mode.get rid off @live_only attribute once this resolved
+    @live_only()
+    @ResourceGroupPreparer(random_name_length=17, name_prefix='clitestosa', location='eastus')
+    @ManagedApplicationPreparer()
+    def test_openshift_create_without_monitoring(self, resource_group, resource_group_location, aad_client_app_id, aad_client_app_secret):
+        # kwargs for string formatting
+        osa_name = self.create_random_name('clitestosa', 15)
+        self.kwargs.update({
+            'resource_group': resource_group,
+            'name': osa_name,
+            'location': resource_group_location,
+            'aad_client_app_id': aad_client_app_id,
+            'aad_client_app_secret': aad_client_app_secret
+        })
+
+        # create
+        create_cmd = 'openshift create --resource-group={resource_group} --name={name} --location={location} ' \
+                     '--compute-count=1 ' \
+                     '--aad-client-app-id {aad_client_app_id} --aad-client-app-secret {aad_client_app_secret}'
+
+        self.cmd(create_cmd, checks=[
+            self.exists('fqdn'),
+            self.check('provisioningState', 'Succeeded'),
+            self.check('monitor_profile', None)
+        ])
+        # show
+        self.cmd('openshift show -g {resource_group} -n {name}', checks=[
+            self.check('name', '{name}'),
+            self.check('resourceGroup', '{resource_group}'),
+            self.exists('openShiftVersion')
+        ])
+        # delete
+        self.cmd('openshift delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
+


### PR DESCRIPTION
Issue https://github.com/Azure/azure-cli/issues/6949#issuecomment-456492503 describes this problem across AKS and Azure Red Hat Openshift when trying to use monitoring when creating clusters.  To clearly distinguish the parameter that Azure Red Hat Openshift needs to create a cluster with monitoring, changing this parameter to `workspace-resource` and providing the context in the help menu when using `az openshift create -h` will allow the user to see what is expected.  The conversation was in PR #10775 and settled on the former but subsequent work will create issues of handling the id with future commands. 

- [x] Change help and parameters to match "workspace-resource"
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
