### PR TITLE
[Network] Update help message for misleading option --registration-vnets in dns zone

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -503,7 +503,8 @@ def load_arguments(self, _):
                    nargs='+',
                    help='Space-separated names or IDs of virtual networks that register hostnames in this DNS zone. '
                         'Number of private DNS zones with virtual network auto-registration enabled is 1. '
-                        'If you need to increase this limit, contact Azure Support.',
+                        'If you need to increase this limit, please contact Azure Support: '
+                        'https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits',
                    validator=get_vnet_validator('registration_vnets'))
         c.argument('resolution_vnets',
                    arg_group='Private Zone',

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -497,8 +497,19 @@ def load_arguments(self, _):
         c.ignore('location')
 
         c.argument('zone_type', help='Type of DNS zone to create.', arg_type=get_enum_type(ZoneType))
-        c.argument('registration_vnets', arg_group='Private Zone', nargs='+', help='Space-separated names or IDs of virtual networks that register hostnames in this DNS zone.', validator=get_vnet_validator('registration_vnets'))
-        c.argument('resolution_vnets', arg_group='Private Zone', nargs='+', help='Space-separated names or IDs of virtual networks that resolve records in this DNS zone.', validator=get_vnet_validator('resolution_vnets'))
+
+        c.argument('registration_vnets',
+                   arg_group='Private Zone',
+                   nargs='+',
+                   help='Space-separated names or IDs of virtual networks that register hostnames in this DNS zone. '
+                        'Number of private DNS zones with virtual network auto-registration enabled is 1. '
+                        'If you need to increase this limit, contact Azure Support.',
+                   validator=get_vnet_validator('registration_vnets'))
+        c.argument('resolution_vnets',
+                   arg_group='Private Zone',
+                   nargs='+',
+                   help='Space-separated names or IDs of virtual networks that resolve records in this DNS zone.',
+                   validator=get_vnet_validator('resolution_vnets'))
 
     with self.argument_context('network dns zone import') as c:
         c.argument('file_name', options_list=['--file-name', '-f'], type=file_type, completer=FilesCompleter(), help='Path to the DNS zone file to import')


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/9410

Number of private DNS zones with virtual network auto-registration (--registration-vnes) enabled is 1. If user want to increase this limit, he needs to contact Azure Support

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
