### PR TITLE
improvement: Add label automatically when creating an issue based on issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41BBug report"
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: Bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41BBug report"
 about: Create a report to help us improve
 title: ''
-labels: Bug
+labels: ''
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -2,7 +2,7 @@
 name: "\U0001F680Feature request"
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: Feature Request
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/Service_team_request.md
+++ b/.github/ISSUE_TEMPLATE/Service_team_request.md
@@ -3,7 +3,7 @@ name: "\U0001F6A7Service Team Support Request"
 about: For select service teams to request CLI-team support for work such as new features,
   commands, etc.
 title: ''
-labels: ''
+labels: Service Team Support Request
 assignees: ''
 
 ---


### PR DESCRIPTION
improvement: Add first level label automatically when creating an issue based on issue template

Following optimization:
Using a bot to extract issue title/description to add second level (service level) labels (such as network, storage, compute and etc.) automatically.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
