### PR TITLE
acr: move helm check to the latest step of check-health command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -168,17 +168,6 @@ def _get_helm_version(ignore_errors):
         _handle_error(obsolete_ver_error, ignore_errors)
 
 
-def _check_health_environment(ignore_errors, yes):
-    from azure.cli.core.util import in_cloud_console
-    if in_cloud_console():
-        logger.warning("Environment checks are not supported in Azure Cloud Shell.")
-        return
-
-    _get_docker_status_and_version(ignore_errors, yes)
-    _get_cli_version()
-    _get_helm_version(ignore_errors)
-
-
 # Checks for the connectivity
 # Check DNS lookup and access to challenge endpoint
 def _get_registry_status(login_server, registry_name, ignore_errors):
@@ -288,7 +277,17 @@ def acr_check_health(cmd,  # pylint: disable useless-return
                      ignore_errors=False,
                      yes=False,
                      registry_name=None):
+    from azure.cli.core.util import in_cloud_console
+    in_cloud_console = in_cloud_console()
+    if in_cloud_console:
+        logger.warning("Environment checks are not supported in Azure Cloud Shell.")
+    else:
+        _get_docker_status_and_version(ignore_errors, yes)
+        _get_cli_version()
 
-    _check_health_environment(ignore_errors, yes)
     _check_health_connectivity(cmd, registry_name, ignore_errors)
+
+    if not in_cloud_console:
+        _get_helm_version(ignore_errors)
+
     print(FAQ_MESSAGE, file=sys.stderr)


### PR DESCRIPTION
This is per ask on supportability that helm is less used and should not block other more important checks. Yes we have `--ignore-errors` flag, but people usually forget it.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
