### PR TITLE
Upgrade virtuelenv to 16.7.7 to support Python 3.8

### DIFF
--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -9,7 +9,7 @@
 # Bash script to install the Azure CLI
 #
 INSTALL_SCRIPT_URL="https://azurecliprod.blob.core.windows.net/install.py"
-INSTALL_SCRIPT_SHA256=bf6b7f778937b7a212e498ccc7235d36d244140721b3cb6cea6a6bc264d1d78d
+INSTALL_SCRIPT_SHA256=9dc76481771bb2e219217187a1331a85a426e685d4070867a42d5825956ee512
 _TTY=/dev/tty
 
 install_script=$(mktemp -t azure_cli_install_tmp_XXXXXX) || exit

--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -42,10 +42,10 @@ AZ_DISPATCH_TEMPLATE = """#!/usr/bin/env bash
 {install_dir}/bin/python -m azure.cli "$@"
 """
 
-VIRTUALENV_VERSION = '15.0.0'
+VIRTUALENV_VERSION = '16.7.7'
 VIRTUALENV_ARCHIVE = 'virtualenv-'+VIRTUALENV_VERSION+'.tar.gz'
 VIRTUALENV_DOWNLOAD_URL = 'https://pypi.python.org/packages/source/v/virtualenv/'+VIRTUALENV_ARCHIVE
-VIRTUALENV_ARCHIVE_SHA256 = '70d63fb7e949d07aeb37f6ecc94e8b60671edb15b890aa86dba5dfaf2225dc19'
+VIRTUALENV_ARCHIVE_SHA256 = 'd257bb3773e48cac60e475a19b608996c73f4d333b3ba2e4e57d5ac6134e0136'
 
 DEFAULT_INSTALL_DIR = os.path.expanduser(os.path.join('~', 'lib', 'azure-cli'))
 DEFAULT_EXEC_DIR = os.path.expanduser(os.path.join('~', 'bin'))

--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -332,8 +332,14 @@ def _native_dependencies_for_dist(verify_cmd_args, install_cmd_args, dep_list):
 
 
 def _get_linux_distro():
-    with open('/etc/os-release') as lines:
-        tokens = [line.strip() for line in lines]
+    if platform.system() != 'Linux':
+        return None, None
+
+    try:
+        with open('/etc/os-release') as lines:
+            tokens = [line.strip() for line in lines]
+    except Exception as e:
+        return None, None
 
     release_info = {}
     for token in tokens:

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+**Install**
+
+* Install script support python 3.8
+
+2.0.77
+
 **ACR**
 
 * Deprecated paramater `--branch` from acr task create/update
@@ -44,10 +50,6 @@ Release History
 * vm/vmss create: Add 'Spot' to 'Priority' enum property
 * [Breaking change] Rename '--max-billing' parameter to '--max-price', for both VM and VMSS, to be consistent with Swagger and Powershell cmdlets
 * vm monitor log show: support query log over linked log analytics workspace.
-
-**Install**
-
-* Install script support python 3.8
 
 **IOT**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -45,6 +45,10 @@ Release History
 * [Breaking change] Rename '--max-billing' parameter to '--max-price', for both VM and VMSS, to be consistent with Swagger and Powershell cmdlets
 * vm monitor log show: support query log over linked log analytics workspace.
 
+**Install**
+
+* Install script support python 3.8
+
 **IOT**
 
 * Fix #2531: Add convenience arguments for hub update.


### PR DESCRIPTION
virtualenv==15.0.0 is too old for Python 3.8. One of dependency `platform.linux_distribution()` it used is deprecated.

* Fix https://github.com/Azure/azure-cli/issues/11344
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
