### PR TITLE
Warn StorageV2 for Storage Account creation only when applicable

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -26,7 +26,7 @@ def create_storage_account(cmd, resource_group_name, account_name, sku=None, loc
     scf = storage_client_factory(cmd.cli_ctx)
     if kind is None:
         logger.warning("The default kind for created storage account will change to 'StorageV2' from 'Storage' "
-                   "in the future")
+                       "in the future")
     params = StorageAccountCreateParameters(sku=Sku(name=sku), kind=Kind(kind), location=location, tags=tags)
     if custom_domain:
         params.custom_domain = CustomDomain(name=custom_domain, use_sub_domain=None)

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -24,7 +24,8 @@ def create_storage_account(cmd, resource_group_name, account_name, sku=None, loc
         cmd.get_models('StorageAccountCreateParameters', 'Kind', 'Sku', 'CustomDomain', 'AccessTier', 'Identity',
                        'Encryption', 'NetworkRuleSet')
     scf = storage_client_factory(cmd.cli_ctx)
-    logger.warning("The default kind for created storage account will change to 'StorageV2' from 'Storage' "
+    if kind is None:
+        logger.warning("The default kind for created storage account will change to 'StorageV2' from 'Storage' "
                    "in the future")
     params = StorageAccountCreateParameters(sku=Sku(name=sku), kind=Kind(kind), location=location, tags=tags)
     if custom_domain:


### PR DESCRIPTION
The warning `The default kind for created storage account will change to 'StorageV2' from 'Storage' in the future` is now always shown on creation of a storage account. This warning is only applicable when using no value.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
