### PR TITLE
[Profile] Change MSI login's subscription list to key by ID

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -346,9 +346,7 @@ class Profile(object):
 
         consolidated = self._normalize_properties(user, subscriptions, is_service_principal=True,
                                                   user_assigned_identity_id=base_name)
-
-        # key-off subscription name to allow accounts with same id(but under different identities)
-        self._set_subscriptions(consolidated, secondary_key_name=_SUBSCRIPTION_NAME)
+        self._set_subscriptions(consolidated)
         return deepcopy(consolidated)
 
     def find_subscriptions_in_cloud_console(self):

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -39,6 +39,7 @@ Release History
 * Polish error when running `az login -u {} -p {}` with Microsoft account
 * Polish `SSLError` when running `az login` behind a proxy with self-signed root certificate
 * Fix #10578: `az login` hangs when more than one instances are launched at the same time on Windows or WSL
+* Fix #11238: After renaming a subscription, logging in with MSI will result in the same subscription appearing twice
 
 **RBAC**
 


### PR DESCRIPTION
Fix #11238: After renaming a subscription, logging in with MSI will result in the same subscription appearing twice

Now **subscription name** is not assembled like `MSI@50342` anymore and is bound to the **subscription ID**. So change `_set_subscriptions` to "key by ID". If subscription is renamed, relogin will cause the previous subscription to be overwritten. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
