### PR TITLE
Remove six~=1.12.0 restriction in Travis CI since astroid's bug has been fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - libssl-dev
       - libffi-dev
       - python-dev
-install: pip install --upgrade pip tox six~=1.12.0
+install: pip install --upgrade pip tox six
 cache: pip
 jobs:
   include:

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -68,7 +68,7 @@ DEPENDENCIES = [
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'pyyaml',
     'requests~=2.20',
-    'six~=1.12',
+    'six',
     'wheel==0.30.0',
     'azure-mgmt-resource~=4.0',
 ]

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -68,7 +68,7 @@ DEPENDENCIES = [
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'pyyaml',
     'requests~=2.20',
-    'six',
+    'six~=1.12',
     'wheel==0.30.0',
     'azure-mgmt-resource~=4.0',
 ]


### PR DESCRIPTION
- Fix https://github.com/Azure/azure-cli/issues/11127
- One of our dependencies astroid's bug that block CI has been fixed [Update six version](https://github.com/PyCQA/astroid/issues/718), remove unnecessary restriction

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
