### PR TITLE
English grammer in deployment warning

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -369,7 +369,7 @@ def enable_zip_deploy(cmd, resource_group_name, name, src, timeout=None, slot=No
         zip_content = fs.read()
         logger.warning("Starting zip deployment. This operation can take a while to complete ...")
         res = requests.post(zip_url, data=zip_content, headers=headers, verify=not should_disable_connection_verify())
-        logger.warning("Deployment endpoint responses with status code %d", res.status_code)
+        logger.warning("Deployment endpoint responded with status code %d", res.status_code)
 
     # check if there's an ongoing process
     if res.status_code == 409:


### PR DESCRIPTION
The sentence *Deployment endpoint responses with status code* should be *Deployment endpoint responded with status code*



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
