### PR TITLE
[TestSDK] Add case_sensitive option for checks

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -158,7 +158,6 @@ class ScenarioTest(ReplayableTest, CheckerMixin, unittest.TestCase):
 
     def cmd(self, command, checks=None, expect_failure=False):
         command = self._apply_kwargs(command)
-        print(command)
         return execute(self.cli_ctx, command, expect_failure=expect_failure).assert_with_checks(checks)
 
     def get_subscription_id(self):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -43,11 +43,11 @@ class CheckerMixin(object):
             raise KeyError("Key '{}' not found in kwargs. Check spelling and ensure it has been registered."
                            .format(ex.args[0]))
 
-    def check(self, query, expected_results):
+    def check(self, query, expected_results, case_sensitive=True):
         from azure.cli.testsdk.checkers import JMESPathCheck
         query = self._apply_kwargs(query)
         expected_results = self._apply_kwargs(expected_results)
-        return JMESPathCheck(query, expected_results)
+        return JMESPathCheck(query, expected_results, case_sensitive)
 
     def exists(self, query):
         from azure.cli.testsdk.checkers import JMESPathCheckExists
@@ -158,6 +158,7 @@ class ScenarioTest(ReplayableTest, CheckerMixin, unittest.TestCase):
 
     def cmd(self, command, checks=None, expect_failure=False):
         command = self._apply_kwargs(command)
+        print(command)
         return execute(self.cli_ctx, command, expect_failure=expect_failure).assert_with_checks(checks)
 
     def get_subscription_id(self):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py
@@ -27,8 +27,8 @@ class JMESPathCheck(object):  # pylint: disable=too-few-public-methods
         if self._case_sensitive:
             equals = actual_result == self._expected_result or str(actual_result) == str(self._expected_result)
         else:
-            equals = isinstance(actual_result, str) and isinstance(self._expected_result, str)\
-                and actual_result.lower() == self._expected_result.lower()
+            equals = actual_result == self._expected_result \
+                or str(actual_result).lower() == str(self._expected_result).lower()
         if not equals:
             if actual_result:
                 raise JMESPathCheckAssertionError(self._query, self._expected_result, actual_result,

--- a/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py
@@ -10,9 +10,10 @@ from .exceptions import JMESPathCheckAssertionError
 
 
 class JMESPathCheck(object):  # pylint: disable=too-few-public-methods
-    def __init__(self, query, expected_result):
+    def __init__(self, query, expected_result, case_sensitive=True):
         self._query = query
         self._expected_result = expected_result
+        self._case_sensitive = case_sensitive
 
     def __call__(self, execution_result):
         json_value = execution_result.get_output_in_json()
@@ -23,7 +24,12 @@ class JMESPathCheck(object):  # pylint: disable=too-few-public-methods
         except jmespath.exceptions.JMESPathTypeError:
             raise JMESPathCheckAssertionError(self._query, self._expected_result, actual_result,
                                               execution_result.output)
-        if actual_result != self._expected_result and str(actual_result) != str(self._expected_result):
+        if self._case_sensitive:
+            equals = actual_result == self._expected_result or str(actual_result) == str(self._expected_result)
+        else:
+            equals = isinstance(actual_result, str) and isinstance(self._expected_result, str)\
+                and actual_result.lower() == self._expected_result.lower()
+        if not equals:
             if actual_result:
                 raise JMESPathCheckAssertionError(self._query, self._expected_result, actual_result,
                                                   execution_result.output)


### PR DESCRIPTION
Azure doesn't distinguish between upper case and lower case names. Current "equals" checks in testing framework is case_sensitive, which blocks the testing in some circumstances. In this PR, I add a case_sensitive option.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
